### PR TITLE
aws(ecr): add additional ECR resources

### DIFF
--- a/docs/aws.md
+++ b/docs/aws.md
@@ -125,11 +125,18 @@ terraformer import aws --resources=sg --regions=us-east-1
 *   `ec2_instance`
     * `aws_instance`
 *   `ecr`
+    * `aws_ecr_account_setting`
     * `aws_ecr_lifecycle_policy`
+    * `aws_ecr_pull_through_cache_rule`
+    * `aws_ecr_registry_policy`
+    * `aws_ecr_registry_scanning_configuration`
+    * `aws_ecr_replication_configuration`
     * `aws_ecr_repository`
+    * `aws_ecr_repository_creation_template`
     * `aws_ecr_repository_policy`
 *   `ecrpublic`
     * `aws_ecrpublic_repository`
+    * `aws_ecrpublic_repository_policy`
 *   `ecs`
     * `aws_ecs_cluster`
     * `aws_ecs_service`

--- a/providers/aws/ecr.go
+++ b/providers/aws/ecr.go
@@ -16,8 +16,10 @@ import (
 
 var ecrAllowEmptyValues = []string{"tags."}
 
+// Unsupported account settings are skipped by the InvalidParameterException guard.
 var ecrAccountSettingNames = []string{
 	"BASIC_SCAN_TYPE_VERSION",
+	"BLOB_MOUNTING",
 	"REGISTRY_POLICY_SCOPE",
 }
 
@@ -194,6 +196,7 @@ func (g *EcrGenerator) getPullThroughCacheRules(svc *ecr.Client) error {
 	for p.HasMorePages() {
 		page, err := p.NextPage(context.TODO())
 		if ecrPullThroughCacheRuleNotFound(err) {
+			// The unfiltered list should only return this before any rules are found.
 			return nil
 		}
 		if err != nil {

--- a/providers/aws/ecr.go
+++ b/providers/aws/ecr.go
@@ -4,14 +4,21 @@ package aws
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
 	"github.com/aws/aws-sdk-go-v2/service/ecr"
+	"github.com/aws/aws-sdk-go-v2/service/ecr/types"
 
 	"github.com/chenrui333/terraformer/terraformutils"
 )
 
 var ecrAllowEmptyValues = []string{"tags."}
+
+var ecrAccountSettingNames = []string{
+	"BASIC_SCAN_TYPE_VERSION",
+	"REGISTRY_POLICY_SCOPE",
+}
 
 type EcrGenerator struct {
 	AWSService
@@ -24,6 +31,25 @@ func (g *EcrGenerator) InitResources() error {
 	}
 
 	svc := ecr.NewFromConfig(config)
+
+	if err := g.getAccountSettings(svc); err != nil {
+		return err
+	}
+	if err := g.getRegistryPolicy(svc); err != nil {
+		return err
+	}
+	if err := g.getRegistryScanningConfiguration(svc); err != nil {
+		return err
+	}
+	if err := g.getReplicationConfiguration(svc); err != nil {
+		return err
+	}
+	if err := g.getPullThroughCacheRules(svc); err != nil {
+		return err
+	}
+	if err := g.getRepositoryCreationTemplates(svc); err != nil {
+		return err
+	}
 
 	p := ecr.NewDescribeRepositoriesPaginator(svc, &ecr.DescribeRepositoriesInput{})
 	for p.HasMorePages() {
@@ -39,11 +65,11 @@ func (g *EcrGenerator) InitResources() error {
 				"aws",
 				ecrAllowEmptyValues))
 
-			_, err := svc.GetRepositoryPolicy(context.TODO(), &ecr.GetRepositoryPolicyInput{
+			repositoryPolicy, err := svc.GetRepositoryPolicy(context.TODO(), &ecr.GetRepositoryPolicyInput{
 				RepositoryName: repository.RepositoryName,
 				RegistryId:     repository.RegistryId,
 			})
-			if err == nil {
+			if err == nil && StringValue(repositoryPolicy.PolicyText) != "" {
 				g.Resources = append(g.Resources, terraformutils.NewSimpleResource(
 					*repository.RepositoryName,
 					*repository.RepositoryName,
@@ -52,11 +78,11 @@ func (g *EcrGenerator) InitResources() error {
 					ecrAllowEmptyValues))
 			}
 
-			_, err = svc.GetLifecyclePolicy(context.TODO(), &ecr.GetLifecyclePolicyInput{
+			lifecyclePolicy, err := svc.GetLifecyclePolicy(context.TODO(), &ecr.GetLifecyclePolicyInput{
 				RepositoryName: repository.RepositoryName,
 				RegistryId:     repository.RegistryId,
 			})
-			if err == nil {
+			if err == nil && StringValue(lifecyclePolicy.LifecyclePolicyText) != "" {
 				g.Resources = append(g.Resources, terraformutils.NewSimpleResource(
 					*repository.RepositoryName,
 					*repository.RepositoryName,
@@ -69,24 +95,184 @@ func (g *EcrGenerator) InitResources() error {
 	return nil
 }
 
-func (g *EcrGenerator) PostConvertHook() error {
-	for i, resource := range g.Resources {
-		switch resource.InstanceInfo.Type {
-		case "aws_ecr_repository_policy":
-			if val, ok := g.Resources[i].Item["policy"]; ok {
-				policy := g.escapeAwsInterpolation(val.(string))
-				g.Resources[i].Item["policy"] = fmt.Sprintf(`<<POLICY
-%s
-POLICY`, policy)
+func (g *EcrGenerator) getAccountSettings(svc *ecr.Client) error {
+	for _, settingName := range ecrAccountSettingNames {
+		setting, err := svc.GetAccountSetting(context.TODO(), &ecr.GetAccountSettingInput{
+			Name: &settingName,
+		})
+		if ecrInvalidParameter(err) {
+			continue
+		}
+		if err != nil {
+			return err
+		}
+		if StringValue(setting.Value) == "" {
+			continue
+		}
+
+		name := StringValue(setting.Name)
+		if name == "" {
+			name = settingName
+		}
+		g.Resources = append(g.Resources, terraformutils.NewSimpleResource(
+			name,
+			name,
+			"aws_ecr_account_setting",
+			"aws",
+			ecrAllowEmptyValues))
+	}
+	return nil
+}
+
+func (g *EcrGenerator) getRegistryPolicy(svc *ecr.Client) error {
+	policy, err := svc.GetRegistryPolicy(context.TODO(), &ecr.GetRegistryPolicyInput{})
+	if ecrRegistryPolicyNotFound(err) {
+		return nil
+	}
+	if err != nil {
+		return err
+	}
+	registryID := StringValue(policy.RegistryId)
+	if registryID == "" || StringValue(policy.PolicyText) == "" {
+		return nil
+	}
+
+	g.Resources = append(g.Resources, terraformutils.NewSimpleResource(
+		registryID,
+		"registry-policy",
+		"aws_ecr_registry_policy",
+		"aws",
+		ecrAllowEmptyValues))
+	return nil
+}
+
+func (g *EcrGenerator) getRegistryScanningConfiguration(svc *ecr.Client) error {
+	scanningConfiguration, err := svc.GetRegistryScanningConfiguration(context.TODO(), &ecr.GetRegistryScanningConfigurationInput{})
+	if err != nil {
+		return err
+	}
+	registryID := StringValue(scanningConfiguration.RegistryId)
+	if registryID == "" || scanningConfiguration.ScanningConfiguration == nil || scanningConfiguration.ScanningConfiguration.ScanType == "" {
+		return nil
+	}
+
+	g.Resources = append(g.Resources, terraformutils.NewSimpleResource(
+		registryID,
+		"registry-scanning-configuration",
+		"aws_ecr_registry_scanning_configuration",
+		"aws",
+		ecrAllowEmptyValues))
+	return nil
+}
+
+func (g *EcrGenerator) getReplicationConfiguration(svc *ecr.Client) error {
+	registry, err := svc.DescribeRegistry(context.TODO(), &ecr.DescribeRegistryInput{})
+	if err != nil {
+		return err
+	}
+	registryID := StringValue(registry.RegistryId)
+	if registryID == "" || registry.ReplicationConfiguration == nil || len(registry.ReplicationConfiguration.Rules) == 0 {
+		return nil
+	}
+
+	g.Resources = append(g.Resources, terraformutils.NewSimpleResource(
+		registryID,
+		"replication-configuration",
+		"aws_ecr_replication_configuration",
+		"aws",
+		ecrAllowEmptyValues))
+	return nil
+}
+
+func (g *EcrGenerator) getPullThroughCacheRules(svc *ecr.Client) error {
+	p := ecr.NewDescribePullThroughCacheRulesPaginator(svc, &ecr.DescribePullThroughCacheRulesInput{})
+	for p.HasMorePages() {
+		page, err := p.NextPage(context.TODO())
+		if ecrPullThroughCacheRuleNotFound(err) {
+			return nil
+		}
+		if err != nil {
+			return err
+		}
+		for _, rule := range page.PullThroughCacheRules {
+			prefix := StringValue(rule.EcrRepositoryPrefix)
+			if prefix == "" {
+				continue
 			}
-		case "aws_ecr_lifecycle_policy":
-			if val, ok := g.Resources[i].Item["policy"]; ok {
-				policy := g.escapeAwsInterpolation(val.(string))
-				g.Resources[i].Item["policy"] = fmt.Sprintf(`<<POLICY
-%s
-POLICY`, policy)
-			}
+			g.Resources = append(g.Resources, terraformutils.NewSimpleResource(
+				prefix,
+				prefix,
+				"aws_ecr_pull_through_cache_rule",
+				"aws",
+				ecrAllowEmptyValues))
 		}
 	}
 	return nil
+}
+
+func (g *EcrGenerator) getRepositoryCreationTemplates(svc *ecr.Client) error {
+	p := ecr.NewDescribeRepositoryCreationTemplatesPaginator(svc, &ecr.DescribeRepositoryCreationTemplatesInput{})
+	for p.HasMorePages() {
+		page, err := p.NextPage(context.TODO())
+		if ecrTemplateNotFound(err) {
+			return nil
+		}
+		if err != nil {
+			return err
+		}
+		for _, template := range page.RepositoryCreationTemplates {
+			prefix := StringValue(template.Prefix)
+			if prefix == "" {
+				continue
+			}
+			g.Resources = append(g.Resources, terraformutils.NewSimpleResource(
+				prefix,
+				prefix,
+				"aws_ecr_repository_creation_template",
+				"aws",
+				ecrAllowEmptyValues))
+		}
+	}
+	return nil
+}
+
+func (g *EcrGenerator) PostConvertHook() error {
+	for i, resource := range g.Resources {
+		switch resource.InstanceInfo.Type {
+		case "aws_ecr_repository_policy", "aws_ecr_lifecycle_policy", "aws_ecr_registry_policy":
+			g.wrapEcrPolicy(i, "policy")
+		case "aws_ecr_repository_creation_template":
+			g.wrapEcrPolicy(i, "repository_policy")
+			g.wrapEcrPolicy(i, "lifecycle_policy")
+		}
+	}
+	return nil
+}
+
+func (g *EcrGenerator) wrapEcrPolicy(resourceIndex int, field string) {
+	policy, ok := g.Resources[resourceIndex].Item[field].(string)
+	if !ok || policy == "" {
+		return
+	}
+	g.Resources[resourceIndex].Item[field] = fmt.Sprintf("<<POLICY\n%s\nPOLICY", g.escapeAwsInterpolation(policy))
+}
+
+func ecrInvalidParameter(err error) bool {
+	var invalidParameter *types.InvalidParameterException
+	return errors.As(err, &invalidParameter)
+}
+
+func ecrRegistryPolicyNotFound(err error) bool {
+	var notFound *types.RegistryPolicyNotFoundException
+	return errors.As(err, &notFound)
+}
+
+func ecrPullThroughCacheRuleNotFound(err error) bool {
+	var notFound *types.PullThroughCacheRuleNotFoundException
+	return errors.As(err, &notFound)
+}
+
+func ecrTemplateNotFound(err error) bool {
+	var notFound *types.TemplateNotFoundException
+	return errors.As(err, &notFound)
 }

--- a/providers/aws/ecr.go
+++ b/providers/aws/ecr.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"log"
 
 	"github.com/aws/aws-sdk-go-v2/service/ecr"
 	"github.com/aws/aws-sdk-go-v2/service/ecr/types"
@@ -20,6 +21,11 @@ var ecrAccountSettingNames = []string{
 	"REGISTRY_POLICY_SCOPE",
 }
 
+type ecrOptionalResourceLoader struct {
+	name string
+	load func() error
+}
+
 type EcrGenerator struct {
 	AWSService
 }
@@ -32,24 +38,15 @@ func (g *EcrGenerator) InitResources() error {
 
 	svc := ecr.NewFromConfig(config)
 
-	if err := g.getAccountSettings(svc); err != nil {
-		return err
-	}
-	if err := g.getRegistryPolicy(svc); err != nil {
-		return err
-	}
-	if err := g.getRegistryScanningConfiguration(svc); err != nil {
-		return err
-	}
-	if err := g.getReplicationConfiguration(svc); err != nil {
-		return err
-	}
-	if err := g.getPullThroughCacheRules(svc); err != nil {
-		return err
-	}
-	if err := g.getRepositoryCreationTemplates(svc); err != nil {
-		return err
-	}
+	// Registry-level resources use separate IAM actions; keep repository import best-effort when those are denied.
+	g.getOptionalRegistryResources(
+		ecrOptionalResourceLoader{name: "account settings", load: func() error { return g.getAccountSettings(svc) }},
+		ecrOptionalResourceLoader{name: "registry policy", load: func() error { return g.getRegistryPolicy(svc) }},
+		ecrOptionalResourceLoader{name: "registry scanning configuration", load: func() error { return g.getRegistryScanningConfiguration(svc) }},
+		ecrOptionalResourceLoader{name: "replication configuration", load: func() error { return g.getReplicationConfiguration(svc) }},
+		ecrOptionalResourceLoader{name: "pull-through cache rules", load: func() error { return g.getPullThroughCacheRules(svc) }},
+		ecrOptionalResourceLoader{name: "repository creation templates", load: func() error { return g.getRepositoryCreationTemplates(svc) }},
+	)
 
 	p := ecr.NewDescribeRepositoriesPaginator(svc, &ecr.DescribeRepositoriesInput{})
 	for p.HasMorePages() {
@@ -93,6 +90,14 @@ func (g *EcrGenerator) InitResources() error {
 		}
 	}
 	return nil
+}
+
+func (g *EcrGenerator) getOptionalRegistryResources(loaders ...ecrOptionalResourceLoader) {
+	for _, loader := range loaders {
+		if err := loader.load(); err != nil {
+			log.Printf("failed to discover optional ECR %s: %s", loader.name, err)
+		}
+	}
 }
 
 func (g *EcrGenerator) getAccountSettings(svc *ecr.Client) error {

--- a/providers/aws/ecr.go
+++ b/providers/aws/ecr.go
@@ -16,10 +16,9 @@ import (
 
 var ecrAllowEmptyValues = []string{"tags."}
 
-// Unsupported account settings are skipped by the InvalidParameterException guard.
+// Keep this list aligned with the AWS provider v5.100 aws_ecr_account_setting schema.
 var ecrAccountSettingNames = []string{
 	"BASIC_SCAN_TYPE_VERSION",
-	"BLOB_MOUNTING",
 	"REGISTRY_POLICY_SCOPE",
 }
 

--- a/providers/aws/ecr_test.go
+++ b/providers/aws/ecr_test.go
@@ -12,7 +12,7 @@ import (
 )
 
 func TestEcrAccountSettingNames(t *testing.T) {
-	want := []string{"BASIC_SCAN_TYPE_VERSION", "REGISTRY_POLICY_SCOPE"}
+	want := []string{"BASIC_SCAN_TYPE_VERSION", "BLOB_MOUNTING", "REGISTRY_POLICY_SCOPE"}
 	if len(ecrAccountSettingNames) != len(want) {
 		t.Fatalf("ecrAccountSettingNames length = %d, want %d", len(ecrAccountSettingNames), len(want))
 	}

--- a/providers/aws/ecr_test.go
+++ b/providers/aws/ecr_test.go
@@ -54,6 +54,35 @@ func TestEcrOptionalErrorHelpers(t *testing.T) {
 	if ecrInvalidParameter(genericErr) {
 		t.Fatal("ecrInvalidParameter() = true for generic error, want false")
 	}
+	if ecrRegistryPolicyNotFound(nil) {
+		t.Fatal("ecrRegistryPolicyNotFound() = true for nil error, want false")
+	}
+	if ecrPullThroughCacheRuleNotFound(nil) {
+		t.Fatal("ecrPullThroughCacheRuleNotFound() = true for nil error, want false")
+	}
+	if ecrTemplateNotFound(nil) {
+		t.Fatal("ecrTemplateNotFound() = true for nil error, want false")
+	}
+	if ecrInvalidParameter(nil) {
+		t.Fatal("ecrInvalidParameter() = true for nil error, want false")
+	}
+}
+
+func TestEcrOptionalRegistryResourcesContinueAfterError(t *testing.T) {
+	g := EcrGenerator{}
+	calledSecondLoader := false
+
+	g.getOptionalRegistryResources(
+		ecrOptionalResourceLoader{name: "denied", load: func() error { return errors.New("access denied") }},
+		ecrOptionalResourceLoader{name: "next", load: func() error {
+			calledSecondLoader = true
+			return nil
+		}},
+	)
+
+	if !calledSecondLoader {
+		t.Fatal("getOptionalRegistryResources() stopped after optional loader error")
+	}
 }
 
 func TestEcrPostConvertHookWrapsPolicyFields(t *testing.T) {
@@ -93,8 +122,14 @@ func TestEcrPublicRepositoryPolicyHelpers(t *testing.T) {
 	if !ecrPublicRepositoryPolicyNotFound(&publictypes.RepositoryPolicyNotFoundException{}) {
 		t.Fatal("ecrPublicRepositoryPolicyNotFound() = false, want true")
 	}
+	if !ecrPublicRepositoryPolicyNotFound(&publictypes.RepositoryNotFoundException{}) {
+		t.Fatal("ecrPublicRepositoryPolicyNotFound() = false for missing repository, want true")
+	}
 	if ecrPublicRepositoryPolicyNotFound(errors.New("boom")) {
 		t.Fatal("ecrPublicRepositoryPolicyNotFound() = true for generic error, want false")
+	}
+	if ecrPublicRepositoryPolicyNotFound(nil) {
+		t.Fatal("ecrPublicRepositoryPolicyNotFound() = true for nil error, want false")
 	}
 }
 

--- a/providers/aws/ecr_test.go
+++ b/providers/aws/ecr_test.go
@@ -12,7 +12,7 @@ import (
 )
 
 func TestEcrAccountSettingNames(t *testing.T) {
-	want := []string{"BASIC_SCAN_TYPE_VERSION", "BLOB_MOUNTING", "REGISTRY_POLICY_SCOPE"}
+	want := []string{"BASIC_SCAN_TYPE_VERSION", "REGISTRY_POLICY_SCOPE"}
 	if len(ecrAccountSettingNames) != len(want) {
 		t.Fatalf("ecrAccountSettingNames length = %d, want %d", len(ecrAccountSettingNames), len(want))
 	}

--- a/providers/aws/ecr_test.go
+++ b/providers/aws/ecr_test.go
@@ -1,0 +1,116 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package aws
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/service/ecr/types"
+	publictypes "github.com/aws/aws-sdk-go-v2/service/ecrpublic/types"
+	"github.com/chenrui333/terraformer/terraformutils"
+)
+
+func TestEcrAccountSettingNames(t *testing.T) {
+	want := []string{"BASIC_SCAN_TYPE_VERSION", "REGISTRY_POLICY_SCOPE"}
+	if len(ecrAccountSettingNames) != len(want) {
+		t.Fatalf("ecrAccountSettingNames length = %d, want %d", len(ecrAccountSettingNames), len(want))
+	}
+	for i, settingName := range ecrAccountSettingNames {
+		if settingName != want[i] {
+			t.Fatalf("ecrAccountSettingNames[%d] = %q, want %q", i, settingName, want[i])
+		}
+	}
+}
+
+func TestEcrOptionalErrorHelpers(t *testing.T) {
+	registryPolicyErr := &types.RegistryPolicyNotFoundException{}
+	pullThroughErr := &types.PullThroughCacheRuleNotFoundException{}
+	templateErr := &types.TemplateNotFoundException{}
+	invalidParameterErr := &types.InvalidParameterException{}
+	genericErr := errors.New("boom")
+
+	if !ecrRegistryPolicyNotFound(registryPolicyErr) {
+		t.Fatal("ecrRegistryPolicyNotFound() = false, want true")
+	}
+	if !ecrPullThroughCacheRuleNotFound(pullThroughErr) {
+		t.Fatal("ecrPullThroughCacheRuleNotFound() = false, want true")
+	}
+	if !ecrTemplateNotFound(templateErr) {
+		t.Fatal("ecrTemplateNotFound() = false, want true")
+	}
+	if !ecrInvalidParameter(invalidParameterErr) {
+		t.Fatal("ecrInvalidParameter() = false, want true")
+	}
+	if ecrRegistryPolicyNotFound(genericErr) {
+		t.Fatal("ecrRegistryPolicyNotFound() = true for generic error, want false")
+	}
+	if ecrPullThroughCacheRuleNotFound(genericErr) {
+		t.Fatal("ecrPullThroughCacheRuleNotFound() = true for generic error, want false")
+	}
+	if ecrTemplateNotFound(genericErr) {
+		t.Fatal("ecrTemplateNotFound() = true for generic error, want false")
+	}
+	if ecrInvalidParameter(genericErr) {
+		t.Fatal("ecrInvalidParameter() = true for generic error, want false")
+	}
+}
+
+func TestEcrPostConvertHookWrapsPolicyFields(t *testing.T) {
+	registryPolicy := terraformutils.NewSimpleResource("123456789012", "registry-policy", "aws_ecr_registry_policy", "aws", ecrAllowEmptyValues)
+	registryPolicy.Item = map[string]interface{}{"policy": "{\"Resource\":\"${aws:ecr}\"}"}
+
+	template := terraformutils.NewSimpleResource("ROOT", "ROOT", "aws_ecr_repository_creation_template", "aws", ecrAllowEmptyValues)
+	template.Item = map[string]interface{}{
+		"repository_policy": "{\"Resource\":\"${aws:ecr}\"}",
+		"lifecycle_policy":  "{\"rules\":[]}",
+	}
+
+	g := EcrGenerator{}
+	g.Resources = []terraformutils.Resource{registryPolicy, template}
+
+	if err := g.PostConvertHook(); err != nil {
+		t.Fatalf("PostConvertHook() returned error: %v", err)
+	}
+
+	wantRegistryPolicy := "<<POLICY\n{\"Resource\":\"$${aws:ecr}\"}\nPOLICY"
+	if got := g.Resources[0].Item["policy"]; got != wantRegistryPolicy {
+		t.Fatalf("registry policy = %q, want %q", got, wantRegistryPolicy)
+	}
+
+	wantRepositoryPolicy := "<<POLICY\n{\"Resource\":\"$${aws:ecr}\"}\nPOLICY"
+	if got := g.Resources[1].Item["repository_policy"]; got != wantRepositoryPolicy {
+		t.Fatalf("repository policy = %q, want %q", got, wantRepositoryPolicy)
+	}
+
+	wantLifecyclePolicy := "<<POLICY\n{\"rules\":[]}\nPOLICY"
+	if got := g.Resources[1].Item["lifecycle_policy"]; got != wantLifecyclePolicy {
+		t.Fatalf("lifecycle policy = %q, want %q", got, wantLifecyclePolicy)
+	}
+}
+
+func TestEcrPublicRepositoryPolicyHelpers(t *testing.T) {
+	if !ecrPublicRepositoryPolicyNotFound(&publictypes.RepositoryPolicyNotFoundException{}) {
+		t.Fatal("ecrPublicRepositoryPolicyNotFound() = false, want true")
+	}
+	if ecrPublicRepositoryPolicyNotFound(errors.New("boom")) {
+		t.Fatal("ecrPublicRepositoryPolicyNotFound() = true for generic error, want false")
+	}
+}
+
+func TestEcrPublicPostConvertHookWrapsPolicy(t *testing.T) {
+	repositoryPolicy := terraformutils.NewSimpleResource("public-repo", "public-repo", "aws_ecrpublic_repository_policy", "aws", ecrPublicAllowEmptyValues)
+	repositoryPolicy.Item = map[string]interface{}{"policy": "{\"Resource\":\"${aws:ecr}\"}"}
+
+	g := EcrPublicGenerator{}
+	g.Resources = []terraformutils.Resource{repositoryPolicy}
+
+	if err := g.PostConvertHook(); err != nil {
+		t.Fatalf("PostConvertHook() returned error: %v", err)
+	}
+
+	want := "<<POLICY\n{\"Resource\":\"$${aws:ecr}\"}\nPOLICY"
+	if got := g.Resources[0].Item["policy"]; got != want {
+		t.Fatalf("policy = %q, want %q", got, want)
+	}
+}

--- a/providers/aws/ecrpublic.go
+++ b/providers/aws/ecrpublic.go
@@ -83,6 +83,7 @@ func (g *EcrPublicGenerator) PostConvertHook() error {
 }
 
 func ecrPublicRepositoryPolicyNotFound(err error) bool {
-	var notFound *types.RepositoryPolicyNotFoundException
-	return errors.As(err, &notFound)
+	var policyNotFound *types.RepositoryPolicyNotFoundException
+	var repositoryNotFound *types.RepositoryNotFoundException
+	return errors.As(err, &policyNotFound) || errors.As(err, &repositoryNotFound)
 }

--- a/providers/aws/ecrpublic.go
+++ b/providers/aws/ecrpublic.go
@@ -4,8 +4,11 @@ package aws
 
 import (
 	"context"
+	"errors"
+	"fmt"
 
 	"github.com/aws/aws-sdk-go-v2/service/ecrpublic"
+	"github.com/aws/aws-sdk-go-v2/service/ecrpublic/types"
 
 	"github.com/chenrui333/terraformer/terraformutils"
 )
@@ -40,7 +43,46 @@ func (g *EcrPublicGenerator) InitResources() error {
 				"aws",
 				ecrPublicAllowEmptyValues)
 			g.Resources = append(g.Resources, resource)
+
+			repositoryPolicy, err := svc.GetRepositoryPolicy(context.TODO(), &ecrpublic.GetRepositoryPolicyInput{
+				RepositoryName: repository.RepositoryName,
+				RegistryId:     repository.RegistryId,
+			})
+			if ecrPublicRepositoryPolicyNotFound(err) {
+				continue
+			}
+			if err != nil {
+				return err
+			}
+			if StringValue(repositoryPolicy.PolicyText) == "" {
+				continue
+			}
+			g.Resources = append(g.Resources, terraformutils.NewSimpleResource(
+				*repository.RepositoryName,
+				*repository.RepositoryName,
+				"aws_ecrpublic_repository_policy",
+				"aws",
+				ecrPublicAllowEmptyValues))
 		}
 	}
 	return nil
+}
+
+func (g *EcrPublicGenerator) PostConvertHook() error {
+	for i, resource := range g.Resources {
+		if resource.InstanceInfo.Type != "aws_ecrpublic_repository_policy" {
+			continue
+		}
+		policy, ok := g.Resources[i].Item["policy"].(string)
+		if !ok || policy == "" {
+			continue
+		}
+		g.Resources[i].Item["policy"] = fmt.Sprintf("<<POLICY\n%s\nPOLICY", g.escapeAwsInterpolation(policy))
+	}
+	return nil
+}
+
+func ecrPublicRepositoryPolicyNotFound(err error) bool {
+	var notFound *types.RepositoryPolicyNotFoundException
+	return errors.As(err, &notFound)
 }

--- a/providers/aws/ecrpublic.go
+++ b/providers/aws/ecrpublic.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"log"
 
 	"github.com/aws/aws-sdk-go-v2/service/ecrpublic"
 	"github.com/aws/aws-sdk-go-v2/service/ecrpublic/types"
@@ -52,7 +53,8 @@ func (g *EcrPublicGenerator) InitResources() error {
 				continue
 			}
 			if err != nil {
-				return err
+				log.Printf("failed to discover optional ECR Public repository policy for %s: %s", StringValue(repository.RepositoryName), err)
+				continue
 			}
 			if StringValue(repositoryPolicy.PolicyText) == "" {
 				continue


### PR DESCRIPTION
## Summary

- add import discovery for ECR account, registry, pull-through cache, replication, and repository creation template resources
- add ECR Public repository policy imports
- update AWS docs and add focused ECR helper tests

## References

- Part of #203
- AWS provider 5.100 ECR resource docs

