### PR TITLE
deps(datadog): update api client from v2.11.0 to v2.59.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -321,7 +321,7 @@ require (
 	cloud.google.com/go/cloudtasks v1.16.0
 	cloud.google.com/go/iam v1.9.0
 	cloud.google.com/go/monitoring v1.27.0
-	github.com/DataDog/datadog-api-client-go/v2 v2.11.0
+	github.com/DataDog/datadog-api-client-go/v2 v2.59.0
 	github.com/Myra-Security-GmbH/myrasec-go/v2 v2.28.0
 	github.com/bradleyfalzon/ghinstallation/v2 v2.1.0
 	github.com/manicminer/hamilton v0.50.0

--- a/go.sum
+++ b/go.sum
@@ -115,8 +115,8 @@ github.com/BurntSushi/toml v1.1.0 h1:ksErzDEI1khOiGPgpwuI7x2ebx/uXQNw7xJpn9Eq1+I
 github.com/BurntSushi/toml v1.1.0/go.mod h1:CxXYINrC8qIiEnFrOxCa7Jy5BFHlXnUU2pbicEuybxQ=
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
 github.com/ChrisTrenkamp/goxpath v0.0.0-20170922090931-c385f95c6022/go.mod h1:nuWgzSkT5PnyOd+272uUmV0dnAnAn42Mk7PiQC5VzN4=
-github.com/DataDog/datadog-api-client-go/v2 v2.11.0 h1:7KCEQ3S90PIH1GcqFHcnwDpNfZbqa2BsiF8OYmLb4Jk=
-github.com/DataDog/datadog-api-client-go/v2 v2.11.0/go.mod h1:kntOqXEh1SmjwSDzW/eJkr9kS7EqttvEkelglWtJRbg=
+github.com/DataDog/datadog-api-client-go/v2 v2.59.0 h1:vCTFSM4OVMX9tgA7Oz0BgsBzr4rLILE+L7ayFCqT80I=
+github.com/DataDog/datadog-api-client-go/v2 v2.59.0/go.mod h1:d3tOEgUd2kfsr9uuHQdY+nXrWp4uikgTgVCPdKNK30U=
 github.com/DataDog/zstd v1.5.2 h1:vUG4lAyuPCXO0TLbXvPv7EB7cNK1QV/luu55UHLrrn8=
 github.com/DataDog/zstd v1.5.2/go.mod h1:g4AWEaM3yOg3HYfnJ3YIawPnVdXJh9QME85blwSAmyw=
 github.com/GoogleCloudPlatform/opentelemetry-operations-go/detectors/gcp v1.32.0 h1:rIkQfkCOVKc1OiRCNcSDD8ml5RJlZbH/Xsq7lbpynwc=

--- a/providers/datadog/synthetics_test_.go
+++ b/providers/datadog/synthetics_test_.go
@@ -34,7 +34,7 @@ type SyntheticsTestGenerator struct {
 	DatadogService
 }
 
-func (g *SyntheticsTestGenerator) createResources(syntheticsList []datadogV1.SyntheticsTestDetails) []terraformutils.Resource {
+func (g *SyntheticsTestGenerator) createResources(syntheticsList []datadogV1.SyntheticsTestDetailsWithoutSteps) []terraformutils.Resource {
 	resources := []terraformutils.Resource{}
 	for _, synthetics := range syntheticsList {
 		resourceName := synthetics.GetPublicId()


### PR DESCRIPTION
Summary
- update github.com/DataDog/datadog-api-client-go/v2 to v2.59.0
- adjust the synthetics test helper for the newer SDK response type

Notes
- Newer Datadog SDK versions return []SyntheticsTestDetailsWithoutSteps from ListTests().GetTests(); Terraformer only needs PublicId for resource IDs, which the new type still exposes.
- This keeps the Datadog update provider-scoped and avoids unrelated dependency churn.
