### PR TITLE
ci: pin golangci-lint version to v2.11.4

### DIFF
--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -22,6 +22,7 @@ jobs:
       uses: reviewdog/action-golangci-lint@v2.10.0
       with:
         cache: true
+        golangci_lint_version: v2.11.4
         go_version_file: go.mod
         github_token: ${{ secrets.GITHUB_TOKEN }}
         tool_name: golangci-lint


### PR DESCRIPTION
Summary
- pin the reviewdog golangci-lint binary to v2.11.4

Notes
- this keeps the required lint gate stable during the dependency renovation work
- the existing golangci-lint v2 config is unchanged