### PR TITLE
docs(release): add release notes workflow guidance

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,53 @@
+documentation:
+  - changed-files:
+      - any-glob-to-any-file:
+          - "**/*.md"
+          - "docs/**"
+
+release:
+  - changed-files:
+      - any-glob-to-any-file:
+          - ".github/release.yml"
+          - ".github/labeler.yml"
+          - ".github/workflows/labeler.yml"
+          - ".github/workflows/release.yaml"
+          - ".goreleaser.yaml"
+          - "CHANGELOG.md"
+          - "RELEASE.md"
+
+ci:
+  - changed-files:
+      - any-glob-to-any-file:
+          - ".github/workflows/**"
+          - ".github/labeler.yml"
+          - ".github/release.yml"
+          - ".golangci.*"
+
+github_actions:
+  - changed-files:
+      - any-glob-to-any-file:
+          - ".github/workflows/**"
+
+dependencies:
+  - changed-files:
+      - any-glob-to-any-file:
+          - "go.mod"
+          - "go.sum"
+          - "renovate.json"
+
+go:
+  - changed-files:
+      - any-glob-to-any-file:
+          - "**/*.go"
+          - "go.mod"
+          - "go.sum"
+
+enhancement:
+  - head-branch:
+      - "^feat/"
+      - "^feature/"
+
+bug:
+  - head-branch:
+      - "^fix/"
+      - "^bugfix/"

--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,32 @@
+changelog:
+  exclude:
+    labels:
+      - ignore-for-release
+      - Stale
+  categories:
+    - title: Breaking Changes
+      labels:
+        - breaking-change
+    - title: Features
+      labels:
+        - enhancement
+    - title: Bug Fixes
+      labels:
+        - bug
+    - title: Release
+      labels:
+        - release
+    - title: CI And Maintenance
+      labels:
+        - ci
+        - github_actions
+    - title: Dependency Updates
+      labels:
+        - dependencies
+        - go
+    - title: Documentation
+      labels:
+        - documentation
+    - title: Other Changes
+      labels:
+        - "*"

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -1,0 +1,27 @@
+name: pull request labels
+
+on:
+  pull_request_target:
+    branches:
+      - main
+    types:
+      - opened
+      - synchronize
+      - reopened
+      - edited
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  labeler:
+    name: label pull request
+    runs-on: ubuntu-latest
+    steps:
+      - name: Apply labels
+        uses: actions/labeler@v6.0.1
+        with:
+          configuration-path: .github/labeler.yml
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          sync-labels: true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,37 @@
+# Changelog
+
+## 0.9.0
+
+`0.9.0` is a minor maintenance release that refreshes Terraformer's supported
+toolchain and dependency base after the repo resumed active maintenance. It raises
+the Go floor to 1.26.2, modernizes GitHub Actions and CI, restores dependency
+automation with Renovate, and updates core provider dependencies across AWS, GCP,
+Kubernetes, Azure, Heroku, Vault, and Terraform helper modules.
+
+## What's Changed
+
+### Toolchain And CI
+
+* Raise the module directive to Go 1.26.2.
+* Move GitHub Actions workflows onto Node.js 24-compatible actions.
+* Split Go validation into tidy, build, test, and vet checks.
+* Add non-blocking `govulncheck` module scanning.
+* Pin lint tooling so required PR checks do not drift during dependency cleanup.
+
+### Dependency And Provider Maintenance
+
+* Replace Dependabot version-update setup with Renovate provider-scoped groups.
+* Refresh security-sensitive Go modules, including Vault API, gRPC, Go JOSE,
+  SAML/XML signature, logrus, go-getter, and xz.
+* Update AWS SDK v2 service modules and migrate APIGatewayV2 off AWS SDK v1.
+* Update GCP/OpenTelemetry and Kubernetes client libraries.
+* Refresh smaller provider dependencies, including Heroku and Azure helpers.
+
+### Repository Maintenance
+
+* Add repository agent guidance for future maintenance work.
+* Refresh repository maintenance status docs after the standalone fork migration.
+* Add release-note categories, PR auto-labeling, and immutable-release guidance for
+  future releases.
+
+**Full Changelog**: https://github.com/chenrui333/terraformer/compare/0.8.30...0.9.0

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,66 @@
+# Release Workflow
+
+Use this checklist when cutting a new Terraformer release.
+
+## Inputs
+
+- Decide the semantic version bump before release prep starts.
+- Review the current milestone or tracking issue for release-specific blockers.
+- Review merged PRs since the previous release and keep the changelog focused on
+  user-visible or maintainer-relevant changes.
+- Make sure `main` is current and the worktree is clean before publishing.
+
+For `0.9.0`, use tracking issue #120 and treat the release as a minor release
+because the Go toolchain floor moved to Go 1.26.2.
+
+## Checklist
+
+1. Update [CHANGELOG.md](CHANGELOG.md) with the new version entry.
+   - Keep the opening paragraph short and release-oriented.
+   - Prefer important toolchain, provider, security, and maintenance changes over
+     pasting every generated PR line.
+   - Keep the compare link at the end of the entry.
+2. Preview GitHub-generated notes for comparison:
+   ```sh
+   gh api repos/chenrui333/terraformer/releases/generate-notes \
+     -f tag_name=0.9.0 \
+     -f previous_tag_name=0.8.30
+   ```
+3. Run the local validation set:
+   ```sh
+   GOWORK=off go mod tidy
+   git diff --exit-code -- go.mod go.sum
+   GOWORK=off go build -v ./...
+   GOWORK=off go test ./... -count=1
+   GOWORK=off go vet ./...
+   git diff --check
+   ```
+4. If GoReleaser is configured, run the release preflight before publishing:
+   ```sh
+   goreleaser check
+   goreleaser release --snapshot --clean --skip=publish
+   ```
+5. Confirm the GitHub release body, tag, and artifact list are final.
+6. Publish the release through the release workflow.
+7. Verify the published release:
+   - the tag points at the intended `main` commit
+   - the release notes match [CHANGELOG.md](CHANGELOG.md)
+   - expected artifacts and checksums are attached
+   - install snippets still match the published artifact names
+
+## Immutable Releases
+
+Release immutability is enabled for this repository. Treat release tags, notes,
+and assets as final before publishing.
+
+- Do not publish a release expecting to replace assets or retarget the tag later.
+- If a published release is wrong, prefer a follow-up release over mutating the
+  existing one.
+- Keep draft/preflight checks ahead of publish so the final release is boring.
+
+## Notes
+
+- Terraformer version tags use plain version tags such as `0.9.0`.
+- Do not add action-style floating major tags such as `v2` or `v3`.
+- The first GoReleaser migration should preserve the existing binary asset names
+  used by README install snippets and downstream packaging.

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -61,6 +61,5 @@ and assets as final before publishing.
 ## Notes
 
 - Terraformer version tags use plain version tags such as `0.9.0`.
-- Do not add action-style floating major tags such as `v2` or `v3`.
 - The first GoReleaser migration should preserve the existing binary asset names
   used by README install snippets and downstream packaging.


### PR DESCRIPTION
Summary
- add a curated 0.9.0 changelog entry and release checklist
- add generated-release-note categories for future releases
- add PR auto-labeling so release-note categories are applied consistently

Notes
Refs #120
