### PR TITLE
deps(ibm): update vpc sdk to v0.83.2

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -17,7 +17,7 @@ require (
 	github.com/IBM/keyprotect-go-client v0.15.1
 	github.com/IBM/networking-go-sdk v0.30.0
 	github.com/IBM/platform-services-go-sdk v0.97.2
-	github.com/IBM/vpc-go-sdk v0.64.0
+	github.com/IBM/vpc-go-sdk v0.83.2
 	github.com/OctopusDeploy/go-octopusdeploy v1.8.6
 	github.com/PaloAltoNetworks/pango v0.10.2
 	github.com/aliyun/alibaba-cloud-sdk-go v1.63.107

--- a/go.sum
+++ b/go.sum
@@ -153,8 +153,8 @@ github.com/IBM/networking-go-sdk v0.30.0 h1:GUfvq4AOK0iTUEodPL2k812y2W1GdZs6hUTa
 github.com/IBM/networking-go-sdk v0.30.0/go.mod h1:tVxXclpQs8nQJYPTr9ZPNC1voaPNQLy8iy/72oVfFtM=
 github.com/IBM/platform-services-go-sdk v0.97.2 h1:CdiLSFB0+oaAsucgVnpwn31YTAr47qFROPes4zXJalk=
 github.com/IBM/platform-services-go-sdk v0.97.2/go.mod h1:t93mozFmKrxexnKNdx2gNOtEI9Wd62dKAVffQYm0vRM=
-github.com/IBM/vpc-go-sdk v0.64.0 h1:0x2jakapXxXYTTr0EdrwuXa6h0couSK+FTDGxd8jChA=
-github.com/IBM/vpc-go-sdk v0.64.0/go.mod h1:VBR6bAznHsNCFA89Ue4JFQpqCcFp8F5neqbCFCyks4Q=
+github.com/IBM/vpc-go-sdk v0.83.2 h1:RLMha7+buktU9hrhvAMF2QRHIvxaAsuU14W6akybJqs=
+github.com/IBM/vpc-go-sdk v0.83.2/go.mod h1:85bJ/0FS7vYAifHdZvlnXypf8pQSmuf9kxReDDI5ZdY=
 github.com/Masterminds/goutils v1.1.1 h1:5nUrii3FMTL5diU80unEVvNevw1nH4+ZV4DSLVJLSYI=
 github.com/Masterminds/goutils v1.1.1/go.mod h1:8cTjp+g8YejhMuvIA5y2vz3BpJxksy863GQaJW2MFNU=
 github.com/Masterminds/semver/v3 v3.1.1/go.mod h1:VPu/7SZ7ePZ3QOrcuXROw5FAcLl4a0cBrbBpGY/8hQs=

--- a/providers/ibm/ibm_is_security_group.go
+++ b/providers/ibm/ibm_is_security_group.go
@@ -19,9 +19,9 @@ import (
 	"os"
 	"reflect"
 
-	"github.com/chenrui333/terraformer/terraformutils"
 	"github.com/IBM/go-sdk-core/v4/core"
 	"github.com/IBM/vpc-go-sdk/vpcv1"
+	"github.com/chenrui333/terraformer/terraformutils"
 )
 
 // SecurityGroupGenerator ...
@@ -118,9 +118,9 @@ func (g *SecurityGroupGenerator) InitResources() error {
 					g.Resources = append(g.Resources, g.createSecurityGroupRuleResources(*group.ID, *rule.ID))
 				}
 
-			case "*vpcv1.SecurityGroupRuleSecurityGroupRuleProtocolAll":
+			case "*vpcv1.SecurityGroupRuleProtocolAny":
 				{
-					rule := sgrule.(*vpcv1.SecurityGroupRuleSecurityGroupRuleProtocolAll)
+					rule := sgrule.(*vpcv1.SecurityGroupRuleProtocolAny)
 					g.Resources = append(g.Resources, g.createSecurityGroupRuleResources(*group.ID, *rule.ID))
 				}
 

--- a/providers/ibm/satellite_data_plane.go
+++ b/providers/ibm/satellite_data_plane.go
@@ -21,9 +21,9 @@ import (
 	"reflect"
 	"strings"
 
-	"github.com/chenrui333/terraformer/terraformutils"
 	bluemix "github.com/IBM-Cloud/bluemix-go"
 	"github.com/IBM-Cloud/bluemix-go/session"
+	"github.com/chenrui333/terraformer/terraformutils"
 
 	"github.com/IBM/go-sdk-core/v3/core"
 	"github.com/IBM/vpc-go-sdk/vpcv1"
@@ -331,9 +331,9 @@ func (g *SatelliteDataPlaneGenerator) InitResources() error {
 							g.Resources = append(g.Resources, g.loadSecurityGroupRuleResources(*group.ID, *rule.ID, sgDependsOn))
 						}
 
-					case "*vpcv1.SecurityGroupRuleSecurityGroupRuleProtocolAll":
+					case "*vpcv1.SecurityGroupRuleProtocolAny":
 						{
-							rule := sgrule.(*vpcv1.SecurityGroupRuleSecurityGroupRuleProtocolAll)
+							rule := sgrule.(*vpcv1.SecurityGroupRuleProtocolAny)
 							g.Resources = append(g.Resources, g.loadSecurityGroupRuleResources(*group.ID, *rule.ID, sgDependsOn))
 						}
 


### PR DESCRIPTION
Summary
- update github.com/IBM/vpc-go-sdk from v0.64.0 to v0.83.2
- adapt security group rule imports to the current all-protocol model type

References
- https://pkg.go.dev/github.com/IBM/vpc-go-sdk/vpcv1#SecurityGroupRule
- https://pkg.go.dev/github.com/IBM/vpc-go-sdk/vpcv1#SecurityGroupRuleProtocolAny

Refs #155
