### PR TITLE
deps(ibm): update networking sdk to v0.53.1

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -15,7 +15,7 @@ require (
 	github.com/IBM/go-sdk-core/v5 v5.21.2
 	github.com/IBM/ibm-cos-sdk-go v1.14.0
 	github.com/IBM/keyprotect-go-client v0.15.1
-	github.com/IBM/networking-go-sdk v0.30.0
+	github.com/IBM/networking-go-sdk v0.53.1
 	github.com/IBM/platform-services-go-sdk v0.97.2
 	github.com/IBM/vpc-go-sdk v0.83.2
 	github.com/OctopusDeploy/go-octopusdeploy v1.8.6

--- a/go.sum
+++ b/go.sum
@@ -142,15 +142,14 @@ github.com/IBM/go-sdk-core/v3 v3.3.1/go.mod h1:lk9eOzNbNltPf3CBpcg1Ewkhw4qC3u2QC
 github.com/IBM/go-sdk-core/v4 v4.10.0 h1:aLoKusSFVsxMJeKHf8csj9tBWt4Y50kVvfxoKh6scN0=
 github.com/IBM/go-sdk-core/v4 v4.10.0/go.mod h1:0uz2ca0MZ2DwsBRGl9Jp3EaCTqxmKZTdvV/CkCB7JnI=
 github.com/IBM/go-sdk-core/v5 v5.5.1/go.mod h1:Sn+z+qTDREQvCr+UFa22TqqfXNxx3o723y8GsfLV8e0=
-github.com/IBM/go-sdk-core/v5 v5.8.0/go.mod h1:+YbdhrjCHC84ls4MeBp+Hj4NZCni+tDAc0XQUqRO9Jc=
 github.com/IBM/go-sdk-core/v5 v5.21.2 h1:mJ5QbLPOm4g5qhZiVB6wbSllfpeUExftGoyPek2hk4M=
 github.com/IBM/go-sdk-core/v5 v5.21.2/go.mod h1:ngpMgwkjur1VNUjqn11LPk3o5eCyOCRbcfg/0YAY7Hc=
 github.com/IBM/ibm-cos-sdk-go v1.14.0 h1:K8uhFw4/yAEVjCHpaFkQXdPaPC4LGa9Zhb66vt3rS3M=
 github.com/IBM/ibm-cos-sdk-go v1.14.0/go.mod h1:Nvo9K1YYlJ3NtolQnnbOwV5MFre24YhnRuMzheMakeI=
 github.com/IBM/keyprotect-go-client v0.15.1 h1:m4qzqF5zOumRxKZ8s7vtK7A/UV/D278L8xpRG+WgT0s=
 github.com/IBM/keyprotect-go-client v0.15.1/go.mod h1:asXtHwL/4uCHA221Vd/7SkXEi2pcRHDzPyyksc1DthE=
-github.com/IBM/networking-go-sdk v0.30.0 h1:GUfvq4AOK0iTUEodPL2k812y2W1GdZs6hUTa81KUKys=
-github.com/IBM/networking-go-sdk v0.30.0/go.mod h1:tVxXclpQs8nQJYPTr9ZPNC1voaPNQLy8iy/72oVfFtM=
+github.com/IBM/networking-go-sdk v0.53.1 h1:WDu3HjRE4tm5rYmzvQ09DHeyEo4c6iEOUdWVvtrbDjQ=
+github.com/IBM/networking-go-sdk v0.53.1/go.mod h1:TAXWyBUk3C3R7aS1m84EfKdnDcBMZMAClwLfDj/SYZc=
 github.com/IBM/platform-services-go-sdk v0.97.2 h1:CdiLSFB0+oaAsucgVnpwn31YTAr47qFROPes4zXJalk=
 github.com/IBM/platform-services-go-sdk v0.97.2/go.mod h1:t93mozFmKrxexnKNdx2gNOtEI9Wd62dKAVffQYm0vRM=
 github.com/IBM/vpc-go-sdk v0.83.2 h1:RLMha7+buktU9hrhvAMF2QRHIvxaAsuU14W6akybJqs=
@@ -561,7 +560,6 @@ github.com/go-openapi/jsonreference v0.20.2/go.mod h1:Bl1zwGIM8/wsvqjsOQLJ/SH+En
 github.com/go-openapi/strfmt v0.19.4/go.mod h1:eftuHTlB/dI8Uq8JJOyRlieZf+WkkxUuk0dgdHXr2Qk=
 github.com/go-openapi/strfmt v0.19.10/go.mod h1:qBBipho+3EoIqn6YDI+4RnQEtj6jT/IdKm+PAlXxSUc=
 github.com/go-openapi/strfmt v0.20.1/go.mod h1:43urheQI9dNtE5lTZQfuFJvjYJKPrxicATpEfZwHUNk=
-github.com/go-openapi/strfmt v0.20.2/go.mod h1:43urheQI9dNtE5lTZQfuFJvjYJKPrxicATpEfZwHUNk=
 github.com/go-openapi/strfmt v0.26.1 h1:7zGCHji7zSYDC2tCXIusoxYQz/48jAf2q+sF6wXTG+c=
 github.com/go-openapi/strfmt v0.26.1/go.mod h1:Zslk5VZPOISLwmWTMBIS7oiVFem1o1EI6zULY8Uer7Y=
 github.com/go-openapi/swag v0.22.3/go.mod h1:UzaqsxGiab7freDnrUUra0MwWfN/q7tE4j+VcZ0yl14=
@@ -1107,7 +1105,6 @@ github.com/onsi/ginkgo v1.16.5/go.mod h1:+E8gABHa3K6zRBolWtd+ROzc/U5bkGt0FwiG042
 github.com/onsi/gomega v1.7.1/go.mod h1:XdKZgCCFLUoM/7CFJVPcG8C1xQ1AJ0vpAezJrB7JYyY=
 github.com/onsi/gomega v1.10.1/go.mod h1:iN09h71vgCQne3DLsj+A5owkum+a2tYe+TOCB1ybHNo=
 github.com/onsi/gomega v1.10.3/go.mod h1:V9xEwhxec5O8UDM77eCW8vLymOMltsqPVYWrpDsH8xc=
-github.com/onsi/gomega v1.10.5/go.mod h1:gza4q3jKQJijlu05nKWRCW/GavJumGt8aNRxWg7mt48=
 github.com/onsi/gomega v1.13.0/go.mod h1:lRk9szgn8TxENtWd0Tp4c3wjlRfMTMH27I+3Je41yGY=
 github.com/onsi/gomega v1.38.2 h1:eZCjf2xjZAqe+LeWvKb5weQ+NcPwX84kqJ0cZNxok2A=
 github.com/onsi/gomega v1.38.2/go.mod h1:W2MJcYxRGV63b418Ai34Ud0hEdTVXq9NW9+Sx6uXf3k=
@@ -1698,7 +1695,6 @@ golang.org/x/net v0.0.0-20200822124328-c89045814202/go.mod h1:/O7V0waA8r7cgGh81R
 golang.org/x/net v0.0.0-20201006153459-a7d1128ccaa0/go.mod h1:sp8m0HH+o8qH0wwXwYZr8TS3Oi6o0r6Gce1SSxlDquU=
 golang.org/x/net v0.0.0-20201021035429-f5854403a974/go.mod h1:sp8m0HH+o8qH0wwXwYZr8TS3Oi6o0r6Gce1SSxlDquU=
 golang.org/x/net v0.0.0-20201031054903-ff519b6c9102/go.mod h1:sp8m0HH+o8qH0wwXwYZr8TS3Oi6o0r6Gce1SSxlDquU=
-golang.org/x/net v0.0.0-20201202161906-c7110b5ffcbb/go.mod h1:sp8m0HH+o8qH0wwXwYZr8TS3Oi6o0r6Gce1SSxlDquU=
 golang.org/x/net v0.0.0-20201209123823-ac852fbbde11/go.mod h1:m0MpNAwzfU5UDzcl9v0D8zg8gWTRqZa9RBIspLL5mdg=
 golang.org/x/net v0.0.0-20201224014010-6772e930b67b/go.mod h1:m0MpNAwzfU5UDzcl9v0D8zg8gWTRqZa9RBIspLL5mdg=
 golang.org/x/net v0.0.0-20210226172049-e18ecbb05110/go.mod h1:m0MpNAwzfU5UDzcl9v0D8zg8gWTRqZa9RBIspLL5mdg=

--- a/providers/ibm/ibm_dl.go
+++ b/providers/ibm/ibm_dl.go
@@ -18,10 +18,10 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/chenrui333/terraformer/terraformutils"
 	"github.com/IBM/go-sdk-core/v4/core"
 	dlProviderV2 "github.com/IBM/networking-go-sdk/directlinkproviderv2"
 	dl "github.com/IBM/networking-go-sdk/directlinkv1"
+	"github.com/chenrui333/terraformer/terraformutils"
 )
 
 // DLGenerator ...
