### PR TITLE
aws(msk): add support for 7 additional MSK resource types

### DIFF
--- a/docs/aws.md
+++ b/docs/aws.md
@@ -216,6 +216,13 @@ terraformer import aws --resources=sg --regions=us-east-1
     * `aws_mq_broker`
 *   `msk`
     * `aws_msk_cluster`
+    * `aws_msk_cluster_policy`
+    * `aws_msk_configuration`
+    * `aws_msk_replicator`
+    * `aws_msk_scram_secret_association`
+    * `aws_msk_serverless_cluster`
+    * `aws_msk_single_scram_secret_association`
+    * `aws_msk_vpc_connection`
 *   `nacl`
     * `aws_network_acl`
 *   `nat`

--- a/providers/aws/msk.go
+++ b/providers/aws/msk.go
@@ -219,12 +219,17 @@ func (g *MskGenerator) loadMskScramSecretAssociations(svc *kafka.Client) error {
 			sp := kafka.NewListScramSecretsPaginator(svc, &kafka.ListScramSecretsInput{
 				ClusterArn: &clusterArn,
 			})
+			var scramErr error
 			for sp.HasMorePages() {
 				secretPage, err := sp.NextPage(context.TODO())
 				if err != nil {
-					return err
+					scramErr = err
+					break
 				}
 				secretArns = append(secretArns, secretPage.SecretArnList...)
+			}
+			if scramErr != nil {
+				continue
 			}
 
 			if len(secretArns) == 0 {

--- a/providers/aws/msk.go
+++ b/providers/aws/msk.go
@@ -14,6 +14,33 @@ import (
 
 var mskAllowEmptyValues = []string{"tags."}
 
+// mskVpcConnectionName extracts a resource name from a VPC connection ARN.
+// ARN format: arn:aws:kafka:region:account:vpc-connection/account/name/uuid
+func mskVpcConnectionName(arn string) string {
+	if parts := strings.Split(arn, "/"); len(parts) >= 3 {
+		return parts[len(parts)-2] + "-" + parts[len(parts)-1]
+	}
+	return arn
+}
+
+// mskClusterPolicyName extracts a resource name from a cluster ARN for policy resources.
+// ARN format: arn:aws:kafka:region:account:cluster/name/uuid
+func mskClusterPolicyName(clusterArn string) string {
+	if parts := strings.Split(clusterArn, "/"); len(parts) >= 2 {
+		return parts[1] + "-policy"
+	}
+	return clusterArn
+}
+
+// mskSecretName extracts the secret name from a Secrets Manager ARN.
+// ARN format: arn:aws:secretsmanager:region:account:secret:name-suffix
+func mskSecretName(secretArn string) string {
+	if parts := strings.Split(secretArn, ":"); len(parts) >= 7 {
+		return parts[6]
+	}
+	return secretArn
+}
+
 type MskGenerator struct {
 	AWSService
 }
@@ -86,14 +113,9 @@ func (g *MskGenerator) loadMskVpcConnections(svc *kafka.Client) error {
 			return err
 		}
 		for _, vpcConn := range page.VpcConnections {
-			// ARN format: arn:aws:kafka:region:account:vpc-connection/account/name/uuid
-			resourceName := StringValue(vpcConn.VpcConnectionArn)
-			if parts := strings.Split(resourceName, "/"); len(parts) >= 3 {
-				resourceName = parts[len(parts)-2] + "-" + parts[len(parts)-1]
-			}
 			g.Resources = append(g.Resources, terraformutils.NewSimpleResource(
 				StringValue(vpcConn.VpcConnectionArn),
-				resourceName,
+				mskVpcConnectionName(StringValue(vpcConn.VpcConnectionArn)),
 				"aws_msk_vpc_connection",
 				"aws",
 				mskAllowEmptyValues,
@@ -164,15 +186,9 @@ func (g *MskGenerator) loadMskClusterPolicies(svc *kafka.Client) error {
 			continue
 		}
 
-		// ARN format: arn:aws:kafka:region:account:cluster/name/uuid
-		resourceName := clusterArn
-		if parts := strings.Split(clusterArn, "/"); len(parts) >= 2 {
-			resourceName = parts[1] + "-policy"
-		}
-
 		g.Resources = append(g.Resources, terraformutils.NewSimpleResource(
 			clusterArn,
-			resourceName,
+			mskClusterPolicyName(clusterArn),
 			"aws_msk_cluster_policy",
 			"aws",
 			mskAllowEmptyValues,
@@ -222,15 +238,9 @@ func (g *MskGenerator) loadMskScramSecretAssociations(svc *kafka.Client) error {
 			for _, secretArn := range secretArns {
 				importID := clusterArn + "," + secretArn
 
-				// ARN format: arn:aws:secretsmanager:region:account:secret:name-suffix
-				secretName := secretArn
-				if parts := strings.Split(secretArn, ":"); len(parts) >= 7 {
-					secretName = parts[6]
-				}
-
 				g.Resources = append(g.Resources, terraformutils.NewSimpleResource(
 					importID,
-					clusterName+"-"+secretName,
+					clusterName+"-"+mskSecretName(secretArn),
 					"aws_msk_single_scram_secret_association",
 					"aws",
 					mskAllowEmptyValues,

--- a/providers/aws/msk.go
+++ b/providers/aws/msk.go
@@ -4,8 +4,11 @@ package aws
 
 import (
 	"context"
+	"sort"
+	"strings"
 
 	"github.com/aws/aws-sdk-go-v2/service/kafka"
+	"github.com/aws/aws-sdk-go-v2/service/kafka/types"
 	"github.com/chenrui333/terraformer/terraformutils"
 )
 
@@ -15,12 +18,7 @@ type MskGenerator struct {
 	AWSService
 }
 
-func (g *MskGenerator) InitResources() error {
-	config, e := g.generateConfig()
-	if e != nil {
-		return e
-	}
-	svc := kafka.NewFromConfig(config)
+func (g *MskGenerator) loadMskClusters(svc *kafka.Client) error {
 	p := kafka.NewListClustersPaginator(svc, &kafka.ListClustersInput{})
 	for p.HasMorePages() {
 		page, err := p.NextPage(context.TODO())
@@ -36,6 +34,244 @@ func (g *MskGenerator) InitResources() error {
 				mskAllowEmptyValues,
 			))
 		}
+	}
+	return nil
+}
+
+func (g *MskGenerator) loadMskConfigurations(svc *kafka.Client) error {
+	p := kafka.NewListConfigurationsPaginator(svc, &kafka.ListConfigurationsInput{})
+	for p.HasMorePages() {
+		page, err := p.NextPage(context.TODO())
+		if err != nil {
+			return err
+		}
+		for _, config := range page.Configurations {
+			g.Resources = append(g.Resources, terraformutils.NewSimpleResource(
+				StringValue(config.Arn),
+				StringValue(config.Name),
+				"aws_msk_configuration",
+				"aws",
+				mskAllowEmptyValues,
+			))
+		}
+	}
+	return nil
+}
+
+func (g *MskGenerator) loadMskReplicators(svc *kafka.Client) error {
+	p := kafka.NewListReplicatorsPaginator(svc, &kafka.ListReplicatorsInput{})
+	for p.HasMorePages() {
+		page, err := p.NextPage(context.TODO())
+		if err != nil {
+			return err
+		}
+		for _, replicator := range page.Replicators {
+			g.Resources = append(g.Resources, terraformutils.NewSimpleResource(
+				StringValue(replicator.ReplicatorArn),
+				StringValue(replicator.ReplicatorName),
+				"aws_msk_replicator",
+				"aws",
+				mskAllowEmptyValues,
+			))
+		}
+	}
+	return nil
+}
+
+func (g *MskGenerator) loadMskVpcConnections(svc *kafka.Client) error {
+	p := kafka.NewListVpcConnectionsPaginator(svc, &kafka.ListVpcConnectionsInput{})
+	for p.HasMorePages() {
+		page, err := p.NextPage(context.TODO())
+		if err != nil {
+			return err
+		}
+		for _, vpcConn := range page.VpcConnections {
+			// ARN format: arn:aws:kafka:region:account:vpc-connection/account/name/uuid
+			resourceName := StringValue(vpcConn.VpcConnectionArn)
+			if parts := strings.Split(resourceName, "/"); len(parts) >= 3 {
+				resourceName = parts[len(parts)-2] + "-" + parts[len(parts)-1]
+			}
+			g.Resources = append(g.Resources, terraformutils.NewSimpleResource(
+				StringValue(vpcConn.VpcConnectionArn),
+				resourceName,
+				"aws_msk_vpc_connection",
+				"aws",
+				mskAllowEmptyValues,
+			))
+		}
+	}
+	return nil
+}
+
+func (g *MskGenerator) loadMskServerlessClusters(svc *kafka.Client) error {
+	serverlessFilter := string(types.ClusterTypeServerless)
+	p := kafka.NewListClustersV2Paginator(svc, &kafka.ListClustersV2Input{
+		ClusterTypeFilter: &serverlessFilter,
+	})
+	for p.HasMorePages() {
+		page, err := p.NextPage(context.TODO())
+		if err != nil {
+			return err
+		}
+		for _, cluster := range page.ClusterInfoList {
+			g.Resources = append(g.Resources, terraformutils.NewSimpleResource(
+				StringValue(cluster.ClusterArn),
+				StringValue(cluster.ClusterName),
+				"aws_msk_serverless_cluster",
+				"aws",
+				mskAllowEmptyValues,
+			))
+		}
+	}
+	return nil
+}
+
+func (g *MskGenerator) loadMskClusterPolicies(svc *kafka.Client) error {
+	clusterArns := []string{}
+
+	p := kafka.NewListClustersPaginator(svc, &kafka.ListClustersInput{})
+	for p.HasMorePages() {
+		page, err := p.NextPage(context.TODO())
+		if err != nil {
+			return err
+		}
+		for _, cluster := range page.ClusterInfoList {
+			clusterArns = append(clusterArns, StringValue(cluster.ClusterArn))
+		}
+	}
+
+	serverlessFilter := string(types.ClusterTypeServerless)
+	pv2 := kafka.NewListClustersV2Paginator(svc, &kafka.ListClustersV2Input{
+		ClusterTypeFilter: &serverlessFilter,
+	})
+	for pv2.HasMorePages() {
+		page, err := pv2.NextPage(context.TODO())
+		if err != nil {
+			return err
+		}
+		for _, cluster := range page.ClusterInfoList {
+			clusterArns = append(clusterArns, StringValue(cluster.ClusterArn))
+		}
+	}
+
+	sort.Strings(clusterArns)
+
+	for _, clusterArn := range clusterArns {
+		_, err := svc.GetClusterPolicy(context.TODO(), &kafka.GetClusterPolicyInput{
+			ClusterArn: &clusterArn,
+		})
+		if err != nil {
+			continue
+		}
+
+		// ARN format: arn:aws:kafka:region:account:cluster/name/uuid
+		resourceName := clusterArn
+		if parts := strings.Split(clusterArn, "/"); len(parts) >= 2 {
+			resourceName = parts[1] + "-policy"
+		}
+
+		g.Resources = append(g.Resources, terraformutils.NewSimpleResource(
+			clusterArn,
+			resourceName,
+			"aws_msk_cluster_policy",
+			"aws",
+			mskAllowEmptyValues,
+		))
+	}
+
+	return nil
+}
+
+func (g *MskGenerator) loadMskScramSecretAssociations(svc *kafka.Client) error {
+	p := kafka.NewListClustersPaginator(svc, &kafka.ListClustersInput{})
+	for p.HasMorePages() {
+		page, err := p.NextPage(context.TODO())
+		if err != nil {
+			return err
+		}
+		for _, cluster := range page.ClusterInfoList {
+			clusterArn := StringValue(cluster.ClusterArn)
+			clusterName := StringValue(cluster.ClusterName)
+
+			secretArns := []string{}
+			sp := kafka.NewListScramSecretsPaginator(svc, &kafka.ListScramSecretsInput{
+				ClusterArn: &clusterArn,
+			})
+			for sp.HasMorePages() {
+				secretPage, err := sp.NextPage(context.TODO())
+				if err != nil {
+					break
+				}
+				secretArns = append(secretArns, secretPage.SecretArnList...)
+			}
+
+			if len(secretArns) == 0 {
+				continue
+			}
+
+			sort.Strings(secretArns)
+
+			g.Resources = append(g.Resources, terraformutils.NewSimpleResource(
+				clusterArn,
+				clusterName+"-scram-secrets",
+				"aws_msk_scram_secret_association",
+				"aws",
+				mskAllowEmptyValues,
+			))
+
+			for _, secretArn := range secretArns {
+				importID := clusterArn + "," + secretArn
+
+				// ARN format: arn:aws:secretsmanager:region:account:secret:name-suffix
+				secretName := secretArn
+				if parts := strings.Split(secretArn, ":"); len(parts) >= 7 {
+					secretName = parts[6]
+					if idx := strings.LastIndex(secretName, "-"); idx > 0 && len(secretName)-idx <= 7 {
+						secretName = secretName[:idx]
+					}
+				}
+
+				g.Resources = append(g.Resources, terraformutils.NewSimpleResource(
+					importID,
+					clusterName+"-"+secretName,
+					"aws_msk_single_scram_secret_association",
+					"aws",
+					mskAllowEmptyValues,
+				))
+			}
+		}
+	}
+
+	return nil
+}
+
+func (g *MskGenerator) InitResources() error {
+	config, e := g.generateConfig()
+	if e != nil {
+		return e
+	}
+	svc := kafka.NewFromConfig(config)
+
+	if err := g.loadMskClusters(svc); err != nil {
+		return err
+	}
+	if err := g.loadMskConfigurations(svc); err != nil {
+		return err
+	}
+	if err := g.loadMskReplicators(svc); err != nil {
+		return err
+	}
+	if err := g.loadMskVpcConnections(svc); err != nil {
+		return err
+	}
+	if err := g.loadMskServerlessClusters(svc); err != nil {
+		return err
+	}
+	if err := g.loadMskClusterPolicies(svc); err != nil {
+		return err
+	}
+	if err := g.loadMskScramSecretAssociations(svc); err != nil {
+		return err
 	}
 
 	return nil

--- a/providers/aws/msk.go
+++ b/providers/aws/msk.go
@@ -4,11 +4,13 @@ package aws
 
 import (
 	"context"
+	"errors"
 	"sort"
 	"strings"
 
 	"github.com/aws/aws-sdk-go-v2/service/kafka"
 	"github.com/aws/aws-sdk-go-v2/service/kafka/types"
+	"github.com/aws/smithy-go"
 	"github.com/chenrui333/terraformer/terraformutils"
 )
 
@@ -35,7 +37,7 @@ func mskClusterPolicyName(clusterArn string) string {
 // mskSecretName extracts the secret name from a Secrets Manager ARN.
 // ARN format: arn:aws:secretsmanager:region:account:secret:name-suffix
 func mskSecretName(secretArn string) string {
-	if parts := strings.Split(secretArn, ":"); len(parts) >= 7 {
+	if parts := strings.SplitN(secretArn, ":", 7); len(parts) == 7 {
 		return parts[6]
 	}
 	return secretArn
@@ -183,7 +185,11 @@ func (g *MskGenerator) loadMskClusterPolicies(svc *kafka.Client) error {
 			ClusterArn: &clusterArn,
 		})
 		if err != nil {
-			continue
+			var apiErr smithy.APIError
+			if errors.As(err, &apiErr) && apiErr.ErrorCode() == "NotFoundException" {
+				continue
+			}
+			return err
 		}
 
 		g.Resources = append(g.Resources, terraformutils.NewSimpleResource(

--- a/providers/aws/msk.go
+++ b/providers/aws/msk.go
@@ -200,7 +200,7 @@ func (g *MskGenerator) loadMskScramSecretAssociations(svc *kafka.Client) error {
 			for sp.HasMorePages() {
 				secretPage, err := sp.NextPage(context.TODO())
 				if err != nil {
-					break
+					return err
 				}
 				secretArns = append(secretArns, secretPage.SecretArnList...)
 			}
@@ -226,9 +226,6 @@ func (g *MskGenerator) loadMskScramSecretAssociations(svc *kafka.Client) error {
 				secretName := secretArn
 				if parts := strings.Split(secretArn, ":"); len(parts) >= 7 {
 					secretName = parts[6]
-					if idx := strings.LastIndex(secretName, "-"); idx > 0 && len(secretName)-idx <= 7 {
-						secretName = secretName[:idx]
-					}
 				}
 
 				g.Resources = append(g.Resources, terraformutils.NewSimpleResource(

--- a/providers/aws/msk_test.go
+++ b/providers/aws/msk_test.go
@@ -87,15 +87,15 @@ func TestMskSecretNameExtraction(t *testing.T) {
 	}{
 		{
 			secretArn:    "arn:aws:secretsmanager:us-east-1:123456789012:secret:my-secret-AbCdEf",
-			expectedName: "my-secret",
+			expectedName: "my-secret-AbCdEf",
 		},
 		{
 			secretArn:    "arn:aws:secretsmanager:us-east-1:123456789012:secret:kafka-credentials-XyZ123",
-			expectedName: "kafka-credentials",
+			expectedName: "kafka-credentials-XyZ123",
 		},
 		{
-			secretArn:    "arn:aws:secretsmanager:us-east-1:123456789012:secret:my-secret-with-longersuffix",
-			expectedName: "my-secret-with-longersuffix",
+			secretArn:    "arn:aws:secretsmanager:us-east-1:123456789012:secret:my-secret-prod",
+			expectedName: "my-secret-prod",
 		},
 	}
 
@@ -103,9 +103,6 @@ func TestMskSecretNameExtraction(t *testing.T) {
 		secretName := tc.secretArn
 		if parts := strings.Split(tc.secretArn, ":"); len(parts) >= 7 {
 			secretName = parts[6]
-			if idx := strings.LastIndex(secretName, "-"); idx > 0 && len(secretName)-idx <= 7 {
-				secretName = secretName[:idx]
-			}
 		}
 		if secretName != tc.expectedName {
 			t.Errorf("Secret name extraction: expected %s, got %s (from %s)", tc.expectedName, secretName, tc.secretArn)

--- a/providers/aws/msk_test.go
+++ b/providers/aws/msk_test.go
@@ -1,0 +1,126 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package aws
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestMskVpcConnectionResourceName(t *testing.T) {
+	testCases := []struct {
+		arn          string
+		expectedName string
+	}{
+		{
+			arn:          "arn:aws:kafka:us-east-1:123456789012:vpc-connection/123456789012/my-connection/abc123-def456",
+			expectedName: "my-connection-abc123-def456",
+		},
+		{
+			arn:          "arn:aws:kafka:eu-west-1:987654321098:vpc-connection/987654321098/test-vpc-conn/xyz789",
+			expectedName: "test-vpc-conn-xyz789",
+		},
+	}
+
+	for _, tc := range testCases {
+		resourceName := tc.arn
+		if parts := strings.Split(resourceName, "/"); len(parts) >= 3 {
+			resourceName = parts[len(parts)-2] + "-" + parts[len(parts)-1]
+		}
+		if resourceName != tc.expectedName {
+			t.Errorf("VPC connection resource name: expected %s, got %s", tc.expectedName, resourceName)
+		}
+	}
+}
+
+func TestMskClusterPolicyResourceName(t *testing.T) {
+	testCases := []struct {
+		arn          string
+		expectedName string
+	}{
+		{
+			arn:          "arn:aws:kafka:us-east-1:123456789012:cluster/my-cluster/abc123-def456",
+			expectedName: "my-cluster-policy",
+		},
+		{
+			arn:          "arn:aws:kafka:eu-west-1:987654321098:cluster/production-kafka/xyz789",
+			expectedName: "production-kafka-policy",
+		},
+	}
+
+	for _, tc := range testCases {
+		resourceName := tc.arn
+		if parts := strings.Split(tc.arn, "/"); len(parts) >= 2 {
+			resourceName = parts[1] + "-policy"
+		}
+		if resourceName != tc.expectedName {
+			t.Errorf("Cluster policy resource name: expected %s, got %s", tc.expectedName, resourceName)
+		}
+	}
+}
+
+func TestMskSingleScramSecretImportID(t *testing.T) {
+	testCases := []struct {
+		clusterArn string
+		secretArn  string
+		expectedID string
+	}{
+		{
+			clusterArn: "arn:aws:kafka:us-east-1:123456789012:cluster/my-cluster/abc123",
+			secretArn:  "arn:aws:secretsmanager:us-east-1:123456789012:secret:my-secret-AbCdEf",
+			expectedID: "arn:aws:kafka:us-east-1:123456789012:cluster/my-cluster/abc123,arn:aws:secretsmanager:us-east-1:123456789012:secret:my-secret-AbCdEf",
+		},
+	}
+
+	for _, tc := range testCases {
+		importID := tc.clusterArn + "," + tc.secretArn
+		if importID != tc.expectedID {
+			t.Errorf("Single SCRAM secret import ID: expected %s, got %s", tc.expectedID, importID)
+		}
+	}
+}
+
+func TestMskSecretNameExtraction(t *testing.T) {
+	testCases := []struct {
+		secretArn    string
+		expectedName string
+	}{
+		{
+			secretArn:    "arn:aws:secretsmanager:us-east-1:123456789012:secret:my-secret-AbCdEf",
+			expectedName: "my-secret",
+		},
+		{
+			secretArn:    "arn:aws:secretsmanager:us-east-1:123456789012:secret:kafka-credentials-XyZ123",
+			expectedName: "kafka-credentials",
+		},
+		{
+			secretArn:    "arn:aws:secretsmanager:us-east-1:123456789012:secret:my-secret-with-longersuffix",
+			expectedName: "my-secret-with-longersuffix",
+		},
+	}
+
+	for _, tc := range testCases {
+		secretName := tc.secretArn
+		if parts := strings.Split(tc.secretArn, ":"); len(parts) >= 7 {
+			secretName = parts[6]
+			if idx := strings.LastIndex(secretName, "-"); idx > 0 && len(secretName)-idx <= 7 {
+				secretName = secretName[:idx]
+			}
+		}
+		if secretName != tc.expectedName {
+			t.Errorf("Secret name extraction: expected %s, got %s (from %s)", tc.expectedName, secretName, tc.secretArn)
+		}
+	}
+}
+
+func TestMskAllowEmptyValues(t *testing.T) {
+	expected := []string{"tags."}
+	if len(mskAllowEmptyValues) != len(expected) {
+		t.Errorf("mskAllowEmptyValues length: expected %d, got %d", len(expected), len(mskAllowEmptyValues))
+	}
+	for i, v := range expected {
+		if mskAllowEmptyValues[i] != v {
+			t.Errorf("mskAllowEmptyValues[%d]: expected %s, got %s", i, v, mskAllowEmptyValues[i])
+		}
+	}
+}

--- a/providers/aws/msk_test.go
+++ b/providers/aws/msk_test.go
@@ -8,82 +8,121 @@ import (
 
 func TestMskVpcConnectionName(t *testing.T) {
 	testCases := []struct {
+		name         string
 		arn          string
 		expectedName string
 	}{
 		{
+			name:         "standard vpc connection arn",
 			arn:          "arn:aws:kafka:us-east-1:123456789012:vpc-connection/123456789012/my-connection/abc123-def456",
 			expectedName: "my-connection-abc123-def456",
 		},
 		{
+			name:         "different region and account",
 			arn:          "arn:aws:kafka:eu-west-1:987654321098:vpc-connection/987654321098/test-vpc-conn/xyz789",
 			expectedName: "test-vpc-conn-xyz789",
 		},
 		{
+			name:         "no slashes fallback",
 			arn:          "no-slashes",
 			expectedName: "no-slashes",
+		},
+		{
+			name:         "empty string",
+			arn:          "",
+			expectedName: "",
 		},
 	}
 
 	for _, tc := range testCases {
-		if got := mskVpcConnectionName(tc.arn); got != tc.expectedName {
-			t.Errorf("mskVpcConnectionName(%q) = %q, want %q", tc.arn, got, tc.expectedName)
-		}
+		t.Run(tc.name, func(t *testing.T) {
+			if got := mskVpcConnectionName(tc.arn); got != tc.expectedName {
+				t.Errorf("mskVpcConnectionName(%q) = %q, want %q", tc.arn, got, tc.expectedName)
+			}
+		})
 	}
 }
 
 func TestMskClusterPolicyName(t *testing.T) {
 	testCases := []struct {
+		name         string
 		arn          string
 		expectedName string
 	}{
 		{
+			name:         "standard cluster arn",
 			arn:          "arn:aws:kafka:us-east-1:123456789012:cluster/my-cluster/abc123-def456",
 			expectedName: "my-cluster-policy",
 		},
 		{
+			name:         "different region and account",
 			arn:          "arn:aws:kafka:eu-west-1:987654321098:cluster/production-kafka/xyz789",
 			expectedName: "production-kafka-policy",
 		},
 		{
+			name:         "no slashes fallback",
 			arn:          "no-slashes",
 			expectedName: "no-slashes",
+		},
+		{
+			name:         "empty string",
+			arn:          "",
+			expectedName: "",
 		},
 	}
 
 	for _, tc := range testCases {
-		if got := mskClusterPolicyName(tc.arn); got != tc.expectedName {
-			t.Errorf("mskClusterPolicyName(%q) = %q, want %q", tc.arn, got, tc.expectedName)
-		}
+		t.Run(tc.name, func(t *testing.T) {
+			if got := mskClusterPolicyName(tc.arn); got != tc.expectedName {
+				t.Errorf("mskClusterPolicyName(%q) = %q, want %q", tc.arn, got, tc.expectedName)
+			}
+		})
 	}
 }
 
 func TestMskSecretName(t *testing.T) {
 	testCases := []struct {
+		name         string
 		secretArn    string
 		expectedName string
 	}{
 		{
+			name:         "standard secret arn",
 			secretArn:    "arn:aws:secretsmanager:us-east-1:123456789012:secret:my-secret-AbCdEf",
 			expectedName: "my-secret-AbCdEf",
 		},
 		{
+			name:         "secret with different suffix",
 			secretArn:    "arn:aws:secretsmanager:us-east-1:123456789012:secret:kafka-credentials-XyZ123",
 			expectedName: "kafka-credentials-XyZ123",
 		},
 		{
+			name:         "secret name ending in -prod",
 			secretArn:    "arn:aws:secretsmanager:us-east-1:123456789012:secret:my-secret-prod",
 			expectedName: "my-secret-prod",
 		},
 		{
+			name:         "secret name with colons",
+			secretArn:    "arn:aws:secretsmanager:us-east-1:123456789012:secret:path/to:name:with:colons",
+			expectedName: "path/to:name:with:colons",
+		},
+		{
+			name:         "short arn fallback",
 			secretArn:    "short:arn",
 			expectedName: "short:arn",
+		},
+		{
+			name:         "empty string",
+			secretArn:    "",
+			expectedName: "",
 		},
 	}
 
 	for _, tc := range testCases {
-		if got := mskSecretName(tc.secretArn); got != tc.expectedName {
-			t.Errorf("mskSecretName(%q) = %q, want %q", tc.secretArn, got, tc.expectedName)
-		}
+		t.Run(tc.name, func(t *testing.T) {
+			if got := mskSecretName(tc.secretArn); got != tc.expectedName {
+				t.Errorf("mskSecretName(%q) = %q, want %q", tc.secretArn, got, tc.expectedName)
+			}
+		})
 	}
 }

--- a/providers/aws/msk_test.go
+++ b/providers/aws/msk_test.go
@@ -3,11 +3,10 @@
 package aws
 
 import (
-	"strings"
 	"testing"
 )
 
-func TestMskVpcConnectionResourceName(t *testing.T) {
+func TestMskVpcConnectionName(t *testing.T) {
 	testCases := []struct {
 		arn          string
 		expectedName string
@@ -20,20 +19,20 @@ func TestMskVpcConnectionResourceName(t *testing.T) {
 			arn:          "arn:aws:kafka:eu-west-1:987654321098:vpc-connection/987654321098/test-vpc-conn/xyz789",
 			expectedName: "test-vpc-conn-xyz789",
 		},
+		{
+			arn:          "no-slashes",
+			expectedName: "no-slashes",
+		},
 	}
 
 	for _, tc := range testCases {
-		resourceName := tc.arn
-		if parts := strings.Split(resourceName, "/"); len(parts) >= 3 {
-			resourceName = parts[len(parts)-2] + "-" + parts[len(parts)-1]
-		}
-		if resourceName != tc.expectedName {
-			t.Errorf("VPC connection resource name: expected %s, got %s", tc.expectedName, resourceName)
+		if got := mskVpcConnectionName(tc.arn); got != tc.expectedName {
+			t.Errorf("mskVpcConnectionName(%q) = %q, want %q", tc.arn, got, tc.expectedName)
 		}
 	}
 }
 
-func TestMskClusterPolicyResourceName(t *testing.T) {
+func TestMskClusterPolicyName(t *testing.T) {
 	testCases := []struct {
 		arn          string
 		expectedName string
@@ -46,41 +45,20 @@ func TestMskClusterPolicyResourceName(t *testing.T) {
 			arn:          "arn:aws:kafka:eu-west-1:987654321098:cluster/production-kafka/xyz789",
 			expectedName: "production-kafka-policy",
 		},
-	}
-
-	for _, tc := range testCases {
-		resourceName := tc.arn
-		if parts := strings.Split(tc.arn, "/"); len(parts) >= 2 {
-			resourceName = parts[1] + "-policy"
-		}
-		if resourceName != tc.expectedName {
-			t.Errorf("Cluster policy resource name: expected %s, got %s", tc.expectedName, resourceName)
-		}
-	}
-}
-
-func TestMskSingleScramSecretImportID(t *testing.T) {
-	testCases := []struct {
-		clusterArn string
-		secretArn  string
-		expectedID string
-	}{
 		{
-			clusterArn: "arn:aws:kafka:us-east-1:123456789012:cluster/my-cluster/abc123",
-			secretArn:  "arn:aws:secretsmanager:us-east-1:123456789012:secret:my-secret-AbCdEf",
-			expectedID: "arn:aws:kafka:us-east-1:123456789012:cluster/my-cluster/abc123,arn:aws:secretsmanager:us-east-1:123456789012:secret:my-secret-AbCdEf",
+			arn:          "no-slashes",
+			expectedName: "no-slashes",
 		},
 	}
 
 	for _, tc := range testCases {
-		importID := tc.clusterArn + "," + tc.secretArn
-		if importID != tc.expectedID {
-			t.Errorf("Single SCRAM secret import ID: expected %s, got %s", tc.expectedID, importID)
+		if got := mskClusterPolicyName(tc.arn); got != tc.expectedName {
+			t.Errorf("mskClusterPolicyName(%q) = %q, want %q", tc.arn, got, tc.expectedName)
 		}
 	}
 }
 
-func TestMskSecretNameExtraction(t *testing.T) {
+func TestMskSecretName(t *testing.T) {
 	testCases := []struct {
 		secretArn    string
 		expectedName string
@@ -97,27 +75,15 @@ func TestMskSecretNameExtraction(t *testing.T) {
 			secretArn:    "arn:aws:secretsmanager:us-east-1:123456789012:secret:my-secret-prod",
 			expectedName: "my-secret-prod",
 		},
+		{
+			secretArn:    "short:arn",
+			expectedName: "short:arn",
+		},
 	}
 
 	for _, tc := range testCases {
-		secretName := tc.secretArn
-		if parts := strings.Split(tc.secretArn, ":"); len(parts) >= 7 {
-			secretName = parts[6]
-		}
-		if secretName != tc.expectedName {
-			t.Errorf("Secret name extraction: expected %s, got %s (from %s)", tc.expectedName, secretName, tc.secretArn)
-		}
-	}
-}
-
-func TestMskAllowEmptyValues(t *testing.T) {
-	expected := []string{"tags."}
-	if len(mskAllowEmptyValues) != len(expected) {
-		t.Errorf("mskAllowEmptyValues length: expected %d, got %d", len(expected), len(mskAllowEmptyValues))
-	}
-	for i, v := range expected {
-		if mskAllowEmptyValues[i] != v {
-			t.Errorf("mskAllowEmptyValues[%d]: expected %s, got %s", i, v, mskAllowEmptyValues[i])
+		if got := mskSecretName(tc.secretArn); got != tc.expectedName {
+			t.Errorf("mskSecretName(%q) = %q, want %q", tc.secretArn, got, tc.expectedName)
 		}
 	}
 }


### PR DESCRIPTION
Add support for importing 7 additional MSK resource types:

- `aws_msk_configuration`
- `aws_msk_serverless_cluster`
- `aws_msk_cluster_policy`
- `aws_msk_scram_secret_association`
- `aws_msk_single_scram_secret_association`
- `aws_msk_replicator`
- `aws_msk_vpc_connection`

Based on upstream GoogleCloudPlatform/terraformer#2126 (commit e19ecf0), adapted for this fork with SPDX license headers and updated module path.

Closes #181