### PR TITLE
deps(cloudflare): update cloudflare-go to v0.116.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -102,7 +102,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/workspaces v1.67.3
 	github.com/aws/aws-sdk-go-v2/service/xray v1.36.22
 	github.com/cenkalti/backoff v2.2.1+incompatible // indirect
-	github.com/cloudflare/cloudflare-go v0.13.6
+	github.com/cloudflare/cloudflare-go v0.116.0
 	github.com/cloudfoundry/jibber_jabber v0.0.0-20151120183258-bcc4c8345a21 // indirect
 	github.com/ddelnano/terraform-provider-mikrotik/client v0.0.0-20250110092516-5bc3b68c6245
 	github.com/ddelnano/terraform-provider-xenorchestra/client v0.0.0-20210401070256-0d721c6762ef
@@ -350,7 +350,7 @@ require (
 	github.com/go-openapi/swag v0.23.0 // indirect
 	github.com/go-playground/validator/v10 v10.28.0 // indirect
 	github.com/go-viper/mapstructure/v2 v2.4.0 // indirect
-	github.com/goccy/go-json v0.10.2 // indirect
+	github.com/goccy/go-json v0.10.5 // indirect
 	github.com/golang-jwt/jwt/v5 v5.3.1 // indirect
 	github.com/google/gnostic-models v0.7.0 // indirect
 	github.com/google/go-github/v84 v84.0.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -445,8 +445,8 @@ github.com/chzyer/test v0.0.0-20180213035817-a1ea475d72b1/go.mod h1:Q3SI9o4m/ZMn
 github.com/clbanning/mxj v1.8.4 h1:HuhwZtbyvyOw+3Z1AowPkU87JkJUSv751ELWaiTpj8I=
 github.com/clbanning/mxj v1.8.4/go.mod h1:BVjHeAH+rl9rs6f+QIpeRl0tfu10SXn1pUSa5PVGJng=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
-github.com/cloudflare/cloudflare-go v0.13.6 h1:G6aw092fOkvkHODCxf8EHLPqHN2BVxHU4RoTFjS51xo=
-github.com/cloudflare/cloudflare-go v0.13.6/go.mod h1:gNGW6MkPPVLhjgaXq4vaS7WnTaQpCfl6DE1W9JuWyt8=
+github.com/cloudflare/cloudflare-go v0.116.0 h1:iRPMnTtnswRpELO65NTwMX4+RTdxZl+Xf/zi+HPE95s=
+github.com/cloudflare/cloudflare-go v0.116.0/go.mod h1:Ds6urDwn/TF2uIU24mu7H91xkKP8gSAHxQ44DSZgVmU=
 github.com/cloudfoundry/jibber_jabber v0.0.0-20151120183258-bcc4c8345a21 h1:tuijfIjZyjZaHq9xDUh0tNitwXshJpbLkqMOJv4H3do=
 github.com/cloudfoundry/jibber_jabber v0.0.0-20151120183258-bcc4c8345a21/go.mod h1:po7NpZ/QiTKzBKyrsEAxwnTamCoh8uDk/egRpQ7siIc=
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
@@ -459,7 +459,6 @@ github.com/coreos/etcd v3.3.10+incompatible/go.mod h1:uF7uidLiAD3TWHmW31ZFd/JWoc
 github.com/coreos/go-semver v0.2.0/go.mod h1:nnelYz7RCh+5ahJtPPxZlU+153eP4D4r3EedlOD2RNk=
 github.com/coreos/go-systemd v0.0.0-20181012123002-c6f51f82210d/go.mod h1:F5haX7vjVVG0kc13fIWeqUViNPyEJxv/OmvnBo0Yme4=
 github.com/coreos/pkg v0.0.0-20180928190104-399ea9e2e55f/go.mod h1:E3G3o1h8I7cfcXa63jLwjI0eiQQMgzzUDFVpN/nH/eA=
-github.com/cpuguy83/go-md2man/v2 v2.0.0-20190314233015-f79a8a8ca69d/go.mod h1:maD7wRr/U5Z6m/iR4s+kqSMx2CaBsrgA7czyZG/E6dU=
 github.com/cpuguy83/go-md2man/v2 v2.0.6/go.mod h1:oOW0eioCTA6cOiMLiUPZOpcVxMig6NIQQ7OS05n1F4g=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/crewjam/saml v0.4.14 h1:g9FBNx62osKusnFzs3QTN5L9CVA/Egfgm+stJShzw/c=
@@ -624,8 +623,9 @@ github.com/gobuffalo/packd v0.1.0/go.mod h1:M2Juc+hhDXf/PnmBANFCqx4DM3wRbgDvnVWe
 github.com/gobuffalo/packr/v2 v2.0.9/go.mod h1:emmyGweYTm6Kdper+iywB6YK5YzuKchGtJQZ0Odn4pQ=
 github.com/gobuffalo/packr/v2 v2.2.0/go.mod h1:CaAwI0GPIAv+5wKLtv8Afwl+Cm78K/I/VCm/3ptBN+0=
 github.com/gobuffalo/syncx v0.0.0-20190224160051-33c29581e754/go.mod h1:HhnNqWY95UYwwW3uSASeV7vtgYkT2t16hJgV3AEPUpw=
-github.com/goccy/go-json v0.10.2 h1:CrxCmQqYDkv1z7lO7Wbh2HN93uovUHgrECaO5ZrCXAU=
 github.com/goccy/go-json v0.10.2/go.mod h1:6MelG93GURQebXPDq3khkgXZkazVtN9CRI+MGFi0w8I=
+github.com/goccy/go-json v0.10.5 h1:Fq85nIqj+gXn/S5ahsiTlK3TmC85qgirsdTP/+DeaC4=
+github.com/goccy/go-json v0.10.5/go.mod h1:oq7eo15ShAhp70Anwd5lgX2pLfOS3QCiwU/PULtXL6M=
 github.com/gofrs/uuid v3.2.0+incompatible h1:y12jRkkFxsd7GpqdSZ+/KCs/fJbqpEXSGd4+jfEaewE=
 github.com/gofrs/uuid v3.2.0+incompatible/go.mod h1:b2aQJv3Z4Fp6yNu3cdSllBxTCLRxnplIgP/c0N/04lM=
 github.com/gofrs/uuid/v3 v3.1.2 h1:V3IBv1oU82x6YIr5txe3azVHgmOKYdyKQTowm9moBlY=
@@ -1026,7 +1026,6 @@ github.com/mattn/go-isatty v0.0.14/go.mod h1:7GGIvUiUoEMVVmxf/4nioHXj79iQHKdU27k
 github.com/mattn/go-isatty v0.0.20 h1:xfD0iDuEKnDkl03q4limB+vH+GxLEtL/jb4xVJSWWEY=
 github.com/mattn/go-isatty v0.0.20/go.mod h1:W+V8PltTTMOvKvAeJH7IuucS94S2C6jfK/D7dTCTo3Y=
 github.com/mattn/go-runewidth v0.0.4/go.mod h1:LwmH8dsx7+W8Uxz3IHJYH5QSwggIsqBzpuz5H//U1FU=
-github.com/mattn/go-runewidth v0.0.7/go.mod h1:H031xJmbD/WCDINGzjvQ9THkh0rPKHF+m2gUSrubnMI=
 github.com/mattn/go-shellwords v1.0.4/go.mod h1:3xCvwCdWdlDJUrvuMn7Wuy9eWs4pE8vqg+NOMyg4B2o=
 github.com/matttproud/golang_protobuf_extensions v1.0.1/go.mod h1:D8He9yQNgCq6Z5Ld7szi9bcBfOoFv/3dc6xSMkL2PC0=
 github.com/microsoft/azure-devops-go-api/azuredevops v1.0.0-b5 h1:YH424zrwLTlyHSH/GzLMJeu5zhYVZSx5RQxGKm1h96s=
@@ -1102,7 +1101,6 @@ github.com/okta/okta-sdk-golang/v5 v5.0.6 h1:p7ptDMB1KxQ/7xSh+6FhMSybwl+ubTV4f1o
 github.com/okta/okta-sdk-golang/v5 v5.0.6/go.mod h1:T/vmECtJX33YPZSVD+sorebd8LLhe38Bi/VrFTjgVX0=
 github.com/okta/terraform-provider-okta v0.0.0-20210924173942-a5a664459d3b h1:ML6q0susBNxEEXZkifQGjY5ILGJHhU0a72Dm2DHEbSg=
 github.com/okta/terraform-provider-okta v0.0.0-20210924173942-a5a664459d3b/go.mod h1:hVb3TxYi4ibGeUpue2Rqm84YhD/473w0Xv0uIlylUY8=
-github.com/olekukonko/tablewriter v0.0.4/go.mod h1:zq6QwlOf5SlnkVbMSr5EoBv3636FWnp+qbPhuoO21uA=
 github.com/onsi/ginkgo v1.6.0/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=
 github.com/onsi/ginkgo v1.12.1/go.mod h1:zj2OWP4+oCPe1qIXoGWkgMRwljMUYCdkwsT2108oapk=
 github.com/onsi/ginkgo v1.14.2/go.mod h1:iSB4RoI2tjJc9BBv4NKIKWKya62Rps+oPG/Lv9klQyY=
@@ -1173,7 +1171,6 @@ github.com/rogpeppe/go-internal v1.14.1/go.mod h1:MaRKkUm5W0goXpeCfT7UZI6fk/L7L7
 github.com/rs/dnscache v0.0.0-20230804202142-fc85eb664529/go.mod h1:qe5TWALJ8/a1Lqznoc5BDHpYX/8HU60Hm2AwRmqzxqA=
 github.com/russellhaering/goxmldsig v1.6.0 h1:8fdWXEPh2k/NZNQBPFNoVfS3JmzS4ZprY/sAOpKQLks=
 github.com/russellhaering/goxmldsig v1.6.0/go.mod h1:TrnaquDcYxWXfJrOjeMBTX4mLBeYAqaHEyUeWPxZlBM=
-github.com/russross/blackfriday/v2 v2.0.1/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/ryanuber/go-glob v1.0.0 h1:iQh3xXAumdQ+4Ufa5b25cRpC5TYKlno6hsv6Cb3pkBk=
 github.com/ryanuber/go-glob v1.0.0/go.mod h1:807d1WSdnB0XRJzKNil9Om6lcp/3a0v4qIHxIXzX/Yc=
@@ -1183,7 +1180,6 @@ github.com/sergi/go-diff v1.0.0/go.mod h1:0CfEIISq7TuYL3j771MWULgwwjU+GofnZX9QAm
 github.com/shopspring/decimal v1.2.0/go.mod h1:DKyhrW/HYNuLGql+MJL6WCR6knT2jwCFRcu2hWCYk4o=
 github.com/shopspring/decimal v1.3.1 h1:2Usl1nmF/WZucqkFZhnfFYxxxu8LG21F6nPQBE5gKV8=
 github.com/shopspring/decimal v1.3.1/go.mod h1:DKyhrW/HYNuLGql+MJL6WCR6knT2jwCFRcu2hWCYk4o=
-github.com/shurcooL/sanitized_anchor_name v1.0.0/go.mod h1:1NzhyTcUVG4SuEtjjoZeVRXNmyL/1OwPU0+IJeTBvfc=
 github.com/sirupsen/logrus v1.2.0/go.mod h1:LxeOpSwHxABJmUn/MG1IvRgCAasNZTLOkJPxbbu5VWo=
 github.com/sirupsen/logrus v1.4.0/go.mod h1:LxeOpSwHxABJmUn/MG1IvRgCAasNZTLOkJPxbbu5VWo=
 github.com/sirupsen/logrus v1.4.1/go.mod h1:ni0Sbl8bgC9z8RoU9G6nDWqqs/fq4eDPysMBDgk/93Q=
@@ -1506,7 +1502,6 @@ github.com/ugorji/go v0.0.0-20180813092308-00b869d2f4a5/go.mod h1:hnLbHMwcvSihnD
 github.com/ulikunitz/xz v0.5.5/go.mod h1:2bypXElzHzzJZwzH67Y6wb67pO62Rzfn7BSiF4ABRW8=
 github.com/ulikunitz/xz v0.5.15 h1:9DNdB5s+SgV3bQ2ApL10xRc35ck0DuIX/isZvIk+ubY=
 github.com/ulikunitz/xz v0.5.15/go.mod h1:nbz6k7qbPmH4IRqmfOplQw/tblSgqTqBwxkY0oWt/14=
-github.com/urfave/cli/v2 v2.3.0/go.mod h1:LJmUH05zAU44vOAcrfzZQKsZbVcdbOG8rtL3/XcUArI=
 github.com/valyala/fastjson v1.6.3 h1:tAKFnnwmeMGPbwJ7IwxcTPCNr3uIzoIj3/Fh90ra4xc=
 github.com/valyala/fastjson v1.6.3/go.mod h1:CLCAqky6SMuOcxStkYQvblddUtoRxhYMGLrsQns1aXY=
 github.com/vmihailenco/msgpack v3.3.3+incompatible/go.mod h1:fy3FlTQTDXWkZ7Bh6AcGMlsjHatGryHQYUTf1ShIgkk=
@@ -1852,7 +1847,6 @@ golang.org/x/text v0.36.0/go.mod h1:NIdBknypM8iqVmPiuco0Dh6P5Jcdk8lJL0CUebqK164=
 golang.org/x/time v0.0.0-20181108054448-85acf8d2951c/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=
 golang.org/x/time v0.0.0-20190308202827-9d24e82272b4/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=
 golang.org/x/time v0.0.0-20191024005414-555d28b269f0/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=
-golang.org/x/time v0.0.0-20200630173020-3af7569d3a1e/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=
 golang.org/x/time v0.15.0 h1:bbrp8t3bGUeFOx08pvsMYRTCVSMk89u4tKbNOZbp88U=
 golang.org/x/time v0.15.0/go.mod h1:Y4YMaQmXwGQZoFaVFk4YpCt4FLQMYKZe9oeV/f4MSno=
 golang.org/x/tools v0.0.0-20180525024113-a5b4c53f6e8b/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
@@ -2063,7 +2057,6 @@ gopkg.in/validator.v2 v2.0.1/go.mod h1:lIUZBlB3Im4s/eYp39Ry/wkR02yOPhZ9IwIRBjuPu
 gopkg.in/yaml.v2 v2.0.0-20170812160011-eb3733d160e7/go.mod h1:JAlM8MvJe8wmxCU4Bli9HhUf9+ttbYbLASfIpnQbh74=
 gopkg.in/yaml.v2 v2.2.1/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
-gopkg.in/yaml.v2 v2.2.3/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.2.4/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.2.8/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.3.0/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=

--- a/providers/cloudflare/access.go
+++ b/providers/cloudflare/access.go
@@ -15,6 +15,7 @@
 package cloudflare
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/chenrui333/terraformer/terraformutils"
@@ -27,7 +28,7 @@ type AccessGenerator struct {
 
 func (g *AccessGenerator) createAccessApplications(api *cf.API, zoneID string) ([]terraformutils.Resource, error) {
 	resources := []terraformutils.Resource{}
-	accessApplications, _, err := api.AccessApplications(zoneID, cf.PaginationOptions{})
+	accessApplications, _, err := api.ListAccessApplications(context.Background(), cf.ZoneIdentifier(zoneID), cf.ListAccessApplicationsParams{})
 	if err != nil {
 		return []terraformutils.Resource{}, err
 	}
@@ -56,7 +57,7 @@ func (g *AccessGenerator) InitResources() error {
 		return err
 	}
 
-	zones, err := api.ListZones()
+	zones, err := api.ListZones(context.Background())
 	if err != nil {
 		return err
 	}

--- a/providers/cloudflare/account_member.go
+++ b/providers/cloudflare/account_member.go
@@ -15,6 +15,8 @@
 package cloudflare
 
 import (
+	"context"
+
 	"github.com/chenrui333/terraformer/terraformutils"
 	cf "github.com/cloudflare/cloudflare-go"
 )
@@ -30,7 +32,7 @@ func (g *AccountMemberGenerator) createAccountMemberResources(api *cf.API) ([]te
 		PerPage: 10}
 
 	for {
-		members, info, err := api.AccountMembers(api.AccountID, pageOpt)
+		members, info, err := api.AccountMembers(context.Background(), g.accountID(), pageOpt)
 		if err != nil {
 			return resources, err
 		}

--- a/providers/cloudflare/cloudflare_service.go
+++ b/providers/cloudflare/cloudflare_service.go
@@ -31,7 +31,6 @@ func (s *CloudflareService) initializeAPI() (*cf.API, error) {
 	apiKey := os.Getenv("CLOUDFLARE_API_KEY")
 	apiEmail := os.Getenv("CLOUDFLARE_EMAIL")
 	apiToken := os.Getenv("CLOUDFLARE_API_TOKEN")
-	accountID := os.Getenv("CLOUDFLARE_ACCOUNT_ID")
 
 	if apiToken == "" && (apiEmail == "" || apiKey == "") {
 		err := errors.New("Either CLOUDFLARE_API_TOKEN or CLOUDFLARE_API_KEY/CLOUDFLARE_EMAIL environment variables must be set")
@@ -40,8 +39,12 @@ func (s *CloudflareService) initializeAPI() (*cf.API, error) {
 	}
 
 	if apiToken != "" {
-		return cf.NewWithAPIToken(apiToken, cf.UsingAccount(accountID))
+		return cf.NewWithAPIToken(apiToken)
 	}
 
-	return cf.New(apiKey, apiEmail, cf.UsingAccount(accountID))
+	return cf.New(apiKey, apiEmail)
+}
+
+func (s *CloudflareService) accountID() string {
+	return os.Getenv("CLOUDFLARE_ACCOUNT_ID")
 }

--- a/providers/cloudflare/dns.go
+++ b/providers/cloudflare/dns.go
@@ -15,6 +15,7 @@
 package cloudflare
 
 import (
+	"context"
 	"fmt"
 	"log"
 
@@ -26,8 +27,8 @@ type DNSGenerator struct {
 	CloudflareService
 }
 
-func (*DNSGenerator) createZonesResource(api *cf.API, zoneID string) ([]terraformutils.Resource, error) {
-	zoneDetails, err := api.ZoneDetails(zoneID)
+func (*DNSGenerator) createZonesResource(api *cf.API, zoneID, _ string) ([]terraformutils.Resource, error) {
+	zoneDetails, err := api.ZoneDetails(context.Background(), zoneID)
 	if err != nil {
 		log.Println(err)
 		return []terraformutils.Resource{}, err
@@ -49,9 +50,9 @@ func (*DNSGenerator) createZonesResource(api *cf.API, zoneID string) ([]terrafor
 	return []terraformutils.Resource{resource}, nil
 }
 
-func (*DNSGenerator) createRecordsResources(api *cf.API, zoneID string) ([]terraformutils.Resource, error) {
+func (*DNSGenerator) createRecordsResources(api *cf.API, zoneID, zoneName string) ([]terraformutils.Resource, error) {
 	resources := []terraformutils.Resource{}
-	records, err := api.DNSRecords(zoneID, cf.DNSRecord{})
+	records, _, err := api.ListDNSRecords(context.Background(), cf.ZoneIdentifier(zoneID), cf.ListDNSRecordsParams{})
 	if err != nil {
 		log.Println(err)
 		return resources, err
@@ -60,12 +61,12 @@ func (*DNSGenerator) createRecordsResources(api *cf.API, zoneID string) ([]terra
 	for _, record := range records {
 		r := terraformutils.NewResource(
 			record.ID,
-			fmt.Sprintf("%s_%s_%s", record.Type, record.ZoneName, record.ID),
+			fmt.Sprintf("%s_%s_%s", record.Type, zoneName, record.ID),
 			"cloudflare_record",
 			"cloudflare",
 			map[string]string{
 				"zone_id": zoneID,
-				"domain":  record.ZoneName,
+				"domain":  zoneName,
 				"name":    record.Name,
 			},
 			[]string{},
@@ -86,20 +87,20 @@ func (g *DNSGenerator) InitResources() error {
 		return err
 	}
 
-	zones, err := api.ListZones()
+	zones, err := api.ListZones(context.Background())
 	if err != nil {
 		log.Println(err)
 		return err
 	}
 
-	funcs := []func(*cf.API, string) ([]terraformutils.Resource, error){
+	funcs := []func(*cf.API, string, string) ([]terraformutils.Resource, error){
 		g.createZonesResource,
 		g.createRecordsResources,
 	}
 
 	for _, zone := range zones {
 		for _, f := range funcs {
-			tmpRes, err := f(api, zone.ID)
+			tmpRes, err := f(api, zone.ID, zone.Name)
 			if err != nil {
 				log.Println(err)
 				return err

--- a/providers/cloudflare/firewall.go
+++ b/providers/cloudflare/firewall.go
@@ -15,6 +15,7 @@
 package cloudflare
 
 import (
+	"context"
 	"fmt"
 	"strings"
 
@@ -28,33 +29,24 @@ type FirewallGenerator struct {
 
 func (*FirewallGenerator) createZoneLockdownsResources(api *cf.API, zoneID, zoneName string) ([]terraformutils.Resource, error) {
 	resources := []terraformutils.Resource{}
-	page := 1
 
-	for {
-		zonelockdowns, err := api.ListZoneLockdowns(zoneID, page)
-		if err != nil {
-			return resources, err
-		}
-		for _, zonelockdown := range zonelockdowns.Result {
-			resources = append(resources, terraformutils.NewResource(
-				zonelockdown.ID,
-				fmt.Sprintf("%s_%s", zoneName, zonelockdown.ID),
-				"cloudflare_zone_lockdown",
-				"cloudflare",
-				map[string]string{
-					"zone_id": zoneID,
-					"zone":    zoneName,
-				},
-				[]string{},
-				map[string]interface{}{},
-			))
-		}
-
-		if zonelockdowns.TotalPages > page {
-			page++
-		} else {
-			break
-		}
+	zonelockdowns, _, err := api.ListZoneLockdowns(context.Background(), cf.ZoneIdentifier(zoneID), cf.LockdownListParams{})
+	if err != nil {
+		return resources, err
+	}
+	for _, zonelockdown := range zonelockdowns {
+		resources = append(resources, terraformutils.NewResource(
+			zonelockdown.ID,
+			fmt.Sprintf("%s_%s", zoneName, zonelockdown.ID),
+			"cloudflare_zone_lockdown",
+			"cloudflare",
+			map[string]string{
+				"zone_id": zoneID,
+				"zone":    zoneName,
+			},
+			[]string{},
+			map[string]interface{}{},
+		))
 	}
 
 	return resources, nil
@@ -62,7 +54,8 @@ func (*FirewallGenerator) createZoneLockdownsResources(api *cf.API, zoneID, zone
 
 func (g *FirewallGenerator) createAccountAccessRuleResources(api *cf.API) ([]terraformutils.Resource, error) {
 	resources := []terraformutils.Resource{}
-	rules, err := api.ListAccountAccessRules(api.AccountID, cf.AccessRule{}, 1)
+	accountID := g.accountID()
+	rules, err := api.ListAccountAccessRules(context.Background(), accountID, cf.AccessRule{}, 1)
 	if err != nil {
 		return resources, err
 	}
@@ -79,7 +72,7 @@ func (g *FirewallGenerator) createAccountAccessRuleResources(api *cf.API) ([]ter
 	}
 
 	for page := 2; page <= totalPages; page++ {
-		rules, err := api.ListAccountAccessRules(api.AccountID, cf.AccessRule{}, page)
+		rules, err := api.ListAccountAccessRules(context.Background(), accountID, cf.AccessRule{}, page)
 		if err != nil {
 			return resources, err
 		}
@@ -99,7 +92,7 @@ func (g *FirewallGenerator) createAccountAccessRuleResources(api *cf.API) ([]ter
 
 func (*FirewallGenerator) createZoneAccessRuleResources(api *cf.API, zoneID, zoneName string) ([]terraformutils.Resource, error) {
 	resources := []terraformutils.Resource{}
-	rules, err := api.ListZoneAccessRules(zoneID, cf.AccessRule{}, 1)
+	rules, err := api.ListZoneAccessRules(context.Background(), zoneID, cf.AccessRule{}, 1)
 	if err != nil {
 		return resources, err
 	}
@@ -122,7 +115,7 @@ func (*FirewallGenerator) createZoneAccessRuleResources(api *cf.API, zoneID, zon
 	}
 
 	for page := 2; page <= totalPages; page++ {
-		rules, err := api.ListZoneAccessRules(zoneID, cf.AccessRule{}, page)
+		rules, err := api.ListZoneAccessRules(context.Background(), zoneID, cf.AccessRule{}, page)
 		if err != nil {
 			return resources, err
 		}
@@ -148,7 +141,7 @@ func (*FirewallGenerator) createZoneAccessRuleResources(api *cf.API, zoneID, zon
 
 func (*FirewallGenerator) createFilterResources(api *cf.API, zoneID, zoneName string) ([]terraformutils.Resource, error) {
 	resources := []terraformutils.Resource{}
-	filters, err := api.Filters(zoneID, cf.PaginationOptions{})
+	filters, _, err := api.Filters(context.Background(), cf.ZoneIdentifier(zoneID), cf.FilterListParams{})
 	if err != nil {
 		return resources, err
 	}
@@ -173,7 +166,7 @@ func (*FirewallGenerator) createFilterResources(api *cf.API, zoneID, zoneName st
 func (*FirewallGenerator) createFirewallRuleResources(api *cf.API, zoneID, zoneName string) ([]terraformutils.Resource, error) {
 	resources := []terraformutils.Resource{}
 
-	fwrules, err := api.FirewallRules(zoneID, cf.PaginationOptions{})
+	fwrules, _, err := api.FirewallRules(context.Background(), cf.ZoneIdentifier(zoneID), cf.FirewallRuleListParams{})
 	if err != nil {
 		return resources, err
 	}
@@ -197,7 +190,7 @@ func (*FirewallGenerator) createFirewallRuleResources(api *cf.API, zoneID, zoneN
 func (g *FirewallGenerator) createRateLimitResources(api *cf.API, zoneID, zoneName string) ([]terraformutils.Resource, error) {
 	var resources []terraformutils.Resource
 
-	rateLimits, err := api.ListAllRateLimits(zoneID)
+	rateLimits, err := api.ListAllRateLimits(context.Background(), zoneID)
 	if err != nil {
 		return resources, err
 	}
@@ -219,7 +212,7 @@ func (g *FirewallGenerator) InitResources() error {
 		return err
 	}
 
-	if len(api.AccountID) > 0 {
+	if g.accountID() != "" {
 		resources, err := g.createAccountAccessRuleResources(api)
 		if err != nil {
 			return err
@@ -228,7 +221,7 @@ func (g *FirewallGenerator) InitResources() error {
 
 	}
 
-	zones, err := api.ListZones()
+	zones, err := api.ListZones(context.Background())
 	if err != nil {
 		return err
 	}

--- a/providers/cloudflare/page_rule.go
+++ b/providers/cloudflare/page_rule.go
@@ -15,6 +15,8 @@
 package cloudflare
 
 import (
+	"context"
+
 	"github.com/chenrui333/terraformer/terraformutils"
 	cf "github.com/cloudflare/cloudflare-go"
 )
@@ -25,7 +27,7 @@ type PageRulesGenerator struct {
 
 func (g *PageRulesGenerator) createPageRules(api *cf.API, zoneID string) ([]terraformutils.Resource, error) {
 	var resources []terraformutils.Resource
-	pageRules, err := api.ListPageRules(zoneID)
+	pageRules, err := api.ListPageRules(context.Background(), zoneID)
 	if err != nil {
 		return resources, err
 	}
@@ -53,7 +55,7 @@ func (g *PageRulesGenerator) InitResources() error {
 		return err
 	}
 
-	zones, err := api.ListZones()
+	zones, err := api.ListZones(context.Background())
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Summary
- update github.com/cloudflare/cloudflare-go from v0.13.6 to v0.116.0
- migrate provider calls to context-aware list/detail APIs
- pass account and zone resource containers explicitly for current SDK methods

References
- https://pkg.go.dev/github.com/cloudflare/cloudflare-go#API.ListZones
- https://pkg.go.dev/github.com/cloudflare/cloudflare-go#API.ListDNSRecords
- https://pkg.go.dev/github.com/cloudflare/cloudflare-go#API.ListAccessApplications
- https://pkg.go.dev/github.com/cloudflare/cloudflare-go#AccountIdentifier
- https://pkg.go.dev/github.com/cloudflare/cloudflare-go#ZoneIdentifier

Refs #155