@@ -89,19 +89,24 @@ func (g *DLGenerator) InitResources() error {
 	}
 	if gateways.Gateways != nil {
 		for _, gateway := range gateways.Gateways {
-			g.Resources = append(g.Resources, g.createDirectLinkGatewayResources(*gateway.ID, *gateway.Name))
+			gatewayID, gatewayName, err := directLinkGatewayIDName(gateway)
+			if err != nil {
+				return err
+			}
+
+			g.Resources = append(g.Resources, g.createDirectLinkGatewayResources(*gatewayID, *gatewayName))
 			resourceName := g.Resources[len(g.Resources)-1:][0].ResourceName
 			var dependsOn []string
 			dependsOn = append(dependsOn, "ibm_dl_gateway."+resourceName)
 			listGatewayVirtualConnectionsOptions := &dl.ListGatewayVirtualConnectionsOptions{
-				GatewayID: gateway.ID,
+				GatewayID: gatewayID,
 			}
 			connections, response, err := dlclient.ListGatewayVirtualConnections(listGatewayVirtualConnectionsOptions)
 			if err != nil {
 				return fmt.Errorf("Error Fetching Direct Link Virtual connections %s\n%s", err, response)
 			}
 			for _, connection := range connections.VirtualConnections {
-				g.Resources = append(g.Resources, g.createDirectLinkVirtualConnectionResources(*gateway.ID, *connection.ID, *connection.Name, dependsOn))
+				g.Resources = append(g.Resources, g.createDirectLinkVirtualConnectionResources(*gatewayID, *connection.ID, *connection.Name, dependsOn))
 			}
 		}
 	}
