### PR TITLE
aws(eks): add additional EKS resources

### DIFF
--- a/docs/aws.md
+++ b/docs/aws.md
@@ -142,8 +142,14 @@ terraformer import aws --resources=sg --regions=us-east-1
 *   `eip`
     * `aws_eip`
 *   `eks`
+    * `aws_eks_access_entry`
+    * `aws_eks_access_policy_association`
+    * `aws_eks_addon`
     * `aws_eks_cluster`
+    * `aws_eks_fargate_profile`
+    * `aws_eks_identity_provider_config`
     * `aws_eks_node_group`
+    * `aws_eks_pod_identity_association`
 *   `elasticache`
     * `aws_elasticache_cluster`
     * `aws_elasticache_parameter_group`

--- a/providers/aws/eks.go
+++ b/providers/aws/eks.go
@@ -5,6 +5,7 @@ package aws
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	"github.com/aws/aws-sdk-go-v2/service/eks"
 	"github.com/chenrui333/terraformer/terraformutils"
@@ -12,8 +13,37 @@ import (
 
 var eksAllowEmptyValues = []string{"tags."}
 
+var eksClusterScopedResourceTypes = map[string]struct{}{
+	"aws_eks_access_entry":              {},
+	"aws_eks_access_policy_association": {},
+	"aws_eks_addon":                     {},
+	"aws_eks_fargate_profile":           {},
+	"aws_eks_identity_provider_config":  {},
+	"aws_eks_node_group":                {},
+	"aws_eks_pod_identity_association":  {},
+}
+
 type EksGenerator struct {
 	AWSService
+}
+
+func eksResourceName(parts ...string) string {
+	nonEmptyParts := []string{}
+	for _, part := range parts {
+		if part != "" {
+			nonEmptyParts = append(nonEmptyParts, part)
+		}
+	}
+	return strings.Join(nonEmptyParts, "-")
+}
+
+func eksArnName(arn string) string {
+	parts := strings.SplitN(arn, ":", 6)
+	if len(parts) != 6 {
+		name := arnLastSegment(arn, "/")
+		return arnLastSegment(name, ":")
+	}
+	return eksResourceName(parts[4], strings.ReplaceAll(parts[5], "/", "-"))
 }
 
 func (g *EksGenerator) getNodeGroups(clusterName string, svc *eks.Client) error {
@@ -38,6 +68,159 @@ func (g *EksGenerator) getNodeGroups(clusterName string, svc *eks.Client) error 
 	return nil
 }
 
+func (g *EksGenerator) getAddons(clusterName string, svc *eks.Client) error {
+	p := eks.NewListAddonsPaginator(svc, &eks.ListAddonsInput{
+		ClusterName: &clusterName,
+	})
+	for p.HasMorePages() {
+		page, err := p.NextPage(context.TODO())
+		if err != nil {
+			return err
+		}
+		for _, addonName := range page.Addons {
+			g.Resources = append(g.Resources, terraformutils.NewSimpleResource(
+				fmt.Sprintf("%s:%s", clusterName, addonName),
+				eksResourceName(clusterName, addonName),
+				"aws_eks_addon",
+				"aws",
+				eksAllowEmptyValues,
+			))
+		}
+	}
+	return nil
+}
+
+func (g *EksGenerator) getFargateProfiles(clusterName string, svc *eks.Client) error {
+	p := eks.NewListFargateProfilesPaginator(svc, &eks.ListFargateProfilesInput{
+		ClusterName: &clusterName,
+	})
+	for p.HasMorePages() {
+		page, err := p.NextPage(context.TODO())
+		if err != nil {
+			return err
+		}
+		for _, profileName := range page.FargateProfileNames {
+			g.Resources = append(g.Resources, terraformutils.NewSimpleResource(
+				fmt.Sprintf("%s:%s", clusterName, profileName),
+				eksResourceName(clusterName, profileName),
+				"aws_eks_fargate_profile",
+				"aws",
+				eksAllowEmptyValues,
+			))
+		}
+	}
+	return nil
+}
+
+func (g *EksGenerator) getIdentityProviderConfigs(clusterName string, svc *eks.Client) error {
+	p := eks.NewListIdentityProviderConfigsPaginator(svc, &eks.ListIdentityProviderConfigsInput{
+		ClusterName: &clusterName,
+	})
+	for p.HasMorePages() {
+		page, err := p.NextPage(context.TODO())
+		if err != nil {
+			return err
+		}
+		for _, config := range page.IdentityProviderConfigs {
+			configName := StringValue(config.Name)
+			if configName == "" {
+				continue
+			}
+			g.Resources = append(g.Resources, terraformutils.NewSimpleResource(
+				fmt.Sprintf("%s:%s", clusterName, configName),
+				eksResourceName(clusterName, configName),
+				"aws_eks_identity_provider_config",
+				"aws",
+				eksAllowEmptyValues,
+			))
+		}
+	}
+	return nil
+}
+
+func (g *EksGenerator) getPodIdentityAssociations(clusterName string, svc *eks.Client) error {
+	p := eks.NewListPodIdentityAssociationsPaginator(svc, &eks.ListPodIdentityAssociationsInput{
+		ClusterName: &clusterName,
+	})
+	for p.HasMorePages() {
+		page, err := p.NextPage(context.TODO())
+		if err != nil {
+			return err
+		}
+		for _, association := range page.Associations {
+			associationID := StringValue(association.AssociationId)
+			if associationID == "" {
+				continue
+			}
+			g.Resources = append(g.Resources, terraformutils.NewSimpleResource(
+				fmt.Sprintf("%s,%s", clusterName, associationID),
+				eksResourceName(clusterName, StringValue(association.Namespace), StringValue(association.ServiceAccount), associationID),
+				"aws_eks_pod_identity_association",
+				"aws",
+				eksAllowEmptyValues,
+			))
+		}
+	}
+	return nil
+}
+
+func (g *EksGenerator) getAccessEntries(clusterName string, svc *eks.Client) error {
+	p := eks.NewListAccessEntriesPaginator(svc, &eks.ListAccessEntriesInput{
+		ClusterName: &clusterName,
+	})
+	for p.HasMorePages() {
+		page, err := p.NextPage(context.TODO())
+		if err != nil {
+			return err
+		}
+		for _, principalArn := range page.AccessEntries {
+			g.Resources = append(g.Resources, terraformutils.NewSimpleResource(
+				fmt.Sprintf("%s:%s", clusterName, principalArn),
+				eksResourceName(clusterName, eksArnName(principalArn)),
+				"aws_eks_access_entry",
+				"aws",
+				eksAllowEmptyValues,
+			))
+			if err := g.getAccessPolicyAssociations(clusterName, principalArn, svc); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+func (g *EksGenerator) getAccessPolicyAssociations(clusterName, principalArn string, svc *eks.Client) error {
+	var nextToken *string
+	for {
+		page, err := svc.ListAssociatedAccessPolicies(context.TODO(), &eks.ListAssociatedAccessPoliciesInput{
+			ClusterName:  &clusterName,
+			PrincipalArn: &principalArn,
+			NextToken:    nextToken,
+		})
+		if err != nil {
+			return err
+		}
+		for _, policy := range page.AssociatedAccessPolicies {
+			policyArn := StringValue(policy.PolicyArn)
+			if policyArn == "" {
+				continue
+			}
+			g.Resources = append(g.Resources, terraformutils.NewSimpleResource(
+				fmt.Sprintf("%s#%s#%s", clusterName, principalArn, policyArn),
+				eksResourceName(clusterName, eksArnName(principalArn), eksArnName(policyArn)),
+				"aws_eks_access_policy_association",
+				"aws",
+				eksAllowEmptyValues,
+			))
+		}
+		nextToken = page.NextToken
+		if nextToken == nil {
+			break
+		}
+	}
+	return nil
+}
+
 func (g *EksGenerator) InitResources() error {
 	config, e := g.generateConfig()
 	if e != nil {
@@ -52,6 +235,26 @@ func (g *EksGenerator) InitResources() error {
 		}
 		for _, clusterName := range page.Clusters {
 			err := g.getNodeGroups(clusterName, svc)
+			if err != nil {
+				return err
+			}
+			err = g.getAddons(clusterName, svc)
+			if err != nil {
+				return err
+			}
+			err = g.getFargateProfiles(clusterName, svc)
+			if err != nil {
+				return err
+			}
+			err = g.getIdentityProviderConfigs(clusterName, svc)
+			if err != nil {
+				return err
+			}
+			err = g.getPodIdentityAssociations(clusterName, svc)
+			if err != nil {
+				return err
+			}
+			err = g.getAccessEntries(clusterName, svc)
 			if err != nil {
 				return err
 			}
@@ -76,11 +279,17 @@ func (g *EksGenerator) PostConvertHook() error {
 			if _, ok := resource.Item["update_config"]; ok {
 				delete(resource.Item["update_config"].([]interface{})[0].(map[string]interface{}), "max_unavailable_percentage")
 			}
-			for cluster := range g.Resources {
-				if g.Resources[cluster].InstanceInfo.Type == "aws_eks_cluster" {
-					if g.Resources[cluster].Item["name"] == resource.Item["cluster_name"] {
-						resource.Item["cluster_name"] = "${aws_eks_cluster." + g.Resources[cluster].InstanceInfo.ResourceAddress().Name + ".name}"
-					}
+		}
+		if _, ok := eksClusterScopedResourceTypes[resource.InstanceInfo.Type]; !ok {
+			continue
+		}
+		if _, ok := resource.Item["cluster_name"]; !ok {
+			continue
+		}
+		for cluster := range g.Resources {
+			if g.Resources[cluster].InstanceInfo.Type == "aws_eks_cluster" {
+				if g.Resources[cluster].Item["name"] == resource.Item["cluster_name"] {
+					resource.Item["cluster_name"] = "${aws_eks_cluster." + g.Resources[cluster].InstanceInfo.ResourceAddress().Name + ".name}"
 				}
 			}
 		}

--- a/providers/aws/eks.go
+++ b/providers/aws/eks.go
@@ -42,10 +42,9 @@ func eksResourceName(parts ...string) string {
 func eksArnName(arn string) string {
 	parts := strings.SplitN(arn, ":", 6)
 	if len(parts) != 6 {
-		name := arnLastSegment(arn, "/")
-		return arnLastSegment(name, ":")
+		return arn
 	}
-	return eksResourceName(parts[4], strings.ReplaceAll(parts[5], "/", "-"))
+	return eksResourceName(parts[4], parts[5])
 }
 
 func eksAccessEntriesUnsupported(err error) bool {

--- a/providers/aws/eks.go
+++ b/providers/aws/eks.go
@@ -4,10 +4,12 @@ package aws
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"strings"
 
 	"github.com/aws/aws-sdk-go-v2/service/eks"
+	"github.com/aws/aws-sdk-go-v2/service/eks/types"
 	"github.com/chenrui333/terraformer/terraformutils"
 )
 
@@ -44,6 +46,11 @@ func eksArnName(arn string) string {
 		return arnLastSegment(name, ":")
 	}
 	return eksResourceName(parts[4], strings.ReplaceAll(parts[5], "/", "-"))
+}
+
+func eksAccessEntriesUnsupported(err error) bool {
+	var invalidRequest *types.InvalidRequestException
+	return errors.As(err, &invalidRequest)
 }
 
 func (g *EksGenerator) getNodeGroups(clusterName string, svc *eks.Client) error {
@@ -171,6 +178,11 @@ func (g *EksGenerator) getAccessEntries(clusterName string, svc *eks.Client) err
 	for p.HasMorePages() {
 		page, err := p.NextPage(context.TODO())
 		if err != nil {
+			// CONFIG_MAP authentication clusters reject this API but can still import
+			// clusters, node groups, add-ons, and other EKS resources.
+			if eksAccessEntriesUnsupported(err) {
+				return nil
+			}
 			return err
 		}
 		for _, principalArn := range page.AccessEntries {

--- a/providers/aws/eks_test.go
+++ b/providers/aws/eks_test.go
@@ -1,0 +1,98 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package aws
+
+import (
+	"testing"
+
+	"github.com/chenrui333/terraformer/terraformutils"
+)
+
+func TestEksResourceName(t *testing.T) {
+	tests := []struct {
+		name  string
+		parts []string
+		want  string
+	}{
+		{
+			name:  "joins non-empty parts",
+			parts: []string{"prod", "kube-system", "aws-node", "a-12345678"},
+			want:  "prod-kube-system-aws-node-a-12345678",
+		},
+		{
+			name:  "skips empty parts",
+			parts: []string{"prod", "", "vpc-cni"},
+			want:  "prod-vpc-cni",
+		},
+		{
+			name:  "empty parts",
+			parts: []string{"", ""},
+			want:  "",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := eksResourceName(tc.parts...); got != tc.want {
+				t.Fatalf("eksResourceName(%v) = %q, want %q", tc.parts, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestEksArnName(t *testing.T) {
+	tests := []struct {
+		name string
+		arn  string
+		want string
+	}{
+		{
+			name: "role arn",
+			arn:  "arn:aws:iam::123456789012:role/Admin",
+			want: "123456789012-role-Admin",
+		},
+		{
+			name: "path role arn",
+			arn:  "arn:aws:iam::123456789012:role/team/Admin",
+			want: "123456789012-role-team-Admin",
+		},
+		{
+			name: "root arn",
+			arn:  "arn:aws:iam::123456789012:root",
+			want: "123456789012-root",
+		},
+		{
+			name: "EKS cluster access policy arn",
+			arn:  "arn:aws:eks::aws:cluster-access-policy/AmazonEKSClusterAdminPolicy",
+			want: "aws-cluster-access-policy-AmazonEKSClusterAdminPolicy",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := eksArnName(tc.arn); got != tc.want {
+				t.Fatalf("eksArnName(%q) = %q, want %q", tc.arn, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestEksPostConvertHookLinksClusterScopedResources(t *testing.T) {
+	cluster := terraformutils.NewSimpleResource("prod", "prod", "aws_eks_cluster", "aws", eksAllowEmptyValues)
+	cluster.Item = map[string]interface{}{"name": "prod"}
+
+	addon := terraformutils.NewSimpleResource("prod:vpc-cni", "prod-vpc-cni", "aws_eks_addon", "aws", eksAllowEmptyValues)
+	addon.Item = map[string]interface{}{"cluster_name": "prod"}
+
+	g := EksGenerator{}
+	g.Resources = []terraformutils.Resource{cluster, addon}
+
+	if err := g.PostConvertHook(); err != nil {
+		t.Fatalf("PostConvertHook() returned error: %v", err)
+	}
+
+	want := "${aws_eks_cluster.tfer--prod.name}"
+	if got := g.Resources[1].Item["cluster_name"]; got != want {
+		t.Fatalf("cluster_name = %q, want %q", got, want)
+	}
+}

--- a/providers/aws/eks_test.go
+++ b/providers/aws/eks_test.go
@@ -3,8 +3,10 @@
 package aws
 
 import (
+	"errors"
 	"testing"
 
+	"github.com/aws/aws-sdk-go-v2/service/eks/types"
 	"github.com/chenrui333/terraformer/terraformutils"
 )
 
@@ -94,5 +96,16 @@ func TestEksPostConvertHookLinksClusterScopedResources(t *testing.T) {
 	want := "${aws_eks_cluster.tfer--prod.name}"
 	if got := g.Resources[1].Item["cluster_name"]; got != want {
 		t.Fatalf("cluster_name = %q, want %q", got, want)
+	}
+}
+
+func TestEksAccessEntriesUnsupported(t *testing.T) {
+	err := &types.InvalidRequestException{}
+	if !eksAccessEntriesUnsupported(err) {
+		t.Fatal("eksAccessEntriesUnsupported() = false, want true")
+	}
+
+	if eksAccessEntriesUnsupported(errors.New("boom")) {
+		t.Fatal("eksAccessEntriesUnsupported() = true for generic error, want false")
 	}
 }

--- a/providers/aws/eks_test.go
+++ b/providers/aws/eks_test.go
@@ -51,12 +51,12 @@ func TestEksArnName(t *testing.T) {
 		{
 			name: "role arn",
 			arn:  "arn:aws:iam::123456789012:role/Admin",
-			want: "123456789012-role-Admin",
+			want: "123456789012-role/Admin",
 		},
 		{
 			name: "path role arn",
 			arn:  "arn:aws:iam::123456789012:role/team/Admin",
-			want: "123456789012-role-team-Admin",
+			want: "123456789012-role/team/Admin",
 		},
 		{
 			name: "root arn",
@@ -66,7 +66,12 @@ func TestEksArnName(t *testing.T) {
 		{
 			name: "EKS cluster access policy arn",
 			arn:  "arn:aws:eks::aws:cluster-access-policy/AmazonEKSClusterAdminPolicy",
-			want: "aws-cluster-access-policy-AmazonEKSClusterAdminPolicy",
+			want: "aws-cluster-access-policy/AmazonEKSClusterAdminPolicy",
+		},
+		{
+			name: "non-arn value",
+			arn:  "role/team/Admin",
+			want: "role/team/Admin",
 		},
 	}
 
@@ -76,6 +81,21 @@ func TestEksArnName(t *testing.T) {
 				t.Fatalf("eksArnName(%q) = %q, want %q", tc.arn, got, tc.want)
 			}
 		})
+	}
+}
+
+func TestEksArnNamePreservesPathSeparators(t *testing.T) {
+	pathRoleName := eksArnName("arn:aws:iam::123456789012:role/team/admin")
+	hyphenRoleName := eksArnName("arn:aws:iam::123456789012:role/team-admin")
+
+	if pathRoleName == hyphenRoleName {
+		t.Fatalf("eksArnName() collapsed distinct role ARNs into %q", pathRoleName)
+	}
+
+	pathResource := terraformutils.NewSimpleResource("id-1", pathRoleName, "aws_eks_access_entry", "aws", eksAllowEmptyValues)
+	hyphenResource := terraformutils.NewSimpleResource("id-2", hyphenRoleName, "aws_eks_access_entry", "aws", eksAllowEmptyValues)
+	if pathResource.ResourceName == hyphenResource.ResourceName {
+		t.Fatalf("sanitized resource names collided: %q", pathResource.ResourceName)
 	}
 }
 


### PR DESCRIPTION
## Summary

- add import discovery for six additional EKS resource types
- link refreshed EKS child resources back to imported `aws_eks_cluster` resources
- document the new EKS resources and add focused unit coverage for naming/link behavior

## References

- Part of #203
- Follows the provider coverage pattern from #185
- AWS provider 5.100.0 EKS resource docs: https://registry.terraform.io/providers/hashicorp/aws/5.100.0/docs/resources/eks_cluster

