### PR TITLE
deps(aws): migrate apigatewayv2 from aws sdk v1.55.8 to v2 v1.34.2

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -409,7 +409,7 @@ require (
 
 require (
 	github.com/IBM/continuous-delivery-go-sdk/v2 v2.0.2
-	github.com/aws/aws-sdk-go v1.55.8
+	github.com/aws/aws-sdk-go-v2/service/apigatewayv2 v1.34.2
 	github.com/aws/aws-sdk-go-v2/service/directconnect v1.38.16
 	github.com/gofrs/uuid/v3 v3.1.2
 	github.com/hashicorp/vault/api v1.23.0

--- a/go.sum
+++ b/go.sum
@@ -230,8 +230,6 @@ github.com/aws/aws-sdk-go v1.15.78/go.mod h1:E3/ieXAlvM0XWO57iftYVDLLvQ824smPP3A
 github.com/aws/aws-sdk-go v1.25.3/go.mod h1:KmX6BPdI08NWTb3/sm4ZGu5ShLoqVDhKgpiN924inxo=
 github.com/aws/aws-sdk-go v1.30.12/go.mod h1:5zCpMtNQVjRREroY7sYe8lOMRSxkhG6MZveU8YkpAk0=
 github.com/aws/aws-sdk-go v1.34.28/go.mod h1:H7NKnBqNVzoTJpGfLrQkkD+ytBA93eiDYi/+8rV9s48=
-github.com/aws/aws-sdk-go v1.55.8 h1:JRmEUbU52aJQZ2AjX4q4Wu7t4uZjOu71uyNmaWlUkJQ=
-github.com/aws/aws-sdk-go v1.55.8/go.mod h1:ZkViS9AqA6otK+JBBNH2++sx1sgxrPKcSzPPvQkUtXk=
 github.com/aws/aws-sdk-go-v2 v1.41.6 h1:1AX0AthnBQzMx1vbmir3Y4WsnJgiydmnJjiLu+LvXOg=
 github.com/aws/aws-sdk-go-v2 v1.41.6/go.mod h1:dy0UzBIfwSeot4grGvY1AqFWN5zgziMmWGzysDnHFcQ=
 github.com/aws/aws-sdk-go-v2/aws/protocol/eventstream v1.7.9 h1:adBsCIIpLbLmYnkQU+nAChU5yhVTvu5PerROm+/Kq2A=
@@ -254,6 +252,8 @@ github.com/aws/aws-sdk-go-v2/service/acm v1.38.2 h1:ozcwethaFOi2ST9h6MKGq1GAIHP6
 github.com/aws/aws-sdk-go-v2/service/acm v1.38.2/go.mod h1:HNtDOv4XmqExPxNIBp171KKc5ZoUJwHH9ZhlCcZmdt0=
 github.com/aws/aws-sdk-go-v2/service/apigateway v1.39.2 h1:cjiL+KicFLUVLR8eiFjG7IuvI5VX5CvTeo/f7E/RqC4=
 github.com/aws/aws-sdk-go-v2/service/apigateway v1.39.2/go.mod h1:3WScseCcG9TEdg5ke0uGNO/Y73OhCzYXucRaXbwuXxU=
+github.com/aws/aws-sdk-go-v2/service/apigatewayv2 v1.34.2 h1:pAWhAeOx2Jwh8TxQBja4u8lPPkO/UhuTHkpu/LUnXZ4=
+github.com/aws/aws-sdk-go-v2/service/apigatewayv2 v1.34.2/go.mod h1:XmFVy7WJuz5Kvi2H9cxJim2RjVGlLi8w58g/IqMklq4=
 github.com/aws/aws-sdk-go-v2/service/appsync v1.53.6 h1:Es1Nkz/ShfBC4X/6D7fPj6bE+7lzZv296Bahm1dSQR4=
 github.com/aws/aws-sdk-go-v2/service/appsync v1.53.6/go.mod h1:LqMr49T/yEheODDep0r8AHpSecCdOiKWyQjSi8O11zw=
 github.com/aws/aws-sdk-go-v2/service/autoscaling v1.66.1 h1:kGlbhb5GMfkP/bcqcbt3oDi50kwDTpRmNzYUY9LqbLk=

--- a/providers/aws/api_gatewayv2.go
+++ b/providers/aws/api_gatewayv2.go
@@ -15,11 +15,12 @@
 package aws
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/GoogleCloudPlatform/terraformer/terraformutils"
-	"github.com/aws/aws-sdk-go/aws/session"
-	"github.com/aws/aws-sdk-go/service/apigatewayv2"
+	"github.com/aws/aws-sdk-go-v2/service/apigatewayv2"
+	"github.com/aws/aws-sdk-go-v2/service/apigatewayv2/types"
 )
 
 var apiGatewayV2AllowEmptyValues = []string{"tags.", "parent_id", "path_part"}
@@ -30,7 +31,11 @@ type APIGatewayV2Generator struct {
 
 func (g *APIGatewayV2Generator) InitResources() error {
 
-	svc := apigatewayv2.New(session.Must(session.NewSession()))
+	config, err := g.generateConfig()
+	if err != nil {
+		return err
+	}
+	svc := apigatewayv2.NewFromConfig(config)
 
 	if err := g.loadRestApis(svc); err != nil {
 		return err
@@ -41,8 +46,8 @@ func (g *APIGatewayV2Generator) InitResources() error {
 	return nil
 }
 
-func (g *APIGatewayV2Generator) loadRestApis(svc *apigatewayv2.ApiGatewayV2) error {
-	output, err := svc.GetApis(&apigatewayv2.GetApisInput{})
+func (g *APIGatewayV2Generator) loadRestApis(svc *apigatewayv2.Client) error {
+	output, err := svc.GetApis(context.TODO(), &apigatewayv2.GetApisInput{})
 	if err != nil {
 		fmt.Println("Failed to list APIs:", err)
 		return err
@@ -55,7 +60,7 @@ func (g *APIGatewayV2Generator) loadRestApis(svc *apigatewayv2.ApiGatewayV2) err
 	}
 
 	for output.NextToken != nil {
-		output, err = svc.GetApis(&apigatewayv2.GetApisInput{
+		output, err = svc.GetApis(context.TODO(), &apigatewayv2.GetApisInput{
 			NextToken: output.NextToken,
 		})
 		if err != nil {
@@ -71,7 +76,7 @@ func (g *APIGatewayV2Generator) loadRestApis(svc *apigatewayv2.ApiGatewayV2) err
 	return nil
 }
 
-func (g *APIGatewayV2Generator) processRestApis(svc *apigatewayv2.ApiGatewayV2, output []*apigatewayv2.Api) error {
+func (g *APIGatewayV2Generator) processRestApis(svc *apigatewayv2.Client, output []types.Api) error {
 	for _, restAPI := range output {
 		g.Resources = append(g.Resources, terraformutils.NewSimpleResource(
 			*restAPI.ApiId,
@@ -98,9 +103,9 @@ func (g *APIGatewayV2Generator) processRestApis(svc *apigatewayv2.ApiGatewayV2, 
 	return nil
 }
 
-func (g *APIGatewayV2Generator) loadStages(svc *apigatewayv2.ApiGatewayV2, restAPIID *string) error {
+func (g *APIGatewayV2Generator) loadStages(svc *apigatewayv2.Client, restAPIID *string) error {
 
-	output, err := svc.GetStages(&apigatewayv2.GetStagesInput{
+	output, err := svc.GetStages(context.TODO(), &apigatewayv2.GetStagesInput{
 		ApiId: restAPIID,
 	})
 	if err != nil {
@@ -112,7 +117,8 @@ func (g *APIGatewayV2Generator) loadStages(svc *apigatewayv2.ApiGatewayV2, restA
 	}
 
 	for output.NextToken != nil {
-		output, err = svc.GetStages(&apigatewayv2.GetStagesInput{
+		output, err = svc.GetStages(context.TODO(), &apigatewayv2.GetStagesInput{
+			ApiId:     restAPIID,
 			NextToken: output.NextToken,
 		})
 		if err != nil {
@@ -127,7 +133,7 @@ func (g *APIGatewayV2Generator) loadStages(svc *apigatewayv2.ApiGatewayV2, restA
 	return nil
 }
 
-func (g *APIGatewayV2Generator) processStages(output []*apigatewayv2.Stage, restAPIID *string) error {
+func (g *APIGatewayV2Generator) processStages(output []types.Stage, restAPIID *string) error {
 	for _, stage := range output {
 		stageID := *restAPIID + "/" + StringValue(stage.StageName)
 		g.Resources = append(g.Resources, terraformutils.NewResource(
@@ -146,9 +152,9 @@ func (g *APIGatewayV2Generator) processStages(output []*apigatewayv2.Stage, rest
 	return nil
 }
 
-func (g *APIGatewayV2Generator) loadModels(svc *apigatewayv2.ApiGatewayV2, restAPIID *string) error {
+func (g *APIGatewayV2Generator) loadModels(svc *apigatewayv2.Client, restAPIID *string) error {
 
-	output, err := svc.GetModels(
+	output, err := svc.GetModels(context.TODO(),
 		&apigatewayv2.GetModelsInput{
 			ApiId: restAPIID,
 		})
@@ -161,8 +167,9 @@ func (g *APIGatewayV2Generator) loadModels(svc *apigatewayv2.ApiGatewayV2, restA
 	}
 
 	for output.NextToken != nil {
-		output, err = svc.GetModels(
+		output, err = svc.GetModels(context.TODO(),
 			&apigatewayv2.GetModelsInput{
+				ApiId:     restAPIID,
 				NextToken: output.NextToken,
 			})
 		if err != nil {
@@ -177,7 +184,7 @@ func (g *APIGatewayV2Generator) loadModels(svc *apigatewayv2.ApiGatewayV2, restA
 	return nil
 }
 
-func (g *APIGatewayV2Generator) processModels(output []*apigatewayv2.Model, restAPIID *string) error {
+func (g *APIGatewayV2Generator) processModels(output []types.Model, restAPIID *string) error {
 	for _, model := range output {
 
 		g.Resources = append(g.Resources, terraformutils.NewResource(
@@ -198,9 +205,9 @@ func (g *APIGatewayV2Generator) processModels(output []*apigatewayv2.Model, rest
 	return nil
 }
 
-func (g *APIGatewayV2Generator) loadRoutes(svc *apigatewayv2.ApiGatewayV2, restAPIID *string) error {
+func (g *APIGatewayV2Generator) loadRoutes(svc *apigatewayv2.Client, restAPIID *string) error {
 
-	output, err := svc.GetRoutes(
+	output, err := svc.GetRoutes(context.TODO(),
 		&apigatewayv2.GetRoutesInput{
 			ApiId: restAPIID,
 		})
@@ -214,8 +221,9 @@ func (g *APIGatewayV2Generator) loadRoutes(svc *apigatewayv2.ApiGatewayV2, restA
 	}
 
 	for output.NextToken != nil {
-		output, err := svc.GetRoutes(
+		output, err := svc.GetRoutes(context.TODO(),
 			&apigatewayv2.GetRoutesInput{
+				ApiId:     restAPIID,
 				NextToken: output.NextToken,
 			})
 		if err != nil {
@@ -231,7 +239,7 @@ func (g *APIGatewayV2Generator) loadRoutes(svc *apigatewayv2.ApiGatewayV2, restA
 	return nil
 }
 
-func (g *APIGatewayV2Generator) processRoutes(svc *apigatewayv2.ApiGatewayV2, output []*apigatewayv2.Route, restAPIID *string) error {
+func (g *APIGatewayV2Generator) processRoutes(svc *apigatewayv2.Client, output []types.Route, restAPIID *string) error {
 	for _, route := range output {
 
 		g.Resources = append(g.Resources, terraformutils.NewResource(
@@ -253,9 +261,9 @@ func (g *APIGatewayV2Generator) processRoutes(svc *apigatewayv2.ApiGatewayV2, ou
 	return nil
 }
 
-func (g *APIGatewayV2Generator) loadResponses(svc *apigatewayv2.ApiGatewayV2, restAPIID *string, routeID *string) error {
+func (g *APIGatewayV2Generator) loadResponses(svc *apigatewayv2.Client, restAPIID *string, routeID *string) error {
 
-	output, err := svc.GetRouteResponses(
+	output, err := svc.GetRouteResponses(context.TODO(),
 		&apigatewayv2.GetRouteResponsesInput{
 			ApiId:   restAPIID,
 			RouteId: routeID,
@@ -270,8 +278,10 @@ func (g *APIGatewayV2Generator) loadResponses(svc *apigatewayv2.ApiGatewayV2, re
 	}
 
 	for output.NextToken != nil {
-		output, err = svc.GetRouteResponses(
+		output, err = svc.GetRouteResponses(context.TODO(),
 			&apigatewayv2.GetRouteResponsesInput{
+				ApiId:     restAPIID,
+				RouteId:   routeID,
 				NextToken: output.NextToken,
 			})
 
@@ -286,7 +296,7 @@ func (g *APIGatewayV2Generator) loadResponses(svc *apigatewayv2.ApiGatewayV2, re
 
 	return nil
 }
-func (g *APIGatewayV2Generator) processResponses(output []*apigatewayv2.RouteResponse, restAPIID *string, routeID *string) error {
+func (g *APIGatewayV2Generator) processResponses(output []types.RouteResponse, restAPIID *string, routeID *string) error {
 	for _, response := range output {
 
 		g.Resources = append(g.Resources, terraformutils.NewResource(
@@ -307,9 +317,9 @@ func (g *APIGatewayV2Generator) processResponses(output []*apigatewayv2.RouteRes
 	return nil
 }
 
-func (g *APIGatewayV2Generator) loadAuthorizers(svc *apigatewayv2.ApiGatewayV2, restAPIID *string) error {
+func (g *APIGatewayV2Generator) loadAuthorizers(svc *apigatewayv2.Client, restAPIID *string) error {
 
-	output, err := svc.GetAuthorizers(
+	output, err := svc.GetAuthorizers(context.TODO(),
 		&apigatewayv2.GetAuthorizersInput{
 			ApiId: restAPIID,
 		})
@@ -319,8 +329,9 @@ func (g *APIGatewayV2Generator) loadAuthorizers(svc *apigatewayv2.ApiGatewayV2, 
 	g.processAuthorizers(output.Items, restAPIID)
 
 	for output.NextToken != nil {
-		output, err = svc.GetAuthorizers(
+		output, err = svc.GetAuthorizers(context.TODO(),
 			&apigatewayv2.GetAuthorizersInput{
+				ApiId:     restAPIID,
 				NextToken: output.NextToken,
 			})
 		if err != nil {
@@ -332,7 +343,7 @@ func (g *APIGatewayV2Generator) loadAuthorizers(svc *apigatewayv2.ApiGatewayV2, 
 	return nil
 }
 
-func (g *APIGatewayV2Generator) processAuthorizers(output []*apigatewayv2.Authorizer, restAPIID *string) error {
+func (g *APIGatewayV2Generator) processAuthorizers(output []types.Authorizer, restAPIID *string) {
 	for _, authoriser := range output {
 
 		g.Resources = append(g.Resources, terraformutils.NewResource(
@@ -343,19 +354,18 @@ func (g *APIGatewayV2Generator) processAuthorizers(output []*apigatewayv2.Author
 			map[string]string{
 				"api_id":          *restAPIID,
 				"name":            StringValue(authoriser.Name),
-				"authorizer_type": *authoriser.AuthorizerType,
+				"authorizer_type": string(authoriser.AuthorizerType),
 			},
 			apiGatewayAllowEmptyValues,
 			map[string]interface{}{},
 		))
 
 	}
-	return nil
 }
 
-func (g *APIGatewayV2Generator) loadVpcLinks(svc *apigatewayv2.ApiGatewayV2) error {
+func (g *APIGatewayV2Generator) loadVpcLinks(svc *apigatewayv2.Client) error {
 
-	output, err := svc.GetVpcLinks(
+	output, err := svc.GetVpcLinks(context.TODO(),
 		&apigatewayv2.GetVpcLinksInput{})
 	if err != nil {
 		return err
@@ -363,7 +373,7 @@ func (g *APIGatewayV2Generator) loadVpcLinks(svc *apigatewayv2.ApiGatewayV2) err
 	g.processVpcLinks(output.Items)
 
 	for output.NextToken != nil {
-		output, err := svc.GetVpcLinks(
+		output, err := svc.GetVpcLinks(context.TODO(),
 			&apigatewayv2.GetVpcLinksInput{
 				NextToken: output.NextToken,
 			})
@@ -376,7 +386,7 @@ func (g *APIGatewayV2Generator) loadVpcLinks(svc *apigatewayv2.ApiGatewayV2) err
 	return nil
 }
 
-func (g *APIGatewayV2Generator) processVpcLinks(output []*apigatewayv2.VpcLink) error {
+func (g *APIGatewayV2Generator) processVpcLinks(output []types.VpcLink) {
 	for _, vpcLink := range output {
 
 		g.Resources = append(g.Resources, terraformutils.NewSimpleResource(
@@ -386,5 +396,4 @@ func (g *APIGatewayV2Generator) processVpcLinks(output []*apigatewayv2.VpcLink) 
 			"aws",
 			apiGatewayAllowEmptyValues))
 	}
-	return nil
 }


### PR DESCRIPTION
Summary
- migrate the APIGatewayV2 generator to AWS SDK for Go v2
- reuse the existing AWS v2 config path for the service client
- remove the remaining AWS SDK for Go v1 module from the graph

Notes
- this clears the AWS SDK v1 no-fixed module scan findings
- the remaining module scan baseline is now IBM jwt-go and Okta go-jose.v2

References
- AWS SDK for Go v1 deprecation notice: https://aws.amazon.com/blogs/developer/announcing-end-of-support-for-aws-sdk-for-go-v1/
- API Gateway V2 SDK module: https://pkg.go.dev/github.com/aws/aws-sdk-go-v2/service/apigatewayv2