@@ -140,4 +145,29 @@ func (g *DLGenerator) InitResources() error {
 		g.Resources = append(g.Resources, g.createDirectLinkProviderGatewayResources(*providerGateway.ID, *providerGateway.Name))
 	}
 	return nil
+}
+
+func directLinkGatewayIDName(gateway dl.GatewayCollectionGatewaysItemIntf) (*string, *string, error) {
+	var id *string
+	var name *string
+
+	switch gateway := gateway.(type) {
+	case *dl.GatewayCollectionGatewaysItem:
+		id = gateway.ID
+		name = gateway.Name
+	case *dl.GatewayCollectionGatewaysItemGateway:
+		id = gateway.ID
+		name = gateway.Name
+	case *dl.GatewayCollectionGatewaysItemCrossAccountGateway:
+		id = gateway.ID
+		name = gateway.Name
+	default:
+		return nil, nil, fmt.Errorf("unsupported Direct Link gateway type %T", gateway)
+	}
+
+	if id == nil || name == nil {
+		return nil, nil, fmt.Errorf("direct link gateway missing id or name")
+	}
+
+	return id, name, nil
 }


### PR DESCRIPTION
Summary
- update github.com/IBM/networking-go-sdk from v0.30.0 to v0.53.1
- adapt Direct Link gateway import to the current gateway collection item interface types

References
- https://pkg.go.dev/github.com/IBM/networking-go-sdk/directlinkv1#GatewayCollectionGatewaysItemIntf
- https://pkg.go.dev/github.com/IBM/networking-go-sdk/directlinkv1#GatewayCollectionGatewaysItemGateway
- https://pkg.go.dev/github.com/IBM/networking-go-sdk/directlinkv1#GatewayCollectionGatewaysItemCrossAccountGateway

Refs #155
