### PR TITLE
ci: split go validation checks

### DIFF
--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -6,6 +6,11 @@ on:
     - main
   workflow_dispatch:
 
+permissions:
+  contents: read
+  pull-requests: read
+  checks: write
+
 jobs:
   linter:
     name: golangci-lint

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,6 +8,12 @@ on:
     branches:
     - main
 
+permissions:
+  contents: read
+
+env:
+  GOWORK: off
+
 jobs:
   test:
     strategy:
@@ -24,5 +30,11 @@ jobs:
         cache-dependency-path: go.sum
     - name: Go Mod Tidy
       run: go mod tidy
+    - name: Check go.mod and go.sum
+      run: git diff --exit-code -- go.mod go.sum
+    - name: Build
+      run: go build -v ./...
     - name: Test
-      run: go build -v && go test ./...
+      run: go test ./... -count=1
+    - name: Vet
+      run: go vet ./...


### PR DESCRIPTION
Summary
- split the Go test workflow into tidy, diff, build, test, and vet steps
- run test workflow commands with `GOWORK=off`
- add explicit workflow permissions for tests and reviewdog linting

Notes
- The required Ubuntu test check remains the fast merge gate.
- macOS still runs for signal, but it should remain non-blocking while hosted runner latency is high.