### PR TITLE
ci(lint): expand golangci audit coverage

### DIFF
--- a/.golangci.json
+++ b/.golangci.json
@@ -18,11 +18,20 @@
     "max-same-issues": 0
   },
   "linters": {
+    "default": "standard",
     "enable": [
+      "bodyclose",
+      "copyloopvar",
+      "errorlint",
       "gocritic",
+      "gosec",
+      "misspell",
+      "nilerr",
+      "nolintlint",
       "revive",
       "unconvert",
-      "unparam"
+      "unparam",
+      "whitespace"
     ],
     "exclusions": {
       "generated": "lax",


### PR DESCRIPTION
Summary
- enable the standard golangci-lint set explicitly
- add audit-oriented linters including gosec, bodyclose, errorlint, nilerr, and nolintlint
- keep the existing reviewdog changed-line workflow shape

Notes
- Replaces the closed stacked PR #128 after #127 was squash-merged and its parent branch was removed.
- Full-repo lint still has legacy baseline noise, so this keeps the existing changed-line gating model.

References
Refs #128
