### PR TITLE
fix(terraform): emit typed state attributes

### DIFF
--- a/.github/scripts/terraform-state-compat.sh
+++ b/.github/scripts/terraform-state-compat.sh
@@ -55,8 +55,8 @@ for minor in $minors; do
   terraform_version_output=$("$terraform_dir/terraform" version)
   printf '%s\n' "${terraform_version_output%%$'\n'*}"
 
-  PATH="$terraform_dir:$PATH" GOWORK=off go test ./terraformutils \
-    -run 'TestPrintTfState(WritesV4ProviderSourceState|CanBeListedByTerraformCLI)$' \
+  PATH="$terraform_dir:$PATH" GOWORK=off TERRAFORMER_TFSTATE_PLAN_TEST=1 go test ./terraformutils \
+    -run 'TestPrintTfState(WritesV4ProviderSourceState|CanBeListedByTerraformCLI|CanPlanWithTerraformCLI)$' \
     -count=1 \
     -v
   echo "::endgroup::"

--- a/cmd/import.go
+++ b/cmd/import.go
@@ -96,6 +96,7 @@ func Import(provider terraformutils.ProviderGenerator, options ImportOptions, ar
 	providerMapping.ConvertTFStates(providerWrapper)
 	// change structs with additional data for each resource
 	providerMapping.CleanupProviders()
+	providerMapping.ConvertTypedStates(providerWrapper)
 
 	err = importFromPlan(providerMapping, options, args)
 

--- a/terraformutils/providers_mapping.go
+++ b/terraformutils/providers_mapping.go
@@ -169,6 +169,15 @@ func (p *ProvidersMapping) ConvertTFStates(providerWrapper *providerwrapper.Prov
 	}
 }
 
