### PR TITLE
ci(release): migrate release flow to goreleaser

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,41 +1,101 @@
-name: "tagged-release"
+name: release
+
 on:
+  pull_request:
+    branches:
+    - main
+    paths:
+    - .github/workflows/release.yaml
+    - .goreleaser.yaml
+    - build/**
+    - go.mod
+    - go.sum
+    - RELEASE.md
   workflow_dispatch:
-    inputs:
-      version:
-        description: Bump Version
-        required: true
+  push:
+    tags:
+    - "[0-9]*.[0-9]*.[0-9]*"
+
 permissions:
-  contents: write
+  contents: read
+
+env:
+  GOWORK: off
+  GORELEASER_VERSION: v2.15.4
+
 jobs:
-  tagged-release:
-    name: "Tagged Release"
-    runs-on: "ubuntu-latest"
+  check:
+    name: GoReleaser Check
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v6
-      - name: Install Go
-        uses: actions/setup-go@v6
-        with:
-          go-version-file: go.mod
-          cache: true
-          cache-dependency-path: go.sum
-      - name: Test
-        run: go build -v && go test ./...
-      - name: Build for linux/amd64
-        run: go build -o terraformer-all-linux-amd64
-      - name: Build for linux/arm64
-        run: GOOS=linux GOARCH=arm64 go build -o terraformer-all-linux-arm64
-      - name: Build for mac
-        run: GOOS=darwin go build -o terraformer-all-darwin-amd64
-      - name: Build for mac Apple Silicon
-        run: GOOS=darwin GOARCH=arm64 go build -o terraformer-all-darwin-arm64
-      - name: Build for all providers
-        run: go run build/multi-build/main.go
+    - uses: actions/checkout@v6
+      with:
+        fetch-depth: 0
+    - name: GoReleaser Check
+      uses: goreleaser/goreleaser-action@v7.1.0
+      with:
+        distribution: goreleaser
+        version: ${{ env.GORELEASER_VERSION }}
+        args: check
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - uses: "softprops/action-gh-release@v3"
-        with:
-          tag_name: ${{ github.event.inputs.version }}
-          prerelease: false
-          files: |
-            terraformer-*
+  snapshot:
+    name: Snapshot Release
+    if: github.event_name == 'workflow_dispatch'
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v6
+      with:
+        fetch-depth: 0
+    - name: Install Go
+      uses: actions/setup-go@v6
+      with:
+        go-version-file: go.mod
+        cache: true
+        cache-dependency-path: go.sum
+    - name: Build
+      run: go build -v ./...
+    - name: Test
+      run: go test ./... -count=1
+    - name: GoReleaser Snapshot
+      uses: goreleaser/goreleaser-action@v7.1.0
+      with:
+        distribution: goreleaser
+        version: ${{ env.GORELEASER_VERSION }}
+        args: release --snapshot --clean --skip=publish
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  release:
+    name: Release
+    if: github.event_name == 'push'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+
+    steps:
+    - uses: actions/checkout@v6
+      with:
+        fetch-depth: 0
+    - name: Install Go
+      uses: actions/setup-go@v6
+      with:
+        go-version-file: go.mod
+        cache: true
+        cache-dependency-path: go.sum
+    - name: Build
+      run: go build -v ./...
+    - name: Test
+      run: go test ./... -count=1
+    - name: GoReleaser Release
+      uses: goreleaser/goreleaser-action@v7.1.0
+      with:
+        distribution: goreleaser
+        version: ${{ env.GORELEASER_VERSION }}
+        args: release --clean
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 .idea
 generated
+dist/
 terraformer*
 cmd/tmp
 .DS_Store

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,0 +1,51 @@
+version: 2
+
+project_name: terraformer
+
+before:
+  hooks:
+    - go mod tidy
+    - rm -rf dist/provider-binaries
+    - env TERRAFORMER_BUILD_OUTPUT_DIR=dist/provider-binaries go run build/multi-build/main.go
+
+builds:
+  - id: all
+    main: .
+    binary: "terraformer-all-{{ .Os }}-{{ .Arch }}"
+    env:
+      - CGO_ENABLED=0
+    goos:
+      - linux
+      - darwin
+    goarch:
+      - amd64
+      - arm64
+    no_unique_dist_dir: true
+
+archives:
+  - id: binaries
+    ids:
+      - all
+    formats:
+      - binary
+    name_template: "{{ .Binary }}"
+
+checksum:
+  name_template: "terraformer_{{ .Version }}_checksums.txt"
+  algorithm: sha256
+  extra_files:
+    - glob: dist/provider-binaries/terraformer-*
+
+changelog:
+  use: github-native
+
+release:
+  github:
+    owner: chenrui333
+    name: terraformer
+  name_template: "{{ .Tag }}"
+  draft: true
+  replace_existing_draft: true
+  mode: replace
+  extra_files:
+    - glob: dist/provider-binaries/terraformer-*

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -35,14 +35,26 @@ because the Go toolchain floor moved to Go 1.26.2.
    GOWORK=off go vet ./...
    git diff --check
    ```
-4. If GoReleaser is configured, run the release preflight before publishing:
+4. Run the GoReleaser config and snapshot preflight before publishing:
    ```sh
    goreleaser check
    goreleaser release --snapshot --clean --skip=publish
    ```
+   You can also run the `release` workflow manually to exercise the same
+   snapshot path in GitHub Actions.
 5. Confirm the GitHub release body, tag, and artifact list are final.
-6. Publish the release through the release workflow.
-7. Verify the published release:
+6. Create and push the release tag from the intended `main` commit:
+   ```sh
+   git fetch origin main --tags
+   git checkout main
+   git pull --ff-only origin main
+   git tag -a 0.9.0 -m "0.9.0"
+   git push origin 0.9.0
+   ```
+   The tag push runs GoReleaser and creates a draft GitHub release.
+7. Review the draft release, then publish it once the notes and assets are
+   final.
+8. Verify the published release:
    - the tag points at the intended `main` commit
    - the release notes match [CHANGELOG.md](CHANGELOG.md)
    - expected artifacts and checksums are attached
@@ -56,10 +68,12 @@ and assets as final before publishing.
 - Do not publish a release expecting to replace assets or retarget the tag later.
 - If a published release is wrong, prefer a follow-up release over mutating the
   existing one.
-- Keep draft/preflight checks ahead of publish so the final release is boring.
+- Keep draft/preflight checks ahead of publish so the final release has no asset
+  or note churn.
 
 ## Notes
 
 - Terraformer version tags use plain version tags such as `0.9.0`.
-- The first GoReleaser migration should preserve the existing binary asset names
-  used by README install snippets and downstream packaging.
+- GoReleaser creates draft releases for manual review before publication.
+- The GoReleaser config preserves the existing binary asset names used by README
+  install snippets and downstream packaging.

--- a/build/multi-build/main.go
+++ b/build/multi-build/main.go
@@ -6,6 +6,7 @@ import (
 	"log"
 	"os"
 	"os/exec"
+	"path/filepath"
 	"strings"
 )
 
@@ -15,6 +16,14 @@ const packageCmdPath = "cmd"
 
 func main() {
 	// provider := os.Args[1]
+	outputDir := os.Getenv("TERRAFORMER_BUILD_OUTPUT_DIR")
+	if outputDir == "" {
+		outputDir = "."
+	}
+	if err := os.MkdirAll(outputDir, os.ModePerm); err != nil {
+		log.Fatal("err:", err)
+	}
+
 	allProviders := []string{}
 	files, err := os.ReadDir(packageCmdPath)
 	if err != nil {
@@ -65,11 +74,26 @@ func main() {
 						log.Println(err)
 					}
 				}
+				restoreProviderFiles := func() {
+					for _, provider := range deletedProvider {
+						err := os.Rename(packageCmdPath+"/tmp/"+filePrefix+provider+fileSuffix, packageCmdPath+"/"+filePrefix+provider+fileSuffix)
+						if err != nil {
+							log.Println(err)
+						}
+					}
+				}
 
 				// comment deleted providers in code
 				rootCode, err := os.ReadFile(packageCmdPath + "/root.go")
 				if err != nil {
+					restoreProviderFiles()
 					log.Fatal("err:", err)
+				}
+				cleanupCodeAndFiles := func() {
+					if err := os.WriteFile(packageCmdPath+"/root.go", rootCode, os.ModePerm); err != nil {
+						log.Println(err)
+					}
+					restoreProviderFiles()
 				}
 				lines := strings.Split(string(rootCode), "\n")
 				newRootCodeLines := make([]string, len(lines))
@@ -87,11 +111,13 @@ func main() {
 				newRootCode := strings.Join(newRootCodeLines, "\n")
 				err = os.WriteFile(packageCmdPath+"/root.go", []byte(newRootCode), os.ModePerm)
 				if err != nil {
+					cleanupCodeAndFiles()
 					log.Fatal("err:", err)
 				}
 
 				// build....
-				cmd := exec.Command("go", "build", "-v", "-o", binaryName)
+				binaryPath := filepath.Join(outputDir, binaryName)
+				cmd := exec.Command("go", "build", "-v", "-o", binaryPath)
 				cmd.Env = os.Environ()
 				cmd.Env = append(cmd.Env, "GOOS="+GOOS)
 				cmd.Env = append(cmd.Env, "GOARCH="+arch)
@@ -100,6 +126,7 @@ func main() {
 				cmd.Stderr = &errb
 				err = cmd.Run()
 				if err != nil {
+					cleanupCodeAndFiles()
 					log.Fatal("err:", errb.String())
 				}
 				fmt.Println(outb.String())
@@ -107,14 +134,10 @@ func main() {
 				// revert code and files
 				err = os.WriteFile(packageCmdPath+"/root.go", rootCode, os.ModePerm)
 				if err != nil {
+					restoreProviderFiles()
 					log.Fatal("err:", err)
 				}
-				for _, provider := range deletedProvider {
-					err := os.Rename(packageCmdPath+"/tmp/"+filePrefix+provider+fileSuffix, "cmd/"+filePrefix+provider+fileSuffix)
-					if err != nil {
-						log.Println(err)
-					}
-				}
+				restoreProviderFiles()
 			}
 		}
 	}


### PR DESCRIPTION
Summary
- migrate release publishing to GoReleaser with draft GitHub releases on version tag pushes
- preserve the existing raw binary asset names and add checksum generation
- update the multi-provider build helper so release artifacts can be staged under dist and temporary provider-file moves are restored on failure

Notes
- PR checks run the lightweight GoReleaser config check; snapshot and publish paths stay manual/tag-driven because the full provider binary matrix is large.
- RELEASE.md now describes the tag-push draft review flow before publishing.

References
Refs #120
