### PR TITLE
deps(myrasec): update myrasec-go to v2.40.20

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -310,7 +310,7 @@ require (
 	cloud.google.com/go/iam v1.9.0
 	cloud.google.com/go/monitoring v1.27.0
 	github.com/DataDog/datadog-api-client-go/v2 v2.59.0
-	github.com/Myra-Security-GmbH/myrasec-go/v2 v2.28.0
+	github.com/Myra-Security-GmbH/myrasec-go/v2 v2.40.20
 	github.com/bradleyfalzon/ghinstallation/v2 v2.18.0
 	github.com/manicminer/hamilton v0.50.0
 	github.com/opalsecurity/opal-go v1.4.0
@@ -329,7 +329,7 @@ require (
 	github.com/GoogleCloudPlatform/opentelemetry-operations-go/internal/resourcemapping v0.55.0 // indirect
 	github.com/Masterminds/semver/v3 v3.1.1 // indirect
 	github.com/Masterminds/sprig/v3 v3.2.1 // indirect
-	github.com/Myra-Security-GmbH/signature v1.0.0 // indirect
+	github.com/Myra-Security-GmbH/signature v1.1.0 // indirect
 	github.com/apparentlymart/go-textseg/v15 v15.0.0 // indirect
 	github.com/avast/retry-go v3.0.0+incompatible // indirect
 	github.com/aws/aws-sdk-go-v2/service/signin v1.0.10 // indirect

--- a/go.sum
+++ b/go.sum
@@ -162,10 +162,10 @@ github.com/Masterminds/semver/v3 v3.1.1 h1:hLg3sBzpNErnxhQtUy/mmLR2I9foDujNK030I
 github.com/Masterminds/semver/v3 v3.1.1/go.mod h1:VPu/7SZ7ePZ3QOrcuXROw5FAcLl4a0cBrbBpGY/8hQs=
 github.com/Masterminds/sprig/v3 v3.2.1 h1:n6EPaDyLSvCEa3frruQvAiHuNp2dhBlMSmkEr+HuzGc=
 github.com/Masterminds/sprig/v3 v3.2.1/go.mod h1:UoaO7Yp8KlPnJIYWTFkMaqPUYKTfGFPhxNuwnnxkKlk=
-github.com/Myra-Security-GmbH/myrasec-go/v2 v2.28.0 h1:/j5vGm0MB++gzimxjR53JCB/7PApCfxdaV52nU5FTC8=
-github.com/Myra-Security-GmbH/myrasec-go/v2 v2.28.0/go.mod h1:A3VaeNipYmfNnHIJVEzyBmfHSWjK7c9aNfbpmRbFiS8=
-github.com/Myra-Security-GmbH/signature v1.0.0 h1:u46nIxnffLLb8pCe6ic2w7OmSSEJk4warn3W4Vp2GjQ=
-github.com/Myra-Security-GmbH/signature v1.0.0/go.mod h1:zgyy5MGBCezqxVOjrG3THQJqsIfJ04LWtQv3Q4Ug2+Y=
+github.com/Myra-Security-GmbH/myrasec-go/v2 v2.40.20 h1:iY6RDw+YZYfgbCuZCaRGf5Djh0gvVQRh1OcIOIiGTjU=
+github.com/Myra-Security-GmbH/myrasec-go/v2 v2.40.20/go.mod h1:wlzlsUZt27+L8mbka1UiBZeoGR0x4Lu8WnxczwWkfO0=
+github.com/Myra-Security-GmbH/signature v1.1.0 h1:/Tv8SilN0P8k5fKArvQHkf9iJWU5H34TSvgEyyZ32f4=
+github.com/Myra-Security-GmbH/signature v1.1.0/go.mod h1:kyX4FQ2XWvJQnvxkWmcyUIqG0jAzGL22fQMf2RTvoj0=
 github.com/OctopusDeploy/go-octopusdeploy v1.8.6 h1:HvdMKaVNhbmlyXF7Y9+HO4ZcF7+e9WlkETcgoTvG5xM=
 github.com/OctopusDeploy/go-octopusdeploy v1.8.6/go.mod h1:53/298KRhEbphPJaTRRpjTuNMBjdb567XCAtnu0yuzg=
 github.com/PaloAltoNetworks/pango v0.10.2 h1:Tjn6vIzzAq6Dd7N0mDuiP8w8pz8k5W9zz/TTSUQCsQY=


### PR DESCRIPTION
Summary
- update github.com/Myra-Security-GmbH/myrasec-go/v2 from v2.28.0 to v2.40.20
- update the paired github.com/Myra-Security-GmbH/signature module to v1.1.0
- stop at v2.40.20 because v2.41.0 removes the rate-limit API currently used by the provider

Refs #155
