### PR TITLE
aws(cloudwatch): add logs and eventbridge resources

### DIFF
--- a/docs/aws.md
+++ b/docs/aws.md
@@ -87,6 +87,11 @@ terraformer import aws --resources=sg --regions=us-east-1
     * `aws_cloudtrail`
 *   `cloudwatch`
     * `aws_cloudwatch_dashboard`
+    * `aws_cloudwatch_event_api_destination`
+    * `aws_cloudwatch_event_archive`
+    * `aws_cloudwatch_event_bus`
+    * `aws_cloudwatch_event_bus_policy`
+    * `aws_cloudwatch_event_connection`
     * `aws_cloudwatch_event_rule`
     * `aws_cloudwatch_event_target`
     * `aws_cloudwatch_metric_alarm`
@@ -216,7 +221,14 @@ terraformer import aws --resources=sg --regions=us-east-1
     * `aws_lambda_layer_version`
     * `aws_lambda_permission`
 *   `logs`
+    * `aws_cloudwatch_log_account_policy`
+    * `aws_cloudwatch_log_data_protection_policy`
+    * `aws_cloudwatch_log_destination`
     * `aws_cloudwatch_log_group`
+    * `aws_cloudwatch_log_metric_filter`
+    * `aws_cloudwatch_log_resource_policy`
+    * `aws_cloudwatch_log_subscription_filter`
+    * `aws_cloudwatch_query_definition`
 *   `media_package`
     * `aws_media_package_channel`
 *   `media_store`

--- a/docs/aws.md
+++ b/docs/aws.md
@@ -91,7 +91,6 @@ terraformer import aws --resources=sg --regions=us-east-1
     * `aws_cloudwatch_event_archive`
     * `aws_cloudwatch_event_bus`
     * `aws_cloudwatch_event_bus_policy`
-    * `aws_cloudwatch_event_connection`
     * `aws_cloudwatch_event_rule`
     * `aws_cloudwatch_event_target`
     * `aws_cloudwatch_metric_alarm`

--- a/providers/aws/cloudwatch.go
+++ b/providers/aws/cloudwatch.go
@@ -4,13 +4,22 @@ package aws
 
 import (
 	"context"
+	"log"
 
+	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/cloudwatch"
 	"github.com/aws/aws-sdk-go-v2/service/cloudwatchevents"
 	"github.com/chenrui333/terraformer/terraformutils"
 )
 
 var cloudwatchAllowEmptyValues = []string{"tags."}
+
+const defaultEventBusName = "default"
+
+type cloudwatchOptionalResourceLoader struct {
+	name string
+	load func() error
+}
 
 type CloudWatchGenerator struct {
 	AWSService
@@ -32,13 +41,31 @@ func (g *CloudWatchGenerator) InitResources() error {
 		return err
 	}
 
-	cloudwatcheventsSvc := cloudwatchevents.NewFromConfig(config)
-	err = g.createRules(cloudwatcheventsSvc)
+	eventsSvc := cloudwatchevents.NewFromConfig(config)
+	eventBusNames, err := g.createEventBuses(eventsSvc)
+	if err != nil {
+		log.Printf("skipping EventBridge event bus discovery: %v", err)
+		eventBusNames = []string{defaultEventBusName}
+	}
+	err = g.createRules(eventsSvc, eventBusNames)
 	if err != nil {
 		return err
 	}
+	g.getOptionalCloudWatchResources(
+		cloudwatchOptionalResourceLoader{name: "EventBridge archives", load: func() error { return g.createArchives(eventsSvc) }},
+		cloudwatchOptionalResourceLoader{name: "EventBridge connections", load: func() error { return g.createConnections(eventsSvc) }},
+		cloudwatchOptionalResourceLoader{name: "EventBridge API destinations", load: func() error { return g.createAPIDestinations(eventsSvc) }},
+	)
 
 	return nil
+}
+
+func (g *CloudWatchGenerator) getOptionalCloudWatchResources(loaders ...cloudwatchOptionalResourceLoader) {
+	for _, loader := range loaders {
+		if err := loader.load(); err != nil {
+			log.Printf("skipping %s discovery: %v", loader.name, err)
+		}
+	}
 }
 
 func (g *CloudWatchGenerator) createMetricAlarms(cloudwatchSvc *cloudwatch.Client) error {
@@ -91,47 +118,117 @@ func (g *CloudWatchGenerator) createDashboards(cloudwatchSvc *cloudwatch.Client)
 	return nil
 }
 
