### PR TITLE
aws(compute): add lambda and ecs resources

### DIFF
--- a/docs/aws.md
+++ b/docs/aws.md
@@ -142,9 +142,12 @@ terraformer import aws --resources=sg --regions=us-east-1
     * `aws_ecrpublic_repository`
     * `aws_ecrpublic_repository_policy`
 *   `ecs`
+    * `aws_ecs_capacity_provider`
     * `aws_ecs_cluster`
+    * `aws_ecs_cluster_capacity_providers`
     * `aws_ecs_service`
     * `aws_ecs_task_definition`
+    * `aws_ecs_task_set`
 *   `efs`
     * `aws_efs_access_point`
     * `aws_efs_file_system`
@@ -214,11 +217,15 @@ terraformer import aws --resources=sg --regions=us-east-1
     * `aws_kms_alias`
     * `aws_kms_grant`
 *   `lambda`
+    * `aws_lambda_alias`
+    * `aws_lambda_code_signing_config`
     * `aws_lambda_event_source_mapping`
     * `aws_lambda_function`
     * `aws_lambda_function_event_invoke_config`
+    * `aws_lambda_function_url`
     * `aws_lambda_layer_version`
     * `aws_lambda_permission`
+    * `aws_lambda_provisioned_concurrency_config`
 *   `logs`
     * `aws_cloudwatch_log_account_policy`
     * `aws_cloudwatch_log_data_protection_policy`

--- a/providers/aws/ecs.go
+++ b/providers/aws/ecs.go
@@ -120,7 +120,7 @@ func (g *EcsGenerator) InitResources() error {
 	}
 
 	g.getOptionalEcsResources(
-		ecsOptionalResourceLoader{name: "capacity providers", load: func() error { return g.addCapacityProviders(svc) }},
+		ecsOptionalResourceLoader{name: "capacity providers", load: func() error { return g.addCapacityProviders(svc, clusters) }},
 		ecsOptionalResourceLoader{name: "cluster capacity providers", load: func() error { return g.addClusterCapacityProviders(svc, clusters) }},
 		ecsOptionalResourceLoader{name: "task sets", load: func() error { return g.addTaskSets(svc, services) }},
 	)
@@ -175,12 +175,36 @@ func (g *EcsGenerator) getOptionalEcsResources(loaders ...ecsOptionalResourceLoa
 	}
 }
 
