### PR TITLE
chore(go): update module directive from 1.25.8 to 1.26.2

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/GoogleCloudPlatform/terraformer
 
-go 1.25.8
+go 1.26.2
 
 require (
 	cloud.google.com/go v0.123.0 // indirect


### PR DESCRIPTION
Summary
- update the module directive to Go 1.26.2
- keep the runtime bump separate from provider dependency updates

Notes
- this sets up the next minor release and unlocks newer provider dependency lines such as Kubernetes v0.36
