### PR TITLE
ci: pin govulncheck from v1.3.0 to v1.1.4

### DIFF
--- a/.github/workflows/govulncheck.yml
+++ b/.github/workflows/govulncheck.yml
@@ -1,6 +1,9 @@
 name: govulncheck
 
 on:
+  pull_request:
+    branches:
+    - main
   workflow_dispatch:
   schedule:
     - cron: "20 4 * * 1"
@@ -24,7 +27,7 @@ jobs:
         cache: true
         cache-dependency-path: go.sum
     - name: Install govulncheck
-      run: go install golang.org/x/vuln/cmd/govulncheck@v1.3.0
+      run: go install golang.org/x/vuln/cmd/govulncheck@v1.1.4
     - name: Run module vulnerability scan
       id: govulncheck
       continue-on-error: true


### PR DESCRIPTION
Summary
- pin govulncheck to v1.1.4 for the current Go 1.24 CI runtime
- run the non-blocking module scan on pull requests, weekly schedule, and manual dispatch

Notes
- govulncheck v1.3.0 requires Go 1.25 and failed before scanning.
- v1.1.4 still supports -scan=module and reports the current baseline findings.
- The vulnerability scan step uses continue-on-error, so current findings stay visible without becoming a merge blocker.