### PR TITLE
deps(azure): update go-azure-helpers from v0.36.0 to v0.48.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -124,7 +124,7 @@ require (
 	github.com/google/go-github/v35 v35.1.0
 	github.com/gophercloud/gophercloud v1.0.0
 	github.com/grafana/grafana-api-golang-client v0.0.0-20210218192924-9ccd2365d2a6
-	github.com/hashicorp/go-azure-helpers v0.36.0
+	github.com/hashicorp/go-azure-helpers v0.48.0
 	github.com/hashicorp/go-cleanhttp v0.5.2
 	github.com/hashicorp/go-hclog v1.6.3
 	github.com/hashicorp/go-memdb v1.3.2 // indirect
@@ -356,7 +356,7 @@ require (
 	github.com/DataDog/datadog-api-client-go/v2 v2.11.0
 	github.com/Myra-Security-GmbH/myrasec-go/v2 v2.28.0
 	github.com/bradleyfalzon/ghinstallation/v2 v2.1.0
-	github.com/manicminer/hamilton v0.44.0
+	github.com/manicminer/hamilton v0.50.0
 	github.com/opalsecurity/opal-go v1.0.19
 	gopkg.in/ns1/ns1-go.v2 v2.6.5
 )

--- a/go.sum
+++ b/go.sum
@@ -1010,8 +1010,8 @@ github.com/hashicorp/errwrap v1.0.0/go.mod h1:YH+1FKiLXxHSkmPseP+kNlulaMuP3n2brv
 github.com/hashicorp/errwrap v1.1.0 h1:OxrOeh75EUXMY8TBjag2fzXGZ40LB6IKw45YeGUDY2I=
 github.com/hashicorp/errwrap v1.1.0/go.mod h1:YH+1FKiLXxHSkmPseP+kNlulaMuP3n2brvKWEqk/Jc4=
 github.com/hashicorp/go-azure-helpers v0.10.0/go.mod h1:YuAtHxm2v74s+IjQwUG88dHBJPd5jL+cXr5BGVzSKhE=
-github.com/hashicorp/go-azure-helpers v0.36.0 h1:8+aX2wh40tnO0tmk6HD1hz7+EGM9qINalBu60ae7di8=
-github.com/hashicorp/go-azure-helpers v0.36.0/go.mod h1:gcutZ/Hf/O7YN9M3UIvyZ9l0Rxv7Yrc9x5sSfM9cuSw=
+github.com/hashicorp/go-azure-helpers v0.48.0 h1:T8yrA0sV/knQHZ7Sc3RjhScgwFVNuXoRYQXyzQ6kiXQ=
+github.com/hashicorp/go-azure-helpers v0.48.0/go.mod h1:jx8ynFKa4GfkbHENsozVhpi/Kk1pJtmcY5MG+XIqx0k=
 github.com/hashicorp/go-checkpoint v0.5.0/go.mod h1:7nfLNL10NsxqO4iWuW6tWW0HjZuDrwkBuEQsVcpCOgg=
 github.com/hashicorp/go-cleanhttp v0.5.0/go.mod h1:JpRdi6/HCYpAwUzNwuwqhbovhLtngrth3wmdIIUrZ80=
 github.com/hashicorp/go-cleanhttp v0.5.1/go.mod h1:JpRdi6/HCYpAwUzNwuwqhbovhLtngrth3wmdIIUrZ80=
@@ -1250,8 +1250,8 @@ github.com/mailru/easyjson v0.0.0-20190626092158-b2ccc519800e/go.mod h1:C1wdFJiN
 github.com/mailru/easyjson v0.7.6 h1:8yTIVnZgCoiM1TgqoeTl+LfU5Jg6/xL3QhGQnimLYnA=
 github.com/mailru/easyjson v0.7.6/go.mod h1:xzfreul335JAWq5oZzymOObrkdz5UnU4kGfJJLY9Nlc=
 github.com/manicminer/hamilton v0.43.0/go.mod h1:lbVyngC+/nCWuDp8UhC6Bw+bh7jcP/E+YwqzHTmzemk=
-github.com/manicminer/hamilton v0.44.0 h1:mLb4Vxbt2dsAvOpaB7xd/5D8LaTTX6ACwVP4TmW8qwE=
-github.com/manicminer/hamilton v0.44.0/go.mod h1:lbVyngC+/nCWuDp8UhC6Bw+bh7jcP/E+YwqzHTmzemk=
+github.com/manicminer/hamilton v0.50.0 h1:EPne7iH6zbXUPPjP/XZvqXzmqkt1WyF5X1A21uosPM4=
+github.com/manicminer/hamilton v0.50.0/go.mod h1:lbVyngC+/nCWuDp8UhC6Bw+bh7jcP/E+YwqzHTmzemk=
 github.com/manicminer/hamilton-autorest v0.2.0 h1:dDL+t2DrQza0EfNYINYCvXISeNwVqzgVAQh+CH/19ZU=
 github.com/manicminer/hamilton-autorest v0.2.0/go.mod h1:NselDpNTImEmOc/fa41kPg6YhDt/6S95ejWbTGZ6tlg=
 github.com/markbates/oncer v0.0.0-20181203154359-bf2de49a0be2/go.mod h1:Ld9puTsIW75CHf65OeIOkyKbteujpZVXDpWK6YGZbxE=


### PR DESCRIPTION
## Summary
- bump `github.com/hashicorp/go-azure-helpers` from `v0.36.0` to `v0.48.0`
- update the paired `github.com/manicminer/hamilton` module from `v0.44.0` to `v0.50.0`

## Notes
`v0.48.0` is the highest no-source-change Azure helpers bump I found. `v0.49.0+` needs Azure/AzureAD provider code updates, so this keeps the cleanup incremental.

## References
- hashicorp/go-azure-helpers: [v0.48.0 release](https://github.com/hashicorp/go-azure-helpers/releases/tag/v0.48.0), [v0.36.0...v0.48.0 compare](https://github.com/hashicorp/go-azure-helpers/compare/v0.36.0...v0.48.0)
- manicminer/hamilton: [v0.50.0 release](https://github.com/manicminer/hamilton/releases/tag/v0.50.0), [v0.44.0...v0.50.0 compare](https://github.com/manicminer/hamilton/compare/v0.44.0...v0.50.0)
