### PR TITLE
aws(s3): add bucket configuration resources

### DIFF
--- a/docs/aws.md
+++ b/docs/aws.md
@@ -306,6 +306,20 @@ terraformer import aws --resources=sg --regions=us-east-1
     * `aws_route_table_association`
 *   `s3`
     * `aws_s3_bucket`
+    * `aws_s3_bucket_accelerate_configuration`
+    * `aws_s3_bucket_cors_configuration`
+    * `aws_s3_bucket_lifecycle_configuration`
+    * `aws_s3_bucket_logging`
+    * `aws_s3_bucket_notification`
+    * `aws_s3_bucket_object_lock_configuration`
+    * `aws_s3_bucket_ownership_controls`
+    * `aws_s3_bucket_policy`
+    * `aws_s3_bucket_public_access_block`
+    * `aws_s3_bucket_replication_configuration`
+    * `aws_s3_bucket_request_payment_configuration`
+    * `aws_s3_bucket_server_side_encryption_configuration`
+    * `aws_s3_bucket_versioning`
+    * `aws_s3_bucket_website_configuration`
 *   `secretsmanager`
     * `aws_secretsmanager_secret`
 *   `securityhub`

--- a/providers/aws/s3.go
+++ b/providers/aws/s3.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"fmt"
 	"log"
+	"strings"
 
 	"github.com/chenrui333/terraformer/terraformutils"
 
