### PR TITLE
test(providers): add unit tests for resource name/ID extraction

### DIFF
--- a/providers/aws/aws_service.go
+++ b/providers/aws/aws_service.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"os"
 	"regexp"
+	"strings"
 
 	"github.com/aws/aws-sdk-go-v2/service/sts"
 
@@ -75,6 +76,13 @@ func (s *AWSService) buildBaseConfig() (aws.Config, error) {
 // for CF interpolation and IAM Policy variables
 func (*AWSService) escapeAwsInterpolation(str string) string {
 	return awsVariable.ReplaceAllString(str, "$$$1")
+}
+
+// arnLastSegment returns the substring after the last occurrence of sep in s.
+// Used to extract resource names from ARNs and URLs.
+func arnLastSegment(s, sep string) string {
+	parts := strings.Split(s, sep)
+	return parts[len(parts)-1]
 }
 
 func (s *AWSService) getAccountNumber(config aws.Config) (*string, error) {

--- a/providers/aws/ecs.go
+++ b/providers/aws/ecs.go
@@ -32,8 +32,7 @@ func (g *EcsGenerator) InitResources() error {
 			return e
 		}
 		for _, clusterArn := range page.ClusterArns {
-			arnParts := strings.Split(clusterArn, "/")
-			clusterName := arnParts[len(arnParts)-1]
+			clusterName := arnLastSegment(clusterArn, "/")
 
 			g.Resources = append(g.Resources, terraformutils.NewSimpleResource(
 				clusterArn,
@@ -53,8 +52,7 @@ func (g *EcsGenerator) InitResources() error {
 					continue
 				}
 				for _, serviceArn := range serviceNextPage.ServiceArns {
-					arnParts := strings.Split(serviceArn, "/")
-					serviceName := arnParts[len(arnParts)-1]
+					serviceName := arnLastSegment(serviceArn, "/")
 
 					serResp, err := svc.DescribeServices(context.TODO(), &ecs.DescribeServicesInput{
 						Services: []string{

--- a/providers/aws/ecs_test.go
+++ b/providers/aws/ecs_test.go
@@ -1,0 +1,31 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package aws
+
+import "testing"
+
+func TestArnLastSegment(t *testing.T) {
+	tests := []struct {
+		name string
+		s    string
+		sep  string
+		want string
+	}{
+		{"ecs cluster arn", "arn:aws:ecs:us-east-1:123456789012:cluster/my-cluster", "/", "my-cluster"},
+		{"ecs service arn", "arn:aws:ecs:us-east-1:123456789012:service/my-cluster/my-service", "/", "my-service"},
+		{"sns topic arn", "arn:aws:sns:us-east-1:123456789012:my-topic", ":", "my-topic"},
+		{"sqs queue url", "https://sqs.us-east-1.amazonaws.com/123456789012/my-queue", "/", "my-queue"},
+		{"sqs fifo url", "https://sqs.eu-west-1.amazonaws.com/987654321098/orders.fifo", "/", "orders.fifo"},
+		{"no separator", "simple-string", "/", "simple-string"},
+		{"empty string", "", "/", ""},
+		{"trailing separator", "a/b/c/", "/", ""},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := arnLastSegment(tc.s, tc.sep); got != tc.want {
+				t.Errorf("arnLastSegment(%q, %q) = %q, want %q", tc.s, tc.sep, got, tc.want)
+			}
+		})
+	}
+}

--- a/providers/aws/route53_test.go
+++ b/providers/aws/route53_test.go
@@ -1,0 +1,68 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package aws
+
+import "testing"
+
+func TestWildcardUnescape(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		want  string
+	}{
+		{"escaped wildcard", "\\052.example.com", "*.example.com"},
+		{"no wildcard", "www.example.com", "www.example.com"},
+		{"empty string", "", ""},
+		{"only wildcard", "\\052", "*"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := wildcardUnescape(tc.input); got != tc.want {
+				t.Errorf("wildcardUnescape(%q) = %q, want %q", tc.input, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestCleanZoneID(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		want  string
+	}{
+		{"with prefix", "/hostedzone/Z1234ABC", "Z1234ABC"},
+		{"without prefix", "Z1234ABC", "Z1234ABC"},
+		{"empty string", "", ""},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := cleanZoneID(tc.input); got != tc.want {
+				t.Errorf("cleanZoneID(%q) = %q, want %q", tc.input, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestCleanPrefix(t *testing.T) {
+	tests := []struct {
+		name   string
+		id     string
+		prefix string
+		want   string
+	}{
+		{"matching prefix", "/hostedzone/Z123", "/hostedzone/", "Z123"},
+		{"no match", "Z123", "/hostedzone/", "Z123"},
+		{"empty id", "", "/hostedzone/", ""},
+		{"empty prefix", "/hostedzone/Z123", "", "/hostedzone/Z123"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := cleanPrefix(tc.id, tc.prefix); got != tc.want {
+				t.Errorf("cleanPrefix(%q, %q) = %q, want %q", tc.id, tc.prefix, got, tc.want)
+			}
+		})
+	}
+}

--- a/providers/aws/sns.go
+++ b/providers/aws/sns.go
@@ -6,7 +6,6 @@ import (
 	"context"
 	"fmt"
 	"log"
-	"strings"
 
 	"github.com/aws/aws-sdk-go-v2/service/sns"
 	"github.com/chenrui333/terraformer/terraformutils"
@@ -36,8 +35,7 @@ func (g *SnsGenerator) InitResources() error {
 			return err
 		}
 		for _, topic := range page.Topics {
-			arnParts := strings.Split(StringValue(topic.TopicArn), ":")
-			topicName := arnParts[len(arnParts)-1]
+			topicName := arnLastSegment(StringValue(topic.TopicArn), ":")
 
 			g.Resources = append(g.Resources, terraformutils.NewSimpleResource(
 				StringValue(topic.TopicArn),
@@ -57,8 +55,7 @@ func (g *SnsGenerator) InitResources() error {
 					continue
 				}
 				for _, subscription := range topicSubsNextPage.Subscriptions {
-					subscriptionArnParts := strings.Split(StringValue(subscription.SubscriptionArn), ":")
-					subscriptionID := subscriptionArnParts[len(subscriptionArnParts)-1]
+					subscriptionID := arnLastSegment(StringValue(subscription.SubscriptionArn), ":")
 
 					if g.isSupportedSubscription(StringValue(subscription.Protocol), subscriptionID) {
 						g.Resources = append(g.Resources, terraformutils.NewSimpleResource(

--- a/providers/aws/sqs.go
+++ b/providers/aws/sqs.go
@@ -6,7 +6,6 @@ import (
 	"context"
 	"fmt"
 	"os"
-	"strings"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/chenrui333/terraformer/terraformutils"
@@ -41,8 +40,7 @@ func (g *SqsGenerator) InitResources() error {
 	}
 
 	for _, queueURL := range queuesList.QueueUrls {
-		urlParts := strings.Split(queueURL, "/")
-		queueName := urlParts[len(urlParts)-1]
+		queueName := arnLastSegment(queueURL, "/")
 
 		g.Resources = append(g.Resources, terraformutils.NewSimpleResource(
 			queueURL,

--- a/providers/azure/helper_test.go
+++ b/providers/azure/helper_test.go
@@ -1,0 +1,108 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package azure
+
+import "testing"
+
+func TestParseAzureResourceID(t *testing.T) {
+	tests := []struct {
+		name           string
+		id             string
+		wantSubID      string
+		wantRG         string
+		wantProvider   string
+		wantPathKey    string
+		wantPathValue  string
+		wantErr        bool
+	}{
+		{
+			name:          "standard resource",
+			id:            "/subscriptions/sub-123/resourceGroups/my-rg/providers/Microsoft.Network/virtualNetworks/my-vnet",
+			wantSubID:     "sub-123",
+			wantRG:        "my-rg",
+			wantProvider:  "Microsoft.Network",
+			wantPathKey:   "virtualNetworks",
+			wantPathValue: "my-vnet",
+		},
+		{
+			name:          "storage account",
+			id:            "/subscriptions/sub-456/resourceGroups/prod-rg/providers/Microsoft.Storage/storageAccounts/mystorage",
+			wantSubID:     "sub-456",
+			wantRG:        "prod-rg",
+			wantProvider:  "Microsoft.Storage",
+			wantPathKey:   "storageAccounts",
+			wantPathValue: "mystorage",
+		},
+		{
+			name:         "lowercase resourcegroups",
+			id:           "/subscriptions/sub-789/resourcegroups/lower-rg/providers/Microsoft.Compute/virtualMachines/my-vm",
+			wantSubID:    "sub-789",
+			wantRG:       "lower-rg",
+			wantProvider: "Microsoft.Compute",
+		},
+		{
+			name:      "resource group only",
+			id:        "/subscriptions/sub-123/resourceGroups/my-rg",
+			wantSubID: "sub-123",
+			wantRG:    "my-rg",
+		},
+		{
+			name:    "invalid url",
+			id:      "not-a-url",
+			wantErr: true,
+		},
+		{
+			name:    "odd number of segments",
+			id:      "/subscriptions/sub-123/resourceGroups",
+			wantErr: true,
+		},
+		{
+			name:    "no subscription",
+			id:      "/resourceGroups/my-rg/providers/Microsoft.Network/virtualNetworks/my-vnet",
+			wantErr: true,
+		},
+		{
+			name:    "empty segment",
+			id:      "/subscriptions//resourceGroups/my-rg",
+			wantErr: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := ParseAzureResourceID(tc.id)
+			if tc.wantErr {
+				if err == nil {
+					t.Fatalf("expected error for %q, got nil", tc.id)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+
+			if got.SubscriptionID != tc.wantSubID {
+				t.Errorf("SubscriptionID = %q, want %q", got.SubscriptionID, tc.wantSubID)
+			}
+			if got.ResourceGroup != tc.wantRG {
+				t.Errorf("ResourceGroup = %q, want %q", got.ResourceGroup, tc.wantRG)
+			}
+			if tc.wantProvider != "" && got.Provider != tc.wantProvider {
+				t.Errorf("Provider = %q, want %q", got.Provider, tc.wantProvider)
+			}
+			if tc.wantPathKey != "" {
+				if v, ok := got.Path[tc.wantPathKey]; !ok || v != tc.wantPathValue {
+					t.Errorf("Path[%q] = %q, want %q", tc.wantPathKey, v, tc.wantPathValue)
+				}
+			}
+		})
+	}
+}
+
+func TestAsHereDoc(t *testing.T) {
+	got := asHereDoc(`{"key":"value"}`)
+	want := "<<JSON\n{\"key\":\"value\"}\nJSON"
+	if got != want {
+		t.Errorf("asHereDoc() = %q, want %q", got, want)
+	}
+}

--- a/providers/gcp/gcp_name_helpers_test.go
+++ b/providers/gcp/gcp_name_helpers_test.go
@@ -1,0 +1,100 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package gcp
+
+import (
+	"strings"
+	"testing"
+)
+
+// These tests validate the GCP resource name extraction conventions used
+// across providers. The parsing pattern (split on "/" and take last segment)
+// is inlined in generated code, so these tests serve as convention guards
+// rather than direct production-code callers.
+
+func TestGCPResourceNameLastSegment(t *testing.T) {
+	tests := []struct {
+		name     string
+		fullName string
+		want     string
+	}{
+		{"cloud function", "projects/p/locations/us-central1/functions/my-func", "my-func"},
+		{"pubsub subscription", "projects/p/subscriptions/my-sub", "my-sub"},
+		{"pubsub topic", "projects/p/topics/my-topic", "my-topic"},
+		{"cloud tasks queue", "projects/p/locations/us-central1/queues/my-queue", "my-queue"},
+		{"memorystore instance", "projects/p/locations/us-central1/instances/my-redis", "my-redis"},
+		{"scheduler job", "projects/p/locations/us-central1/jobs/my-job", "my-job"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			parts := strings.Split(tc.fullName, "/")
+			got := parts[len(parts)-1]
+			if got != tc.want {
+				t.Errorf("last segment of %q = %q, want %q", tc.fullName, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestBigQueryDatasetIDExtraction(t *testing.T) {
+	tests := []struct {
+		name   string
+		fullID string
+		want   string
+	}{
+		{"standard dataset", "my-project:my_dataset", "my_dataset"},
+		{"dataset with numbers", "project-123:dataset_2024", "dataset_2024"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := strings.Split(tc.fullID, ":")[1]
+			if got != tc.want {
+				t.Errorf("dataset name from %q = %q, want %q", tc.fullID, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestKMSKeyRingIDComposition(t *testing.T) {
+	tests := []struct {
+		name     string
+		fullName string
+		wantID   string
+	}{
+		{"global key ring", "projects/my-project/locations/global/keyRings/my-ring", "my-project/global/my-ring"},
+		{"regional key ring", "projects/my-project/locations/us-east1/keyRings/prod-ring", "my-project/us-east1/prod-ring"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			parts := strings.Split(tc.fullName, "/")
+			got := parts[1] + "/" + parts[3] + "/" + parts[5]
+			if got != tc.wantID {
+				t.Errorf("KMS key ring ID from %q = %q, want %q", tc.fullName, got, tc.wantID)
+			}
+		})
+	}
+}
+
+func TestGCPZoneFromLink(t *testing.T) {
+	tests := []struct {
+		name     string
+		zoneLink string
+		want     string
+	}{
+		{"us zone", "https://www.googleapis.com/compute/v1/projects/p/zones/us-central1-a", "us-central1-a"},
+		{"eu zone", "https://www.googleapis.com/compute/v1/projects/p/zones/europe-west1-b", "europe-west1-b"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			parts := strings.Split(tc.zoneLink, "/")
+			got := parts[len(parts)-1]
+			if got != tc.want {
+				t.Errorf("zone from %q = %q, want %q", tc.zoneLink, got, tc.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

Add unit tests across AWS, GCP, and Azure providers covering resource name and ID extraction logic.

### Source changes

- Extract `arnLastSegment` shared helper in `providers/aws/aws_service.go`
- Refactor `ecs.go`, `sns.go`, `sqs.go` to use `arnLastSegment` instead of inline `strings.Split` calls

### New test files

- `providers/aws/ecs_test.go` — `arnLastSegment` (shared helper covering ECS, SNS, SQS, and general ARN/URL parsing)
- `providers/aws/route53_test.go` — `wildcardUnescape`, `cleanZoneID`, `cleanPrefix` (production helpers)
- `providers/gcp/gcp_name_helpers_test.go` — GCP resource name conventions (last-segment, BigQuery dataset ID, KMS key ring ID composition, zone link)
- `providers/azure/helper_test.go` — `ParseAzureResourceID` (standard, lowercase, RG-only, error cases), `asHereDoc`

### Approach

AWS tests call extracted production helpers directly (`arnLastSegment`, Route53 helpers). Azure tests call the existing `ParseAzureResourceID` production code. GCP tests validate the naming convention used across generated files, documented as convention guards.

Closes #194