### PR TITLE
aws(apigatewayv2): add API Gateway v2 resources

### DIFF
--- a/docs/aws.md
+++ b/docs/aws.md
@@ -59,6 +59,19 @@ terraformer import aws --resources=sg --regions=us-east-1
     * `aws_api_gateway_stage`
     * `aws_api_gateway_usage_plan`
     * `aws_api_gateway_vpc_link`
+*   `api_gatewayv2`
+    * `aws_apigatewayv2_api`
+    * `aws_apigatewayv2_api_mapping`
+    * `aws_apigatewayv2_authorizer`
+    * `aws_apigatewayv2_deployment`
+    * `aws_apigatewayv2_domain_name`
+    * `aws_apigatewayv2_integration`
+    * `aws_apigatewayv2_integration_response`
+    * `aws_apigatewayv2_model`
+    * `aws_apigatewayv2_route`
+    * `aws_apigatewayv2_route_response`
+    * `aws_apigatewayv2_stage`
+    * `aws_apigatewayv2_vpc_link`
 *   `appsync`
     * `aws_appsync_graphql_api`
 *   `auto_scaling`

--- a/providers/aws/api_gatewayv2.go
+++ b/providers/aws/api_gatewayv2.go
@@ -38,6 +38,8 @@ func (g *APIGatewayV2Generator) InitResources() error {
 	if err := g.loadVpcLinks(svc); err != nil {
 		return err
 	}
+	// Domain names are account-level and often require separate permissions from API listing.
+	// Keep this best-effort so users who can enumerate APIs still get baseline API imports.
 	if err := g.loadDomainNames(svc); err != nil {
 		if !apiGatewayV2ResourceMissing(err) {
 			log.Printf("Skipping API Gateway V2 domain names: %v", err)

--- a/providers/aws/api_gatewayv2.go
+++ b/providers/aws/api_gatewayv2.go
@@ -4,14 +4,22 @@ package aws
 
 import (
 	"context"
-	"fmt"
+	"errors"
+	"log"
+	"strings"
 
+	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/apigatewayv2"
 	"github.com/aws/aws-sdk-go-v2/service/apigatewayv2/types"
 	"github.com/chenrui333/terraformer/terraformutils"
 )
 
-var apiGatewayV2AllowEmptyValues = []string{"tags.", "parent_id", "path_part"}
+var apiGatewayV2AllowEmptyValues = []string{"tags."}
+
+type apiGatewayV2OptionalResourceLoader struct {
+	name string
+	load func() error
+}
 
 type APIGatewayV2Generator struct {
 	AWSService
@@ -30,327 +38,465 @@ func (g *APIGatewayV2Generator) InitResources() error {
 	if err := g.loadVpcLinks(svc); err != nil {
 		return err
 	}
+	if err := g.loadDomainNames(svc); err != nil {
+		if !apiGatewayV2ResourceMissing(err) {
+			log.Printf("Skipping API Gateway V2 domain names: %v", err)
+		}
+	}
 	return nil
+}
+
+func (g *APIGatewayV2Generator) loadOptionalResources(loaders []apiGatewayV2OptionalResourceLoader) {
+	for _, loader := range loaders {
+		if err := loader.load(); err != nil {
+			if apiGatewayV2ResourceMissing(err) {
+				continue
+			}
+			log.Printf("Skipping API Gateway V2 %s: %v", loader.name, err)
+		}
+	}
 }
 
 func (g *APIGatewayV2Generator) loadRestApis(svc *apigatewayv2.Client) error {
 	output, err := svc.GetApis(context.TODO(), &apigatewayv2.GetApisInput{})
 	if err != nil {
-		fmt.Println("Failed to list APIs:", err)
 		return err
 	}
-
-	err = g.processRestApis(svc, output.Items)
-	if err != nil {
-		fmt.Println("Failed to list APIs:", err)
-		return err
-	}
+	g.processRestApis(svc, output.Items)
 
 	for output.NextToken != nil {
 		output, err = svc.GetApis(context.TODO(), &apigatewayv2.GetApisInput{
 			NextToken: output.NextToken,
 		})
 		if err != nil {
-			fmt.Println("Failed to list APIs:", err)
 			return err
 		}
-		if err = g.processRestApis(svc, output.Items); err != nil {
-			fmt.Println("Failed to list APIs:", err)
-			return err
-		}
+		g.processRestApis(svc, output.Items)
 	}
 
 	return nil
 }
 
-func (g *APIGatewayV2Generator) processRestApis(svc *apigatewayv2.Client, output []types.Api) error {
+func (g *APIGatewayV2Generator) processRestApis(svc *apigatewayv2.Client, output []types.Api) {
 	for _, restAPI := range output {
+		apiID := StringValue(restAPI.ApiId)
+		if apiID == "" {
+			continue
+		}
+
 		g.Resources = append(g.Resources, terraformutils.NewSimpleResource(
-			*restAPI.ApiId,
-			*restAPI.ApiId+"_"+*restAPI.Name,
+			apiID,
+			apiGatewayV2ResourceName(apiID, StringValue(restAPI.Name)),
 			"aws_apigatewayv2_api",
 			"aws",
 			apiGatewayV2AllowEmptyValues,
 		))
-		if err := g.loadStages(svc, restAPI.ApiId); err != nil {
-			return err
-		}
-		if err := g.loadModels(svc, restAPI.ApiId); err != nil {
-			return err
-		}
-		if err := g.loadRoutes(svc, restAPI.ApiId); err != nil {
-			return err
-		}
 
-		if err := g.loadAuthorizers(svc, restAPI.ApiId); err != nil {
-			return err
-		}
+		g.loadOptionalResources([]apiGatewayV2OptionalResourceLoader{
+			{name: "stages", load: func() error { return g.loadStages(svc, apiID) }},
+			{name: "models", load: func() error { return g.loadModels(svc, apiID) }},
+			{name: "routes", load: func() error { return g.loadRoutes(svc, apiID) }},
+			{name: "integrations", load: func() error { return g.loadIntegrations(svc, apiID) }},
+			{name: "deployments", load: func() error { return g.loadDeployments(svc, apiID) }},
+			{name: "authorizers", load: func() error { return g.loadAuthorizers(svc, apiID) }},
+		})
 	}
-	return nil
 }
 
-func (g *APIGatewayV2Generator) loadStages(svc *apigatewayv2.Client, restAPIID *string) error {
+func (g *APIGatewayV2Generator) loadStages(svc *apigatewayv2.Client, apiID string) error {
 	output, err := svc.GetStages(context.TODO(), &apigatewayv2.GetStagesInput{
-		ApiId: restAPIID,
+		ApiId: aws.String(apiID),
 	})
 	if err != nil {
 		return err
 	}
-	err = g.processStages(output.Items, restAPIID)
-	if err != nil {
-		return err
-	}
+	g.processStages(output.Items, apiID)
 
 	for output.NextToken != nil {
 		output, err = svc.GetStages(context.TODO(), &apigatewayv2.GetStagesInput{
-			ApiId:     restAPIID,
+			ApiId:     aws.String(apiID),
 			NextToken: output.NextToken,
 		})
 		if err != nil {
 			return err
 		}
-		err = g.processStages(output.Items, restAPIID)
-		if err != nil {
-			return err
-		}
+		g.processStages(output.Items, apiID)
 	}
 
 	return nil
 }
 
-func (g *APIGatewayV2Generator) processStages(output []types.Stage, restAPIID *string) error {
+func (g *APIGatewayV2Generator) processStages(output []types.Stage, apiID string) {
 	for _, stage := range output {
-		stageID := *restAPIID + "/" + StringValue(stage.StageName)
+		if apiGatewayV2Managed(stage.ApiGatewayManaged) {
+			continue
+		}
+		stageName := StringValue(stage.StageName)
+		if stageName == "" {
+			continue
+		}
+		stageID := apiGatewayV2ImportID(apiID, stageName)
 		g.Resources = append(g.Resources, terraformutils.NewResource(
 			stageID,
 			stageID,
-			"aws_api_gateway_stage",
+			"aws_apigatewayv2_stage",
 			"aws",
 			map[string]string{
-				"rest_api_id": *restAPIID,
-				"stage_name":  *stage.StageName,
+				"api_id": apiID,
+				"name":   stageName,
 			},
-			apiGatewayAllowEmptyValues,
+			apiGatewayV2AllowEmptyValues,
 			map[string]interface{}{},
 		))
 	}
-	return nil
 }
 
-func (g *APIGatewayV2Generator) loadModels(svc *apigatewayv2.Client, restAPIID *string) error {
-	output, err := svc.GetModels(context.TODO(),
-		&apigatewayv2.GetModelsInput{
-			ApiId: restAPIID,
-		})
+func (g *APIGatewayV2Generator) loadModels(svc *apigatewayv2.Client, apiID string) error {
+	output, err := svc.GetModels(context.TODO(), &apigatewayv2.GetModelsInput{
+		ApiId: aws.String(apiID),
+	})
 	if err != nil {
 		return err
 	}
-	err = g.processModels(output.Items, restAPIID)
-	if err != nil {
-		return err
-	}
+	g.processModels(output.Items, apiID)
 
 	for output.NextToken != nil {
-		output, err = svc.GetModels(context.TODO(),
-			&apigatewayv2.GetModelsInput{
-				ApiId:     restAPIID,
-				NextToken: output.NextToken,
-			})
+		output, err = svc.GetModels(context.TODO(), &apigatewayv2.GetModelsInput{
+			ApiId:     aws.String(apiID),
+			NextToken: output.NextToken,
+		})
 		if err != nil {
 			return err
 		}
-		err = g.processModels(output.Items, restAPIID)
-		if err != nil {
-			return err
-		}
+		g.processModels(output.Items, apiID)
 	}
 
 	return nil
 }
 
-func (g *APIGatewayV2Generator) processModels(output []types.Model, restAPIID *string) error {
+func (g *APIGatewayV2Generator) processModels(output []types.Model, apiID string) {
 	for _, model := range output {
+		modelID := StringValue(model.ModelId)
+		if modelID == "" {
+			continue
+		}
 		g.Resources = append(g.Resources, terraformutils.NewResource(
-			*model.ModelId,
-			*model.ModelId,
+			apiGatewayV2ImportID(apiID, modelID),
+			apiGatewayV2ResourceName(apiID, modelID),
 			"aws_apigatewayv2_model",
 			"aws",
 			map[string]string{
-				"name":         StringValue(model.Name),
+				"api_id":       apiID,
 				"content_type": StringValue(model.ContentType),
+				"name":         StringValue(model.Name),
 				"schema":       StringValue(model.Schema),
-				"api_id":       StringValue(restAPIID),
 			},
-			apiGatewayAllowEmptyValues,
+			apiGatewayV2AllowEmptyValues,
 			map[string]interface{}{},
 		))
 	}
-	return nil
 }
 
-func (g *APIGatewayV2Generator) loadRoutes(svc *apigatewayv2.Client, restAPIID *string) error {
-	output, err := svc.GetRoutes(context.TODO(),
-		&apigatewayv2.GetRoutesInput{
-			ApiId: restAPIID,
-		})
+func (g *APIGatewayV2Generator) loadRoutes(svc *apigatewayv2.Client, apiID string) error {
+	output, err := svc.GetRoutes(context.TODO(), &apigatewayv2.GetRoutesInput{
+		ApiId: aws.String(apiID),
+	})
 	if err != nil {
 		return err
 	}
-
-	err = g.processRoutes(svc, output.Items, restAPIID)
-	if err != nil {
-		return err
-	}
+	g.processRoutes(svc, output.Items, apiID)
 
 	for output.NextToken != nil {
-		output, err := svc.GetRoutes(context.TODO(),
-			&apigatewayv2.GetRoutesInput{
-				ApiId:     restAPIID,
-				NextToken: output.NextToken,
-			})
+		output, err = svc.GetRoutes(context.TODO(), &apigatewayv2.GetRoutesInput{
+			ApiId:     aws.String(apiID),
+			NextToken: output.NextToken,
+		})
 		if err != nil {
 			return err
 		}
-
-		err = g.processRoutes(svc, output.Items, restAPIID)
-		if err != nil {
-			return err
-		}
+		g.processRoutes(svc, output.Items, apiID)
 	}
 
 	return nil
 }
 
-func (g *APIGatewayV2Generator) processRoutes(svc *apigatewayv2.Client, output []types.Route, restAPIID *string) error {
+func (g *APIGatewayV2Generator) processRoutes(svc *apigatewayv2.Client, output []types.Route, apiID string) {
 	for _, route := range output {
+		if apiGatewayV2Managed(route.ApiGatewayManaged) {
+			continue
+		}
+		routeID := StringValue(route.RouteId)
+		if routeID == "" {
+			continue
+		}
 		g.Resources = append(g.Resources, terraformutils.NewResource(
-			*route.RouteId,
-			*route.RouteId,
+			apiGatewayV2ImportID(apiID, routeID),
+			apiGatewayV2ResourceName(apiID, routeID),
 			"aws_apigatewayv2_route",
 			"aws",
 			map[string]string{
-				"api_id":    *restAPIID,
-				"route_key": *route.RouteKey,
+				"api_id":    apiID,
+				"route_key": StringValue(route.RouteKey),
+				"target":    StringValue(route.Target),
 			},
-			apiGatewayAllowEmptyValues,
+			apiGatewayV2AllowEmptyValues,
 			map[string]interface{}{},
 		))
-		if err := g.loadResponses(svc, restAPIID, route.RouteId); err != nil {
-			return err
+		if err := g.loadRouteResponses(svc, apiID, routeID); err != nil {
+			if !apiGatewayV2ResourceMissing(err) {
+				log.Printf("Skipping API Gateway V2 route responses for %s/%s: %v", apiID, routeID, err)
+			}
 		}
 	}
-	return nil
 }
 
-func (g *APIGatewayV2Generator) loadResponses(svc *apigatewayv2.Client, restAPIID *string, routeID *string) error {
-	output, err := svc.GetRouteResponses(context.TODO(),
-		&apigatewayv2.GetRouteResponsesInput{
-			ApiId:   restAPIID,
-			RouteId: routeID,
-		})
-
+func (g *APIGatewayV2Generator) loadRouteResponses(svc *apigatewayv2.Client, apiID string, routeID string) error {
+	output, err := svc.GetRouteResponses(context.TODO(), &apigatewayv2.GetRouteResponsesInput{
+		ApiId:   aws.String(apiID),
+		RouteId: aws.String(routeID),
+	})
 	if err != nil {
 		return err
 	}
-	err = g.processResponses(output.Items, restAPIID, routeID)
-	if err != nil {
-		return err
-	}
+	g.processRouteResponses(output.Items, apiID, routeID)
 
 	for output.NextToken != nil {
-		output, err = svc.GetRouteResponses(context.TODO(),
-			&apigatewayv2.GetRouteResponsesInput{
-				ApiId:     restAPIID,
-				RouteId:   routeID,
-				NextToken: output.NextToken,
-			})
-
+		output, err = svc.GetRouteResponses(context.TODO(), &apigatewayv2.GetRouteResponsesInput{
+			ApiId:     aws.String(apiID),
+			RouteId:   aws.String(routeID),
+			NextToken: output.NextToken,
+		})
 		if err != nil {
 			return err
 		}
-		err = g.processResponses(output.Items, restAPIID, routeID)
-		if err != nil {
-			return err
-		}
+		g.processRouteResponses(output.Items, apiID, routeID)
 	}
 
 	return nil
 }
-func (g *APIGatewayV2Generator) processResponses(output []types.RouteResponse, restAPIID *string, routeID *string) error {
+
+func (g *APIGatewayV2Generator) processRouteResponses(output []types.RouteResponse, apiID string, routeID string) {
 	for _, response := range output {
+		responseID := StringValue(response.RouteResponseId)
+		if responseID == "" {
+			continue
+		}
 		g.Resources = append(g.Resources, terraformutils.NewResource(
-			*response.RouteResponseId,
-			*response.RouteResponseId,
+			apiGatewayV2ImportID(apiID, routeID, responseID),
+			apiGatewayV2ResourceName(apiID, routeID, responseID),
 			"aws_apigatewayv2_route_response",
 			"aws",
 			map[string]string{
-				"api_id":             *restAPIID,
-				"route_id":           *routeID,
-				"route_response_key": "$default",
+				"api_id":             apiID,
+				"route_id":           routeID,
+				"route_response_key": StringValue(response.RouteResponseKey),
 			},
-			apiGatewayAllowEmptyValues,
+			apiGatewayV2AllowEmptyValues,
 			map[string]interface{}{},
 		))
 	}
-	return nil
 }
 
-func (g *APIGatewayV2Generator) loadAuthorizers(svc *apigatewayv2.Client, restAPIID *string) error {
-	output, err := svc.GetAuthorizers(context.TODO(),
-		&apigatewayv2.GetAuthorizersInput{
-			ApiId: restAPIID,
-		})
+func (g *APIGatewayV2Generator) loadIntegrations(svc *apigatewayv2.Client, apiID string) error {
+	output, err := svc.GetIntegrations(context.TODO(), &apigatewayv2.GetIntegrationsInput{
+		ApiId: aws.String(apiID),
+	})
 	if err != nil {
 		return err
 	}
-	g.processAuthorizers(output.Items, restAPIID)
+	g.processIntegrations(svc, output.Items, apiID)
 
 	for output.NextToken != nil {
-		output, err = svc.GetAuthorizers(context.TODO(),
-			&apigatewayv2.GetAuthorizersInput{
-				ApiId:     restAPIID,
-				NextToken: output.NextToken,
-			})
+		output, err = svc.GetIntegrations(context.TODO(), &apigatewayv2.GetIntegrationsInput{
+			ApiId:     aws.String(apiID),
+			NextToken: output.NextToken,
+		})
 		if err != nil {
 			return err
 		}
-		g.processAuthorizers(output.Items, restAPIID)
+		g.processIntegrations(svc, output.Items, apiID)
 	}
 
 	return nil
 }
 
-func (g *APIGatewayV2Generator) processAuthorizers(output []types.Authorizer, restAPIID *string) {
-	for _, authoriser := range output {
+func (g *APIGatewayV2Generator) processIntegrations(svc *apigatewayv2.Client, output []types.Integration, apiID string) {
+	for _, integration := range output {
+		if apiGatewayV2Managed(integration.ApiGatewayManaged) {
+			continue
+		}
+		integrationID := StringValue(integration.IntegrationId)
+		if integrationID == "" {
+			continue
+		}
 		g.Resources = append(g.Resources, terraformutils.NewResource(
-			*authoriser.AuthorizerId,
-			*authoriser.AuthorizerId,
+			apiGatewayV2ImportID(apiID, integrationID),
+			apiGatewayV2ResourceName(apiID, integrationID),
+			"aws_apigatewayv2_integration",
+			"aws",
+			map[string]string{
+				"api_id":             apiID,
+				"integration_method": StringValue(integration.IntegrationMethod),
+				"integration_type":   string(integration.IntegrationType),
+				"integration_uri":    StringValue(integration.IntegrationUri),
+			},
+			apiGatewayV2AllowEmptyValues,
+			map[string]interface{}{},
+		))
+		if err := g.loadIntegrationResponses(svc, apiID, integrationID); err != nil {
+			if !apiGatewayV2ResourceMissing(err) {
+				log.Printf("Skipping API Gateway V2 integration responses for %s/%s: %v", apiID, integrationID, err)
+			}
+		}
+	}
+}
+
+func (g *APIGatewayV2Generator) loadIntegrationResponses(svc *apigatewayv2.Client, apiID string, integrationID string) error {
+	output, err := svc.GetIntegrationResponses(context.TODO(), &apigatewayv2.GetIntegrationResponsesInput{
+		ApiId:         aws.String(apiID),
+		IntegrationId: aws.String(integrationID),
+	})
+	if err != nil {
+		return err
+	}
+	g.processIntegrationResponses(output.Items, apiID, integrationID)
+
+	for output.NextToken != nil {
+		output, err = svc.GetIntegrationResponses(context.TODO(), &apigatewayv2.GetIntegrationResponsesInput{
+			ApiId:         aws.String(apiID),
+			IntegrationId: aws.String(integrationID),
+			NextToken:     output.NextToken,
+		})
+		if err != nil {
+			return err
+		}
+		g.processIntegrationResponses(output.Items, apiID, integrationID)
+	}
+
+	return nil
+}
+
+func (g *APIGatewayV2Generator) processIntegrationResponses(output []types.IntegrationResponse, apiID string, integrationID string) {
+	for _, response := range output {
+		responseID := StringValue(response.IntegrationResponseId)
+		if responseID == "" {
+			continue
+		}
+		g.Resources = append(g.Resources, terraformutils.NewResource(
+			apiGatewayV2ImportID(apiID, integrationID, responseID),
+			apiGatewayV2ResourceName(apiID, integrationID, responseID),
+			"aws_apigatewayv2_integration_response",
+			"aws",
+			map[string]string{
+				"api_id":                   apiID,
+				"integration_id":           integrationID,
+				"integration_response_key": StringValue(response.IntegrationResponseKey),
+			},
+			apiGatewayV2AllowEmptyValues,
+			map[string]interface{}{},
+		))
+	}
+}
+
+func (g *APIGatewayV2Generator) loadDeployments(svc *apigatewayv2.Client, apiID string) error {
+	output, err := svc.GetDeployments(context.TODO(), &apigatewayv2.GetDeploymentsInput{
+		ApiId: aws.String(apiID),
+	})
+	if err != nil {
+		return err
+	}
+	g.processDeployments(output.Items, apiID)
+
+	for output.NextToken != nil {
+		output, err = svc.GetDeployments(context.TODO(), &apigatewayv2.GetDeploymentsInput{
+			ApiId:     aws.String(apiID),
+			NextToken: output.NextToken,
+		})
+		if err != nil {
+			return err
+		}
+		g.processDeployments(output.Items, apiID)
+	}
+
+	return nil
+}
+
+func (g *APIGatewayV2Generator) processDeployments(output []types.Deployment, apiID string) {
+	for _, deployment := range output {
+		deploymentID := StringValue(deployment.DeploymentId)
+		if deploymentID == "" {
+			continue
+		}
+		g.Resources = append(g.Resources, terraformutils.NewResource(
+			apiGatewayV2ImportID(apiID, deploymentID),
+			apiGatewayV2ResourceName(apiID, deploymentID),
+			"aws_apigatewayv2_deployment",
+			"aws",
+			map[string]string{
+				"api_id": apiID,
+			},
+			apiGatewayV2AllowEmptyValues,
+			map[string]interface{}{},
+		))
+	}
+}
+
+func (g *APIGatewayV2Generator) loadAuthorizers(svc *apigatewayv2.Client, apiID string) error {
+	output, err := svc.GetAuthorizers(context.TODO(), &apigatewayv2.GetAuthorizersInput{
+		ApiId: aws.String(apiID),
+	})
+	if err != nil {
+		return err
+	}
+	g.processAuthorizers(output.Items, apiID)
+
+	for output.NextToken != nil {
+		output, err = svc.GetAuthorizers(context.TODO(), &apigatewayv2.GetAuthorizersInput{
+			ApiId:     aws.String(apiID),
+			NextToken: output.NextToken,
+		})
+		if err != nil {
+			return err
+		}
+		g.processAuthorizers(output.Items, apiID)
+	}
+
+	return nil
+}
+
+func (g *APIGatewayV2Generator) processAuthorizers(output []types.Authorizer, apiID string) {
+	for _, authorizer := range output {
+		authorizerID := StringValue(authorizer.AuthorizerId)
+		if authorizerID == "" {
+			continue
+		}
+		g.Resources = append(g.Resources, terraformutils.NewResource(
+			apiGatewayV2ImportID(apiID, authorizerID),
+			apiGatewayV2ResourceName(apiID, authorizerID),
 			"aws_apigatewayv2_authorizer",
 			"aws",
 			map[string]string{
-				"api_id":          *restAPIID,
-				"name":            StringValue(authoriser.Name),
-				"authorizer_type": string(authoriser.AuthorizerType),
+				"api_id":          apiID,
+				"authorizer_type": string(authorizer.AuthorizerType),
+				"name":            StringValue(authorizer.Name),
 			},
-			apiGatewayAllowEmptyValues,
+			apiGatewayV2AllowEmptyValues,
 			map[string]interface{}{},
 		))
 	}
 }
 
 func (g *APIGatewayV2Generator) loadVpcLinks(svc *apigatewayv2.Client) error {
-	output, err := svc.GetVpcLinks(context.TODO(),
-		&apigatewayv2.GetVpcLinksInput{})
+	output, err := svc.GetVpcLinks(context.TODO(), &apigatewayv2.GetVpcLinksInput{})
 	if err != nil {
 		return err
 	}
 	g.processVpcLinks(output.Items)
 
 	for output.NextToken != nil {
-		output, err := svc.GetVpcLinks(context.TODO(),
-			&apigatewayv2.GetVpcLinksInput{
-				NextToken: output.NextToken,
-			})
+		output, err = svc.GetVpcLinks(context.TODO(), &apigatewayv2.GetVpcLinksInput{
+			NextToken: output.NextToken,
+		})
 		if err != nil {
 			return err
 		}
@@ -362,11 +508,130 @@ func (g *APIGatewayV2Generator) loadVpcLinks(svc *apigatewayv2.Client) error {
 
 func (g *APIGatewayV2Generator) processVpcLinks(output []types.VpcLink) {
 	for _, vpcLink := range output {
+		vpcLinkID := StringValue(vpcLink.VpcLinkId)
+		if vpcLinkID == "" {
+			continue
+		}
 		g.Resources = append(g.Resources, terraformutils.NewSimpleResource(
-			*vpcLink.VpcLinkId,
-			*vpcLink.VpcLinkId,
+			vpcLinkID,
+			vpcLinkID,
 			"aws_apigatewayv2_vpc_link",
 			"aws",
-			apiGatewayAllowEmptyValues))
+			apiGatewayV2AllowEmptyValues,
+		))
 	}
+}
+
+func (g *APIGatewayV2Generator) loadDomainNames(svc *apigatewayv2.Client) error {
+	output, err := svc.GetDomainNames(context.TODO(), &apigatewayv2.GetDomainNamesInput{})
+	if err != nil {
+		return err
+	}
+	g.processDomainNames(svc, output.Items)
+
+	for output.NextToken != nil {
+		output, err = svc.GetDomainNames(context.TODO(), &apigatewayv2.GetDomainNamesInput{
+			NextToken: output.NextToken,
+		})
+		if err != nil {
+			return err
+		}
+		g.processDomainNames(svc, output.Items)
+	}
+
+	return nil
+}
+
+func (g *APIGatewayV2Generator) processDomainNames(svc *apigatewayv2.Client, output []types.DomainName) {
+	for _, domainName := range output {
+		domain := StringValue(domainName.DomainName)
+		if domain == "" {
+			continue
+		}
+		g.Resources = append(g.Resources, terraformutils.NewResource(
+			domain,
+			domain,
+			"aws_apigatewayv2_domain_name",
+			"aws",
+			map[string]string{
+				"domain_name": domain,
+			},
+			apiGatewayV2AllowEmptyValues,
+			map[string]interface{}{},
+		))
+		if err := g.loadAPIMappings(svc, domain); err != nil {
+			if !apiGatewayV2ResourceMissing(err) {
+				log.Printf("Skipping API Gateway V2 API mappings for %s: %v", domain, err)
+			}
+		}
+	}
+}
+
+func (g *APIGatewayV2Generator) loadAPIMappings(svc *apigatewayv2.Client, domainName string) error {
+	output, err := svc.GetApiMappings(context.TODO(), &apigatewayv2.GetApiMappingsInput{
+		DomainName: aws.String(domainName),
+	})
+	if err != nil {
+		return err
+	}
+	g.processAPIMappings(output.Items, domainName)
+
+	for output.NextToken != nil {
+		output, err = svc.GetApiMappings(context.TODO(), &apigatewayv2.GetApiMappingsInput{
+			DomainName: aws.String(domainName),
+			NextToken:  output.NextToken,
+		})
+		if err != nil {
+			return err
+		}
+		g.processAPIMappings(output.Items, domainName)
+	}
+
+	return nil
+}
+
+func (g *APIGatewayV2Generator) processAPIMappings(output []types.ApiMapping, domainName string) {
+	for _, mapping := range output {
+		mappingID := StringValue(mapping.ApiMappingId)
+		if mappingID == "" {
+			continue
+		}
+		g.Resources = append(g.Resources, terraformutils.NewResource(
+			apiGatewayV2ImportID(mappingID, domainName),
+			apiGatewayV2ResourceName(domainName, mappingID),
+			"aws_apigatewayv2_api_mapping",
+			"aws",
+			map[string]string{
+				"api_id":          StringValue(mapping.ApiId),
+				"api_mapping_key": StringValue(mapping.ApiMappingKey),
+				"domain_name":     domainName,
+				"stage":           StringValue(mapping.Stage),
+			},
+			apiGatewayV2AllowEmptyValues,
+			map[string]interface{}{},
+		))
+	}
+}
+
+func apiGatewayV2ImportID(parts ...string) string {
+	return strings.Join(parts, "/")
+}
+
+func apiGatewayV2ResourceName(parts ...string) string {
+	filtered := make([]string, 0, len(parts))
+	for _, part := range parts {
+		if part != "" {
+			filtered = append(filtered, part)
+		}
+	}
+	return strings.Join(filtered, "/")
+}
+
+func apiGatewayV2Managed(managed *bool) bool {
+	return managed != nil && *managed
+}
+
+func apiGatewayV2ResourceMissing(err error) bool {
+	var notFound *types.NotFoundException
+	return errors.As(err, &notFound)
 }

--- a/providers/aws/api_gatewayv2_test.go
+++ b/providers/aws/api_gatewayv2_test.go
@@ -1,0 +1,141 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package aws
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/apigatewayv2/types"
+)
+
+func TestAPIGatewayV2ImportID(t *testing.T) {
+	tests := []struct {
+		name  string
+		parts []string
+		want  string
+	}{
+		{name: "stage", parts: []string{"api-123", "prod"}, want: "api-123/prod"},
+		{name: "model", parts: []string{"api-123", "model-456"}, want: "api-123/model-456"},
+		{name: "route", parts: []string{"api-123", "route-456"}, want: "api-123/route-456"},
+		{name: "route response", parts: []string{"api-123", "route-456", "response-789"}, want: "api-123/route-456/response-789"},
+		{name: "integration", parts: []string{"api-123", "integration-456"}, want: "api-123/integration-456"},
+		{name: "integration response", parts: []string{"api-123", "integration-456", "response-789"}, want: "api-123/integration-456/response-789"},
+		{name: "deployment", parts: []string{"api-123", "deployment-456"}, want: "api-123/deployment-456"},
+		{name: "api mapping", parts: []string{"mapping-123", "api.example.com"}, want: "mapping-123/api.example.com"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := apiGatewayV2ImportID(tt.parts...); got != tt.want {
+				t.Fatalf("apiGatewayV2ImportID() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestAPIGatewayV2ResourceNamePreservesSegments(t *testing.T) {
+	if got, want := apiGatewayV2ResourceName("default", "x"), "default/x"; got != want {
+		t.Fatalf("apiGatewayV2ResourceName() = %q, want %q", got, want)
+	}
+	if got, want := apiGatewayV2ResourceName("api", "", "route/default"), "api/route/default"; got != want {
+		t.Fatalf("apiGatewayV2ResourceName() = %q, want %q", got, want)
+	}
+}
+
+func TestAPIGatewayV2ProcessStagesUsesV2ResourceType(t *testing.T) {
+	g := &APIGatewayV2Generator{}
+	g.processStages([]types.Stage{{StageName: aws.String("prod")}}, "api-123")
+	if len(g.Resources) != 1 {
+		t.Fatalf("len(Resources) = %d, want 1", len(g.Resources))
+	}
+	resource := g.Resources[0]
+	if got, want := resource.InstanceInfo.Type, "aws_apigatewayv2_stage"; got != want {
+		t.Fatalf("resource type = %q, want %q", got, want)
+	}
+	if got, want := resource.InstanceState.ID, "api-123/prod"; got != want {
+		t.Fatalf("resource ID = %q, want %q", got, want)
+	}
+	if got, want := resource.InstanceState.Attributes["name"], "prod"; got != want {
+		t.Fatalf("stage name attr = %q, want %q", got, want)
+	}
+}
+
+func TestAPIGatewayV2SkipsManagedQuickCreateResources(t *testing.T) {
+	g := &APIGatewayV2Generator{}
+	g.processStages([]types.Stage{{
+		ApiGatewayManaged: aws.Bool(true),
+		StageName:         aws.String("$default"),
+	}}, "api-123")
+	g.processRoutes(nil, []types.Route{{
+		ApiGatewayManaged: aws.Bool(true),
+		RouteId:           aws.String("route-1"),
+	}}, "api-123")
+	g.processIntegrations(nil, []types.Integration{{
+		ApiGatewayManaged: aws.Bool(true),
+		IntegrationId:     aws.String("integration-1"),
+	}}, "api-123")
+
+	if len(g.Resources) != 0 {
+		t.Fatalf("len(Resources) = %d, want 0", len(g.Resources))
+	}
+}
+
+func TestAPIGatewayV2ProcessChildResources(t *testing.T) {
+	g := &APIGatewayV2Generator{}
+	g.processModels([]types.Model{{
+		ModelId:     aws.String("model-1"),
+		Name:        aws.String("Pet"),
+		ContentType: aws.String("application/json"),
+		Schema:      aws.String("{}"),
+	}}, "api-123")
+	g.processRouteResponses([]types.RouteResponse{{
+		RouteResponseId:  aws.String("response-1"),
+		RouteResponseKey: aws.String("$default"),
+	}}, "api-123", "route-1")
+	g.processIntegrationResponses([]types.IntegrationResponse{{
+		IntegrationResponseId:  aws.String("response-2"),
+		IntegrationResponseKey: aws.String("/200/"),
+	}}, "api-123", "integration-1")
+	g.processDeployments([]types.Deployment{{
+		DeploymentId: aws.String("deployment-1"),
+	}}, "api-123")
+	g.processAPIMappings([]types.ApiMapping{{
+		ApiId:         aws.String("api-123"),
+		ApiMappingId:  aws.String("mapping-1"),
+		ApiMappingKey: aws.String("v1"),
+		Stage:         aws.String("prod"),
+	}}, "api.example.com")
+
+	wantIDs := map[string]string{
+		"aws_apigatewayv2_model":                "api-123/model-1",
+		"aws_apigatewayv2_route_response":       "api-123/route-1/response-1",
+		"aws_apigatewayv2_integration_response": "api-123/integration-1/response-2",
+		"aws_apigatewayv2_deployment":           "api-123/deployment-1",
+		"aws_apigatewayv2_api_mapping":          "mapping-1/api.example.com",
+	}
+	if len(g.Resources) != len(wantIDs) {
+		t.Fatalf("len(Resources) = %d, want %d", len(g.Resources), len(wantIDs))
+	}
+	for _, resource := range g.Resources {
+		wantID, ok := wantIDs[resource.InstanceInfo.Type]
+		if !ok {
+			t.Fatalf("unexpected resource type %q", resource.InstanceInfo.Type)
+		}
+		if resource.InstanceState.ID != wantID {
+			t.Fatalf("%s ID = %q, want %q", resource.InstanceInfo.Type, resource.InstanceState.ID, wantID)
+		}
+	}
+}
+
+func TestAPIGatewayV2ResourceMissing(t *testing.T) {
+	if !apiGatewayV2ResourceMissing(&types.NotFoundException{}) {
+		t.Fatal("apiGatewayV2ResourceMissing() = false, want true for NotFoundException")
+	}
+	if apiGatewayV2ResourceMissing(errors.New("boom")) {
+		t.Fatal("apiGatewayV2ResourceMissing() = true, want false for generic error")
+	}
+	if apiGatewayV2ResourceMissing(nil) {
+		t.Fatal("apiGatewayV2ResourceMissing() = true, want false for nil error")
+	}
+}


### PR DESCRIPTION
## Summary

- add discovery for API Gateway v2 integrations, integration responses, deployments, domain names, and API mappings
- fix API Gateway v2 import IDs and the stage resource type to match the AWS provider v5 import formats
- document the supported `api_gatewayv2` resources and add focused helper/resource tests

## Notes

- child API and domain-name discovery are best-effort so optional lookup failures do not block baseline API import
- quick-create managed stage, route, and integration resources are skipped because the AWS provider documents them as non-importable