-func (g *EcsGenerator) addCapacityProviders(svc *ecs.Client) error {
+func (g *EcsGenerator) addCapacityProviders(svc *ecs.Client, clusters []ecsClusterReference) error {
+	seen := map[string]struct{}{}
+	if err := g.addCapacityProvidersForCluster(svc, nil, seen); err != nil {
+		return err
+	}
+	for _, cluster := range clusters {
+		clusterID := ecsCapacityProviderClusterID(cluster)
+		if clusterID == "" {
+			continue
+		}
+		if err := g.addCapacityProvidersForCluster(svc, &clusterID, seen); err != nil {
+			if ecsClusterNotFound(err) {
+				continue
+			}
+			return err
+		}
+	}
+	return nil
+}
+
+func (g *EcsGenerator) addCapacityProvidersForCluster(svc *ecs.Client, cluster *string, seen map[string]struct{}) error {
 	var nextToken *string
 	for {
-		output, err := svc.DescribeCapacityProviders(context.TODO(), &ecs.DescribeCapacityProvidersInput{
+		input := &ecs.DescribeCapacityProvidersInput{
 			NextToken: nextToken,
-		})
+		}
+		if cluster != nil {
+			input.Cluster = cluster
+		}
+		output, err := svc.DescribeCapacityProviders(context.TODO(), input)
 		if err != nil {
 			return err
 		}
@@ -193,6 +217,10 @@ func (g *EcsGenerator) addCapacityProviders(svc *ecs.Client) error {
 			if capacityProviderARN == "" || capacityProviderName == "" {
 				continue
 			}
+			if _, ok := seen[capacityProviderARN]; ok {
+				continue
+			}
+			seen[capacityProviderARN] = struct{}{}
 			g.Resources = append(g.Resources, terraformutils.NewResource(
 				capacityProviderARN,
 				capacityProviderName,
@@ -211,6 +239,13 @@ func (g *EcsGenerator) addCapacityProviders(svc *ecs.Client) error {
 		}
 	}
 	return nil
+}
+
+func ecsCapacityProviderClusterID(cluster ecsClusterReference) string {
+	if cluster.name != "" {
+		return cluster.name
+	}
+	return cluster.arn
 }
 
 func (g *EcsGenerator) addClusterCapacityProviders(svc *ecs.Client, clusters []ecsClusterReference) error {
@@ -339,7 +374,11 @@ func ecsTaskSetUnsupported(err error) bool {
 		return true
 	}
 	var clientException *ecstypes.ClientException
-	return errors.As(err, &clientException)
+	if errors.As(err, &clientException) {
+		return true
+	}
+	var unsupportedFeature *ecstypes.UnsupportedFeatureException
+	return errors.As(err, &unsupportedFeature)
 }
 
 func ecsTaskSetDiscoverySkipError(err error) bool {

--- a/providers/aws/ecs.go
+++ b/providers/aws/ecs.go
@@ -37,6 +37,10 @@ type ecsOptionalResourceLoader struct {
 	load func() error
 }
 
+func ecsCapacityProviderImportable(capacityProvider ecstypes.CapacityProvider) bool {
+	return capacityProvider.AutoScalingGroupProvider != nil || capacityProvider.ManagedInstancesProvider != nil
+}
+
 func (g *EcsGenerator) InitResources() error {
 	config, e := g.generateConfig()
 	if e != nil {
@@ -181,7 +185,7 @@ func (g *EcsGenerator) addCapacityProviders(svc *ecs.Client) error {
 			return err
 		}
 		for _, capacityProvider := range output.CapacityProviders {
-			if capacityProvider.AutoScalingGroupProvider == nil {
+			if !ecsCapacityProviderImportable(capacityProvider) {
 				continue
 			}
 			capacityProviderARN := StringValue(capacityProvider.CapacityProviderArn)

--- a/providers/aws/ecs.go
+++ b/providers/aws/ecs.go
@@ -256,7 +256,7 @@ func (g *EcsGenerator) addTaskSets(svc *ecs.Client, services []ecsServiceReferen
 			Service: &service.name,
 		})
 		if err != nil {
-			if ecsTaskSetScopeNotFound(err) {
+			if ecsTaskSetDiscoverySkipError(err) {
 				continue
 			}
 			return err
@@ -331,4 +331,17 @@ func ecsTaskSetScopeNotFound(err error) bool {
 	}
 	var taskSetNotFound *ecstypes.TaskSetNotFoundException
 	return errors.As(err, &taskSetNotFound)
+}
+
+func ecsTaskSetUnsupported(err error) bool {
+	var invalidParameter *ecstypes.InvalidParameterException
+	if errors.As(err, &invalidParameter) {
+		return true
+	}
+	var clientException *ecstypes.ClientException
+	return errors.As(err, &clientException)
+}
+
+func ecsTaskSetDiscoverySkipError(err error) bool {
+	return ecsTaskSetScopeNotFound(err) || ecsTaskSetUnsupported(err)
 }

--- a/providers/aws/ecs.go
+++ b/providers/aws/ecs.go
@@ -4,11 +4,14 @@ package aws
 
 import (
 	"context"
+	"errors"
 	"fmt"
+	"log"
 	"strconv"
 	"strings"
 
 	"github.com/aws/aws-sdk-go-v2/service/ecs"
+	ecstypes "github.com/aws/aws-sdk-go-v2/service/ecs/types"
 	"github.com/chenrui333/terraformer/terraformutils"
 )
 
@@ -18,6 +21,22 @@ type EcsGenerator struct {
 	AWSService
 }
 
+type ecsClusterReference struct {
+	arn  string
+	name string
+}
+
+type ecsServiceReference struct {
+	name        string
+	clusterARN  string
+	clusterName string
+}
+
+type ecsOptionalResourceLoader struct {
+	name string
+	load func() error
+}
+
 func (g *EcsGenerator) InitResources() error {
 	config, e := g.generateConfig()
 	if e != nil {
@@ -25,6 +44,8 @@ func (g *EcsGenerator) InitResources() error {
 	}
 	svc := ecs.NewFromConfig(config)
 
+	var clusters []ecsClusterReference
+	var services []ecsServiceReference
 	p := ecs.NewListClustersPaginator(svc, &ecs.ListClustersInput{})
 	for p.HasMorePages() {
 		page, e := p.NextPage(context.TODO())
@@ -33,6 +54,10 @@ func (g *EcsGenerator) InitResources() error {
 		}
 		for _, clusterArn := range page.ClusterArns {
 			clusterName := arnLastSegment(clusterArn, "/")
+			clusters = append(clusters, ecsClusterReference{
+				arn:  clusterArn,
+				name: clusterName,
+			})
 
 			g.Resources = append(g.Resources, terraformutils.NewSimpleResource(
 				clusterArn,
@@ -53,6 +78,11 @@ func (g *EcsGenerator) InitResources() error {
 				}
 				for _, serviceArn := range serviceNextPage.ServiceArns {
 					serviceName := arnLastSegment(serviceArn, "/")
+					services = append(services, ecsServiceReference{
+						name:        serviceName,
+						clusterARN:  clusterArn,
+						clusterName: clusterName,
+					})
 
 					serResp, err := svc.DescribeServices(context.TODO(), &ecs.DescribeServicesInput{
 						Services: []string{
@@ -84,6 +114,12 @@ func (g *EcsGenerator) InitResources() error {
 			}
 		}
 	}
+
+	g.getOptionalEcsResources(
+		ecsOptionalResourceLoader{name: "capacity providers", load: func() error { return g.addCapacityProviders(svc) }},
+		ecsOptionalResourceLoader{name: "cluster capacity providers", load: func() error { return g.addClusterCapacityProviders(svc, clusters) }},
+		ecsOptionalResourceLoader{name: "task sets", load: func() error { return g.addTaskSets(svc, services) }},
+	)
 
 	taskDefinitionsMap := map[string]terraformutils.Resource{}
 	taskDefinitionsPage := ecs.NewListTaskDefinitionsPaginator(svc, &ecs.ListTaskDefinitionsInput{})
@@ -127,6 +163,122 @@ func (g *EcsGenerator) InitResources() error {
 	return nil
 }
 
+func (g *EcsGenerator) getOptionalEcsResources(loaders ...ecsOptionalResourceLoader) {
+	for _, loader := range loaders {
+		if err := loader.load(); err != nil {
+			log.Printf("skipping ECS %s discovery: %v", loader.name, err)
+		}
+	}
+}
+
+func (g *EcsGenerator) addCapacityProviders(svc *ecs.Client) error {
+	var nextToken *string
+	for {
+		output, err := svc.DescribeCapacityProviders(context.TODO(), &ecs.DescribeCapacityProvidersInput{
+			NextToken: nextToken,
+		})
+		if err != nil {
+			return err
+		}
+		for _, capacityProvider := range output.CapacityProviders {
+			if capacityProvider.AutoScalingGroupProvider == nil {
+				continue
+			}
+			capacityProviderARN := StringValue(capacityProvider.CapacityProviderArn)
+			capacityProviderName := StringValue(capacityProvider.Name)
+			if capacityProviderARN == "" || capacityProviderName == "" {
+				continue
+			}
+			g.Resources = append(g.Resources, terraformutils.NewResource(
+				capacityProviderARN,
+				capacityProviderName,
+				"aws_ecs_capacity_provider",
+				"aws",
+				map[string]string{
+					"name": capacityProviderName,
+				},
+				ecsAllowEmptyValues,
+				map[string]interface{}{},
+			))
+		}
+		nextToken = output.NextToken
+		if nextToken == nil {
+			break
+		}
+	}
+	return nil
+}
+
+func (g *EcsGenerator) addClusterCapacityProviders(svc *ecs.Client, clusters []ecsClusterReference) error {
+	for _, cluster := range clusters {
+		output, err := svc.DescribeClusters(context.TODO(), &ecs.DescribeClustersInput{
+			Clusters: []string{cluster.arn},
+		})
+		if err != nil {
+			if ecsClusterNotFound(err) {
+				continue
+			}
+			return err
+		}
+		for _, describedCluster := range output.Clusters {
+			clusterName := StringValue(describedCluster.ClusterName)
+			if clusterName == "" {
+				clusterName = cluster.name
+			}
+			if clusterName == "" || (len(describedCluster.CapacityProviders) == 0 && len(describedCluster.DefaultCapacityProviderStrategy) == 0) {
+				continue
+			}
+			g.Resources = append(g.Resources, terraformutils.NewResource(
+				clusterName,
+				clusterName,
+				"aws_ecs_cluster_capacity_providers",
+				"aws",
+				map[string]string{
+					"cluster_name": clusterName,
+				},
+				ecsAllowEmptyValues,
+				map[string]interface{}{},
+			))
+		}
+	}
+	return nil
+}
+
+func (g *EcsGenerator) addTaskSets(svc *ecs.Client, services []ecsServiceReference) error {
+	for _, service := range services {
+		output, err := svc.DescribeTaskSets(context.TODO(), &ecs.DescribeTaskSetsInput{
+			Cluster: &service.clusterARN,
+			Include: []ecstypes.TaskSetField{ecstypes.TaskSetFieldTags},
+			Service: &service.name,
+		})
+		if err != nil {
+			if ecsTaskSetScopeNotFound(err) {
+				continue
+			}
+			return err
+		}
+		for _, taskSet := range output.TaskSets {
+			taskSetID := StringValue(taskSet.Id)
+			if taskSetID == "" {
+				continue
+			}
+			g.Resources = append(g.Resources, terraformutils.NewResource(
+				ecsTaskSetImportID(taskSetID, service.name, service.clusterName),
+				ecsResourceName(service.clusterName, service.name, taskSetID),
+				"aws_ecs_task_set",
+				"aws",
+				map[string]string{
+					"cluster": service.clusterName,
+					"service": service.name,
+				},
+				ecsAllowEmptyValues,
+				map[string]interface{}{},
+			))
+		}
+	}
+	return nil
+}
+
 func (g *EcsGenerator) PostConvertHook() error {
 	for _, r := range g.Resources {
 		if r.InstanceInfo.Type != "aws_ecs_service" {
@@ -139,4 +291,40 @@ func (g *EcsGenerator) PostConvertHook() error {
 	}
 
 	return nil
+}
+
+func ecsTaskSetImportID(taskSetID, service, cluster string) string {
+	return strings.Join([]string{taskSetID, service, cluster}, ",")
+}
+
+func ecsResourceName(parts ...string) string {
+	var name string
+	for _, part := range parts {
+		if part == "" {
+			continue
+		}
+		if name != "" {
+			name += "_"
+		}
+		name += part
+	}
+	return name
+}
+
+func ecsClusterNotFound(err error) bool {
+	var notFound *ecstypes.ClusterNotFoundException
+	return errors.As(err, &notFound)
+}
+
+func ecsTaskSetScopeNotFound(err error) bool {
+	var clusterNotFound *ecstypes.ClusterNotFoundException
+	if errors.As(err, &clusterNotFound) {
+		return true
+	}
+	var serviceNotFound *ecstypes.ServiceNotFoundException
+	if errors.As(err, &serviceNotFound) {
+		return true
+	}
+	var taskSetNotFound *ecstypes.TaskSetNotFoundException
+	return errors.As(err, &taskSetNotFound)
 }

--- a/providers/aws/ecs_test.go
+++ b/providers/aws/ecs_test.go
@@ -61,6 +61,42 @@ func TestEcsResourceName(t *testing.T) {
 	}
 }
 
+func TestEcsCapacityProviderImportable(t *testing.T) {
+	tests := []struct {
+		name             string
+		capacityProvider ecstypes.CapacityProvider
+		want             bool
+	}{
+		{
+			name: "auto scaling group provider",
+			capacityProvider: ecstypes.CapacityProvider{
+				AutoScalingGroupProvider: &ecstypes.AutoScalingGroupProvider{},
+			},
+			want: true,
+		},
+		{
+			name: "managed instances provider",
+			capacityProvider: ecstypes.CapacityProvider{
+				ManagedInstancesProvider: &ecstypes.ManagedInstancesProvider{},
+			},
+			want: true,
+		},
+		{
+			name:             "built in provider",
+			capacityProvider: ecstypes.CapacityProvider{},
+			want:             false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := ecsCapacityProviderImportable(tt.capacityProvider); got != tt.want {
+				t.Fatalf("ecsCapacityProviderImportable() = %t, want %t", got, tt.want)
+			}
+		})
+	}
+}
+
 func TestEcsClusterNotFound(t *testing.T) {
 	if !ecsClusterNotFound(&ecstypes.ClusterNotFoundException{}) {
 		t.Fatal("ecsClusterNotFound() = false for ClusterNotFoundException, want true")

--- a/providers/aws/ecs_test.go
+++ b/providers/aws/ecs_test.go
@@ -139,6 +139,7 @@ func TestEcsTaskSetUnsupported(t *testing.T) {
 	}{
 		{name: "invalid parameter", err: &ecstypes.InvalidParameterException{}, want: true},
 		{name: "client exception", err: &ecstypes.ClientException{}, want: true},
+		{name: "unsupported feature", err: &ecstypes.UnsupportedFeatureException{}, want: true},
 		{name: "generic error", err: errors.New("boom"), want: false},
 		{name: "nil", want: false},
 	}

--- a/providers/aws/ecs_test.go
+++ b/providers/aws/ecs_test.go
@@ -130,3 +130,45 @@ func TestEcsTaskSetScopeNotFound(t *testing.T) {
 		})
 	}
 }
+
+func TestEcsTaskSetUnsupported(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{name: "invalid parameter", err: &ecstypes.InvalidParameterException{}, want: true},
+		{name: "client exception", err: &ecstypes.ClientException{}, want: true},
+		{name: "generic error", err: errors.New("boom"), want: false},
+		{name: "nil", want: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := ecsTaskSetUnsupported(tt.err); got != tt.want {
+				t.Fatalf("ecsTaskSetUnsupported() = %t, want %t", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestEcsTaskSetDiscoverySkipError(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{name: "scope missing", err: &ecstypes.ServiceNotFoundException{}, want: true},
+		{name: "unsupported service", err: &ecstypes.InvalidParameterException{}, want: true},
+		{name: "generic error", err: errors.New("boom"), want: false},
+		{name: "nil", want: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := ecsTaskSetDiscoverySkipError(tt.err); got != tt.want {
+				t.Fatalf("ecsTaskSetDiscoverySkipError() = %t, want %t", got, tt.want)
+			}
+		})
+	}
+}

--- a/providers/aws/ecs_test.go
+++ b/providers/aws/ecs_test.go
@@ -2,7 +2,12 @@
 
 package aws
 
-import "testing"
+import (
+	"errors"
+	"testing"
+
+	ecstypes "github.com/aws/aws-sdk-go-v2/service/ecs/types"
+)
 
 func TestArnLastSegment(t *testing.T) {
 	tests := []struct {
@@ -25,6 +30,66 @@ func TestArnLastSegment(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			if got := arnLastSegment(tc.s, tc.sep); got != tc.want {
 				t.Errorf("arnLastSegment(%q, %q) = %q, want %q", tc.s, tc.sep, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestEcsTaskSetImportID(t *testing.T) {
+	if got, want := ecsTaskSetImportID("task-set-id", "service", "cluster"), "task-set-id,service,cluster"; got != want {
+		t.Fatalf("ecsTaskSetImportID() = %q, want %q", got, want)
+	}
+}
+
+func TestEcsResourceName(t *testing.T) {
+	tests := []struct {
+		name  string
+		parts []string
+		want  string
+	}{
+		{name: "joins parts", parts: []string{"cluster", "service"}, want: "cluster_service"},
+		{name: "omits empty parts", parts: []string{"", "cluster", "", "service"}, want: "cluster_service"},
+		{name: "empty", parts: []string{"", ""}, want: ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := ecsResourceName(tt.parts...); got != tt.want {
+				t.Fatalf("ecsResourceName() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestEcsClusterNotFound(t *testing.T) {
+	if !ecsClusterNotFound(&ecstypes.ClusterNotFoundException{}) {
+		t.Fatal("ecsClusterNotFound() = false for ClusterNotFoundException, want true")
+	}
+	if ecsClusterNotFound(errors.New("boom")) {
+		t.Fatal("ecsClusterNotFound() = true for generic error, want false")
+	}
+	if ecsClusterNotFound(nil) {
+		t.Fatal("ecsClusterNotFound() = true for nil, want false")
+	}
+}
+
+func TestEcsTaskSetScopeNotFound(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{name: "cluster missing", err: &ecstypes.ClusterNotFoundException{}, want: true},
+		{name: "service missing", err: &ecstypes.ServiceNotFoundException{}, want: true},
+		{name: "task set missing", err: &ecstypes.TaskSetNotFoundException{}, want: true},
+		{name: "generic error", err: errors.New("boom"), want: false},
+		{name: "nil", want: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := ecsTaskSetScopeNotFound(tt.err); got != tt.want {
+				t.Fatalf("ecsTaskSetScopeNotFound() = %t, want %t", got, tt.want)
 			}
 		})
 	}

--- a/providers/aws/lambda.go
+++ b/providers/aws/lambda.go
@@ -340,7 +340,7 @@ func (g *LambdaGenerator) addEventSourceMappings(svc *lambda.Client) error {
 			mappingUUID := StringValue(mapping.UUID)
 			eventSourceARN := StringValue(mapping.EventSourceArn)
 			functionARN := StringValue(mapping.FunctionArn)
-			if mappingUUID == "" || eventSourceARN == "" || functionARN == "" {
+			if mappingUUID == "" || functionARN == "" {
 				continue
 			}
 			g.Resources = append(g.Resources, terraformutils.NewResource(
@@ -348,16 +348,23 @@ func (g *LambdaGenerator) addEventSourceMappings(svc *lambda.Client) error {
 				mappingUUID,
 				"aws_lambda_event_source_mapping",
 				"aws",
-				map[string]string{
-					"event_source_arn": eventSourceARN,
-					"function_name":    functionARN,
-				},
+				lambdaEventSourceMappingAttributes(functionARN, eventSourceARN),
 				lambdaAllowEmptyValues,
 				map[string]interface{}{},
 			))
 		}
 	}
 	return nil
+}
+
+func lambdaEventSourceMappingAttributes(functionARN, eventSourceARN string) map[string]string {
+	attributes := map[string]string{
+		"function_name": functionARN,
+	}
+	if eventSourceARN != "" {
+		attributes["event_source_arn"] = eventSourceARN
+	}
+	return attributes
 }
 
 func lambdaAliasImportID(functionName, aliasName string) string {

--- a/providers/aws/lambda.go
+++ b/providers/aws/lambda.go
@@ -201,7 +201,7 @@ func (g *LambdaGenerator) addAliases(svc *lambda.Client, functions []lambdaFunct
 			page, err := p.NextPage(context.TODO())
 			if err != nil {
 				if lambdaResourceNotFound(err) {
-					continue
+					break
 				}
 				return err
 			}
@@ -237,7 +237,7 @@ func (g *LambdaGenerator) addFunctionURLs(svc *lambda.Client, functions []lambda
 			page, err := p.NextPage(context.TODO())
 			if err != nil {
 				if lambdaResourceNotFound(err) {
-					continue
+					break
 				}
 				return err
 			}
@@ -273,7 +273,7 @@ func (g *LambdaGenerator) addProvisionedConcurrencyConfigs(svc *lambda.Client, f
 			page, err := p.NextPage(context.TODO())
 			if err != nil {
 				if lambdaResourceNotFound(err) {
-					continue
+					break
 				}
 				return err
 			}
@@ -337,14 +337,20 @@ func (g *LambdaGenerator) addEventSourceMappings(svc *lambda.Client) error {
 			return err
 		}
 		for _, mapping := range page.EventSourceMappings {
+			mappingUUID := StringValue(mapping.UUID)
+			eventSourceARN := StringValue(mapping.EventSourceArn)
+			functionARN := StringValue(mapping.FunctionArn)
+			if mappingUUID == "" || eventSourceARN == "" || functionARN == "" {
+				continue
+			}
 			g.Resources = append(g.Resources, terraformutils.NewResource(
-				*mapping.UUID,
-				*mapping.UUID,
+				mappingUUID,
+				mappingUUID,
 				"aws_lambda_event_source_mapping",
 				"aws",
 				map[string]string{
-					"event_source_arn": *mapping.EventSourceArn,
-					"function_name":    *mapping.FunctionArn,
+					"event_source_arn": eventSourceARN,
+					"function_name":    functionARN,
 				},
 				lambdaAllowEmptyValues,
 				map[string]interface{}{},

--- a/providers/aws/lambda.go
+++ b/providers/aws/lambda.go
@@ -6,9 +6,13 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"log"
+	"strconv"
+	"strings"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/lambda"
+	lambdatypes "github.com/aws/aws-sdk-go-v2/service/lambda/types"
 	"github.com/aws/smithy-go"
 	"github.com/chenrui333/terraformer/terraformutils"
 )
@@ -17,6 +21,15 @@ var lambdaAllowEmptyValues = []string{"tags."}
 
 type LambdaGenerator struct {
 	AWSService
+}
+
+type lambdaFunctionReference struct {
+	name string
+}
+
+type lambdaOptionalResourceLoader struct {
+	name string
+	load func() error
 }
 
 type Statement struct {
@@ -36,10 +49,16 @@ func (g *LambdaGenerator) InitResources() error {
 	}
 	svc := lambda.NewFromConfig(config)
 
-	err := g.addFunctions(svc)
+	functions, err := g.addFunctions(svc)
 	if err != nil {
 		return err
 	}
+	g.getOptionalLambdaResources(
+		lambdaOptionalResourceLoader{name: "aliases", load: func() error { return g.addAliases(svc, functions) }},
+		lambdaOptionalResourceLoader{name: "function URLs", load: func() error { return g.addFunctionURLs(svc, functions) }},
+		lambdaOptionalResourceLoader{name: "provisioned concurrency configs", load: func() error { return g.addProvisionedConcurrencyConfigs(svc, functions) }},
+		lambdaOptionalResourceLoader{name: "code signing configs", load: func() error { return g.addCodeSigningConfigs(svc) }},
+	)
 	err = g.addEventSourceMappings(svc)
 	if err != nil {
 		return err
@@ -71,35 +90,52 @@ func (g *LambdaGenerator) PostConvertHook() error {
 	return nil
 }
 
-func (g *LambdaGenerator) addFunctions(svc *lambda.Client) error {
+func (g *LambdaGenerator) getOptionalLambdaResources(loaders ...lambdaOptionalResourceLoader) {
+	for _, loader := range loaders {
+		if err := loader.load(); err != nil {
+			log.Printf("skipping Lambda %s discovery: %v", loader.name, err)
+		}
+	}
+}
+
+func (g *LambdaGenerator) addFunctions(svc *lambda.Client) ([]lambdaFunctionReference, error) {
+	functions := []lambdaFunctionReference{}
 	p := lambda.NewListFunctionsPaginator(svc, &lambda.ListFunctionsInput{})
 	for p.HasMorePages() {
 		page, err := p.NextPage(context.TODO())
 		if err != nil {
-			return err
+			return functions, err
 		}
 		for _, function := range page.Functions {
+			functionARN := StringValue(function.FunctionArn)
+			functionName := StringValue(function.FunctionName)
+			if functionARN == "" || functionName == "" {
+				continue
+			}
+			functions = append(functions, lambdaFunctionReference{
+				name: functionName,
+			})
 			g.Resources = append(g.Resources, terraformutils.NewResource(
-				*function.FunctionArn,
-				*function.FunctionName,
+				functionARN,
+				functionName,
 				"aws_lambda_function",
 				"aws",
 				map[string]string{
-					"function_name": *function.FunctionName,
+					"function_name": functionName,
 				},
 				lambdaAllowEmptyValues,
 				map[string]interface{}{},
 			))
 
 			gp, err := svc.GetPolicy(context.TODO(), &lambda.GetPolicyInput{
-				FunctionName: aws.String(*function.FunctionArn),
+				FunctionName: aws.String(functionARN),
 			})
 
 			if err != nil {
 				// skip ResourceNotFoundException, because there may be only inline policy defined
 				var apiErr smithy.APIError
 				if !errors.As(err, &apiErr) || apiErr.ErrorCode() != "ResourceNotFoundException" {
-					return err
+					return functions, err
 				}
 			}
 
@@ -109,7 +145,7 @@ func (g *LambdaGenerator) addFunctions(svc *lambda.Client) error {
 				err = json.Unmarshal([]byte(outputPolicy), &policy)
 
 				if err != nil {
-					return err
+					return functions, err
 				}
 
 				for _, statement := range policy.Statement {
@@ -120,7 +156,7 @@ func (g *LambdaGenerator) addFunctions(svc *lambda.Client) error {
 						"aws",
 						map[string]string{
 							"statement_id":  statement.Sid,
-							"function_name": *function.FunctionArn,
+							"function_name": functionARN,
 						},
 						lambdaAllowEmptyValues,
 						map[string]interface{}{},
@@ -130,23 +166,164 @@ func (g *LambdaGenerator) addFunctions(svc *lambda.Client) error {
 
 			pi := lambda.NewListFunctionEventInvokeConfigsPaginator(svc,
 				&lambda.ListFunctionEventInvokeConfigsInput{
-					FunctionName: function.FunctionName,
+					FunctionName: &functionName,
 				})
 			for pi.HasMorePages() {
 				piage, err := pi.NextPage(context.TODO())
 				if err != nil {
-					return err
+					return functions, err
 				}
 				for _, functionEventInvokeConfig := range piage.FunctionEventInvokeConfigs {
+					functionEventInvokeConfigARN := StringValue(functionEventInvokeConfig.FunctionArn)
+					if functionEventInvokeConfigARN == "" {
+						continue
+					}
 					g.Resources = append(g.Resources, terraformutils.NewSimpleResource(
-						*function.FunctionArn,
-						"feic_"+*functionEventInvokeConfig.FunctionArn,
+						functionARN,
+						"feic_"+functionEventInvokeConfigARN,
 						"aws_lambda_function_event_invoke_config",
 						"aws",
 						lambdaAllowEmptyValues,
 					))
 				}
 			}
+		}
+	}
+	return functions, nil
+}
+
+func (g *LambdaGenerator) addAliases(svc *lambda.Client, functions []lambdaFunctionReference) error {
+	for _, function := range functions {
+		p := lambda.NewListAliasesPaginator(svc, &lambda.ListAliasesInput{
+			FunctionName: &function.name,
+		})
+		for p.HasMorePages() {
+			page, err := p.NextPage(context.TODO())
+			if err != nil {
+				if lambdaResourceNotFound(err) {
+					continue
+				}
+				return err
+			}
+			for _, alias := range page.Aliases {
+				aliasName := StringValue(alias.Name)
+				if aliasName == "" {
+					continue
+				}
+				g.Resources = append(g.Resources, terraformutils.NewResource(
+					lambdaAliasImportID(function.name, aliasName),
+					lambdaResourceName(function.name, aliasName),
+					"aws_lambda_alias",
+					"aws",
+					map[string]string{
+						"function_name": function.name,
+						"name":          aliasName,
+					},
+					lambdaAllowEmptyValues,
+					map[string]interface{}{},
+				))
+			}
+		}
+	}
+	return nil
+}
+
+func (g *LambdaGenerator) addFunctionURLs(svc *lambda.Client, functions []lambdaFunctionReference) error {
+	for _, function := range functions {
+		p := lambda.NewListFunctionUrlConfigsPaginator(svc, &lambda.ListFunctionUrlConfigsInput{
+			FunctionName: &function.name,
+		})
+		for p.HasMorePages() {
+			page, err := p.NextPage(context.TODO())
+			if err != nil {
+				if lambdaResourceNotFound(err) {
+					continue
+				}
+				return err
+			}
+			for _, functionURL := range page.FunctionUrlConfigs {
+				qualifier := lambdaQualifierFromFunctionARN(StringValue(functionURL.FunctionArn), function.name)
+				attributes := map[string]string{
+					"function_name": function.name,
+				}
+				if qualifier != "" {
+					attributes["qualifier"] = qualifier
+				}
+				g.Resources = append(g.Resources, terraformutils.NewResource(
+					lambdaFunctionURLImportID(function.name, qualifier),
+					lambdaResourceName(function.name, "url", qualifier),
+					"aws_lambda_function_url",
+					"aws",
+					attributes,
+					lambdaAllowEmptyValues,
+					map[string]interface{}{},
+				))
+			}
+		}
+	}
+	return nil
+}
+
+func (g *LambdaGenerator) addProvisionedConcurrencyConfigs(svc *lambda.Client, functions []lambdaFunctionReference) error {
+	for _, function := range functions {
+		p := lambda.NewListProvisionedConcurrencyConfigsPaginator(svc, &lambda.ListProvisionedConcurrencyConfigsInput{
+			FunctionName: &function.name,
+		})
+		for p.HasMorePages() {
+			page, err := p.NextPage(context.TODO())
+			if err != nil {
+				if lambdaResourceNotFound(err) {
+					continue
+				}
+				return err
+			}
+			for _, config := range page.ProvisionedConcurrencyConfigs {
+				qualifier := lambdaQualifierFromFunctionARN(StringValue(config.FunctionArn), function.name)
+				if qualifier == "" {
+					continue
+				}
+				g.Resources = append(g.Resources, terraformutils.NewResource(
+					lambdaProvisionedConcurrencyConfigImportID(function.name, qualifier),
+					lambdaResourceName(function.name, "provisioned_concurrency", qualifier),
+					"aws_lambda_provisioned_concurrency_config",
+					"aws",
+					map[string]string{
+						"function_name":                     function.name,
+						"qualifier":                         qualifier,
+						"provisioned_concurrent_executions": strconv.FormatInt(int64(aws.ToInt32(config.AllocatedProvisionedConcurrentExecutions)), 10),
+					},
+					lambdaAllowEmptyValues,
+					map[string]interface{}{},
+				))
+			}
+		}
+	}
+	return nil
+}
+
+func (g *LambdaGenerator) addCodeSigningConfigs(svc *lambda.Client) error {
+	p := lambda.NewListCodeSigningConfigsPaginator(svc, &lambda.ListCodeSigningConfigsInput{})
+	for p.HasMorePages() {
+		page, err := p.NextPage(context.TODO())
+		if err != nil {
+			return err
+		}
+		for _, config := range page.CodeSigningConfigs {
+			configARN := StringValue(config.CodeSigningConfigArn)
+			if configARN == "" {
+				continue
+			}
+			resourceName := StringValue(config.CodeSigningConfigId)
+			if resourceName == "" {
+				resourceName = configARN
+			}
+			g.Resources = append(g.Resources, terraformutils.NewSimpleResource(
+				configARN,
+				lambdaResourceName("code_signing", resourceName),
+				"aws_lambda_code_signing_config",
+				"aws",
+				lambdaAllowEmptyValues,
+			))
 		}
 	}
 	return nil
@@ -175,6 +352,58 @@ func (g *LambdaGenerator) addEventSourceMappings(svc *lambda.Client) error {
 		}
 	}
 	return nil
+}
+
+func lambdaAliasImportID(functionName, aliasName string) string {
+	return functionName + "/" + aliasName
+}
+
+func lambdaFunctionURLImportID(functionName, qualifier string) string {
+	if qualifier == "" {
+		return functionName
+	}
+	return functionName + "/" + qualifier
+}
+
+func lambdaProvisionedConcurrencyConfigImportID(functionName, qualifier string) string {
+	return functionName + "," + qualifier
+}
+
+func lambdaQualifierFromFunctionARN(functionARN, functionName string) string {
+	_, qualifiedName, found := strings.Cut(functionARN, ":function:")
+	if !found || qualifiedName == "" || qualifiedName == functionName {
+		return ""
+	}
+
+	prefix := functionName + ":"
+	if strings.HasPrefix(qualifiedName, prefix) {
+		return strings.TrimPrefix(qualifiedName, prefix)
+	}
+
+	_, qualifier, found := strings.Cut(qualifiedName, ":")
+	if !found {
+		return ""
+	}
+	return qualifier
+}
+
+func lambdaResourceName(parts ...string) string {
+	var name string
+	for _, part := range parts {
+		if part == "" {
+			continue
+		}
+		if name != "" {
+			name += "_"
+		}
+		name += part
+	}
+	return name
+}
+
+func lambdaResourceNotFound(err error) bool {
+	var notFound *lambdatypes.ResourceNotFoundException
+	return errors.As(err, &notFound)
 }
 
 func (g *LambdaGenerator) addLayerVersions(svc *lambda.Client) error {

--- a/providers/aws/lambda_test.go
+++ b/providers/aws/lambda_test.go
@@ -41,6 +41,46 @@ func TestLambdaProvisionedConcurrencyConfigImportID(t *testing.T) {
 	}
 }
 
+func TestLambdaEventSourceMappingAttributes(t *testing.T) {
+	tests := []struct {
+		name           string
+		functionARN    string
+		eventSourceARN string
+		want           map[string]string
+	}{
+		{
+			name:           "managed event source",
+			functionARN:    "arn:aws:lambda:us-east-1:123456789012:function:consumer",
+			eventSourceARN: "arn:aws:sqs:us-east-1:123456789012:queue",
+			want: map[string]string{
+				"event_source_arn": "arn:aws:sqs:us-east-1:123456789012:queue",
+				"function_name":    "arn:aws:lambda:us-east-1:123456789012:function:consumer",
+			},
+		},
+		{
+			name:        "self managed event source",
+			functionARN: "arn:aws:lambda:us-east-1:123456789012:function:consumer",
+			want: map[string]string{
+				"function_name": "arn:aws:lambda:us-east-1:123456789012:function:consumer",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := lambdaEventSourceMappingAttributes(tt.functionARN, tt.eventSourceARN)
+			if len(got) != len(tt.want) {
+				t.Fatalf("lambdaEventSourceMappingAttributes() = %#v, want %#v", got, tt.want)
+			}
+			for key, want := range tt.want {
+				if got[key] != want {
+					t.Fatalf("lambdaEventSourceMappingAttributes()[%q] = %q, want %q", key, got[key], want)
+				}
+			}
+		})
+	}
+}
+
 func TestLambdaQualifierFromFunctionARN(t *testing.T) {
 	tests := []struct {
 		name         string

--- a/providers/aws/lambda_test.go
+++ b/providers/aws/lambda_test.go
@@ -1,0 +1,114 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package aws
+
+import (
+	"errors"
+	"testing"
+
+	lambdatypes "github.com/aws/aws-sdk-go-v2/service/lambda/types"
+)
+
+func TestLambdaAliasImportID(t *testing.T) {
+	if got, want := lambdaAliasImportID("my-function", "prod"), "my-function/prod"; got != want {
+		t.Fatalf("lambdaAliasImportID() = %q, want %q", got, want)
+	}
+}
+
+func TestLambdaFunctionURLImportID(t *testing.T) {
+	tests := []struct {
+		name         string
+		functionName string
+		qualifier    string
+		want         string
+	}{
+		{name: "unqualified", functionName: "my-function", want: "my-function"},
+		{name: "qualified", functionName: "my-function", qualifier: "prod", want: "my-function/prod"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := lambdaFunctionURLImportID(tt.functionName, tt.qualifier); got != tt.want {
+				t.Fatalf("lambdaFunctionURLImportID() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestLambdaProvisionedConcurrencyConfigImportID(t *testing.T) {
+	if got, want := lambdaProvisionedConcurrencyConfigImportID("my-function", "prod"), "my-function,prod"; got != want {
+		t.Fatalf("lambdaProvisionedConcurrencyConfigImportID() = %q, want %q", got, want)
+	}
+}
+
+func TestLambdaQualifierFromFunctionARN(t *testing.T) {
+	tests := []struct {
+		name         string
+		functionARN  string
+		functionName string
+		want         string
+	}{
+		{
+			name:         "unqualified arn",
+			functionARN:  "arn:aws:lambda:us-east-1:123456789012:function:my-function",
+			functionName: "my-function",
+		},
+		{
+			name:         "alias qualifier",
+			functionARN:  "arn:aws:lambda:us-east-1:123456789012:function:my-function:prod",
+			functionName: "my-function",
+			want:         "prod",
+		},
+		{
+			name:         "version qualifier",
+			functionARN:  "arn:aws:lambda:us-east-1:123456789012:function:my-function:42",
+			functionName: "my-function",
+			want:         "42",
+		},
+		{
+			name:         "malformed arn",
+			functionARN:  "my-function:prod",
+			functionName: "my-function",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := lambdaQualifierFromFunctionARN(tt.functionARN, tt.functionName); got != tt.want {
+				t.Fatalf("lambdaQualifierFromFunctionARN() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestLambdaResourceName(t *testing.T) {
+	tests := []struct {
+		name  string
+		parts []string
+		want  string
+	}{
+		{name: "joins parts", parts: []string{"function", "alias"}, want: "function_alias"},
+		{name: "omits empty parts", parts: []string{"", "function", "", "url"}, want: "function_url"},
+		{name: "empty", parts: []string{"", ""}, want: ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := lambdaResourceName(tt.parts...); got != tt.want {
+				t.Fatalf("lambdaResourceName() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestLambdaResourceNotFound(t *testing.T) {
+	if !lambdaResourceNotFound(&lambdatypes.ResourceNotFoundException{}) {
+		t.Fatal("lambdaResourceNotFound() = false for ResourceNotFoundException, want true")
+	}
+	if lambdaResourceNotFound(errors.New("boom")) {
+		t.Fatal("lambdaResourceNotFound() = true for generic error, want false")
+	}
+	if lambdaResourceNotFound(nil) {
+		t.Fatal("lambdaResourceNotFound() = true for nil, want false")
+	}
+}


### PR DESCRIPTION
## Summary

- add Lambda discovery for aliases, function URLs, provisioned concurrency configs, and code signing configs
- add ECS discovery for ASG-backed capacity providers, cluster capacity provider assignments, and task sets
- keep the new Lambda/ECS discovery paths best-effort where they depend on optional or narrower IAM APIs
- update AWS provider docs and add focused import ID / not-found helper tests

## Notes

Refs #203
