### PR TITLE
deps(octopusdeploy): update go-octopusdeploy to v1.8.6

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -18,7 +18,7 @@ require (
 	github.com/IBM/networking-go-sdk v0.30.0
 	github.com/IBM/platform-services-go-sdk v0.26.1
 	github.com/IBM/vpc-go-sdk v0.64.0
-	github.com/OctopusDeploy/go-octopusdeploy v1.6.0
+	github.com/OctopusDeploy/go-octopusdeploy v1.8.6
 	github.com/PaloAltoNetworks/pango v0.10.2
 	github.com/aliyun/alibaba-cloud-sdk-go v1.63.107
 	github.com/aliyun/aliyun-tablestore-go-sdk v4.1.3+incompatible
@@ -397,7 +397,6 @@ require (
 	google.golang.org/genproto/googleapis/api v0.0.0-20260414002931-afd174a4e478 // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20260414002931-afd174a4e478 // indirect
 	gopkg.in/evanphx/json-patch.v4 v4.13.0 // indirect
-	gopkg.in/go-playground/assert.v1 v1.2.1 // indirect
 	gopkg.in/validator.v2 v2.0.1 // indirect
 	k8s.io/kube-openapi v0.0.0-20260317180543-43fb72c5454a // indirect
 	sigs.k8s.io/json v0.0.0-20250730193827-2d320260d730 // indirect

--- a/go.sum
+++ b/go.sum
@@ -166,8 +166,8 @@ github.com/Myra-Security-GmbH/myrasec-go/v2 v2.28.0 h1:/j5vGm0MB++gzimxjR53JCB/7
 github.com/Myra-Security-GmbH/myrasec-go/v2 v2.28.0/go.mod h1:A3VaeNipYmfNnHIJVEzyBmfHSWjK7c9aNfbpmRbFiS8=
 github.com/Myra-Security-GmbH/signature v1.0.0 h1:u46nIxnffLLb8pCe6ic2w7OmSSEJk4warn3W4Vp2GjQ=
 github.com/Myra-Security-GmbH/signature v1.0.0/go.mod h1:zgyy5MGBCezqxVOjrG3THQJqsIfJ04LWtQv3Q4Ug2+Y=
-github.com/OctopusDeploy/go-octopusdeploy v1.6.0 h1:r9ThVuANGkzm3noAjLF/i7LUcxQxbCJwpvn1DLwPoOA=
-github.com/OctopusDeploy/go-octopusdeploy v1.6.0/go.mod h1:maPbD8azyb2mcNN6E4SGrwiLN7XmDSML5ui+mcWR/R0=
+github.com/OctopusDeploy/go-octopusdeploy v1.8.6 h1:HvdMKaVNhbmlyXF7Y9+HO4ZcF7+e9WlkETcgoTvG5xM=
+github.com/OctopusDeploy/go-octopusdeploy v1.8.6/go.mod h1:53/298KRhEbphPJaTRRpjTuNMBjdb567XCAtnu0yuzg=
 github.com/PaloAltoNetworks/pango v0.10.2 h1:Tjn6vIzzAq6Dd7N0mDuiP8w8pz8k5W9zz/TTSUQCsQY=
 github.com/PaloAltoNetworks/pango v0.10.2/go.mod h1:GztcRnVLur7G+VFG7Z5ZKNFgScLtsycwPMp1qVebE5g=
 github.com/PuerkitoBio/rehttp v1.0.0 h1:aJ7A7YI2lIvOxcJVeUZY4P6R7kKZtLeONjgyKGwOIu8=
@@ -478,7 +478,6 @@ github.com/decred/dcrd/dcrec/secp256k1/v4 v4.2.0 h1:8UrgZ3GkP4i/CLijOJx79Yu+etly
 github.com/decred/dcrd/dcrec/secp256k1/v4 v4.2.0/go.mod h1:v57UDF4pDQJcEfFUCRop3lJL149eHGSe9Jvczhzjo/0=
 github.com/denverdino/aliyungo v0.0.0-20230411124812-ab98a9173ace h1:1SnCTPFh2AADpm7ti864EYaugexyiDFt55BW188+d6k=
 github.com/denverdino/aliyungo v0.0.0-20230411124812-ab98a9173ace/go.mod h1:TK05uvk4XXfK2kdvRwfcZ1NaxjDxmm7H3aQLko0mJxA=
-github.com/dghubble/sling v1.1.0/go.mod h1:ZcPRuLm0qrcULW2gOrjXrAWgf76sahqSyxXyVOvkunE=
 github.com/dghubble/sling v1.4.0 h1:/n8MRosVTthvMbwlNZgLx579OGVjUOy3GNEv5BIqAWY=
 github.com/dghubble/sling v1.4.0/go.mod h1:0r40aNsU9EdDUVBNhfCstAtFgutjgJGYbO1oNzkMoM8=
 github.com/digitalocean/godo v1.187.0 h1:Ga+pkJdebdhnzWmIjusyehDzm+WZ/joLiXM00tPOXVs=
@@ -701,7 +700,6 @@ github.com/google/go-github/v35 v35.3.0 h1:fU+WBzuukn0VssbayTT+Zo3/ESKX9JYWjbZTL
 github.com/google/go-github/v35 v35.3.0/go.mod h1:yWB7uCcVWaUbUP74Aq3whuMySRMatyRmq5U9FTNlbio=
 github.com/google/go-github/v84 v84.0.0 h1:I/0Xn5IuChMe8TdmI2bbim5nyhaRFJ7DEdzmD2w+yVA=
 github.com/google/go-github/v84 v84.0.0/go.mod h1:WwYL1z1ajRdlaPszjVu/47x1L0PXukJBn73xsiYrRRQ=
-github.com/google/go-querystring v0.0.0-20170111101155-53e6ce116135/go.mod h1:odCYkC5MyYFN7vkCjXpyrEuKhc/BUO6wN/zVPAxq5ck=
 github.com/google/go-querystring v1.0.0/go.mod h1:odCYkC5MyYFN7vkCjXpyrEuKhc/BUO6wN/zVPAxq5ck=
 github.com/google/go-querystring v1.1.0/go.mod h1:Kcdr2DB4koayq7X8pmAG4sNG59So17icRSOU623lUBU=
 github.com/google/go-querystring v1.2.0 h1:yhqkPbu2/OH+V9BfpCVPZkNmUXhb2gBxJArfhIxNtP0=
@@ -929,6 +927,8 @@ github.com/kelseyhightower/envconfig v1.4.0/go.mod h1:cccZRl6mQpaq41TPp5QxidR+Sa
 github.com/keybase/go-crypto v0.0.0-20161004153544-93f5b35093ba/go.mod h1:ghbZscTyKdM07+Fw3KSi0hcJm+AlEUWj8QLlPtijN/M=
 github.com/keycloak/terraform-provider-keycloak v0.0.0-20260424143515-c4c53ecc9c95 h1:MOoil9Uh6IEQBiXKBdwNAdAV39giHX2Hy24txwYF6iQ=
 github.com/keycloak/terraform-provider-keycloak v0.0.0-20260424143515-c4c53ecc9c95/go.mod h1:aRsFYoOv8xK0gZ5S/21ZUPtwIligF7fi521RlEFli8g=
+github.com/kinbiko/jsonassert v1.1.0 h1:AakKgkRFsuzE1FNLYrcxTI7ga5YYcbujOUbSf8l+WmU=
+github.com/kinbiko/jsonassert v1.1.0/go.mod h1:QRwBwiAsrcJpjw+L+Q4WS8psLxuUY+HylVZS/4j74TM=
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
 github.com/klauspost/compress v1.9.5/go.mod h1:RyIbtBH6LamlWaDj8nUwkbUhJ87Yi3uG0guNDohfE1A=
 github.com/klauspost/compress v1.13.6/go.mod h1:/3/Vjq9QcHkK5uEr5lBEmyoZ1iFhe47etQ6QUkpK6sk=
@@ -2029,7 +2029,6 @@ gopkg.in/evanphx/json-patch.v4 v4.13.0/go.mod h1:p8EYWUEYMpynmqDbY58zCKCFZw8pRWM
 gopkg.in/fsnotify.v1 v1.4.7/go.mod h1:Tz8NjZHkW78fSQdbUxIjBTcgA1z1m8ZHf0WmKUhAMys=
 gopkg.in/go-playground/assert.v1 v1.2.1 h1:xoYuJVE7KT85PYWrN730RguIQO0ePzVRfFMXadIrXTM=
 gopkg.in/go-playground/assert.v1 v1.2.1/go.mod h1:9RXL0bg/zibRAgZUYszZSwO/z8Y/a8bDuhia5mkpMnE=
-gopkg.in/go-playground/validator.v9 v9.19.0/go.mod h1:+c9/zcJMFNgbLvly1L1V+PpxWdVbfP1avr/N00E2vyQ=
 gopkg.in/go-playground/validator.v9 v9.30.0/go.mod h1:+c9/zcJMFNgbLvly1L1V+PpxWdVbfP1avr/N00E2vyQ=
 gopkg.in/go-playground/validator.v9 v9.31.0 h1:bmXmP2RSNtFES+bn4uYuHT7iJFJv7Vj+an+ZQdDaD1M=
 gopkg.in/go-playground/validator.v9 v9.31.0/go.mod h1:+c9/zcJMFNgbLvly1L1V+PpxWdVbfP1avr/N00E2vyQ=

--- a/providers/octopusdeploy/generic_resources.go
+++ b/providers/octopusdeploy/generic_resources.go
@@ -3,8 +3,8 @@ package octopusdeploy
 import (
 	"strings"
 
-	"github.com/chenrui333/terraformer/terraformutils"
 	"github.com/OctopusDeploy/go-octopusdeploy/octopusdeploy"
+	"github.com/chenrui333/terraformer/terraformutils"
 )
 
 type GenericGenerator struct {
@@ -37,29 +37,29 @@ func (g *GenericGenerator) InitResources() error {
 func (g *GenericGenerator) createResources(client *octopusdeploy.Client) error {
 	switch strings.ToLower(g.APIService) {
 	case "accounts":
-		resources, err := client.Account.GetAll()
+		resources, err := client.Accounts.GetAll()
 		if err != nil {
 			return err
 		}
 
-		for _, ressource := range *resources {
+		for _, ressource := range resources {
 			g.Resources = append(g.Resources, terraformutils.NewSimpleResource(
-				ressource.ID,
-				ressource.Name,
+				ressource.GetID(),
+				ressource.GetName(),
 				"octopusdeploy_account",
 				g.ProviderName,
 				[]string{},
 			))
 		}
 	case "certificates":
-		resources, err := client.Certificate.GetAll()
+		resources, err := client.Certificates.GetAll()
 		if err != nil {
 			return err
 		}
 
-		for _, ressource := range *resources {
+		for _, ressource := range resources {
 			g.Resources = append(g.Resources, terraformutils.NewSimpleResource(
-				ressource.ID,
+				ressource.GetID(),
 				ressource.Name,
 				"octopusdeploy_certificate",
 				g.ProviderName,
@@ -71,14 +71,14 @@ func (g *GenericGenerator) createResources(client *octopusdeploy.Client) error {
 	//    2020/02/24 16:35:55 octopusdeploy importing... channels
 	//    2020/02/24 16:35:55 cannot find the item
 
-	// 	resources, err := client.Channel.GetAll()
+	// 	resources, err := client.Channels.GetAll()
 	// 	if err != nil {
 	// 		return err
 	// 	}
 
 	// 	for _, ressource := range *resources {
 	// 		g.Resources = append(g.Resources, terraformutils.NewSimpleResource(
-	// 			ressource.ID,
+	// 			ressource.GetID(),
 	// 			ressource.Name
 	// 			"octopusdeploy_channel",
 	// 			g.ProviderName,
@@ -86,14 +86,14 @@ func (g *GenericGenerator) createResources(client *octopusdeploy.Client) error {
 	// 		))
 	// 	}
 	case "environments":
-		resources, err := client.Environment.GetAll()
+		resources, err := client.Environments.GetAll()
 		if err != nil {
 			return err
 		}
 
-		for _, ressource := range *resources {
+		for _, ressource := range resources {
 			g.Resources = append(g.Resources, terraformutils.NewSimpleResource(
-				ressource.ID,
+				ressource.GetID(),
 				ressource.Name,
 				"octopusdeploy_environment",
 				g.ProviderName,
@@ -101,29 +101,29 @@ func (g *GenericGenerator) createResources(client *octopusdeploy.Client) error {
 			))
 		}
 	case "feeds":
-		resources, err := client.Feed.GetAll()
+		resources, err := client.Feeds.GetAll()
 		if err != nil {
 			return err
 		}
 
-		for _, ressource := range *resources {
+		for _, ressource := range resources {
 			g.Resources = append(g.Resources, terraformutils.NewSimpleResource(
-				ressource.ID,
-				ressource.Name,
+				ressource.GetID(),
+				ressource.GetName(),
 				"octopusdeploy_feed",
 				g.ProviderName,
 				[]string{},
 			))
 		}
 	case "libraryvariablesets":
-		resources, err := client.LibraryVariableSet.GetAll()
+		resources, err := client.LibraryVariableSets.GetAll()
 		if err != nil {
 			return err
 		}
 
-		for _, ressource := range *resources {
+		for _, ressource := range resources {
 			g.Resources = append(g.Resources, terraformutils.NewSimpleResource(
-				ressource.ID,
+				ressource.GetID(),
 				ressource.Name,
 				"octopusdeploy_library_variable_set",
 				g.ProviderName,
@@ -131,14 +131,14 @@ func (g *GenericGenerator) createResources(client *octopusdeploy.Client) error {
 			))
 		}
 	case "lifecycles":
-		resources, err := client.Lifecycle.GetAll()
+		resources, err := client.Lifecycles.GetAll()
 		if err != nil {
 			return err
 		}
 
-		for _, ressource := range *resources {
+		for _, ressource := range resources {
 			g.Resources = append(g.Resources, terraformutils.NewSimpleResource(
-				ressource.ID,
+				ressource.GetID(),
 				ressource.Name,
 				"octopusdeploy_lifecycle",
 				g.ProviderName,
@@ -146,14 +146,14 @@ func (g *GenericGenerator) createResources(client *octopusdeploy.Client) error {
 			))
 		}
 	case "projects":
-		resources, err := client.Project.GetAll()
+		resources, err := client.Projects.GetAll()
 		if err != nil {
 			return err
 		}
 
-		for _, ressource := range *resources {
+		for _, ressource := range resources {
 			g.Resources = append(g.Resources, terraformutils.NewSimpleResource(
-				ressource.ID,
+				ressource.GetID(),
 				ressource.Name,
 				"octopusdeploy_project",
 				g.ProviderName,
@@ -161,14 +161,14 @@ func (g *GenericGenerator) createResources(client *octopusdeploy.Client) error {
 			))
 		}
 	case "projectgroups":
-		resources, err := client.ProjectGroup.GetAll()
+		resources, err := client.ProjectGroups.GetAll()
 		if err != nil {
 			return err
 		}
 
-		for _, ressource := range *resources {
+		for _, ressource := range resources {
 			g.Resources = append(g.Resources, terraformutils.NewSimpleResource(
-				ressource.ID,
+				ressource.GetID(),
 				ressource.Name,
 				"octopusdeploy_project_group",
 				g.ProviderName,
@@ -176,14 +176,14 @@ func (g *GenericGenerator) createResources(client *octopusdeploy.Client) error {
 			))
 		}
 	case "projecttriggers":
-		resources, err := client.ProjectTrigger.GetAll()
+		resources, err := client.ProjectTriggers.GetAll()
 		if err != nil {
 			return err
 		}
 
-		for _, ressource := range *resources {
+		for _, ressource := range resources {
 			g.Resources = append(g.Resources, terraformutils.NewSimpleResource(
-				ressource.ID,
+				ressource.GetID(),
 				ressource.Name,
 				"octopusdeploy_project_deployment_target_trigger",
 				g.ProviderName,
@@ -191,14 +191,14 @@ func (g *GenericGenerator) createResources(client *octopusdeploy.Client) error {
 			))
 		}
 	case "tagsets":
-		resources, err := client.TagSet.GetAll()
+		resources, err := client.TagSets.GetAll()
 		if err != nil {
 			return err
 		}
 
-		for _, ressource := range *resources {
+		for _, ressource := range resources {
 			g.Resources = append(g.Resources, terraformutils.NewSimpleResource(
-				ressource.ID,
+				ressource.GetID(),
 				ressource.Name,
 				"octopusdeploy_tag_set",
 				g.ProviderName,
@@ -215,14 +215,14 @@ func (g *GenericGenerator) createResources(client *octopusdeploy.Client) error {
 
 		// for _, project := range *projects {
 		// 	// Variable.GetAll() returns all the variables for a specific project ID.
-		// 	resources, err := client.Variable.GetAll(project.ID)
+		// 	resources, err := client.Variables.GetAll(project.GetID())
 		// 	if err != nil {
 		// 		return err
 		// 	}
 
 		// 	for _, ressource := range resources.Variables {
 		// 		g.Resources = append(g.Resources, terraformutils.NewSimpleResource(
-		// 			ressource.ID,
+		// 			ressource.GetID(),
 		// 			ressource.Name
 		// 			"octopusdeploy_variable",
 		// 			g.ProviderName,

--- a/providers/octopusdeploy/octopusdeploy_service.go
+++ b/providers/octopusdeploy/octopusdeploy_service.go
@@ -3,9 +3,10 @@ package octopusdeploy
 import (
 	"errors"
 	"net/http"
+	"net/url"
 
-	"github.com/chenrui333/terraformer/terraformutils"
 	"github.com/OctopusDeploy/go-octopusdeploy/octopusdeploy"
+	"github.com/chenrui333/terraformer/terraformutils"
 )
 
 type OctopusDeployService struct { //nolint
@@ -21,8 +22,16 @@ func (s *OctopusDeployService) Client() (*octopusdeploy.Client, error) {
 		return nil, err
 	}
 
+	apiURL, err := url.Parse(octopusURL)
+	if err != nil {
+		return nil, err
+	}
+
 	httpClient := http.Client{}
-	client := octopusdeploy.NewClient(&httpClient, octopusURL, octopusAPIKey)
+	client, err := octopusdeploy.NewClient(&httpClient, apiURL, octopusAPIKey, "")
+	if err != nil {
+		return nil, err
+	}
 
 	return client, nil
 }


### PR DESCRIPTION
Summary
- update github.com/OctopusDeploy/go-octopusdeploy from v1.6.0 to v1.8.6
- migrate Octopus Deploy provider code to the current plural client services and NewClient signature
- read resource IDs through the SDK resource accessors

Reference
- https://pkg.go.dev/github.com/OctopusDeploy/go-octopusdeploy/octopusdeploy#Client
- https://pkg.go.dev/github.com/OctopusDeploy/go-octopusdeploy/octopusdeploy#NewClient

Refs #155
