### PR TITLE
deps(commercetools): update sdk to v1.9.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -128,7 +128,7 @@ require (
 	github.com/ionos-cloud/sdk-go-dbaas-postgres v1.1.4
 	github.com/ionos-cloud/sdk-go/v6 v6.3.7
 	github.com/jmespath/go-jmespath v0.4.0
-	github.com/labd/commercetools-go-sdk v0.3.1
+	github.com/labd/commercetools-go-sdk v1.9.0
 	github.com/linode/linodego v1.68.0
 	github.com/microsoft/azure-devops-go-api/azuredevops v1.0.0-b5
 	github.com/nicksnyder/go-i18n v1.10.3 // indirect
@@ -185,7 +185,6 @@ require (
 	github.com/Masterminds/goutils v1.1.1 // indirect
 	github.com/agext/levenshtein v1.2.3 // indirect
 	github.com/apparentlymart/go-cidr v1.1.0 // indirect
-	github.com/appscode/go-querystring v0.0.0-20170504095604-0126cfb3f1dc // indirect
 	github.com/armon/go-radix v1.0.0 // indirect
 	github.com/aws/aws-sdk-go-v2/aws/protocol/eventstream v1.7.9 // indirect
 	github.com/aws/aws-sdk-go-v2/feature/ec2/imds v1.18.22 // indirect

--- a/go.sum
+++ b/go.sum
@@ -208,8 +208,6 @@ github.com/apparentlymart/go-textseg v1.0.0/go.mod h1:z96Txxhf3xSFMPmb5X/1W05FF/
 github.com/apparentlymart/go-textseg/v15 v15.0.0 h1:uYvfpb3DyLSCGWnctWKGj857c6ew1u1fNQOlOtuGxQY=
 github.com/apparentlymart/go-textseg/v15 v15.0.0/go.mod h1:K8XmNZdhEBkdlyDdvbmmsvpAG721bKi0joRfFdHIWJ4=
 github.com/apparentlymart/go-versions v0.0.2-0.20180815153302-64b99f7cb171/go.mod h1:JXY95WvQrPJQtudvNARshgWajS7jNNlM90altXIPNyI=
-github.com/appscode/go-querystring v0.0.0-20170504095604-0126cfb3f1dc h1:LoL75er+LKDHDUfU5tRvFwxH0LjPpZN8OoG8Ll+liGU=
-github.com/appscode/go-querystring v0.0.0-20170504095604-0126cfb3f1dc/go.mod h1:w648aMHEgFYS6xb0KVMMtZ2uMeemhiKCuD2vj6gY52A=
 github.com/armon/circbuf v0.0.0-20190214190532-5111143e8da2/go.mod h1:3U/XgcO3hCbHZ8TKRvWD2dDTCfh9M9ya+I9JpbB7O8o=
 github.com/armon/go-metrics v0.0.0-20180917152333-f0300d1749da/go.mod h1:Q73ZrmVTwzkszR9V5SSuryQ31EELlFMUz1kKyl939pY=
 github.com/armon/go-radix v0.0.0-20180808171621-7fddfc383310/go.mod h1:ufUuZ+zHj4x4TnLV4JWEpy2hxWSpsRywHrMgIH9cCH8=
@@ -466,7 +464,6 @@ github.com/cpuguy83/go-md2man/v2 v2.0.6/go.mod h1:oOW0eioCTA6cOiMLiUPZOpcVxMig6N
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/crewjam/saml v0.4.14 h1:g9FBNx62osKusnFzs3QTN5L9CVA/Egfgm+stJShzw/c=
 github.com/crewjam/saml v0.4.14/go.mod h1:UVSZCf18jJkk6GpWNVqcyQJMD5HsRugBPf4I1nl2mME=
-github.com/dave/jennifer v1.4.0/go.mod h1:fIb+770HOpJ2fmN9EPPKOqm1vMGhB+TwXKMZhrIygKg=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc h1:U9qPSI2PIWSS1VwoXQT9A3Wy9MM3WgvqSxFWenqJduM=
@@ -877,7 +874,6 @@ github.com/huandu/xstrings v1.3.1/go.mod h1:y5/lhBue+AyNmUVz9RLU9xbLR0o4KIIExikq
 github.com/huandu/xstrings v1.3.2/go.mod h1:y5/lhBue+AyNmUVz9RLU9xbLR0o4KIIExikq4ovT0aE=
 github.com/huandu/xstrings v1.3.3 h1:/Gcsuc1x8JVbJ9/rlye4xZnVAbEkGauT8lbebqcQws4=
 github.com/huandu/xstrings v1.3.3/go.mod h1:y5/lhBue+AyNmUVz9RLU9xbLR0o4KIIExikq4ovT0aE=
-github.com/iancoleman/strcase v0.0.0-20191112232945-16388991a334/go.mod h1:SK73tn/9oHe+/Y0h39VT4UCxmurVJkR5NA7kMEAOgSE=
 github.com/iancoleman/strcase v0.3.0 h1:nTXanmYxhfFAMjZL34Ov6gkzEsSJZ5DbhxWjvSASxEI=
 github.com/iancoleman/strcase v0.3.0/go.mod h1:iwCmte+B7n89clKwxIoIXy/HfoL7AsD47ZCWhYzw7ho=
 github.com/ianlancetaylor/demangle v0.0.0-20181102032728-5e5cf60278f6/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=
@@ -963,8 +959,8 @@ github.com/kr/text v0.2.0/go.mod h1:eLer722TekiGuMkidMxC/pM04lWEeraHUUmBw8l2grE=
 github.com/kylelemons/godebug v0.0.0-20170820004349-d65d576e9348/go.mod h1:B69LEHPfb2qLo0BaaOLcbitczOKLWTsrBG9LczfCD4k=
 github.com/kylelemons/godebug v1.1.0 h1:RPNrshWIDI6G2gRW9EHilWtl7Z6Sb1BR0xunSBf0SNc=
 github.com/kylelemons/godebug v1.1.0/go.mod h1:9/0rRGxNHcop5bhtWyNeEfOS8JIWk580+fNqagV/RAw=
-github.com/labd/commercetools-go-sdk v0.3.1 h1:Fk8/VKKDSNHhyVhDywJdmzUt3JSpNoFZbHJndwjVBls=
-github.com/labd/commercetools-go-sdk v0.3.1/go.mod h1:I+KKNALlg6PcSertsVA7E442koO99GT7gldWqwZlUGo=
+github.com/labd/commercetools-go-sdk v1.9.0 h1:ZeAtYM5RL7uNb+STvIr6rKJGMMWYZAjyKg6sWWrmrFk=
+github.com/labd/commercetools-go-sdk v1.9.0/go.mod h1:QMG2KGTVY7uyVDJTKvaaFnw8h5lZwq/SEBlPVPrMrQ0=
 github.com/launchdarkly/api-client-go v5.3.0+incompatible h1:xB4QGNbNzAUm2UDdtlsHhmCrs6l7OQGWFgs1xB6s/u8=
 github.com/launchdarkly/api-client-go v5.3.0+incompatible/go.mod h1:INGa7NUZYSwVozwPV7l6ikgD7pzSOpZvg9I5sqCZIWs=
 github.com/leodido/go-urn v1.2.0/go.mod h1:+8+nEpDfqqsY+g338gtMEUOtuK+4dEMhiQEgxpxOKII=
@@ -1058,7 +1054,6 @@ github.com/mitchellh/go-wordwrap v1.0.1/go.mod h1:R62XHJLzvMFRBbcrT7m7WgmE1eOyTS
 github.com/mitchellh/hashstructure v1.0.0 h1:ZkRJX1CyOoTkar7p/mLS5TZU4nJ1Rn/F8u9dGS02Q3Y=
 github.com/mitchellh/hashstructure v1.0.0/go.mod h1:QjSHrPWS+BGUVBYkbTZWEnOh3G1DutKwClXU/ABz6AQ=
 github.com/mitchellh/mapstructure v1.1.2/go.mod h1:FVVH3fgwuzCH5S8UJGiWEs2h04kUh9fWfEaFds41c1Y=
-github.com/mitchellh/mapstructure v1.3.2/go.mod h1:bFUtVrKA4DC2yAKiSyO/QUcy7e+RRV2QTWOzhPopBRo=
 github.com/mitchellh/mapstructure v1.3.3/go.mod h1:bFUtVrKA4DC2yAKiSyO/QUcy7e+RRV2QTWOzhPopBRo=
 github.com/mitchellh/mapstructure v1.4.3/go.mod h1:bFUtVrKA4DC2yAKiSyO/QUcy7e+RRV2QTWOzhPopBRo=
 github.com/mitchellh/mapstructure v1.5.0 h1:jeMsZIYE/09sWLaz43PL7Gy6RuMjD2eJVyuac5Z2hdY=

--- a/providers/commercetools/api_extension.go
+++ b/providers/commercetools/api_extension.go
@@ -17,9 +17,7 @@ package commercetools
 import (
 	"context"
 
-	"github.com/chenrui333/terraformer/providers/commercetools/connectivity"
 	"github.com/chenrui333/terraformer/terraformutils"
-	"github.com/labd/commercetools-go-sdk/commercetools"
 )
 
 type APIExtensionGenerator struct {
@@ -28,24 +26,19 @@ type APIExtensionGenerator struct {
 
 // InitResources generates Terraform Resources from Commercetools API
 func (g *APIExtensionGenerator) InitResources() error {
-	cfg := connectivity.Config{
-		ClientID:     g.GetArgs()["client_id"].(string),
-		ClientSecret: g.GetArgs()["client_secret"].(string),
-		ClientScope:  g.GetArgs()["client_scope"].(string),
-		TokenURL:     g.GetArgs()["token_url"].(string) + "/oauth/token",
-		BaseURL:      g.GetArgs()["base_url"].(string),
+	client, err := g.newClient()
+	if err != nil {
+		return err
 	}
 
-	client := cfg.NewClient()
-
-	extensions, err := client.ExtensionQuery(context.Background(), &commercetools.QueryInput{})
+	extensions, err := client.Project().Extensions().Get().Execute(context.Background())
 	if err != nil {
 		return err
 	}
 	for _, extension := range extensions.Results {
 		g.Resources = append(g.Resources, terraformutils.NewResource(
 			extension.ID,
-			extension.Key,
+			stringValue(extension.Key),
 			"commercetools_api_extension",
 			"commercetools",
 			map[string]string{},

--- a/providers/commercetools/channel.go
+++ b/providers/commercetools/channel.go
@@ -17,9 +17,7 @@ package commercetools
 import (
 	"context"
 
-	"github.com/chenrui333/terraformer/providers/commercetools/connectivity"
 	"github.com/chenrui333/terraformer/terraformutils"
-	"github.com/labd/commercetools-go-sdk/commercetools"
 )
 
 type ChannelGenerator struct {
@@ -28,17 +26,12 @@ type ChannelGenerator struct {
 
 // InitResources generates Terraform Resources from Commercetools API
 func (g *ChannelGenerator) InitResources() error {
-	cfg := connectivity.Config{
-		ClientID:     g.GetArgs()["client_id"].(string),
-		ClientSecret: g.GetArgs()["client_secret"].(string),
-		ClientScope:  g.GetArgs()["client_scope"].(string),
-		TokenURL:     g.GetArgs()["token_url"].(string) + "/oauth/token",
-		BaseURL:      g.GetArgs()["base_url"].(string),
+	client, err := g.newClient()
+	if err != nil {
+		return err
 	}
 
-	client := cfg.NewClient()
-
-	channels, err := client.ChannelQuery(context.Background(), &commercetools.QueryInput{})
+	channels, err := client.Project().Channels().Get().Execute(context.Background())
 	if err != nil {
 		return err
 	}

--- a/providers/commercetools/commercetools_service.go
+++ b/providers/commercetools/commercetools_service.go
@@ -14,8 +14,24 @@
 
 package commercetools
 
-import "github.com/chenrui333/terraformer/terraformutils"
+import (
+	"github.com/chenrui333/terraformer/providers/commercetools/connectivity"
+	"github.com/chenrui333/terraformer/terraformutils"
+)
 
 type CommercetoolsService struct { //nolint
 	terraformutils.Service
+}
+
+func (s *CommercetoolsService) newClient() (*connectivity.Client, error) {
+	cfg := connectivity.Config{
+		ClientID:     s.GetArgs()["client_id"].(string),
+		ClientSecret: s.GetArgs()["client_secret"].(string),
+		ClientScope:  s.GetArgs()["client_scope"].(string),
+		ProjectKey:   s.GetArgs()["project_key"].(string),
+		TokenURL:     s.GetArgs()["token_url"].(string) + "/oauth/token",
+		BaseURL:      s.GetArgs()["base_url"].(string),
+	}
+
+	return cfg.NewClient()
 }

--- a/providers/commercetools/connectivity/client.go
+++ b/providers/commercetools/connectivity/client.go
@@ -1,27 +1,35 @@
 package connectivity
 
 import (
-	"context"
 	"strings"
 
-	"github.com/labd/commercetools-go-sdk/commercetools"
+	"github.com/labd/commercetools-go-sdk/platform"
 	"golang.org/x/oauth2/clientcredentials"
 )
 
-func (c *Config) NewClient() *commercetools.Client {
-	oauth2Config := &clientcredentials.Config{
-		ClientID:     c.ClientID,
-		ClientSecret: c.ClientSecret,
-		Scopes:       strings.Split(c.ClientScope, " "),
-		TokenURL:     c.TokenURL,
+type Client struct {
+	*platform.Client
+	projectKey string
+}
+
+func (c *Config) NewClient() (*Client, error) {
+	client, err := platform.NewClient(&platform.ClientConfig{
+		URL: c.BaseURL,
+		Credentials: &clientcredentials.Config{
+			ClientID:     c.ClientID,
+			ClientSecret: c.ClientSecret,
+			Scopes:       strings.Split(c.ClientScope, " "),
+			TokenURL:     c.TokenURL,
+		},
+		UserAgent: "terraformer",
+	})
+	if err != nil {
+		return nil, err
 	}
 
-	httpClient := oauth2Config.Client(context.TODO())
+	return &Client{Client: client, projectKey: c.ProjectKey}, nil
+}
 
-	return commercetools.New(&commercetools.Config{
-		ProjectKey:  c.ProjectKey,
-		URL:         c.BaseURL,
-		HTTPClient:  httpClient,
-		LibraryName: "terraformer",
-	})
+func (c *Client) Project() *platform.ByProjectKeyRequestBuilder {
+	return c.WithProjectKey(c.projectKey)
 }

--- a/providers/commercetools/custom_object.go
+++ b/providers/commercetools/custom_object.go
@@ -17,9 +17,7 @@ package commercetools
 import (
 	"context"
 
-	"github.com/chenrui333/terraformer/providers/commercetools/connectivity"
 	"github.com/chenrui333/terraformer/terraformutils"
-	"github.com/labd/commercetools-go-sdk/commercetools"
 )
 
 type CustomObjectGenerator struct {
@@ -28,17 +26,12 @@ type CustomObjectGenerator struct {
 
 // InitResources generates Terraform Resources from Commercetools API
 func (g *CustomObjectGenerator) InitResources() error {
-	cfg := connectivity.Config{
-		ClientID:     g.GetArgs()["client_id"].(string),
-		ClientSecret: g.GetArgs()["client_secret"].(string),
-		ClientScope:  g.GetArgs()["client_scope"].(string),
-		TokenURL:     g.GetArgs()["token_url"].(string) + "/oauth/token",
-		BaseURL:      g.GetArgs()["base_url"].(string),
+	client, err := g.newClient()
+	if err != nil {
+		return err
 	}
 
-	client := cfg.NewClient()
-
-	customObjects, err := client.CustomObjectQuery(context.Background(), &commercetools.QueryInput{})
+	customObjects, err := client.Project().CustomObjects().Get().Execute(context.Background())
 	if err != nil {
 		return err
 	}

--- a/providers/commercetools/helpers.go
+++ b/providers/commercetools/helpers.go
@@ -31,3 +31,11 @@ func normalizeResourceName(s string) string {
 
 	return strings.ToLower(s)
 }
+
+func stringValue(value *string) string {
+	if value == nil {
+		return ""
+	}
+
+	return *value
+}

--- a/providers/commercetools/product_type.go
+++ b/providers/commercetools/product_type.go
@@ -17,9 +17,7 @@ package commercetools
 import (
 	"context"
 
-	"github.com/chenrui333/terraformer/providers/commercetools/connectivity"
 	"github.com/chenrui333/terraformer/terraformutils"
-	"github.com/labd/commercetools-go-sdk/commercetools"
 )
 
 type ProductTypeGenerator struct {
@@ -28,22 +26,17 @@ type ProductTypeGenerator struct {
 
 // InitResources generates Terraform Resources from Commercetools API
 func (g *ProductTypeGenerator) InitResources() error {
-	cfg := connectivity.Config{
-		ClientID:     g.GetArgs()["client_id"].(string),
-		ClientSecret: g.GetArgs()["client_secret"].(string),
-		ClientScope:  g.GetArgs()["client_scope"].(string),
-		TokenURL:     g.GetArgs()["token_url"].(string) + "/oauth/token",
-		BaseURL:      g.GetArgs()["base_url"].(string),
+	client, err := g.newClient()
+	if err != nil {
+		return err
 	}
 
-	client := cfg.NewClient()
-
-	productTypes, err := client.ProductTypeQuery(context.Background(), &commercetools.QueryInput{})
+	productTypes, err := client.Project().ProductTypes().Get().Execute(context.Background())
 	if err != nil {
 		return err
 	}
 	for _, productType := range productTypes.Results {
-		resourceName := productType.Key
+		resourceName := stringValue(productType.Key)
 		if resourceName == "" {
 			resourceName = normalizeResourceName(productType.Name)
 		}

--- a/providers/commercetools/shipping_method.go
+++ b/providers/commercetools/shipping_method.go
@@ -17,9 +17,7 @@ package commercetools
 import (
 	"context"
 
-	"github.com/chenrui333/terraformer/providers/commercetools/connectivity"
 	"github.com/chenrui333/terraformer/terraformutils"
-	"github.com/labd/commercetools-go-sdk/commercetools"
 )
 
 type ShippingMethodGenerator struct {
@@ -28,24 +26,19 @@ type ShippingMethodGenerator struct {
 
 // InitResources generates Terraform Resources from Commercetools API
 func (g *ShippingMethodGenerator) InitResources() error {
-	cfg := connectivity.Config{
-		ClientID:     g.GetArgs()["client_id"].(string),
-		ClientSecret: g.GetArgs()["client_secret"].(string),
-		ClientScope:  g.GetArgs()["client_scope"].(string),
-		TokenURL:     g.GetArgs()["token_url"].(string) + "/oauth/token",
-		BaseURL:      g.GetArgs()["base_url"].(string),
+	client, err := g.newClient()
+	if err != nil {
+		return err
 	}
 
-	client := cfg.NewClient()
-
-	zones, err := client.ShippingMethodQuery(context.Background(), &commercetools.QueryInput{})
+	zones, err := client.Project().ShippingMethods().Get().Execute(context.Background())
 	if err != nil {
 		return err
 	}
 	for _, zone := range zones.Results {
 		g.Resources = append(g.Resources, terraformutils.NewResource(
 			zone.ID,
-			zone.Key,
+			stringValue(zone.Key),
 			"commercetools_shipping_method",
 			"commercetools",
 			map[string]string{},

--- a/providers/commercetools/shipping_zone.go
+++ b/providers/commercetools/shipping_zone.go
@@ -17,9 +17,7 @@ package commercetools
 import (
 	"context"
 
-	"github.com/chenrui333/terraformer/providers/commercetools/connectivity"
 	"github.com/chenrui333/terraformer/terraformutils"
-	"github.com/labd/commercetools-go-sdk/commercetools"
 )
 
 type ShippingZoneGenerator struct {
@@ -28,22 +26,17 @@ type ShippingZoneGenerator struct {
 
 // InitResources generates Terraform Resources from Commercetools API
 func (g *ShippingZoneGenerator) InitResources() error {
-	cfg := connectivity.Config{
-		ClientID:     g.GetArgs()["client_id"].(string),
-		ClientSecret: g.GetArgs()["client_secret"].(string),
-		ClientScope:  g.GetArgs()["client_scope"].(string),
-		TokenURL:     g.GetArgs()["token_url"].(string) + "/oauth/token",
-		BaseURL:      g.GetArgs()["base_url"].(string),
+	client, err := g.newClient()
+	if err != nil {
+		return err
 	}
 
-	client := cfg.NewClient()
-
-	zones, err := client.ZoneQuery(context.Background(), &commercetools.QueryInput{})
+	zones, err := client.Project().Zones().Get().Execute(context.Background())
 	if err != nil {
 		return err
 	}
 	for _, zone := range zones.Results {
-		resourceName := zone.Key
+		resourceName := stringValue(zone.Key)
 		if resourceName == "" {
 			resourceName = zone.Name
 		}

--- a/providers/commercetools/state.go
+++ b/providers/commercetools/state.go
@@ -17,9 +17,7 @@ package commercetools
 import (
 	"context"
 
-	"github.com/chenrui333/terraformer/providers/commercetools/connectivity"
 	"github.com/chenrui333/terraformer/terraformutils"
-	"github.com/labd/commercetools-go-sdk/commercetools"
 )
 
 type StateGenerator struct {
@@ -28,17 +26,12 @@ type StateGenerator struct {
 
 // InitResources generates Terraform Resources from Commercetools API
 func (g *StateGenerator) InitResources() error {
-	cfg := connectivity.Config{
-		ClientID:     g.GetArgs()["client_id"].(string),
-		ClientSecret: g.GetArgs()["client_secret"].(string),
-		ClientScope:  g.GetArgs()["client_scope"].(string),
-		TokenURL:     g.GetArgs()["token_url"].(string) + "/oauth/token",
-		BaseURL:      g.GetArgs()["base_url"].(string),
+	client, err := g.newClient()
+	if err != nil {
+		return err
 	}
 
-	client := cfg.NewClient()
-
-	states, err := client.StateQuery(context.Background(), &commercetools.QueryInput{})
+	states, err := client.Project().States().Get().Execute(context.Background())
 	if err != nil {
 		return err
 	}

--- a/providers/commercetools/store.go
+++ b/providers/commercetools/store.go
@@ -17,9 +17,7 @@ package commercetools
 import (
 	"context"
 
-	"github.com/chenrui333/terraformer/providers/commercetools/connectivity"
 	"github.com/chenrui333/terraformer/terraformutils"
-	"github.com/labd/commercetools-go-sdk/commercetools"
 )
 
 type StoreGenerator struct {
@@ -28,17 +26,12 @@ type StoreGenerator struct {
 
 // InitResources generates Terraform Resources from Commercetools API
 func (g *StoreGenerator) InitResources() error {
-	cfg := connectivity.Config{
-		ClientID:     g.GetArgs()["client_id"].(string),
-		ClientSecret: g.GetArgs()["client_secret"].(string),
-		ClientScope:  g.GetArgs()["client_scope"].(string),
-		TokenURL:     g.GetArgs()["token_url"].(string) + "/oauth/token",
-		BaseURL:      g.GetArgs()["base_url"].(string),
+	client, err := g.newClient()
+	if err != nil {
+		return err
 	}
 
-	client := cfg.NewClient()
-
-	stores, err := client.StoreQuery(context.Background(), &commercetools.QueryInput{})
+	stores, err := client.Project().Stores().Get().Execute(context.Background())
 	if err != nil {
 		return err
 	}

--- a/providers/commercetools/subscription.go
+++ b/providers/commercetools/subscription.go
@@ -17,9 +17,7 @@ package commercetools
 import (
 	"context"
 
-	"github.com/chenrui333/terraformer/providers/commercetools/connectivity"
 	"github.com/chenrui333/terraformer/terraformutils"
-	"github.com/labd/commercetools-go-sdk/commercetools"
 )
 
 type SubscriptionGenerator struct {
@@ -28,24 +26,19 @@ type SubscriptionGenerator struct {
 
 // InitResources generates Terraform Resources from Commercetools API
 func (g *SubscriptionGenerator) InitResources() error {
-	cfg := connectivity.Config{
-		ClientID:     g.GetArgs()["client_id"].(string),
-		ClientSecret: g.GetArgs()["client_secret"].(string),
-		ClientScope:  g.GetArgs()["client_scope"].(string),
-		TokenURL:     g.GetArgs()["token_url"].(string) + "/oauth/token",
-		BaseURL:      g.GetArgs()["base_url"].(string),
+	client, err := g.newClient()
+	if err != nil {
+		return err
 	}
 
-	client := cfg.NewClient()
-
-	subscriptions, err := client.SubscriptionQuery(context.Background(), &commercetools.QueryInput{})
+	subscriptions, err := client.Project().Subscriptions().Get().Execute(context.Background())
 	if err != nil {
 		return err
 	}
 	for _, subscription := range subscriptions.Results {
 		g.Resources = append(g.Resources, terraformutils.NewResource(
 			subscription.ID,
-			subscription.Key,
+			stringValue(subscription.Key),
 			"commercetools_subscription",
 			"commercetools",
 			map[string]string{},

--- a/providers/commercetools/tax_category.go
+++ b/providers/commercetools/tax_category.go
@@ -17,9 +17,7 @@ package commercetools
 import (
 	"context"
 
-	"github.com/chenrui333/terraformer/providers/commercetools/connectivity"
 	"github.com/chenrui333/terraformer/terraformutils"
-	"github.com/labd/commercetools-go-sdk/commercetools"
 )
 
 type TaxCategoryGenerator struct {
@@ -28,24 +26,19 @@ type TaxCategoryGenerator struct {
 
 // InitResources generates Terraform Resources from Commercetools API
 func (g *TaxCategoryGenerator) InitResources() error {
-	cfg := connectivity.Config{
-		ClientID:     g.GetArgs()["client_id"].(string),
-		ClientSecret: g.GetArgs()["client_secret"].(string),
-		ClientScope:  g.GetArgs()["client_scope"].(string),
-		TokenURL:     g.GetArgs()["token_url"].(string) + "/oauth/token",
-		BaseURL:      g.GetArgs()["base_url"].(string),
+	client, err := g.newClient()
+	if err != nil {
+		return err
 	}
 
-	client := cfg.NewClient()
-
-	categories, err := client.TaxCategoryQuery(context.Background(), &commercetools.QueryInput{})
+	categories, err := client.Project().TaxCategories().Get().Execute(context.Background())
 	if err != nil {
 		return err
 	}
 	for _, category := range categories.Results {
 		g.Resources = append(g.Resources, terraformutils.NewResource(
 			category.ID,
-			category.Key,
+			stringValue(category.Key),
 			"commercetools_tax_category",
 			"commercetools",
 			map[string]string{},

--- a/providers/commercetools/types.go
+++ b/providers/commercetools/types.go
@@ -17,9 +17,7 @@ package commercetools
 import (
 	"context"
 
-	"github.com/chenrui333/terraformer/providers/commercetools/connectivity"
 	"github.com/chenrui333/terraformer/terraformutils"
-	"github.com/labd/commercetools-go-sdk/commercetools"
 )
 
 type TypesGenerator struct {
@@ -28,17 +26,12 @@ type TypesGenerator struct {
 
 // InitResources generates Terraform Resources from Commercetools API
 func (g *TypesGenerator) InitResources() error {
-	cfg := connectivity.Config{
-		ClientID:     g.GetArgs()["client_id"].(string),
-		ClientSecret: g.GetArgs()["client_secret"].(string),
-		ClientScope:  g.GetArgs()["client_scope"].(string),
-		TokenURL:     g.GetArgs()["token_url"].(string) + "/oauth/token",
-		BaseURL:      g.GetArgs()["base_url"].(string),
+	client, err := g.newClient()
+	if err != nil {
+		return err
 	}
 
-	client := cfg.NewClient()
-
-	types, err := client.TypeQuery(context.Background(), &commercetools.QueryInput{})
+	types, err := client.Project().Types().Get().Execute(context.Background())
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Summary
- update github.com/labd/commercetools-go-sdk from v0.3.1 to v1.9.0
- migrate provider client setup to the current platform client
- replace legacy query helpers with project-scoped request builders

References
- https://pkg.go.dev/github.com/labd/commercetools-go-sdk/platform#NewClient
- https://pkg.go.dev/github.com/labd/commercetools-go-sdk/platform#Client.WithProjectKey
- https://pkg.go.dev/github.com/labd/commercetools-go-sdk/platform#ByProjectKeyRequestBuilder

Refs #155
