### PR TITLE
chore(lint): suppress gosec G101 in test files

### DIFF
--- a/.golangci.json
+++ b/.golangci.json
@@ -45,6 +45,13 @@
         "common-false-positives",
         "legacy",
         "std-error-handling"
+      ],
+      "rules": [
+        {
+          "linters": ["gosec"],
+          "text": "G101",
+          "path": "_test\\.go$"
+        }
       ]
     }
   },


### PR DESCRIPTION
## Summary

Exclude gosec G101 (hardcoded credentials) from test files in `.golangci.json`. The 4 findings were false positives on `secretArn` field names in `msk_test.go` test fixtures — ARN strings, not credentials.

This brings the repo to a fully clean lint baseline.

Closes #191