+func (p *ProvidersMapping) ConvertTypedStates(providerWrapper *providerwrapper.ProviderWrapper) {
+	for resource := range p.Resources {
+		err := resource.ConvertTypedState(providerWrapper)
+		if err != nil {
+			log.Printf("failed to convert typed state for resource %s because of error %s", resource.InstanceInfo.Id, err)
+		}
+	}
+}
+
 func (p *ProvidersMapping) CleanupProviders() {
 	for provider := range p.Providers {
 		provider.GetService().PostRefreshCleanup()

--- a/terraformutils/resource.go
+++ b/terraformutils/resource.go
@@ -165,6 +165,10 @@ func (r *Resource) ConvertTFstate(provider *providerwrapper.ProviderWrapper) err
 }
 
 func (r *Resource) ConvertTypedState(provider *providerwrapper.ProviderWrapper) error {
+	if r.InstanceState.HasCurrentTypedAttributes() {
+		return nil
+	}
+
 	schema := provider.GetSchema()
 	resourceSchema, ok := schema.ResourceTypes[r.InstanceInfo.Type]
 	if !ok {
@@ -178,7 +182,7 @@ func (r *Resource) ConvertTypedState(provider *providerwrapper.ProviderWrapper) 
 	if err != nil {
 		return err
 	}
-	r.InstanceState.TypedAttributes = typedAttributes
+	r.InstanceState.SetTypedAttributes(typedAttributes)
 	return nil
 }
 

--- a/terraformutils/resource.go
+++ b/terraformutils/resource.go
@@ -164,6 +164,24 @@ func (r *Resource) ConvertTFstate(provider *providerwrapper.ProviderWrapper) err
 	return r.ParseTFstate(parser, impliedType)
 }
 
+func (r *Resource) ConvertTypedState(provider *providerwrapper.ProviderWrapper) error {
+	schema := provider.GetSchema()
+	resourceSchema, ok := schema.ResourceTypes[r.InstanceInfo.Type]
+	if !ok {
+		return fmt.Errorf("missing schema for resource type %q", r.InstanceInfo.Type)
+	}
+	value, err := r.InstanceState.AttrsAsObjectValue(resourceSchema.Block.ImpliedType())
+	if err != nil {
+		return err
+	}
+	typedAttributes, err := tfcompat.MarshalTypedAttributesFromValue(value)
+	if err != nil {
+		return err
+	}
+	r.InstanceState.TypedAttributes = typedAttributes
+	return nil
+}
+
 func (r *Resource) ServiceName() string {
 	return strings.TrimPrefix(r.InstanceInfo.Type, r.Provider+"_")
 }

--- a/terraformutils/state_test.go
+++ b/terraformutils/state_test.go
@@ -3,6 +3,7 @@
 package terraformutils
 
 import (
+	"bytes"
 	"encoding/json"
 	"os"
 	"os/exec"
@@ -116,6 +117,31 @@ func TestPrintTfStateFallsBackToAttributesFlat(t *testing.T) {
 	}
 }
 
+func TestConvertTypedStatePreservesCurrentTypedAttributes(t *testing.T) {
+	resource := NewResource(
+		"kind-lemur",
+		"example",
+		"random_pet",
+		"random",
+		nil,
+		nil,
+		nil,
+	)
+	resource.InstanceState = tfcompat.NewInstanceStateShimmedFromValue(cty.ObjectVal(map[string]cty.Value{
+		"id":        cty.StringVal("kind-lemur"),
+		"length":    cty.NumberIntVal(2),
+		"separator": cty.StringVal("-"),
+	}), 0)
+	originalTypedAttributes := append([]byte(nil), resource.InstanceState.TypedAttributes...)
+
+	if err := resource.ConvertTypedState(nil); err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(resource.InstanceState.TypedAttributes, originalTypedAttributes) {
+		t.Fatalf("typed attributes were re-derived: got %s, want %s", resource.InstanceState.TypedAttributes, originalTypedAttributes)
+	}
+}
+
 func TestPrintTfStateCanBeListedByTerraformCLI(t *testing.T) {
 	terraformPath, err := exec.LookPath("terraform")
 	if err != nil {
@@ -175,6 +201,7 @@ func TestPrintTfStateCanPlanWithTerraformCLI(t *testing.T) {
   required_providers {
     random = {
       source = "hashicorp/random"
+      version = "3.7.2"
     }
   }
 }

--- a/terraformutils/state_test.go
+++ b/terraformutils/state_test.go
@@ -74,6 +74,48 @@ func TestPrintTfStateWritesV4ProviderSourceState(t *testing.T) {
 	}
 }
 
+func TestPrintTfStateFallsBackToAttributesFlat(t *testing.T) {
+	resource := NewResource(
+		"vpc-123",
+		"main",
+		"aws_vpc",
+		"aws",
+		map[string]string{"cidr_block": "10.0.0.0/16"},
+		nil,
+		nil,
+	)
+	resource.InstanceState.Meta = map[string]interface{}{"schema_version": 2}
+
+	stateBytes, err := PrintTfState([]Resource{resource})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var state map[string]interface{}
+	if err := json.Unmarshal(stateBytes, &state); err != nil {
+		t.Fatal(err)
+	}
+
+	resources := state["resources"].([]interface{})
+	gotResource := resources[0].(map[string]interface{})
+	instances := gotResource["instances"].([]interface{})
+	instance := instances[0].(map[string]interface{})
+
+	if _, ok := instance["attributes"]; ok {
+		t.Fatal("state instance contains typed attributes, want attributes_flat fallback")
+	}
+	attributesFlat := instance["attributes_flat"].(map[string]interface{})
+	if got := attributesFlat["id"].(string); got != "vpc-123" {
+		t.Fatalf("id attribute = %q, want %q", got, "vpc-123")
+	}
+	if got := attributesFlat["cidr_block"].(string); got != "10.0.0.0/16" {
+		t.Fatalf("cidr_block attribute = %q, want %q", got, "10.0.0.0/16")
+	}
+	if _, ok := instance["sensitive_attributes"]; ok {
+		t.Fatal("state instance contains sensitive_attributes for flat fallback")
+	}
+}
+
 func TestPrintTfStateCanBeListedByTerraformCLI(t *testing.T) {
 	terraformPath, err := exec.LookPath("terraform")
 	if err != nil {

--- a/terraformutils/state_test.go
+++ b/terraformutils/state_test.go
@@ -11,6 +11,7 @@ import (
 	"testing"
 
 	"github.com/chenrui333/terraformer/terraformutils/tfcompat"
+	"github.com/zclconf/go-cty/cty"
 )
 
 func TestPrintTfStateWritesV4ProviderSourceState(t *testing.T) {
@@ -53,9 +54,23 @@ func TestPrintTfStateWritesV4ProviderSourceState(t *testing.T) {
 	if got := int(instance["schema_version"].(float64)); got != 2 {
 		t.Fatalf("schema version = %d, want 2", got)
 	}
-	attributes := instance["attributes_flat"].(map[string]interface{})
+	if _, ok := instance["attributes_flat"]; ok {
+		t.Fatal("state instance contains legacy attributes_flat")
+	}
+	attributes := instance["attributes"].(map[string]interface{})
 	if got := attributes["id"].(string); got != "vpc-123" {
-		t.Fatalf("flat id attribute = %q, want %q", got, "vpc-123")
+		t.Fatalf("id attribute = %q, want %q", got, "vpc-123")
+	}
+	if got := attributes["enable_dns_hostnames"].(bool); !got {
+		t.Fatal("enable_dns_hostnames = false, want true")
+	}
+	tags := attributes["tags"].(map[string]interface{})
+	if got := tags["env"].(string); got != "test" {
+		t.Fatalf("tags.env = %q, want %q", got, "test")
+	}
+	sensitiveAttributes := instance["sensitive_attributes"].([]interface{})
+	if len(sensitiveAttributes) != 0 {
+		t.Fatalf("sensitive attributes = %v, want empty", sensitiveAttributes)
 	}
 }
 
@@ -79,6 +94,68 @@ func TestPrintTfStateCanBeListedByTerraformCLI(t *testing.T) {
 	}
 }
 
+func TestPrintTfStateCanPlanWithTerraformCLI(t *testing.T) {
+	if os.Getenv("TERRAFORMER_TFSTATE_PLAN_TEST") == "" {
+		t.Skip("set TERRAFORMER_TFSTATE_PLAN_TEST to run provider-backed plan check")
+	}
+	terraformPath, err := exec.LookPath("terraform")
+	if err != nil {
+		t.Skip("terraform CLI not found")
+	}
+
+	resource := NewResource(
+		"kind-lemur",
+		"example",
+		"random_pet",
+		"random",
+		nil,
+		nil,
+		nil,
+	)
+	resource.InstanceState = tfcompat.NewInstanceStateShimmedFromValue(cty.ObjectVal(map[string]cty.Value{
+		"id":        cty.StringVal("kind-lemur"),
+		"keepers":   cty.NullVal(cty.Map(cty.String)),
+		"length":    cty.NumberIntVal(2),
+		"prefix":    cty.NullVal(cty.String),
+		"separator": cty.StringVal("-"),
+	}), 0)
+
+	testDir := t.TempDir()
+	stateBytes, err := PrintTfState([]Resource{resource})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(testDir, "terraform.tfstate"), stateBytes, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	mainTF := []byte(`terraform {
+  required_version = ">= 1.9, < 1.15"
+  required_providers {
+    random = {
+      source = "hashicorp/random"
+    }
+  }
+}
+
+resource "random_pet" "tfer--example" {
+  length    = 2
+  separator = "-"
+}
+`)
+	if err := os.WriteFile(filepath.Join(testDir, "main.tf"), mainTF, 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	initOut, err := exec.Command(terraformPath, "-chdir="+testDir, "init", "-backend=false", "-input=false", "-no-color").CombinedOutput()
+	if err != nil {
+		t.Fatalf("terraform init failed: %s\n%s", err, initOut)
+	}
+	planOut, err := exec.Command(terraformPath, "-chdir="+testDir, "plan", "-refresh=false", "-input=false", "-no-color", "-detailed-exitcode").CombinedOutput()
+	if err != nil {
+		t.Fatalf("terraform plan failed: %s\n%s", err, planOut)
+	}
+}
+
 func testStateBytes(t *testing.T) []byte {
 	t.Helper()
 
@@ -91,7 +168,14 @@ func testStateBytes(t *testing.T) []byte {
 		nil,
 		nil,
 	)
-	resource.InstanceState.Meta = map[string]interface{}{"schema_version": 2}
+	resource.InstanceState = tfcompat.NewInstanceStateShimmedFromValue(cty.ObjectVal(map[string]cty.Value{
+		"cidr_block":           cty.StringVal("10.0.0.0/16"),
+		"enable_dns_hostnames": cty.BoolVal(true),
+		"id":                   cty.StringVal("vpc-123"),
+		"tags": cty.MapVal(map[string]cty.Value{
+			"env": cty.StringVal("test"),
+		}),
+	}), 2)
 	resource.Outputs = map[string]*tfcompat.OutputState{
 		"aws_vpc_main_id": {
 			Type:  "string",

--- a/terraformutils/tfcompat/state.go
+++ b/terraformutils/tfcompat/state.go
@@ -3,9 +3,11 @@
 package tfcompat
 
 import (
+	"encoding/json"
 	"strings"
 
 	"github.com/zclconf/go-cty/cty"
+	ctyjson "github.com/zclconf/go-cty/cty/json"
 )
 
 const (
@@ -42,9 +44,10 @@ func (r *ResourceAddress) String() string {
 }
 
 type InstanceState struct {
-	ID         string
-	Attributes map[string]string
-	Meta       map[string]interface{}
+	ID              string
+	Attributes      map[string]string
+	TypedAttributes json.RawMessage `json:"typed_attributes,omitempty"`
+	Meta            map[string]interface{}
 }
 
 type OutputState struct {
@@ -56,12 +59,33 @@ type OutputState struct {
 func NewInstanceStateShimmedFromValue(state cty.Value, schemaVersion int) *InstanceState {
 	attributes := FlatmapValueFromHCL2(state)
 	return &InstanceState{
-		ID:         attributes["id"],
-		Attributes: attributes,
+		ID:              attributes["id"],
+		Attributes:      attributes,
+		TypedAttributes: TypedAttributesFromValue(state),
 		Meta: map[string]interface{}{
 			"schema_version": schemaVersion,
 		},
 	}
+}
+
+func TypedAttributesFromValue(state cty.Value) json.RawMessage {
+	raw, err := MarshalTypedAttributesFromValue(state)
+	if err != nil {
+		return nil
+	}
+	return raw
+}
+
+func MarshalTypedAttributesFromValue(state cty.Value) (json.RawMessage, error) {
+	if state == cty.NilVal || state.IsNull() {
+		return nil, nil
+	}
+	unmarked, _ := state.UnmarkDeep()
+	raw, err := ctyjson.Marshal(unmarked, unmarked.Type())
+	if err != nil {
+		return nil, err
+	}
+	return raw, nil
 }
 
 func (s *InstanceState) AttrsAsObjectValue(ty cty.Type) (cty.Value, error) {

--- a/terraformutils/tfcompat/state.go
+++ b/terraformutils/tfcompat/state.go
@@ -44,8 +44,10 @@ func (r *ResourceAddress) String() string {
 }
 
 type InstanceState struct {
-	ID              string
-	Attributes      map[string]string
+	ID         string
+	Attributes map[string]string
+	// TypedAttributes is serialized only for Terraformer plan/import handoff.
+	// Final tfstate output writes this payload as TfInstanceV4.Attributes.
 	TypedAttributes json.RawMessage `json:"typed_attributes,omitempty"`
 	Meta            map[string]interface{}
 }
@@ -61,14 +63,14 @@ func NewInstanceStateShimmedFromValue(state cty.Value, schemaVersion int) *Insta
 	return &InstanceState{
 		ID:              attributes["id"],
 		Attributes:      attributes,
-		TypedAttributes: TypedAttributesFromValue(state),
+		TypedAttributes: TryTypedAttributesFromValue(state),
 		Meta: map[string]interface{}{
 			"schema_version": schemaVersion,
 		},
 	}
 }
 
-func TypedAttributesFromValue(state cty.Value) json.RawMessage {
+func TryTypedAttributesFromValue(state cty.Value) json.RawMessage {
 	raw, err := MarshalTypedAttributesFromValue(state)
 	if err != nil {
 		return nil

--- a/terraformutils/tfcompat/state.go
+++ b/terraformutils/tfcompat/state.go
@@ -48,8 +48,9 @@ type InstanceState struct {
 	Attributes map[string]string
 	// TypedAttributes is serialized only for Terraformer plan/import handoff.
 	// Final tfstate output writes this payload as TfInstanceV4.Attributes.
-	TypedAttributes json.RawMessage `json:"typed_attributes,omitempty"`
-	Meta            map[string]interface{}
+	TypedAttributes        json.RawMessage `json:"typed_attributes,omitempty"`
+	typedAttributesFlatmap map[string]string
+	Meta                   map[string]interface{}
 }
 
 type OutputState struct {
@@ -60,7 +61,7 @@ type OutputState struct {
 
 func NewInstanceStateShimmedFromValue(state cty.Value, schemaVersion int) *InstanceState {
 	attributes := FlatmapValueFromHCL2(state)
-	return &InstanceState{
+	instanceState := &InstanceState{
 		ID:              attributes["id"],
 		Attributes:      attributes,
 		TypedAttributes: TryTypedAttributesFromValue(state),
@@ -68,6 +69,8 @@ func NewInstanceStateShimmedFromValue(state cty.Value, schemaVersion int) *Insta
 			"schema_version": schemaVersion,
 		},
 	}
+	instanceState.trackTypedAttributesFlatmap()
+	return instanceState
 }
 
 func TryTypedAttributesFromValue(state cty.Value) json.RawMessage {
@@ -90,6 +93,28 @@ func MarshalTypedAttributesFromValue(state cty.Value) (json.RawMessage, error) {
 	return raw, nil
 }
 
+func (s *InstanceState) HasCurrentTypedAttributes() bool {
+	if s == nil || len(s.TypedAttributes) == 0 || s.typedAttributesFlatmap == nil {
+		return false
+	}
+	return stringMapsEqual(s.typedAttributesFlatmap, s.Attributes)
+}
+
+func (s *InstanceState) SetTypedAttributes(raw json.RawMessage) {
+	if s == nil {
+		return
+	}
+	s.TypedAttributes = append(json.RawMessage(nil), raw...)
+	s.trackTypedAttributesFlatmap()
+}
+
+func (s *InstanceState) trackTypedAttributesFlatmap() {
+	if s == nil || len(s.TypedAttributes) == 0 {
+		return
+	}
+	s.typedAttributesFlatmap = cloneStringMap(s.Attributes)
+}
+
 func (s *InstanceState) AttrsAsObjectValue(ty cty.Type) (cty.Value, error) {
 	if s == nil {
 		s = &InstanceState{}
@@ -101,4 +126,24 @@ func (s *InstanceState) AttrsAsObjectValue(ty cty.Type) (cty.Value, error) {
 		s.Attributes["id"] = s.ID
 	}
 	return HCL2ValueFromFlatmap(s.Attributes, ty)
+}
+
+func cloneStringMap(input map[string]string) map[string]string {
+	output := make(map[string]string, len(input))
+	for key, value := range input {
+		output[key] = value
+	}
+	return output
+}
+
+func stringMapsEqual(left, right map[string]string) bool {
+	if len(left) != len(right) {
+		return false
+	}
+	for key, leftValue := range left {
+		if right[key] != leftValue {
+			return false
+		}
+	}
+	return true
 }

--- a/terraformutils/tfcompat/state_test.go
+++ b/terraformutils/tfcompat/state_test.go
@@ -3,6 +3,7 @@
 package tfcompat
 
 import (
+	"encoding/json"
 	"testing"
 
 	"github.com/zclconf/go-cty/cty"
@@ -63,6 +64,17 @@ func TestNewInstanceStateShimmedFromValue(t *testing.T) {
 	}
 	if got := state.Meta["schema_version"]; got != 7 {
 		t.Fatalf("schema_version = %#v, want 7", got)
+	}
+
+	var typed map[string]interface{}
+	if err := json.Unmarshal(state.TypedAttributes, &typed); err != nil {
+		t.Fatal(err)
+	}
+	if got := typed["id"].(string); got != "vpc-123" {
+		t.Fatalf("typed id attribute = %q, want %q", got, "vpc-123")
+	}
+	if got := typed["name"].(string); got != "main" {
+		t.Fatalf("typed name attribute = %q, want %q", got, "main")
 	}
 }
 

--- a/terraformutils/utils.go
+++ b/terraformutils/utils.go
@@ -42,8 +42,10 @@ type TfResourceV4 struct {
 }
 
 type TfInstanceV4 struct {
-	SchemaVersion uint64            `json:"schema_version"`
-	Attributes    map[string]string `json:"attributes_flat"`
+	SchemaVersion       uint64            `json:"schema_version"`
+	Attributes          json.RawMessage   `json:"attributes,omitempty"`
+	AttributesFlat      map[string]string `json:"attributes_flat,omitempty"`
+	SensitiveAttributes *[]interface{}    `json:"sensitive_attributes,omitempty"`
 }
 
 func NewTfState(resources []Resource) *TfStateV4 {
@@ -65,23 +67,14 @@ func NewTfState(resources []Resource) *TfStateV4 {
 		}
 	}
 	for _, resource := range resources {
-		attributes := map[string]string{}
-		for k, v := range resource.InstanceState.Attributes {
-			attributes[k] = v
-		}
-		if _, ok := attributes["id"]; !ok && resource.InstanceState.ID != "" {
-			attributes["id"] = resource.InstanceState.ID
-		}
+		instance := newTfInstance(resource)
 
 		tfstate.Resources = append(tfstate.Resources, TfResourceV4{
-			Mode:     "managed",
-			Type:     resource.InstanceInfo.Type,
-			Name:     resource.ResourceName,
-			Provider: ProviderConfigAddress(resource.Provider),
-			Instances: []TfInstanceV4{{
-				SchemaVersion: schemaVersion(resource.InstanceState.Meta),
-				Attributes:    attributes,
-			}},
+			Mode:      "managed",
+			Type:      resource.InstanceInfo.Type,
+			Name:      resource.ResourceName,
+			Provider:  ProviderConfigAddress(resource.Provider),
+			Instances: []TfInstanceV4{instance},
 		})
 	}
 	sort.Slice(tfstate.Resources, func(i, j int) bool {
@@ -90,6 +83,28 @@ func NewTfState(resources []Resource) *TfStateV4 {
 		return left < right
 	})
 	return tfstate
+}
+
+func newTfInstance(resource Resource) TfInstanceV4 {
+	instance := TfInstanceV4{
+		SchemaVersion: schemaVersion(resource.InstanceState.Meta),
+	}
+	if len(resource.InstanceState.TypedAttributes) > 0 {
+		emptySensitiveAttributes := []interface{}{}
+		instance.Attributes = resource.InstanceState.TypedAttributes
+		instance.SensitiveAttributes = &emptySensitiveAttributes
+		return instance
+	}
+
+	attributes := map[string]string{}
+	for k, v := range resource.InstanceState.Attributes {
+		attributes[k] = v
+	}
+	if _, ok := attributes["id"]; !ok && resource.InstanceState.ID != "" {
+		attributes["id"] = resource.InstanceState.ID
+	}
+	instance.AttributesFlat = attributes
+	return instance
 }
 
 func PrintTfState(resources []Resource) ([]byte, error) {


### PR DESCRIPTION
## Summary

- emit Terraform 1.x typed `attributes` state from provider refresh results instead of legacy `attributes_flat`
- re-derive typed state after provider cleanup hooks so final state includes post-refresh attribute adjustments
- extend the state compatibility workflow to run a provider-backed `terraform plan -refresh=false` check across Terraform 1.9-1.14

## References

- Follow-up to #187
- Related to #180