@@ -19,6 +20,20 @@ import (
 var S3AllowEmptyValues = []string{"tags."}
 
 var S3AdditionalFields = map[string]interface{}{}
+
+var s3BucketSplitResourceInlineFields = map[string][]string{
+	"aws_s3_bucket_accelerate_configuration":             {"acceleration_status"},
+	"aws_s3_bucket_cors_configuration":                   {"cors_rule"},
+	"aws_s3_bucket_lifecycle_configuration":              {"lifecycle_rule"},
+	"aws_s3_bucket_logging":                              {"logging"},
+	"aws_s3_bucket_object_lock_configuration":            {"object_lock_configuration", "object_lock_enabled"},
+	"aws_s3_bucket_policy":                               {"policy"},
+	"aws_s3_bucket_replication_configuration":            {"replication_configuration"},
+	"aws_s3_bucket_request_payment_configuration":        {"request_payer"},
+	"aws_s3_bucket_server_side_encryption_configuration": {"server_side_encryption_configuration"},
+	"aws_s3_bucket_versioning":                           {"versioning"},
+	"aws_s3_bucket_website_configuration":                {"website"},
+}
 
 type S3Generator struct {
 	AWSService
@@ -265,8 +280,11 @@ func (g *S3Generator) InitResources() error {
 // PostGenerateHook for add bucket policy json as heredoc
 // support only bucket with policy
 func (g *S3Generator) PostConvertHook() error {
+	inlineFieldsByBucket := s3BucketInlineFieldsByBucket(g.Resources)
 	for i, resource := range g.Resources {
-		if resource.InstanceInfo.Type == "aws_s3_bucket" {
+		switch resource.InstanceInfo.Type {
+		case "aws_s3_bucket":
+			removeS3BucketInlineFields(&g.Resources[i], inlineFieldsByBucket[resource.InstanceState.ID])
 			if val, ok := g.Resources[i].Item["acl"]; ok && val == "private" {
 				delete(g.Resources[i].Item, "acl")
 			}
@@ -275,7 +293,70 @@ func (g *S3Generator) PostConvertHook() error {
 %s
 POLICY`, g.escapeAwsInterpolation(val.(string)))
 			}
+		case "aws_s3_bucket_policy":
+			if val, ok := g.Resources[i].Item["policy"]; ok {
+				g.Resources[i].Item["policy"] = fmt.Sprintf(`<<POLICY
+%s
+POLICY`, g.escapeAwsInterpolation(val.(string)))
+			}
 		}
 	}
 	return nil
+}
+
+func s3BucketInlineFieldsByBucket(resources []terraformutils.Resource) map[string]map[string]struct{} {
+	fieldsByBucket := map[string]map[string]struct{}{}
+	for _, resource := range resources {
+		fields, ok := s3BucketSplitResourceInlineFields[resource.InstanceInfo.Type]
+		if !ok {
+			continue
+		}
+		bucketName := s3BucketNameForSplitResource(resource)
+		if bucketName == "" {
+			continue
+		}
+		if fieldsByBucket[bucketName] == nil {
+			fieldsByBucket[bucketName] = map[string]struct{}{}
+		}
+		for _, field := range fields {
+			fieldsByBucket[bucketName][field] = struct{}{}
+		}
+	}
+	return fieldsByBucket
+}
+
+func s3BucketNameForSplitResource(resource terraformutils.Resource) string {
+	if resource.InstanceState != nil && resource.InstanceState.Attributes != nil {
+		if bucketName := resource.InstanceState.Attributes["bucket"]; bucketName != "" {
+			return bucketName
+		}
+	}
+	if resource.InstanceState != nil {
+		return resource.InstanceState.ID
+	}
+	return ""
+}
+
+func removeS3BucketInlineFields(resource *terraformutils.Resource, fields map[string]struct{}) {
+	if resource == nil {
+		return
+	}
+	for field := range fields {
+		if resource.Item != nil {
+			delete(resource.Item, field)
+		}
+		if resource.InstanceState != nil {
+			deleteFlatmapAttribute(resource.InstanceState.Attributes, field)
+		}
+	}
+}
+
+func deleteFlatmapAttribute(attributes map[string]string, field string) {
+	delete(attributes, field)
+	prefix := field + "."
+	for key := range attributes {
+		if strings.HasPrefix(key, prefix) {
+			delete(attributes, key)
+		}
+	}
 }

--- a/providers/aws/s3.go
+++ b/providers/aws/s3.go
@@ -4,6 +4,7 @@ package aws
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log"
 
@@ -11,6 +12,8 @@ import (
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/s3"
+	"github.com/aws/aws-sdk-go-v2/service/s3/types"
+	"github.com/aws/smithy-go"
 )
 
 var S3AllowEmptyValues = []string{"tags."}
@@ -41,6 +44,7 @@ func (g *S3Generator) createResources(config aws.Config, buckets *s3.ListBuckets
 				"force_destroy": "false",
 				"acl":           "private",
 			}
+			g.addBucketConfigurationResources(svc, &resources, resourceName)
 			// try get policy
 			var policy *s3.GetBucketPolicyOutput
 			policy, err = svc.GetBucketPolicy(context.TODO(), &s3.GetBucketPolicyInput{
@@ -69,6 +73,176 @@ func (g *S3Generator) createResources(config aws.Config, buckets *s3.ListBuckets
 		}
 	}
 	return resources
+}
+
+func (g *S3Generator) addBucketConfigurationResources(svc *s3.Client, resources *[]terraformutils.Resource, bucketName string) {
+	if bucketName == "" {
+		return
+	}
+	if output, err := svc.GetBucketAccelerateConfiguration(context.TODO(), &s3.GetBucketAccelerateConfigurationInput{Bucket: &bucketName}); err == nil {
+		if output.Status == types.BucketAccelerateStatusEnabled {
+			addS3BucketConfigurationResource(resources, bucketName, "aws_s3_bucket_accelerate_configuration")
+		}
+	} else {
+		logS3OptionalBucketConfigurationError(bucketName, "aws_s3_bucket_accelerate_configuration", err)
+	}
+	if output, err := svc.GetBucketCors(context.TODO(), &s3.GetBucketCorsInput{Bucket: &bucketName}); err == nil {
+		if len(output.CORSRules) > 0 {
+			addS3BucketConfigurationResource(resources, bucketName, "aws_s3_bucket_cors_configuration")
+		}
+	} else {
+		logS3OptionalBucketConfigurationError(bucketName, "aws_s3_bucket_cors_configuration", err)
+	}
+	if output, err := svc.GetBucketLifecycleConfiguration(context.TODO(), &s3.GetBucketLifecycleConfigurationInput{Bucket: &bucketName}); err == nil {
+		if len(output.Rules) > 0 {
+			addS3BucketConfigurationResource(resources, bucketName, "aws_s3_bucket_lifecycle_configuration")
+		}
+	} else {
+		logS3OptionalBucketConfigurationError(bucketName, "aws_s3_bucket_lifecycle_configuration", err)
+	}
+	if output, err := svc.GetBucketLogging(context.TODO(), &s3.GetBucketLoggingInput{Bucket: &bucketName}); err == nil {
+		if output.LoggingEnabled != nil {
+			addS3BucketConfigurationResource(resources, bucketName, "aws_s3_bucket_logging")
+		}
+	} else {
+		logS3OptionalBucketConfigurationError(bucketName, "aws_s3_bucket_logging", err)
+	}
+	if output, err := svc.GetBucketNotificationConfiguration(context.TODO(), &s3.GetBucketNotificationConfigurationInput{Bucket: &bucketName}); err == nil {
+		if s3BucketNotificationConfigured(output) {
+			addS3BucketConfigurationResource(resources, bucketName, "aws_s3_bucket_notification")
+		}
+	} else {
+		logS3OptionalBucketConfigurationError(bucketName, "aws_s3_bucket_notification", err)
+	}
+	if output, err := svc.GetObjectLockConfiguration(context.TODO(), &s3.GetObjectLockConfigurationInput{Bucket: &bucketName}); err == nil {
+		if s3ObjectLockConfigured(output) {
+			addS3BucketConfigurationResource(resources, bucketName, "aws_s3_bucket_object_lock_configuration")
+		}
+	} else {
+		logS3OptionalBucketConfigurationError(bucketName, "aws_s3_bucket_object_lock_configuration", err)
+	}
+	if output, err := svc.GetBucketOwnershipControls(context.TODO(), &s3.GetBucketOwnershipControlsInput{Bucket: &bucketName}); err == nil {
+		if output.OwnershipControls != nil && len(output.OwnershipControls.Rules) > 0 {
+			addS3BucketConfigurationResource(resources, bucketName, "aws_s3_bucket_ownership_controls")
+		}
+	} else {
+		logS3OptionalBucketConfigurationError(bucketName, "aws_s3_bucket_ownership_controls", err)
+	}
+	if output, err := svc.GetPublicAccessBlock(context.TODO(), &s3.GetPublicAccessBlockInput{Bucket: &bucketName}); err == nil {
+		if output.PublicAccessBlockConfiguration != nil {
+			addS3BucketConfigurationResource(resources, bucketName, "aws_s3_bucket_public_access_block")
+		}
+	} else {
+		logS3OptionalBucketConfigurationError(bucketName, "aws_s3_bucket_public_access_block", err)
+	}
+	if output, err := svc.GetBucketReplication(context.TODO(), &s3.GetBucketReplicationInput{Bucket: &bucketName}); err == nil {
+		if output.ReplicationConfiguration != nil && len(output.ReplicationConfiguration.Rules) > 0 {
+			addS3BucketConfigurationResource(resources, bucketName, "aws_s3_bucket_replication_configuration")
+		}
+	} else {
+		logS3OptionalBucketConfigurationError(bucketName, "aws_s3_bucket_replication_configuration", err)
+	}
+	if output, err := svc.GetBucketRequestPayment(context.TODO(), &s3.GetBucketRequestPaymentInput{Bucket: &bucketName}); err == nil {
+		if output.Payer == types.PayerRequester {
+			addS3BucketConfigurationResource(resources, bucketName, "aws_s3_bucket_request_payment_configuration")
+		}
+	} else {
+		logS3OptionalBucketConfigurationError(bucketName, "aws_s3_bucket_request_payment_configuration", err)
+	}
+	if output, err := svc.GetBucketEncryption(context.TODO(), &s3.GetBucketEncryptionInput{Bucket: &bucketName}); err == nil {
+		if output.ServerSideEncryptionConfiguration != nil && len(output.ServerSideEncryptionConfiguration.Rules) > 0 {
+			addS3BucketConfigurationResource(resources, bucketName, "aws_s3_bucket_server_side_encryption_configuration")
+		}
+	} else {
+		logS3OptionalBucketConfigurationError(bucketName, "aws_s3_bucket_server_side_encryption_configuration", err)
+	}
+	if output, err := svc.GetBucketVersioning(context.TODO(), &s3.GetBucketVersioningInput{Bucket: &bucketName}); err == nil {
+		if output.Status != "" || output.MFADelete != "" {
+			addS3BucketConfigurationResource(resources, bucketName, "aws_s3_bucket_versioning")
+		}
+	} else {
+		logS3OptionalBucketConfigurationError(bucketName, "aws_s3_bucket_versioning", err)
+	}
+	if output, err := svc.GetBucketWebsite(context.TODO(), &s3.GetBucketWebsiteInput{Bucket: &bucketName}); err == nil {
+		if s3BucketWebsiteConfigured(output) {
+			addS3BucketConfigurationResource(resources, bucketName, "aws_s3_bucket_website_configuration")
+		}
+	} else {
+		logS3OptionalBucketConfigurationError(bucketName, "aws_s3_bucket_website_configuration", err)
+	}
+}
+
+func addS3BucketConfigurationResource(resources *[]terraformutils.Resource, bucketName, resourceType string) {
+	*resources = append(*resources, terraformutils.NewResource(
+		bucketName,
+		bucketName,
+		resourceType,
+		"aws",
+		map[string]string{
+			"bucket": bucketName,
+		},
+		S3AllowEmptyValues,
+		S3AdditionalFields,
+	))
+}
+
+func s3BucketNotificationConfigured(output *s3.GetBucketNotificationConfigurationOutput) bool {
+	return output != nil &&
+		(output.EventBridgeConfiguration != nil ||
+			len(output.LambdaFunctionConfigurations) > 0 ||
+			len(output.QueueConfigurations) > 0 ||
+			len(output.TopicConfigurations) > 0)
+}
+
+func s3ObjectLockConfigured(output *s3.GetObjectLockConfigurationOutput) bool {
+	return output != nil &&
+		output.ObjectLockConfiguration != nil &&
+		(output.ObjectLockConfiguration.ObjectLockEnabled != "" || output.ObjectLockConfiguration.Rule != nil)
+}
+
+func s3BucketWebsiteConfigured(output *s3.GetBucketWebsiteOutput) bool {
+	return output != nil &&
+		(output.ErrorDocument != nil ||
+			output.IndexDocument != nil ||
+			output.RedirectAllRequestsTo != nil ||
+			len(output.RoutingRules) > 0)
+}
+
+func logS3OptionalBucketConfigurationError(bucketName, resourceType string, err error) {
+	if s3BucketConfigurationMissing(err) {
+		return
+	}
+	log.Printf("skipping %s discovery for S3 bucket %s: %v", resourceType, bucketName, err)
+}
+
+func s3BucketConfigurationMissing(err error) bool {
+	var noSuchBucket *types.NoSuchBucket
+	if errors.As(err, &noSuchBucket) {
+		return true
+	}
+	var notFound *types.NotFound
+	if errors.As(err, &notFound) {
+		return true
+	}
+	var apiErr smithy.APIError
+	if !errors.As(err, &apiErr) {
+		return false
+	}
+	switch apiErr.ErrorCode() {
+	case "NoSuchBucket",
+		"NoSuchBucketPolicy",
+		"NoSuchCORSConfiguration",
+		"NoSuchLifecycleConfiguration",
+		"NoSuchPublicAccessBlockConfiguration",
+		"NoSuchWebsiteConfiguration",
+		"ObjectLockConfigurationNotFoundError",
+		"OwnershipControlsNotFoundError",
+		"ReplicationConfigurationNotFoundError",
+		"ServerSideEncryptionConfigurationNotFoundError":
+		return true
+	default:
+		return false
+	}
 }
 
 // Generate TerraformResources from AWS API,

--- a/providers/aws/s3_test.go
+++ b/providers/aws/s3_test.go
@@ -122,3 +122,82 @@ func TestS3BucketConfigurationMissing(t *testing.T) {
 		})
 	}
 }
+
+func TestS3BucketInlineFieldsByBucket(t *testing.T) {
+	versioning := terraformutils.NewResource(
+		"versioned-bucket",
+		"versioned-bucket",
+		"aws_s3_bucket_versioning",
+		"aws",
+		map[string]string{"bucket": "versioned-bucket"},
+		S3AllowEmptyValues,
+		S3AdditionalFields,
+	)
+	policy := terraformutils.NewResource(
+		"policy-bucket",
+		"policy-bucket",
+		"aws_s3_bucket_policy",
+		"aws",
+		nil,
+		S3AllowEmptyValues,
+		S3AdditionalFields,
+	)
+
+	fieldsByBucket := s3BucketInlineFieldsByBucket([]terraformutils.Resource{versioning, policy})
+	if _, ok := fieldsByBucket["versioned-bucket"]["versioning"]; !ok {
+		t.Fatalf("versioning inline field was not tracked: %#v", fieldsByBucket)
+	}
+	if _, ok := fieldsByBucket["policy-bucket"]["policy"]; !ok {
+		t.Fatalf("policy inline field was not tracked from resource ID fallback: %#v", fieldsByBucket)
+	}
+}
+
+func TestRemoveS3BucketInlineFields(t *testing.T) {
+	resource := terraformutils.NewResource(
+		"example-bucket",
+		"example-bucket",
+		"aws_s3_bucket",
+		"aws",
+		map[string]string{
+			"bucket":                                 "example-bucket",
+			"id":                                     "example-bucket",
+			"versioning.#":                           "1",
+			"versioning.0.enabled":                   "true",
+			"lifecycle_rule.#":                       "1",
+			"lifecycle_rule.0.id":                    "expire",
+			"server_side_encryption_configuration.#": "1",
+		},
+		S3AllowEmptyValues,
+		S3AdditionalFields,
+	)
+	resource.Item = map[string]interface{}{
+		"bucket":                               "example-bucket",
+		"versioning":                           []interface{}{map[string]interface{}{"enabled": true}},
+		"lifecycle_rule":                       []interface{}{map[string]interface{}{"id": "expire"}},
+		"server_side_encryption_configuration": []interface{}{map[string]interface{}{}},
+	}
+
+	removeS3BucketInlineFields(&resource, map[string]struct{}{
+		"versioning":                           {},
+		"server_side_encryption_configuration": {},
+	})
+
+	if _, ok := resource.Item["versioning"]; ok {
+		t.Fatal("versioning was not removed from rendered item")
+	}
+	if _, ok := resource.Item["server_side_encryption_configuration"]; ok {
+		t.Fatal("server_side_encryption_configuration was not removed from rendered item")
+	}
+	if _, ok := resource.Item["lifecycle_rule"]; !ok {
+		t.Fatal("unselected lifecycle_rule was removed from rendered item")
+	}
+	if _, ok := resource.InstanceState.Attributes["versioning.#"]; ok {
+		t.Fatal("versioning flatmap prefix was not removed")
+	}
+	if _, ok := resource.InstanceState.Attributes["server_side_encryption_configuration.#"]; ok {
+		t.Fatal("server_side_encryption_configuration flatmap prefix was not removed")
+	}
+	if _, ok := resource.InstanceState.Attributes["lifecycle_rule.#"]; !ok {
+		t.Fatal("unselected lifecycle_rule flatmap prefix was removed")
+	}
+}

--- a/providers/aws/s3_test.go
+++ b/providers/aws/s3_test.go
@@ -1,0 +1,124 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package aws
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/service/s3"
+	"github.com/aws/aws-sdk-go-v2/service/s3/types"
+	"github.com/aws/smithy-go"
+	"github.com/chenrui333/terraformer/terraformutils"
+)
+
+func TestAddS3BucketConfigurationResource(t *testing.T) {
+	var resources []terraformutils.Resource
+	addS3BucketConfigurationResource(&resources, "example-bucket", "aws_s3_bucket_versioning")
+	if len(resources) != 1 {
+		t.Fatalf("len(resources) = %d, want 1", len(resources))
+	}
+	resource := resources[0]
+	if resource.InstanceState.ID != "example-bucket" {
+		t.Fatalf("InstanceState.ID = %q, want %q", resource.InstanceState.ID, "example-bucket")
+	}
+	if resource.InstanceInfo.Type != "aws_s3_bucket_versioning" {
+		t.Fatalf("InstanceInfo.Type = %q, want %q", resource.InstanceInfo.Type, "aws_s3_bucket_versioning")
+	}
+	if resource.InstanceState.Attributes["bucket"] != "example-bucket" {
+		t.Fatalf("bucket attribute = %q, want %q", resource.InstanceState.Attributes["bucket"], "example-bucket")
+	}
+}
+
+func TestS3BucketNotificationConfigured(t *testing.T) {
+	tests := []struct {
+		name   string
+		output *s3.GetBucketNotificationConfigurationOutput
+		want   bool
+	}{
+		{name: "nil", want: false},
+		{name: "empty", output: &s3.GetBucketNotificationConfigurationOutput{}, want: false},
+		{name: "eventbridge", output: &s3.GetBucketNotificationConfigurationOutput{EventBridgeConfiguration: &types.EventBridgeConfiguration{}}, want: true},
+		{name: "lambda", output: &s3.GetBucketNotificationConfigurationOutput{LambdaFunctionConfigurations: []types.LambdaFunctionConfiguration{{}}}, want: true},
+		{name: "queue", output: &s3.GetBucketNotificationConfigurationOutput{QueueConfigurations: []types.QueueConfiguration{{}}}, want: true},
+		{name: "topic", output: &s3.GetBucketNotificationConfigurationOutput{TopicConfigurations: []types.TopicConfiguration{{}}}, want: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := s3BucketNotificationConfigured(tt.output); got != tt.want {
+				t.Fatalf("s3BucketNotificationConfigured() = %t, want %t", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestS3ObjectLockConfigured(t *testing.T) {
+	tests := []struct {
+		name   string
+		output *s3.GetObjectLockConfigurationOutput
+		want   bool
+	}{
+		{name: "nil", want: false},
+		{name: "empty", output: &s3.GetObjectLockConfigurationOutput{}, want: false},
+		{name: "empty config", output: &s3.GetObjectLockConfigurationOutput{ObjectLockConfiguration: &types.ObjectLockConfiguration{}}, want: false},
+		{name: "enabled", output: &s3.GetObjectLockConfigurationOutput{ObjectLockConfiguration: &types.ObjectLockConfiguration{ObjectLockEnabled: types.ObjectLockEnabledEnabled}}, want: true},
+		{name: "rule", output: &s3.GetObjectLockConfigurationOutput{ObjectLockConfiguration: &types.ObjectLockConfiguration{Rule: &types.ObjectLockRule{}}}, want: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := s3ObjectLockConfigured(tt.output); got != tt.want {
+				t.Fatalf("s3ObjectLockConfigured() = %t, want %t", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestS3BucketWebsiteConfigured(t *testing.T) {
+	tests := []struct {
+		name   string
+		output *s3.GetBucketWebsiteOutput
+		want   bool
+	}{
+		{name: "nil", want: false},
+		{name: "empty", output: &s3.GetBucketWebsiteOutput{}, want: false},
+		{name: "index", output: &s3.GetBucketWebsiteOutput{IndexDocument: &types.IndexDocument{}}, want: true},
+		{name: "error", output: &s3.GetBucketWebsiteOutput{ErrorDocument: &types.ErrorDocument{}}, want: true},
+		{name: "redirect", output: &s3.GetBucketWebsiteOutput{RedirectAllRequestsTo: &types.RedirectAllRequestsTo{}}, want: true},
+		{name: "routing rule", output: &s3.GetBucketWebsiteOutput{RoutingRules: []types.RoutingRule{{}}}, want: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := s3BucketWebsiteConfigured(tt.output); got != tt.want {
+				t.Fatalf("s3BucketWebsiteConfigured() = %t, want %t", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestS3BucketConfigurationMissing(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{name: "typed no such bucket", err: &types.NoSuchBucket{}, want: true},
+		{name: "typed not found", err: &types.NotFound{}, want: true},
+		{name: "cors missing", err: &smithy.GenericAPIError{Code: "NoSuchCORSConfiguration"}, want: true},
+		{name: "lifecycle missing", err: &smithy.GenericAPIError{Code: "NoSuchLifecycleConfiguration"}, want: true},
+		{name: "encryption missing", err: &smithy.GenericAPIError{Code: "ServerSideEncryptionConfigurationNotFoundError"}, want: true},
+		{name: "access denied", err: &smithy.GenericAPIError{Code: "AccessDenied"}, want: false},
+		{name: "generic error", err: errors.New("boom"), want: false},
+		{name: "nil", want: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := s3BucketConfigurationMissing(tt.err); got != tt.want {
+				t.Fatalf("s3BucketConfigurationMissing() = %t, want %t", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

- add best-effort S3 bucket configuration discovery for standalone AWS provider v5 resources
- seed bucket-name import IDs and bucket attributes for discovered S3 subresources
- skip empty or missing bucket configuration responses so Terraformer does not emit phantom resources
- document the expanded S3 resource coverage and add focused helper tests

## Notes

- S3 public access block and default encryption are imported when AWS returns them. AWS does not expose whether these returned values are service defaults or explicit user configuration, and the AWS provider imports/reads them as bucket-scoped resources.
- `aws_s3_bucket_policy` was already discovered by Terraformer but was missing from the AWS docs list.

Refs #203

