### PR TITLE
deps(launchdarkly): migrate api-client-go from v5 to v16

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -160,11 +160,7 @@ require (
 	github.com/okta/terraform-provider-okta v0.0.0-20260428063648-33f61ad39f19
 )
 
-require (
-	github.com/antihax/optional v1.0.0 // indirect
-	github.com/gofrs/uuid v3.3.0+incompatible // indirect
-	github.com/launchdarkly/api-client-go v5.3.0+incompatible
-)
+require github.com/gofrs/uuid v3.3.0+incompatible // indirect
 
 require (
 	github.com/Azure/azure-pipeline-go v0.2.3 // indirect
@@ -384,6 +380,7 @@ require (
 	github.com/ionos-cloud/sdk-go-dns v1.4.0
 	github.com/ionos-cloud/sdk-go-logging v1.3.0
 	github.com/keycloak/terraform-provider-keycloak v0.0.0-20260427092706-7d5f3cbff050
+	github.com/launchdarkly/api-client-go/v16 v16.1.1
 	github.com/logzio/logzio_terraform_client v1.30.2
 	github.com/newrelic/newrelic-client-go v1.1.0
 	github.com/okta/okta-sdk-golang/v5 v5.0.6

--- a/go.sum
+++ b/go.sum
@@ -149,8 +149,6 @@ github.com/aliyun/alibaba-cloud-sdk-go v1.63.107 h1:qagvUyrgOnBIlVRQWOyCZGVKUIYb
 github.com/aliyun/alibaba-cloud-sdk-go v1.63.107/go.mod h1:SOSDHfe1kX91v3W5QiBsWSLqeLxImobbMX1mxrFHsVQ=
 github.com/aliyun/aliyun-tablestore-go-sdk v4.1.3+incompatible h1:UbBDubZ5xDDaB50NvikAEPxz9dNG4+JVgIvV4y3dvFM=
 github.com/aliyun/aliyun-tablestore-go-sdk v4.1.3+incompatible/go.mod h1:LDQHRZylxvcg8H7wBIDfvO5g/cy4/sz1iucBlc2l3Jw=
-github.com/antihax/optional v1.0.0 h1:xK2lYat7ZLaVVcIuj82J8kIro4V6kDe0AUDFboUCwcg=
-github.com/antihax/optional v1.0.0/go.mod h1:uupD/76wgC+ih3iEmQUL+0Ugr19nfwCT1kdvxnR2qWY=
 github.com/apache/openwhisk-client-go v0.0.0-20250309042127-fa7fa7e48863 h1:W+tgDSyt1num4A844IFtgNj67qklY89UDFHwLHgpfDE=
 github.com/apache/openwhisk-client-go v0.0.0-20250309042127-fa7fa7e48863/go.mod h1:2ipmJ/3d2lYbfhmHq3bNj5Q876f20daGybloGmdrbzQ=
 github.com/apparentlymart/go-textseg/v15 v15.0.0 h1:uYvfpb3DyLSCGWnctWKGj857c6ew1u1fNQOlOtuGxQY=
@@ -786,8 +784,8 @@ github.com/kylelemons/godebug v1.1.0 h1:RPNrshWIDI6G2gRW9EHilWtl7Z6Sb1BR0xunSBf0
 github.com/kylelemons/godebug v1.1.0/go.mod h1:9/0rRGxNHcop5bhtWyNeEfOS8JIWk580+fNqagV/RAw=
 github.com/labd/commercetools-go-sdk v1.9.0 h1:ZeAtYM5RL7uNb+STvIr6rKJGMMWYZAjyKg6sWWrmrFk=
 github.com/labd/commercetools-go-sdk v1.9.0/go.mod h1:QMG2KGTVY7uyVDJTKvaaFnw8h5lZwq/SEBlPVPrMrQ0=
-github.com/launchdarkly/api-client-go v5.3.0+incompatible h1:xB4QGNbNzAUm2UDdtlsHhmCrs6l7OQGWFgs1xB6s/u8=
-github.com/launchdarkly/api-client-go v5.3.0+incompatible/go.mod h1:INGa7NUZYSwVozwPV7l6ikgD7pzSOpZvg9I5sqCZIWs=
+github.com/launchdarkly/api-client-go/v16 v16.1.1 h1:YkGeHD0Syls1NL+ta6FJOXxkACfT58LPB0itaG29mNk=
+github.com/launchdarkly/api-client-go/v16 v16.1.1/go.mod h1:LTKQebyewnd5lsscGIAjaJEG9TTRD6qglalv+1bixME=
 github.com/leodido/go-urn v1.2.0/go.mod h1:+8+nEpDfqqsY+g338gtMEUOtuK+4dEMhiQEgxpxOKII=
 github.com/leodido/go-urn v1.4.0 h1:WT9HwE9SGECu3lg4d/dIA+jxlljEa1/ffXKmRjqdmIQ=
 github.com/leodido/go-urn v1.4.0/go.mod h1:bvxc+MVxLKB4z00jd1z+Dvzr47oO32F/QSNjSBOlFxI=

--- a/providers/launchdarkly/feature_flags.go
+++ b/providers/launchdarkly/feature_flags.go
@@ -38,11 +38,21 @@ func (g *FeatureFlagsGenerator) loadFeatureFlagEnv(ctx context.Context, client *
 }
 
 func (g *FeatureFlagsGenerator) loadFeatureFlags(ctx context.Context, client *ldapi.APIClient, project string) error {
-	featureFlags, _, err := client.FeatureFlagsApi.GetFeatureFlags(ctx, project).Execute()
-	if err != nil {
-		return err
+	var allFlags []ldapi.FeatureFlag
+	for offset := int64(0); ; offset += pageSize {
+		featureFlags, _, err := client.FeatureFlagsApi.GetFeatureFlags(ctx, project).
+			Limit(pageSize).
+			Offset(offset).
+			Execute()
+		if err != nil {
+			return err
+		}
+		allFlags = append(allFlags, featureFlags.Items...)
+		if featureFlags.TotalCount == nil || int64(len(allFlags)) >= int64(*featureFlags.TotalCount) {
+			break
+		}
 	}
-	for _, featureFlag := range featureFlags.Items {
+	for _, featureFlag := range allFlags {
 		resource := terraformutils.NewResource(
 			featureFlag.Key,
 			project+"-"+featureFlag.Name,
@@ -55,7 +65,7 @@ func (g *FeatureFlagsGenerator) loadFeatureFlags(ctx context.Context, client *ld
 			featureFlagsAllowEmptyValues,
 			map[string]interface{}{})
 		resource.IgnoreKeys = append(resource.IgnoreKeys, "include_in_snippet")
-		err = g.loadFeatureFlagEnv(ctx, client, project, featureFlag.Key)
+		err := g.loadFeatureFlagEnv(ctx, client, project, featureFlag.Key)
 		if err != nil {
 			return err
 		}
@@ -69,7 +79,7 @@ func (g *FeatureFlagsGenerator) InitResources() error {
 	if err != nil {
 		return err
 	}
-	for _, project := range projects.Items {
+	for _, project := range projects {
 		if err := g.loadFeatureFlags(g.GetArgs()["ctx"].(context.Context), g.GetArgs()["client"].(*ldapi.APIClient), project.Key); err != nil {
 			return err
 		}

--- a/providers/launchdarkly/feature_flags.go
+++ b/providers/launchdarkly/feature_flags.go
@@ -6,7 +6,7 @@ import (
 	"context"
 
 	"github.com/chenrui333/terraformer/terraformutils"
-	launchdarkly "github.com/launchdarkly/api-client-go"
+	ldapi "github.com/launchdarkly/api-client-go/v16"
 )
 
 var featureFlagsAllowEmptyValues = []string{"variations.*.value"}
@@ -15,8 +15,8 @@ type FeatureFlagsGenerator struct {
 	LaunchDarklyService
 }
 
-func (g *FeatureFlagsGenerator) loadFeatureFlagEnv(ctx context.Context, client *launchdarkly.APIClient, projectKey, flagKey string) error {
-	ff, _, err := client.FeatureFlagsApi.GetFeatureFlag(ctx, projectKey, flagKey, &launchdarkly.FeatureFlagsApiGetFeatureFlagOpts{})
+func (g *FeatureFlagsGenerator) loadFeatureFlagEnv(ctx context.Context, client *ldapi.APIClient, projectKey, flagKey string) error {
+	ff, _, err := client.FeatureFlagsApi.GetFeatureFlag(ctx, projectKey, flagKey).Execute()
 	if err != nil {
 		return err
 	}
@@ -37,8 +37,8 @@ func (g *FeatureFlagsGenerator) loadFeatureFlagEnv(ctx context.Context, client *
 	return nil
 }
 
-func (g *FeatureFlagsGenerator) loadFeatureFlags(ctx context.Context, client *launchdarkly.APIClient, project string) error {
-	featureFlags, _, err := client.FeatureFlagsApi.GetFeatureFlags(ctx, project, &launchdarkly.FeatureFlagsApiGetFeatureFlagsOpts{})
+func (g *FeatureFlagsGenerator) loadFeatureFlags(ctx context.Context, client *ldapi.APIClient, project string) error {
+	featureFlags, _, err := client.FeatureFlagsApi.GetFeatureFlags(ctx, project).Execute()
 	if err != nil {
 		return err
 	}
@@ -65,12 +65,12 @@ func (g *FeatureFlagsGenerator) loadFeatureFlags(ctx context.Context, client *la
 }
 
 func (g *FeatureFlagsGenerator) InitResources() error {
-	projects, err := getProjects(g.GetArgs()["ctx"].(context.Context), g.GetArgs()["client"].(*launchdarkly.APIClient))
+	projects, err := getProjects(g.GetArgs()["ctx"].(context.Context), g.GetArgs()["client"].(*ldapi.APIClient))
 	if err != nil {
 		return err
 	}
 	for _, project := range projects.Items {
-		if err := g.loadFeatureFlags(g.GetArgs()["ctx"].(context.Context), g.GetArgs()["client"].(*launchdarkly.APIClient), project.Key); err != nil {
+		if err := g.loadFeatureFlags(g.GetArgs()["ctx"].(context.Context), g.GetArgs()["client"].(*ldapi.APIClient), project.Key); err != nil {
 			return err
 		}
 	}

--- a/providers/launchdarkly/launchdarkly_provider.go
+++ b/providers/launchdarkly/launchdarkly_provider.go
@@ -5,25 +5,20 @@ package launchdarkly
 import (
 	"context"
 	"errors"
-	"fmt"
 	"os"
 
 	"github.com/chenrui333/terraformer/terraformutils"
-	launchdarkly "github.com/launchdarkly/api-client-go"
+	ldapi "github.com/launchdarkly/api-client-go/v16"
 )
 
 type LaunchDarklyProvider struct { //nolint
 	terraformutils.Provider
 	apiKey string
-	client *launchdarkly.APIClient
+	client *ldapi.APIClient
 	ctx    context.Context
 }
 
-const (
-	basePath   = "https://app.launchdarkly.com/api/v2"
-	version    = "0.0.1"
-	APIVersion = "20191212"
-)
+const APIVersion = "20240415"
 
 func (p *LaunchDarklyProvider) Init(_ []string) error {
 	if os.Getenv("LAUNCHDARKLY_ACCESS_TOKEN") == "" {
@@ -31,17 +26,13 @@ func (p *LaunchDarklyProvider) Init(_ []string) error {
 	}
 	p.apiKey = os.Getenv("LAUNCHDARKLY_ACCESS_TOKEN")
 
-	cfg := &launchdarkly.Configuration{
-		BasePath:      basePath,
-		DefaultHeader: make(map[string]string),
-		UserAgent:     fmt.Sprintf("launchdarkly-terraformer/%s", version),
-	}
+	cfg := ldapi.NewConfiguration()
 	cfg.AddDefaultHeader("LD-API-Version", APIVersion)
 
-	p.client = launchdarkly.NewAPIClient(cfg)
+	p.client = ldapi.NewAPIClient(cfg)
 
-	p.ctx = context.WithValue(context.Background(), launchdarkly.ContextAPIKey, launchdarkly.APIKey{
-		Key: p.apiKey,
+	p.ctx = context.WithValue(context.Background(), ldapi.ContextAPIKeys, map[string]ldapi.APIKey{
+		"ApiKey": {Key: p.apiKey},
 	})
 	return nil
 }

--- a/providers/launchdarkly/project.go
+++ b/providers/launchdarkly/project.go
@@ -21,7 +21,6 @@ func getProjects(ctx context.Context, client *ldapi.APIClient) ([]ldapi.Project,
 		projects, _, err := client.ProjectsApi.GetProjects(ctx).
 			Limit(pageSize).
 			Offset(offset).
-			Expand("environments").
 			Execute()
 		if err != nil {
 			return nil, err

--- a/providers/launchdarkly/project.go
+++ b/providers/launchdarkly/project.go
@@ -6,19 +6,19 @@ import (
 	"context"
 
 	"github.com/chenrui333/terraformer/terraformutils"
-	launchdarkly "github.com/launchdarkly/api-client-go"
+	ldapi "github.com/launchdarkly/api-client-go/v16"
 )
 
 type ProjectGenerator struct {
 	LaunchDarklyService
 }
 
-func getProjects(ctx context.Context, client *launchdarkly.APIClient) (launchdarkly.Projects, error) {
-	projects, _, err := client.ProjectsApi.GetProjects(ctx)
+func getProjects(ctx context.Context, client *ldapi.APIClient) (*ldapi.Projects, error) {
+	projects, _, err := client.ProjectsApi.GetProjects(ctx).Execute()
 	return projects, err
 }
 
-func (g *ProjectGenerator) loadProjects(ctx context.Context, client *launchdarkly.APIClient) error {
+func (g *ProjectGenerator) loadProjects(ctx context.Context, client *ldapi.APIClient) error {
 	projects, err := getProjects(ctx, client)
 	if err != nil {
 		return err
@@ -41,7 +41,7 @@ func (g *ProjectGenerator) loadProjects(ctx context.Context, client *launchdarkl
 }
 
 func (g *ProjectGenerator) InitResources() error {
-	if err := g.loadProjects(g.GetArgs()["ctx"].(context.Context), g.GetArgs()["client"].(*launchdarkly.APIClient)); err != nil {
+	if err := g.loadProjects(g.GetArgs()["ctx"].(context.Context), g.GetArgs()["client"].(*ldapi.APIClient)); err != nil {
 		return err
 	}
 

--- a/providers/launchdarkly/project.go
+++ b/providers/launchdarkly/project.go
@@ -9,13 +9,29 @@ import (
 	ldapi "github.com/launchdarkly/api-client-go/v16"
 )
 
+const pageSize = 20
+
 type ProjectGenerator struct {
 	LaunchDarklyService
 }
 
-func getProjects(ctx context.Context, client *ldapi.APIClient) (*ldapi.Projects, error) {
-	projects, _, err := client.ProjectsApi.GetProjects(ctx).Execute()
-	return projects, err
+func getProjects(ctx context.Context, client *ldapi.APIClient) ([]ldapi.Project, error) {
+	var allProjects []ldapi.Project
+	for offset := int64(0); ; offset += pageSize {
+		projects, _, err := client.ProjectsApi.GetProjects(ctx).
+			Limit(pageSize).
+			Offset(offset).
+			Expand("environments").
+			Execute()
+		if err != nil {
+			return nil, err
+		}
+		allProjects = append(allProjects, projects.Items...)
+		if projects.TotalCount == nil || int64(len(allProjects)) >= int64(*projects.TotalCount) {
+			break
+		}
+	}
+	return allProjects, nil
 }
 
 func (g *ProjectGenerator) loadProjects(ctx context.Context, client *ldapi.APIClient) error {
@@ -23,7 +39,7 @@ func (g *ProjectGenerator) loadProjects(ctx context.Context, client *ldapi.APICl
 	if err != nil {
 		return err
 	}
-	for _, project := range projects.Items {
+	for _, project := range projects {
 		resource := terraformutils.NewResource(
 			project.Key,
 			project.Key,

--- a/providers/launchdarkly/segment.go
+++ b/providers/launchdarkly/segment.go
@@ -13,6 +13,24 @@ type SegmentGenerator struct {
 	LaunchDarklyService
 }
 
+func getEnvironments(ctx context.Context, client *ldapi.APIClient, projectKey string) ([]ldapi.Environment, error) {
+	var allEnvs []ldapi.Environment
+	for offset := int64(0); ; offset += pageSize {
+		envs, _, err := client.EnvironmentsApi.GetEnvironmentsByProject(ctx, projectKey).
+			Limit(pageSize).
+			Offset(offset).
+			Execute()
+		if err != nil {
+			return nil, err
+		}
+		allEnvs = append(allEnvs, envs.Items...)
+		if envs.TotalCount == nil || int64(len(allEnvs)) >= int64(*envs.TotalCount) {
+			break
+		}
+	}
+	return allEnvs, nil
+}
+
 func (g *SegmentGenerator) loadSegment(ctx context.Context, client *ldapi.APIClient, project, envKey string) error {
 	var allSegments []ldapi.UserSegment
 	for offset := int64(0); ; offset += pageSize {
@@ -48,16 +66,20 @@ func (g *SegmentGenerator) loadSegment(ctx context.Context, client *ldapi.APICli
 }
 
 func (g *SegmentGenerator) InitResources() error {
-	projects, err := getProjects(g.GetArgs()["ctx"].(context.Context), g.GetArgs()["client"].(*ldapi.APIClient))
+	ctx := g.GetArgs()["ctx"].(context.Context)
+	client := g.GetArgs()["client"].(*ldapi.APIClient)
+
+	projects, err := getProjects(ctx, client)
 	if err != nil {
 		return err
 	}
 	for _, project := range projects {
-		if project.Environments == nil {
-			continue
+		envs, err := getEnvironments(ctx, client, project.Key)
+		if err != nil {
+			return err
 		}
-		for _, env := range project.Environments.Items {
-			if err := g.loadSegment(g.GetArgs()["ctx"].(context.Context), g.GetArgs()["client"].(*ldapi.APIClient), project.Key, env.Key); err != nil {
+		for _, env := range envs {
+			if err := g.loadSegment(ctx, client, project.Key, env.Key); err != nil {
 				return err
 			}
 		}

--- a/providers/launchdarkly/segment.go
+++ b/providers/launchdarkly/segment.go
@@ -14,11 +14,21 @@ type SegmentGenerator struct {
 }
 
 func (g *SegmentGenerator) loadSegment(ctx context.Context, client *ldapi.APIClient, project, envKey string) error {
-	segments, _, err := client.SegmentsApi.GetSegments(ctx, project, envKey).Execute()
-	if err != nil {
-		return err
+	var allSegments []ldapi.UserSegment
+	for offset := int64(0); ; offset += pageSize {
+		segments, _, err := client.SegmentsApi.GetSegments(ctx, project, envKey).
+			Limit(pageSize).
+			Offset(offset).
+			Execute()
+		if err != nil {
+			return err
+		}
+		allSegments = append(allSegments, segments.Items...)
+		if int64(len(allSegments)) >= int64(segments.TotalCount) {
+			break
+		}
 	}
-	for _, segment := range segments.Items {
+	for _, segment := range allSegments {
 		resource := terraformutils.NewResource(
 			segment.Key,
 			project+"-"+envKey+"-"+segment.Name,
@@ -42,7 +52,7 @@ func (g *SegmentGenerator) InitResources() error {
 	if err != nil {
 		return err
 	}
-	for _, project := range projects.Items {
+	for _, project := range projects {
 		if project.Environments == nil {
 			continue
 		}

--- a/providers/launchdarkly/segment.go
+++ b/providers/launchdarkly/segment.go
@@ -6,15 +6,15 @@ import (
 	"context"
 
 	"github.com/chenrui333/terraformer/terraformutils"
-	launchdarkly "github.com/launchdarkly/api-client-go"
+	ldapi "github.com/launchdarkly/api-client-go/v16"
 )
 
 type SegmentGenerator struct {
 	LaunchDarklyService
 }
 
-func (g *SegmentGenerator) loadSegment(ctx context.Context, client *launchdarkly.APIClient, project, envKey string) error {
-	segments, _, err := client.UserSegmentsApi.GetUserSegments(ctx, project, envKey, &launchdarkly.UserSegmentsApiGetUserSegmentsOpts{})
+func (g *SegmentGenerator) loadSegment(ctx context.Context, client *ldapi.APIClient, project, envKey string) error {
+	segments, _, err := client.SegmentsApi.GetSegments(ctx, project, envKey).Execute()
 	if err != nil {
 		return err
 	}
@@ -38,13 +38,16 @@ func (g *SegmentGenerator) loadSegment(ctx context.Context, client *launchdarkly
 }
 
 func (g *SegmentGenerator) InitResources() error {
-	projects, err := getProjects(g.GetArgs()["ctx"].(context.Context), g.GetArgs()["client"].(*launchdarkly.APIClient))
+	projects, err := getProjects(g.GetArgs()["ctx"].(context.Context), g.GetArgs()["client"].(*ldapi.APIClient))
 	if err != nil {
 		return err
 	}
 	for _, project := range projects.Items {
-		for _, env := range project.Environments {
-			if err := g.loadSegment(g.GetArgs()["ctx"].(context.Context), g.GetArgs()["client"].(*launchdarkly.APIClient), project.Key, env.Key); err != nil {
+		if project.Environments == nil {
+			continue
+		}
+		for _, env := range project.Environments.Items {
+			if err := g.loadSegment(g.GetArgs()["ctx"].(context.Context), g.GetArgs()["client"].(*ldapi.APIClient), project.Key, env.Key); err != nil {
 				return err
 			}
 		}


### PR DESCRIPTION
## Summary

Migrate the LaunchDarkly provider from the deprecated `github.com/launchdarkly/api-client-go` v5.3.0+incompatible to `github.com/launchdarkly/api-client-go/v16` v16.1.1.

The old SDK was generated from a manually curated Swagger 2.0 spec targeting API version `20191212` (deprecated). No updates since 2021.

### Changes

- **Config**: manual `BasePath` struct → `NewConfiguration()`
- **Auth**: `ContextAPIKey` (singular) → `ContextAPIKeys` (map-based)
- **API calls**: direct returns → builder pattern with `.Execute()`
- **Segments**: `UserSegmentsApi` → `SegmentsApi`, `project.Environments` is now `*Environments` with `.Items` field
- **API version**: `20191212` → `20240415`
- Net reduction of 11 lines

Closes #205