-func (g *CloudWatchGenerator) createRules(cloudwatcheventsSvc *cloudwatchevents.Client) error {
+func (g *CloudWatchGenerator) createEventBuses(eventsSvc *cloudwatchevents.Client) ([]string, error) {
+	var eventBusNames []string
+	var nextToken *string
+	for {
+		output, err := eventsSvc.ListEventBuses(context.TODO(), &cloudwatchevents.ListEventBusesInput{
+			NextToken: nextToken,
+		})
+		if err != nil {
+			return eventBusNames, err
+		}
+		for _, eventBus := range output.EventBuses {
+			eventBusName := StringValue(eventBus.Name)
+			if eventBusName == "" {
+				continue
+			}
+			eventBusNames = append(eventBusNames, eventBusName)
+			if eventBusName != defaultEventBusName {
+				g.Resources = append(g.Resources, terraformutils.NewSimpleResource(
+					eventBusName,
+					eventBusName,
+					"aws_cloudwatch_event_bus",
+					"aws",
+					cloudwatchAllowEmptyValues))
+			}
+			if StringValue(eventBus.Policy) != "" {
+				g.Resources = append(g.Resources, terraformutils.NewSimpleResource(
+					eventBusName,
+					cloudwatchEventResourceName(eventBusName, "policy"),
+					"aws_cloudwatch_event_bus_policy",
+					"aws",
+					cloudwatchAllowEmptyValues))
+			}
+		}
+		nextToken = output.NextToken
+		if nextToken == nil {
+			break
+		}
+	}
+	if len(eventBusNames) == 0 {
+		eventBusNames = append(eventBusNames, defaultEventBusName)
+	}
+	return eventBusNames, nil
+}
+
+func (g *CloudWatchGenerator) createRules(eventsSvc *cloudwatchevents.Client, eventBusNames []string) error {
+	for _, eventBusName := range eventBusNames {
+		if err := g.createRulesForEventBus(eventsSvc, eventBusName); err != nil {
+			if eventBusName != defaultEventBusName {
+				log.Printf("skipping EventBridge rules for event bus %s: %v", eventBusName, err)
+				continue
+			}
+			return err
+		}
+	}
+	return nil
+}
+
+func (g *CloudWatchGenerator) createRulesForEventBus(eventsSvc *cloudwatchevents.Client, eventBusName string) error {
 	var listRulesNextToken *string
 	for {
-		output, err := cloudwatcheventsSvc.ListRules(context.TODO(), &cloudwatchevents.ListRulesInput{
-			NextToken: listRulesNextToken,
-		})
+		input := &cloudwatchevents.ListRulesInput{
+			EventBusName: aws.String(eventBusName),
+			NextToken:    listRulesNextToken,
+		}
+		output, err := eventsSvc.ListRules(context.TODO(), input)
 		if err != nil {
 			return err
 		}
 		for _, rule := range output.Rules {
+			ruleName := StringValue(rule.Name)
+			if ruleName == "" {
+				continue
+			}
 			g.Resources = append(g.Resources, terraformutils.NewSimpleResource(
-				*rule.Name,
-				*rule.Name,
+				cloudwatchEventRuleImportID(eventBusName, ruleName),
+				cloudwatchEventResourceName(eventBusName, ruleName),
 				"aws_cloudwatch_event_rule",
 				"aws",
 				cloudwatchAllowEmptyValues))
 
 			var listTargetsNextToken *string
 			for {
-				targetResponse, err := cloudwatcheventsSvc.ListTargetsByRule(context.TODO(), &cloudwatchevents.ListTargetsByRuleInput{
-					Rule:      rule.Name,
-					NextToken: listTargetsNextToken,
+				targetResponse, err := eventsSvc.ListTargetsByRule(context.TODO(), &cloudwatchevents.ListTargetsByRuleInput{
+					EventBusName: aws.String(eventBusName),
+					Rule:         aws.String(ruleName),
+					NextToken:    listTargetsNextToken,
 				})
 				if err != nil {
 					return err
 				}
 				for _, target := range targetResponse.Targets {
-					targetRef := *rule.Name + "/" + *target.Id
+					targetID := StringValue(target.Id)
+					if targetID == "" {
+						continue
+					}
+					targetRef := cloudwatchEventTargetImportID(eventBusName, ruleName, targetID)
+					attributes := map[string]string{
+						"event_bus_name": eventBusName,
+						"rule":           ruleName,
+						"target_id":      targetID,
+					}
 					g.Resources = append(g.Resources, terraformutils.NewResource(
 						targetRef,
-						targetRef,
+						cloudwatchEventResourceName(eventBusName, ruleName, targetID),
 						"aws_cloudwatch_event_target",
 						"aws",
-						map[string]string{
-							"rule":      *rule.Name,
-							"target_id": *target.Id,
-						},
+						attributes,
 						cloudwatchAllowEmptyValues,
 						map[string]interface{}{}))
 				}
-				listTargetsNextToken = output.NextToken
+				listTargetsNextToken = targetResponse.NextToken
 				if listTargetsNextToken == nil {
 					break
 				}
@@ -144,4 +241,119 @@ func (g *CloudWatchGenerator) createRules(cloudwatcheventsSvc *cloudwatchevents.
 	}
 
 	return nil
+}
+
+func (g *CloudWatchGenerator) createArchives(eventsSvc *cloudwatchevents.Client) error {
+	var nextToken *string
+	for {
+		output, err := eventsSvc.ListArchives(context.TODO(), &cloudwatchevents.ListArchivesInput{
+			NextToken: nextToken,
+		})
+		if err != nil {
+			return err
+		}
+		for _, archive := range output.Archives {
+			archiveName := StringValue(archive.ArchiveName)
+			if archiveName == "" {
+				continue
+			}
+			g.Resources = append(g.Resources, terraformutils.NewSimpleResource(
+				archiveName,
+				archiveName,
+				"aws_cloudwatch_event_archive",
+				"aws",
+				cloudwatchAllowEmptyValues))
+		}
+		nextToken = output.NextToken
+		if nextToken == nil {
+			break
+		}
+	}
+	return nil
+}
+
+func (g *CloudWatchGenerator) createConnections(eventsSvc *cloudwatchevents.Client) error {
+	var nextToken *string
+	for {
+		output, err := eventsSvc.ListConnections(context.TODO(), &cloudwatchevents.ListConnectionsInput{
+			NextToken: nextToken,
+		})
+		if err != nil {
+			return err
+		}
+		for _, connection := range output.Connections {
+			connectionName := StringValue(connection.Name)
+			if connectionName == "" {
+				continue
+			}
+			g.Resources = append(g.Resources, terraformutils.NewSimpleResource(
+				connectionName,
+				connectionName,
+				"aws_cloudwatch_event_connection",
+				"aws",
+				cloudwatchAllowEmptyValues))
+		}
+		nextToken = output.NextToken
+		if nextToken == nil {
+			break
+		}
+	}
+	return nil
+}
+
+func (g *CloudWatchGenerator) createAPIDestinations(eventsSvc *cloudwatchevents.Client) error {
+	var nextToken *string
+	for {
+		output, err := eventsSvc.ListApiDestinations(context.TODO(), &cloudwatchevents.ListApiDestinationsInput{
+			NextToken: nextToken,
+		})
+		if err != nil {
+			return err
+		}
+		for _, destination := range output.ApiDestinations {
+			destinationName := StringValue(destination.Name)
+			if destinationName == "" {
+				continue
+			}
+			g.Resources = append(g.Resources, terraformutils.NewSimpleResource(
+				destinationName,
+				destinationName,
+				"aws_cloudwatch_event_api_destination",
+				"aws",
+				cloudwatchAllowEmptyValues))
+		}
+		nextToken = output.NextToken
+		if nextToken == nil {
+			break
+		}
+	}
+	return nil
+}
+
+func cloudwatchEventRuleImportID(eventBusName, ruleName string) string {
+	if eventBusName == "" || eventBusName == defaultEventBusName {
+		return ruleName
+	}
+	return eventBusName + "/" + ruleName
+}
+
+func cloudwatchEventTargetImportID(eventBusName, ruleName, targetID string) string {
+	if eventBusName == "" || eventBusName == defaultEventBusName {
+		return ruleName + "/" + targetID
+	}
+	return eventBusName + "/" + ruleName + "/" + targetID
+}
+
+func cloudwatchEventResourceName(parts ...string) string {
+	var name string
+	for _, part := range parts {
+		if part == "" || part == defaultEventBusName {
+			continue
+		}
+		if name != "" {
+			name += "_"
+		}
+		name += part
+	}
+	return name
 }

--- a/providers/aws/cloudwatch.go
+++ b/providers/aws/cloudwatch.go
@@ -346,8 +346,8 @@ func cloudwatchEventTargetImportID(eventBusName, ruleName, targetID string) stri
 
 func cloudwatchEventResourceName(parts ...string) string {
 	var name string
-	for _, part := range parts {
-		if part == "" || part == defaultEventBusName {
+	for i, part := range parts {
+		if part == "" || (i == 0 && part == defaultEventBusName) {
 			continue
 		}
 		if name != "" {

--- a/providers/aws/cloudwatch.go
+++ b/providers/aws/cloudwatch.go
@@ -53,7 +53,6 @@ func (g *CloudWatchGenerator) InitResources() error {
 	}
 	g.getOptionalCloudWatchResources(
 		cloudwatchOptionalResourceLoader{name: "EventBridge archives", load: func() error { return g.createArchives(eventsSvc) }},
-		cloudwatchOptionalResourceLoader{name: "EventBridge connections", load: func() error { return g.createConnections(eventsSvc) }},
 		cloudwatchOptionalResourceLoader{name: "EventBridge API destinations", load: func() error { return g.createAPIDestinations(eventsSvc) }},
 	)
 
@@ -261,35 +260,6 @@ func (g *CloudWatchGenerator) createArchives(eventsSvc *cloudwatchevents.Client)
 				archiveName,
 				archiveName,
 				"aws_cloudwatch_event_archive",
-				"aws",
-				cloudwatchAllowEmptyValues))
-		}
-		nextToken = output.NextToken
-		if nextToken == nil {
-			break
-		}
-	}
-	return nil
-}
-
-func (g *CloudWatchGenerator) createConnections(eventsSvc *cloudwatchevents.Client) error {
-	var nextToken *string
-	for {
-		output, err := eventsSvc.ListConnections(context.TODO(), &cloudwatchevents.ListConnectionsInput{
-			NextToken: nextToken,
-		})
-		if err != nil {
-			return err
-		}
-		for _, connection := range output.Connections {
-			connectionName := StringValue(connection.Name)
-			if connectionName == "" {
-				continue
-			}
-			g.Resources = append(g.Resources, terraformutils.NewSimpleResource(
-				connectionName,
-				connectionName,
-				"aws_cloudwatch_event_connection",
 				"aws",
 				cloudwatchAllowEmptyValues))
 		}

--- a/providers/aws/cloudwatch_test.go
+++ b/providers/aws/cloudwatch_test.go
@@ -1,0 +1,70 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package aws
+
+import "testing"
+
+func TestCloudWatchEventRuleImportID(t *testing.T) {
+	tests := []struct {
+		name         string
+		eventBusName string
+		ruleName     string
+		want         string
+	}{
+		{name: "default bus", eventBusName: defaultEventBusName, ruleName: "daily", want: "daily"},
+		{name: "empty bus", eventBusName: "", ruleName: "daily", want: "daily"},
+		{name: "custom bus", eventBusName: "orders", ruleName: "daily", want: "orders/daily"},
+		{name: "partner bus", eventBusName: "aws.partner/example.com/source", ruleName: "daily", want: "aws.partner/example.com/source/daily"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := cloudwatchEventRuleImportID(tt.eventBusName, tt.ruleName); got != tt.want {
+				t.Fatalf("cloudwatchEventRuleImportID() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestCloudWatchEventTargetImportID(t *testing.T) {
+	tests := []struct {
+		name         string
+		eventBusName string
+		ruleName     string
+		targetID     string
+		want         string
+	}{
+		{name: "default bus", eventBusName: defaultEventBusName, ruleName: "daily", targetID: "target", want: "daily/target"},
+		{name: "empty bus", eventBusName: "", ruleName: "daily", targetID: "target", want: "daily/target"},
+		{name: "custom bus", eventBusName: "orders", ruleName: "daily", targetID: "target", want: "orders/daily/target"},
+		{name: "partner bus", eventBusName: "aws.partner/example.com/source", ruleName: "daily", targetID: "target", want: "aws.partner/example.com/source/daily/target"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := cloudwatchEventTargetImportID(tt.eventBusName, tt.ruleName, tt.targetID); got != tt.want {
+				t.Fatalf("cloudwatchEventTargetImportID() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestCloudWatchEventResourceName(t *testing.T) {
+	tests := []struct {
+		name  string
+		parts []string
+		want  string
+	}{
+		{name: "default bus omitted", parts: []string{defaultEventBusName, "daily"}, want: "daily"},
+		{name: "custom bus included", parts: []string{"orders", "daily"}, want: "orders_daily"},
+		{name: "empty parts omitted", parts: []string{"", "orders", "", "daily"}, want: "orders_daily"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := cloudwatchEventResourceName(tt.parts...); got != tt.want {
+				t.Fatalf("cloudwatchEventResourceName() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}

--- a/providers/aws/cloudwatch_test.go
+++ b/providers/aws/cloudwatch_test.go
@@ -56,6 +56,8 @@ func TestCloudWatchEventResourceName(t *testing.T) {
 		want  string
 	}{
 		{name: "default bus omitted", parts: []string{defaultEventBusName, "daily"}, want: "daily"},
+		{name: "default rule name preserved", parts: []string{defaultEventBusName, defaultEventBusName}, want: "default"},
+		{name: "default target ID preserved", parts: []string{defaultEventBusName, "daily", defaultEventBusName}, want: "daily_default"},
 		{name: "custom bus included", parts: []string{"orders", "daily"}, want: "orders_daily"},
 		{name: "empty parts omitted", parts: []string{"", "orders", "", "daily"}, want: "orders_daily"},
 	}

--- a/providers/aws/logs.go
+++ b/providers/aws/logs.go
@@ -8,7 +8,6 @@ import (
 	"fmt"
 	"log"
 	"strconv"
-	"strings"
 
 	"github.com/aws/aws-sdk-go-v2/service/cloudwatchlogs"
 	"github.com/aws/aws-sdk-go-v2/service/cloudwatchlogs/types"
@@ -90,13 +89,7 @@ func (g *LogsGenerator) InitResources() error {
 		logsOptionalResourceLoader{name: "destinations", load: func() error { return g.addDestinations(svc) }},
 		logsOptionalResourceLoader{name: "resource policies", load: func() error { return g.addResourcePolicies(svc) }},
 		logsOptionalResourceLoader{name: "account policies", load: func() error { return g.addAccountPolicies(svc) }},
-		logsOptionalResourceLoader{name: "query definitions", load: func() error {
-			account, err := g.getAccountNumber(config)
-			if err != nil {
-				return err
-			}
-			return g.addQueryDefinitions(svc, config.Region, StringValue(account))
-		}},
+		logsOptionalResourceLoader{name: "query definitions", load: func() error { return g.addQueryDefinitions(svc) }},
 	)
 	return nil
 }
@@ -124,9 +117,8 @@ func (g *LogsGenerator) addMetricFilters(svc *cloudwatchlogs.Client, logGroupNam
 				if filterName == "" {
 					continue
 				}
-				id := fmt.Sprintf("%s:%s", logGroupName, filterName)
 				g.Resources = append(g.Resources, terraformutils.NewResource(
-					id,
+					filterName,
 					logsResourceName(logGroupName, filterName),
 					"aws_cloudwatch_log_metric_filter",
 					"aws",
@@ -175,6 +167,8 @@ func (g *LogsGenerator) addSubscriptionFilters(svc *cloudwatchlogs.Client, logGr
 	return nil
 }
 
+// AWS does not provide a list API for log group data protection policies, so
+// this optional loader probes each imported log group.
 func (g *LogsGenerator) addDataProtectionPolicies(svc *cloudwatchlogs.Client, logGroupNames []string) error {
 	for _, logGroupName := range logGroupNames {
 		output, err := svc.GetDataProtectionPolicy(context.TODO(), &cloudwatchlogs.GetDataProtectionPolicyInput{
@@ -236,16 +230,18 @@ func (g *LogsGenerator) addResourcePolicies(svc *cloudwatchlogs.Client) error {
 			return err
 		}
 		for _, policy := range output.ResourcePolicies {
-			policyName := StringValue(policy.PolicyName)
-			if policyName == "" || StringValue(policy.PolicyDocument) == "" {
+			policyID, resourceName, attributes := logsResourcePolicyResource(policy)
+			if policyID == "" || StringValue(policy.PolicyDocument) == "" {
 				continue
 			}
-			g.Resources = append(g.Resources, terraformutils.NewSimpleResource(
-				policyName,
-				policyName,
+			g.Resources = append(g.Resources, terraformutils.NewResource(
+				policyID,
+				resourceName,
 				"aws_cloudwatch_log_resource_policy",
 				"aws",
-				logsAllowEmptyValues))
+				attributes,
+				logsAllowEmptyValues,
+				map[string]interface{}{}))
 		}
 		nextToken = output.NextToken
 		if nextToken == nil {
@@ -272,9 +268,8 @@ func (g *LogsGenerator) addAccountPolicies(svc *cloudwatchlogs.Client) error {
 					continue
 				}
 				policyTypeName := string(policy.PolicyType)
-				id := fmt.Sprintf("%s:%s", policyName, policyTypeName)
 				g.Resources = append(g.Resources, terraformutils.NewResource(
-					id,
+					policyName,
 					logsResourceName(policyName, policyTypeName),
 					"aws_cloudwatch_log_account_policy",
 					"aws",
@@ -294,7 +289,7 @@ func (g *LogsGenerator) addAccountPolicies(svc *cloudwatchlogs.Client) error {
 	return nil
 }
 
-func (g *LogsGenerator) addQueryDefinitions(svc *cloudwatchlogs.Client, region, account string) error {
+func (g *LogsGenerator) addQueryDefinitions(svc *cloudwatchlogs.Client) error {
 	var nextToken *string
 	for {
 		output, err := svc.DescribeQueryDefinitions(context.TODO(), &cloudwatchlogs.DescribeQueryDefinitionsInput{
@@ -308,13 +303,16 @@ func (g *LogsGenerator) addQueryDefinitions(svc *cloudwatchlogs.Client, region, 
 			if queryDefinitionID == "" {
 				continue
 			}
-			queryDefinitionARN := logsQueryDefinitionARN(region, account, queryDefinitionID)
-			g.Resources = append(g.Resources, terraformutils.NewSimpleResource(
-				queryDefinitionARN,
+			g.Resources = append(g.Resources, terraformutils.NewResource(
+				queryDefinitionID,
 				logsResourceName(StringValue(queryDefinition.Name), queryDefinitionID),
 				"aws_cloudwatch_query_definition",
 				"aws",
-				logsAllowEmptyValues))
+				map[string]string{
+					"name": StringValue(queryDefinition.Name),
+				},
+				logsAllowEmptyValues,
+				map[string]interface{}{}))
 		}
 		nextToken = output.NextToken
 		if nextToken == nil {
@@ -353,17 +351,23 @@ func logsResourceNotFound(err error) bool {
 	return errors.As(err, &notFound)
 }
 
-func logsQueryDefinitionARN(region, account, queryDefinitionID string) string {
-	return fmt.Sprintf("arn:%s:logs:%s:%s:query-definition:%s", awsPartitionFromRegion(region), region, account, queryDefinitionID)
-}
+func logsResourcePolicyResource(policy types.ResourcePolicy) (string, string, map[string]string) {
+	if policy.PolicyScope == types.PolicyScopeResource {
+		resourceArn := StringValue(policy.ResourceArn)
+		if resourceArn == "" {
+			return "", "", nil
+		}
+		return resourceArn, logsResourceName(StringValue(policy.PolicyName), resourceArn), map[string]string{
+			"policy_scope": string(types.PolicyScopeResource),
+			"resource_arn": resourceArn,
+		}
+	}
 
-func awsPartitionFromRegion(region string) string {
-	switch {
-	case strings.HasPrefix(region, "cn-"):
-		return "aws-cn"
-	case strings.HasPrefix(region, "us-gov-"):
-		return "aws-us-gov"
-	default:
-		return "aws"
+	policyName := StringValue(policy.PolicyName)
+	if policyName == "" {
+		return "", "", nil
+	}
+	return policyName, policyName, map[string]string{
+		"policy_name": policyName,
 	}
 }

--- a/providers/aws/logs.go
+++ b/providers/aws/logs.go
@@ -4,13 +4,30 @@ package aws
 
 import (
 	"context"
+	"errors"
+	"fmt"
+	"log"
 	"strconv"
+	"strings"
 
 	"github.com/aws/aws-sdk-go-v2/service/cloudwatchlogs"
+	"github.com/aws/aws-sdk-go-v2/service/cloudwatchlogs/types"
 	"github.com/chenrui333/terraformer/terraformutils"
 )
 
 var logsAllowEmptyValues = []string{"tags."}
+
+var logsAccountPolicyTypes = []types.PolicyType{
+	types.PolicyTypeDataProtectionPolicy,
+	types.PolicyTypeSubscriptionFilterPolicy,
+	types.PolicyTypeFieldIndexPolicy,
+	types.PolicyTypeTransformerPolicy,
+}
+
+type logsOptionalResourceLoader struct {
+	name string
+	load func() error
+}
 
 type LogsGenerator struct {
 	AWSService
@@ -51,6 +68,7 @@ func (g *LogsGenerator) InitResources() error {
 	}
 	svc := cloudwatchlogs.NewFromConfig(config)
 
+	var logGroupNames []string
 	p := cloudwatchlogs.NewDescribeLogGroupsPaginator(svc, &cloudwatchlogs.DescribeLogGroupsInput{})
 	for p.HasMorePages() {
 		page, err := p.NextPage(context.TODO())
@@ -58,6 +76,250 @@ func (g *LogsGenerator) InitResources() error {
 			return err
 		}
 		g.Resources = append(g.Resources, g.createResources(page)...)
+		for _, logGroup := range page.LogGroups {
+			logGroupName := StringValue(logGroup.LogGroupName)
+			if logGroupName != "" {
+				logGroupNames = append(logGroupNames, logGroupName)
+			}
+		}
+	}
+	g.getOptionalLogResources(
+		logsOptionalResourceLoader{name: "metric filters", load: func() error { return g.addMetricFilters(svc, logGroupNames) }},
+		logsOptionalResourceLoader{name: "subscription filters", load: func() error { return g.addSubscriptionFilters(svc, logGroupNames) }},
+		logsOptionalResourceLoader{name: "data protection policies", load: func() error { return g.addDataProtectionPolicies(svc, logGroupNames) }},
+		logsOptionalResourceLoader{name: "destinations", load: func() error { return g.addDestinations(svc) }},
+		logsOptionalResourceLoader{name: "resource policies", load: func() error { return g.addResourcePolicies(svc) }},
+		logsOptionalResourceLoader{name: "account policies", load: func() error { return g.addAccountPolicies(svc) }},
+		logsOptionalResourceLoader{name: "query definitions", load: func() error {
+			account, err := g.getAccountNumber(config)
+			if err != nil {
+				return err
+			}
+			return g.addQueryDefinitions(svc, config.Region, StringValue(account))
+		}},
+	)
+	return nil
+}
+
+func (g *LogsGenerator) getOptionalLogResources(loaders ...logsOptionalResourceLoader) {
+	for _, loader := range loaders {
+		if err := loader.load(); err != nil {
+			log.Printf("skipping CloudWatch Logs %s discovery: %v", loader.name, err)
+		}
+	}
+}
+
+func (g *LogsGenerator) addMetricFilters(svc *cloudwatchlogs.Client, logGroupNames []string) error {
+	for _, logGroupName := range logGroupNames {
+		p := cloudwatchlogs.NewDescribeMetricFiltersPaginator(svc, &cloudwatchlogs.DescribeMetricFiltersInput{
+			LogGroupName: &logGroupName,
+		})
+		for p.HasMorePages() {
+			page, err := p.NextPage(context.TODO())
+			if err != nil {
+				return err
+			}
+			for _, filter := range page.MetricFilters {
+				filterName := StringValue(filter.FilterName)
+				if filterName == "" {
+					continue
+				}
+				id := fmt.Sprintf("%s:%s", logGroupName, filterName)
+				g.Resources = append(g.Resources, terraformutils.NewResource(
+					id,
+					logsResourceName(logGroupName, filterName),
+					"aws_cloudwatch_log_metric_filter",
+					"aws",
+					map[string]string{
+						"log_group_name": logGroupName,
+						"name":           filterName,
+					},
+					logsAllowEmptyValues,
+					map[string]interface{}{}))
+			}
+		}
+	}
+	return nil
+}
+
+func (g *LogsGenerator) addSubscriptionFilters(svc *cloudwatchlogs.Client, logGroupNames []string) error {
+	for _, logGroupName := range logGroupNames {
+		p := cloudwatchlogs.NewDescribeSubscriptionFiltersPaginator(svc, &cloudwatchlogs.DescribeSubscriptionFiltersInput{
+			LogGroupName: &logGroupName,
+		})
+		for p.HasMorePages() {
+			page, err := p.NextPage(context.TODO())
+			if err != nil {
+				return err
+			}
+			for _, filter := range page.SubscriptionFilters {
+				filterName := StringValue(filter.FilterName)
+				if filterName == "" {
+					continue
+				}
+				id := fmt.Sprintf("%s|%s", logGroupName, filterName)
+				g.Resources = append(g.Resources, terraformutils.NewResource(
+					id,
+					logsResourceName(logGroupName, filterName),
+					"aws_cloudwatch_log_subscription_filter",
+					"aws",
+					map[string]string{
+						"log_group_name": logGroupName,
+						"name":           filterName,
+					},
+					logsAllowEmptyValues,
+					map[string]interface{}{}))
+			}
+		}
+	}
+	return nil
+}
+
+func (g *LogsGenerator) addDataProtectionPolicies(svc *cloudwatchlogs.Client, logGroupNames []string) error {
+	for _, logGroupName := range logGroupNames {
+		output, err := svc.GetDataProtectionPolicy(context.TODO(), &cloudwatchlogs.GetDataProtectionPolicyInput{
+			LogGroupIdentifier: &logGroupName,
+		})
+		if err != nil {
+			if logsResourceNotFound(err) {
+				continue
+			}
+			return err
+		}
+		if StringValue(output.PolicyDocument) == "" {
+			continue
+		}
+		g.Resources = append(g.Resources, terraformutils.NewResource(
+			logGroupName,
+			logGroupName,
+			"aws_cloudwatch_log_data_protection_policy",
+			"aws",
+			map[string]string{
+				"log_group_name": logGroupName,
+			},
+			logsAllowEmptyValues,
+			map[string]interface{}{}))
+	}
+	return nil
+}
+
+func (g *LogsGenerator) addDestinations(svc *cloudwatchlogs.Client) error {
+	p := cloudwatchlogs.NewDescribeDestinationsPaginator(svc, &cloudwatchlogs.DescribeDestinationsInput{})
+	for p.HasMorePages() {
+		page, err := p.NextPage(context.TODO())
+		if err != nil {
+			return err
+		}
+		for _, destination := range page.Destinations {
+			destinationName := StringValue(destination.DestinationName)
+			if destinationName == "" {
+				continue
+			}
+			g.Resources = append(g.Resources, terraformutils.NewSimpleResource(
+				destinationName,
+				destinationName,
+				"aws_cloudwatch_log_destination",
+				"aws",
+				logsAllowEmptyValues))
+		}
+	}
+	return nil
+}
+
+func (g *LogsGenerator) addResourcePolicies(svc *cloudwatchlogs.Client) error {
+	var nextToken *string
+	for {
+		output, err := svc.DescribeResourcePolicies(context.TODO(), &cloudwatchlogs.DescribeResourcePoliciesInput{
+			NextToken: nextToken,
+		})
+		if err != nil {
+			return err
+		}
+		for _, policy := range output.ResourcePolicies {
+			policyName := StringValue(policy.PolicyName)
+			if policyName == "" || StringValue(policy.PolicyDocument) == "" {
+				continue
+			}
+			g.Resources = append(g.Resources, terraformutils.NewSimpleResource(
+				policyName,
+				policyName,
+				"aws_cloudwatch_log_resource_policy",
+				"aws",
+				logsAllowEmptyValues))
+		}
+		nextToken = output.NextToken
+		if nextToken == nil {
+			break
+		}
+	}
+	return nil
+}
+
+func (g *LogsGenerator) addAccountPolicies(svc *cloudwatchlogs.Client) error {
+	for _, policyType := range logsAccountPolicyTypes {
+		var nextToken *string
+		for {
+			output, err := svc.DescribeAccountPolicies(context.TODO(), &cloudwatchlogs.DescribeAccountPoliciesInput{
+				PolicyType: policyType,
+				NextToken:  nextToken,
+			})
+			if err != nil {
+				return err
+			}
+			for _, policy := range output.AccountPolicies {
+				policyName := StringValue(policy.PolicyName)
+				if policyName == "" || StringValue(policy.PolicyDocument) == "" {
+					continue
+				}
+				policyTypeName := string(policy.PolicyType)
+				id := fmt.Sprintf("%s:%s", policyName, policyTypeName)
+				g.Resources = append(g.Resources, terraformutils.NewResource(
+					id,
+					logsResourceName(policyName, policyTypeName),
+					"aws_cloudwatch_log_account_policy",
+					"aws",
+					map[string]string{
+						"policy_name": policyName,
+						"policy_type": policyTypeName,
+					},
+					logsAllowEmptyValues,
+					map[string]interface{}{}))
+			}
+			nextToken = output.NextToken
+			if nextToken == nil {
+				break
+			}
+		}
+	}
+	return nil
+}
+
+func (g *LogsGenerator) addQueryDefinitions(svc *cloudwatchlogs.Client, region, account string) error {
+	var nextToken *string
+	for {
+		output, err := svc.DescribeQueryDefinitions(context.TODO(), &cloudwatchlogs.DescribeQueryDefinitionsInput{
+			NextToken: nextToken,
+		})
+		if err != nil {
+			return err
+		}
+		for _, queryDefinition := range output.QueryDefinitions {
+			queryDefinitionID := StringValue(queryDefinition.QueryDefinitionId)
+			if queryDefinitionID == "" {
+				continue
+			}
+			queryDefinitionARN := logsQueryDefinitionARN(region, account, queryDefinitionID)
+			g.Resources = append(g.Resources, terraformutils.NewSimpleResource(
+				queryDefinitionARN,
+				logsResourceName(StringValue(queryDefinition.Name), queryDefinitionID),
+				"aws_cloudwatch_query_definition",
+				"aws",
+				logsAllowEmptyValues))
+		}
+		nextToken = output.NextToken
+		if nextToken == nil {
+			break
+		}
 	}
 	return nil
 }
@@ -70,4 +332,38 @@ func (g *LogsGenerator) PostConvertHook() error {
 		}
 	}
 	return nil
+}
+
+func logsResourceName(parts ...string) string {
+	var name string
+	for _, part := range parts {
+		if part == "" {
+			continue
+		}
+		if name != "" {
+			name += "_"
+		}
+		name += part
+	}
+	return name
+}
+
+func logsResourceNotFound(err error) bool {
+	var notFound *types.ResourceNotFoundException
+	return errors.As(err, &notFound)
+}
+
+func logsQueryDefinitionARN(region, account, queryDefinitionID string) string {
+	return fmt.Sprintf("arn:%s:logs:%s:%s:query-definition:%s", awsPartitionFromRegion(region), region, account, queryDefinitionID)
+}
+
+func awsPartitionFromRegion(region string) string {
+	switch {
+	case strings.HasPrefix(region, "cn-"):
+		return "aws-cn"
+	case strings.HasPrefix(region, "us-gov-"):
+		return "aws-us-gov"
+	default:
+		return "aws"
+	}
 }

--- a/providers/aws/logs_test.go
+++ b/providers/aws/logs_test.go
@@ -58,41 +58,79 @@ func TestLogsResourceNotFound(t *testing.T) {
 	}
 }
 
-func TestLogsQueryDefinitionARN(t *testing.T) {
+func TestLogsResourcePolicyResource(t *testing.T) {
+	policyName := "account-policy"
+	policyDocument := "{}"
+	resourceArn := "arn:aws:logs:us-east-1:123456789012:log-group:/aws/lambda/example"
+
 	tests := []struct {
-		name              string
-		region            string
-		account           string
-		queryDefinitionID string
-		want              string
+		name           string
+		policy         types.ResourcePolicy
+		wantID         string
+		wantName       string
+		wantAttributes map[string]string
 	}{
 		{
-			name:              "standard partition",
-			region:            "us-east-1",
-			account:           "123456789012",
-			queryDefinitionID: "269951d7-6f75-496d-9d7b-6b7a5486bdbd",
-			want:              "arn:aws:logs:us-east-1:123456789012:query-definition:269951d7-6f75-496d-9d7b-6b7a5486bdbd",
+			name: "account scoped policy uses policy name",
+			policy: types.ResourcePolicy{
+				PolicyDocument: &policyDocument,
+				PolicyName:     &policyName,
+				PolicyScope:    types.PolicyScopeAccount,
+			},
+			wantID:   policyName,
+			wantName: policyName,
+			wantAttributes: map[string]string{
+				"policy_name": policyName,
+			},
 		},
 		{
-			name:              "china partition",
-			region:            "cn-north-1",
-			account:           "123456789012",
-			queryDefinitionID: "query-id",
-			want:              "arn:aws-cn:logs:cn-north-1:123456789012:query-definition:query-id",
+			name: "resource scoped policy uses resource ARN",
+			policy: types.ResourcePolicy{
+				PolicyDocument: &policyDocument,
+				PolicyName:     &policyName,
+				PolicyScope:    types.PolicyScopeResource,
+				ResourceArn:    &resourceArn,
+			},
+			wantID:   resourceArn,
+			wantName: logsResourceName(policyName, resourceArn),
+			wantAttributes: map[string]string{
+				"policy_scope": string(types.PolicyScopeResource),
+				"resource_arn": resourceArn,
+			},
 		},
 		{
-			name:              "gov partition",
-			region:            "us-gov-west-1",
-			account:           "123456789012",
-			queryDefinitionID: "query-id",
-			want:              "arn:aws-us-gov:logs:us-gov-west-1:123456789012:query-definition:query-id",
+			name: "resource scoped policy without ARN is skipped",
+			policy: types.ResourcePolicy{
+				PolicyDocument: &policyDocument,
+				PolicyName:     &policyName,
+				PolicyScope:    types.PolicyScopeResource,
+			},
+		},
+		{
+			name: "account scoped policy without name is skipped",
+			policy: types.ResourcePolicy{
+				PolicyDocument: &policyDocument,
+				PolicyScope:    types.PolicyScopeAccount,
+			},
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := logsQueryDefinitionARN(tt.region, tt.account, tt.queryDefinitionID); got != tt.want {
-				t.Fatalf("logsQueryDefinitionARN() = %q, want %q", got, tt.want)
+			gotID, gotName, gotAttributes := logsResourcePolicyResource(tt.policy)
+			if gotID != tt.wantID {
+				t.Fatalf("logsResourcePolicyResource() id = %q, want %q", gotID, tt.wantID)
+			}
+			if gotName != tt.wantName {
+				t.Fatalf("logsResourcePolicyResource() name = %q, want %q", gotName, tt.wantName)
+			}
+			if len(gotAttributes) != len(tt.wantAttributes) {
+				t.Fatalf("logsResourcePolicyResource() attributes = %#v, want %#v", gotAttributes, tt.wantAttributes)
+			}
+			for key, want := range tt.wantAttributes {
+				if gotAttributes[key] != want {
+					t.Fatalf("logsResourcePolicyResource() attributes[%q] = %q, want %q", key, gotAttributes[key], want)
+				}
 			}
 		})
 	}

--- a/providers/aws/logs_test.go
+++ b/providers/aws/logs_test.go
@@ -1,0 +1,99 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package aws
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/service/cloudwatchlogs/types"
+)
+
+func TestLogsAccountPolicyTypes(t *testing.T) {
+	want := []types.PolicyType{
+		types.PolicyTypeDataProtectionPolicy,
+		types.PolicyTypeSubscriptionFilterPolicy,
+		types.PolicyTypeFieldIndexPolicy,
+		types.PolicyTypeTransformerPolicy,
+	}
+	if len(logsAccountPolicyTypes) != len(want) {
+		t.Fatalf("logsAccountPolicyTypes length = %d, want %d", len(logsAccountPolicyTypes), len(want))
+	}
+	for i, policyType := range logsAccountPolicyTypes {
+		if policyType != want[i] {
+			t.Fatalf("logsAccountPolicyTypes[%d] = %q, want %q", i, policyType, want[i])
+		}
+	}
+}
+
+func TestLogsResourceName(t *testing.T) {
+	tests := []struct {
+		name  string
+		parts []string
+		want  string
+	}{
+		{name: "joins parts", parts: []string{"group", "filter"}, want: "group_filter"},
+		{name: "omits empty parts", parts: []string{"", "group", "", "filter"}, want: "group_filter"},
+		{name: "empty", parts: []string{"", ""}, want: ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := logsResourceName(tt.parts...); got != tt.want {
+				t.Fatalf("logsResourceName() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestLogsResourceNotFound(t *testing.T) {
+	if !logsResourceNotFound(&types.ResourceNotFoundException{}) {
+		t.Fatal("logsResourceNotFound() = false for ResourceNotFoundException, want true")
+	}
+	if logsResourceNotFound(errors.New("boom")) {
+		t.Fatal("logsResourceNotFound() = true for generic error, want false")
+	}
+	if logsResourceNotFound(nil) {
+		t.Fatal("logsResourceNotFound() = true for nil, want false")
+	}
+}
+
+func TestLogsQueryDefinitionARN(t *testing.T) {
+	tests := []struct {
+		name              string
+		region            string
+		account           string
+		queryDefinitionID string
+		want              string
+	}{
+		{
+			name:              "standard partition",
+			region:            "us-east-1",
+			account:           "123456789012",
+			queryDefinitionID: "269951d7-6f75-496d-9d7b-6b7a5486bdbd",
+			want:              "arn:aws:logs:us-east-1:123456789012:query-definition:269951d7-6f75-496d-9d7b-6b7a5486bdbd",
+		},
+		{
+			name:              "china partition",
+			region:            "cn-north-1",
+			account:           "123456789012",
+			queryDefinitionID: "query-id",
+			want:              "arn:aws-cn:logs:cn-north-1:123456789012:query-definition:query-id",
+		},
+		{
+			name:              "gov partition",
+			region:            "us-gov-west-1",
+			account:           "123456789012",
+			queryDefinitionID: "query-id",
+			want:              "arn:aws-us-gov:logs:us-gov-west-1:123456789012:query-definition:query-id",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := logsQueryDefinitionARN(tt.region, tt.account, tt.queryDefinitionID); got != tt.want {
+				t.Fatalf("logsQueryDefinitionARN() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

- add EventBridge discovery for event buses, bus policies, archives, API destinations, and custom-bus rules/targets
- add CloudWatch Logs discovery for account policies, data protection policies, destinations, metric filters, resource policies, subscription filters, and query definitions
- keep new optional CloudWatch Logs/EventBridge API discovery best-effort so baseline log group and rule imports still work with narrower IAM roles
- update AWS provider docs and add focused helper tests

## Notes

Refs #203
