### PR TITLE
ci: update govulncheck from v1.1.4 to v1.3.0

### DIFF
--- a/.github/workflows/govulncheck.yml
+++ b/.github/workflows/govulncheck.yml
@@ -27,7 +27,7 @@ jobs:
         cache: true
         cache-dependency-path: go.sum
     - name: Install govulncheck
-      run: go install golang.org/x/vuln/cmd/govulncheck@v1.1.4
+      run: go install golang.org/x/vuln/cmd/govulncheck@v1.3.0
     - name: Run module vulnerability scan
       id: govulncheck
       continue-on-error: true


### PR DESCRIPTION
Summary
- update the govulncheck workflow pin to v1.3.0

Notes
- the repo now uses Go 1.25.8, so the current govulncheck release installs cleanly
- the module scan remains non-blocking while the current vulnerability baseline is being reduced