### PR TITLE
ci: stop linting legacy baseline on main push

### DIFF
--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -1,12 +1,10 @@
 name: linter
 
 on:
-  push:
-    branches:
-    - main
   pull_request:
     branches:
     - main
+  workflow_dispatch:
 
 jobs:
   linter:


### PR DESCRIPTION
## Summary
- stop running golangci-lint on every push to main
- keep golangci-lint as a pull request gate
- leave manual workflow_dispatch available for ad hoc baseline lint checks

## Context
The main-branch run at https://github.com/chenrui333/terraformer/runs/73028804451 failed because the updated linter path runs against the full legacy baseline and reports hundreds of existing issues. PR checks still protect new changes, while a later cleanup can address full-repo linting deliberately.

## Validation
- `git diff --check`
- `actionlint .github/workflows/linter.yml`
