### PR TITLE
chore(go): update module directive from 1.24.0 to 1.25.8

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/GoogleCloudPlatform/terraformer
 
-go 1.24.0
+go 1.25.8
 
 require (
 	cloud.google.com/go v0.116.0 // indirect


### PR DESCRIPTION
Summary
- update the module Go directive from 1.24.0 to 1.25.8

Notes
- this keeps the runtime/toolchain migration separate from provider dependency updates
- 1.25.8 matches the highest Go 1.25 minimum already seen in planned dependency paths

References
- Go modules reference: https://go.dev/ref/mod#go-mod-file-go