### PR TITLE
aws(cloudfront): add additional CloudFront resources

### DIFF
--- a/docs/aws.md
+++ b/docs/aws.md
@@ -91,8 +91,22 @@ terraformer import aws --resources=sg --regions=us-east-1
     * `aws_cloudformation_stack_set`
     * `aws_cloudformation_stack_set_instance`
 *   `cloudfront`
-    * `aws_cloudfront_distribution`
     * `aws_cloudfront_cache_policy`
+    * `aws_cloudfront_continuous_deployment_policy`
+    * `aws_cloudfront_distribution`
+    * `aws_cloudfront_field_level_encryption_config`
+    * `aws_cloudfront_field_level_encryption_profile`
+    * `aws_cloudfront_function`
+    * `aws_cloudfront_key_group`
+    * `aws_cloudfront_key_value_store`
+    * `aws_cloudfront_monitoring_subscription`
+    * `aws_cloudfront_origin_access_control`
+    * `aws_cloudfront_origin_access_identity`
+    * `aws_cloudfront_origin_request_policy`
+    * `aws_cloudfront_public_key`
+    * `aws_cloudfront_realtime_log_config`
+    * `aws_cloudfront_response_headers_policy`
+    * `aws_cloudfront_vpc_origin`
 *   `cloudhsm`
     * `aws_cloudhsm_v2_cluster`
     * `aws_cloudhsm_v2_hsm`

--- a/providers/aws/cloud_front.go
+++ b/providers/aws/cloud_front.go
@@ -141,6 +141,7 @@ func (g *CloudFrontGenerator) loadCachePolicy(svc *cloudfront.Client) error {
 	for {
 		out, err := svc.ListCachePolicies(context.TODO(), &cloudfront.ListCachePoliciesInput{
 			Marker: marker,
+			Type:   types.CachePolicyTypeCustom,
 		})
 		if err != nil {
 			return err
@@ -233,7 +234,10 @@ func (g *CloudFrontGenerator) loadOriginAccessIdentities(svc *cloudfront.Client)
 func (g *CloudFrontGenerator) loadOriginRequestPolicies(svc *cloudfront.Client) error {
 	var marker *string
 	for {
-		out, err := svc.ListOriginRequestPolicies(context.TODO(), &cloudfront.ListOriginRequestPoliciesInput{Marker: marker})
+		out, err := svc.ListOriginRequestPolicies(context.TODO(), &cloudfront.ListOriginRequestPoliciesInput{
+			Marker: marker,
+			Type:   types.OriginRequestPolicyTypeCustom,
+		})
 		if err != nil {
 			return err
 		}
@@ -267,7 +271,10 @@ func (g *CloudFrontGenerator) loadOriginRequestPolicies(svc *cloudfront.Client) 
 func (g *CloudFrontGenerator) loadResponseHeadersPolicies(svc *cloudfront.Client) error {
 	var marker *string
 	for {
-		out, err := svc.ListResponseHeadersPolicies(context.TODO(), &cloudfront.ListResponseHeadersPoliciesInput{Marker: marker})
+		out, err := svc.ListResponseHeadersPolicies(context.TODO(), &cloudfront.ListResponseHeadersPoliciesInput{
+			Marker: marker,
+			Type:   types.ResponseHeadersPolicyTypeCustom,
+		})
 		if err != nil {
 			return err
 		}
@@ -331,6 +338,8 @@ func (g *CloudFrontGenerator) loadRealtimeLogConfigs(svc *cloudfront.Client) err
 
 func (g *CloudFrontGenerator) loadFunctions(svc *cloudfront.Client) error {
 	var marker *string
+	// Function names are the Terraform import ID, and list results can include multiple
+	// stages of the same function. Emit one resource per function name.
 	seen := map[string]struct{}{}
 	for {
 		out, err := svc.ListFunctions(context.TODO(), &cloudfront.ListFunctionsInput{Marker: marker})
@@ -639,8 +648,8 @@ func (g *CloudFrontGenerator) replaceOriginID(distributionIndex int, field strin
 
 	if origins, ok := distribution.Item["origin"].([]interface{}); ok {
 		for _, origin := range origins {
-			if origin, ok := origin.(map[string]interface{}); ok {
-				cloudFrontReplaceFieldValue(origin, field, refID, ref)
+			if originMap, ok := origin.(map[string]interface{}); ok {
+				cloudFrontReplaceFieldValue(originMap, field, refID, ref)
 			}
 		}
 	}

--- a/providers/aws/cloud_front.go
+++ b/providers/aws/cloud_front.go
@@ -4,12 +4,21 @@ package aws
 
 import (
 	"context"
+	"errors"
+	"log"
 
+	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/cloudfront"
+	"github.com/aws/aws-sdk-go-v2/service/cloudfront/types"
 	"github.com/chenrui333/terraformer/terraformutils"
 )
 
 var cloudFrontAllowEmptyValues = []string{"tags."}
+
+type cloudFrontOptionalResourceLoader struct {
+	name string
+	load func() error
+}
 
 type CloudFrontGenerator struct {
 	AWSService
@@ -30,7 +39,34 @@ func (g *CloudFrontGenerator) InitResources() error {
 		return err
 	}
 
+	g.loadOptionalResources([]cloudFrontOptionalResourceLoader{
+		{name: "origin access controls", load: func() error { return g.loadOriginAccessControls(svc) }},
+		{name: "origin access identities", load: func() error { return g.loadOriginAccessIdentities(svc) }},
+		{name: "origin request policies", load: func() error { return g.loadOriginRequestPolicies(svc) }},
+		{name: "response headers policies", load: func() error { return g.loadResponseHeadersPolicies(svc) }},
+		{name: "realtime log configs", load: func() error { return g.loadRealtimeLogConfigs(svc) }},
+		{name: "functions", load: func() error { return g.loadFunctions(svc) }},
+		{name: "public keys", load: func() error { return g.loadPublicKeys(svc) }},
+		{name: "key groups", load: func() error { return g.loadKeyGroups(svc) }},
+		{name: "field-level encryption configs", load: func() error { return g.loadFieldLevelEncryptionConfigs(svc) }},
+		{name: "field-level encryption profiles", load: func() error { return g.loadFieldLevelEncryptionProfiles(svc) }},
+		{name: "continuous deployment policies", load: func() error { return g.loadContinuousDeploymentPolicies(svc) }},
+		{name: "VPC origins", load: func() error { return g.loadVpcOrigins(svc) }},
+		{name: "key value stores", load: func() error { return g.loadKeyValueStores(svc) }},
+	})
+
 	return nil
+}
+
+func (g *CloudFrontGenerator) loadOptionalResources(loaders []cloudFrontOptionalResourceLoader) {
+	for _, loader := range loaders {
+		if err := loader.load(); err != nil {
+			if cloudFrontResourceMissing(err) {
+				continue
+			}
+			log.Printf("Skipping CloudFront %s: %v", loader.name, err)
+		}
+	}
 }
 
 func (g *CloudFrontGenerator) loadDistribution(svc *cloudfront.Client) error {
@@ -40,10 +76,17 @@ func (g *CloudFrontGenerator) loadDistribution(svc *cloudfront.Client) error {
 		if e != nil {
 			return e
 		}
+		if page.DistributionList == nil {
+			continue
+		}
 		for _, distribution := range page.DistributionList.Items {
+			distributionID := StringValue(distribution.Id)
+			if distributionID == "" {
+				continue
+			}
 			r := terraformutils.NewResource(
-				StringValue(distribution.Id),
-				StringValue(distribution.Id),
+				distributionID,
+				distributionID,
 				"aws_cloudfront_distribution",
 				"aws",
 				map[string]string{
@@ -54,8 +97,42 @@ func (g *CloudFrontGenerator) loadDistribution(svc *cloudfront.Client) error {
 			)
 			r.IgnoreKeys = append(r.IgnoreKeys, "^active_trusted_signers.(.*)")
 			g.Resources = append(g.Resources, r)
+
+			if err := g.loadMonitoringSubscription(svc, distributionID); err != nil {
+				if !cloudFrontResourceMissing(err) {
+					log.Printf("Skipping CloudFront monitoring subscription for %s: %v", distributionID, err)
+				}
+			}
 		}
 	}
+	return nil
+}
+
+func (g *CloudFrontGenerator) loadMonitoringSubscription(svc *cloudfront.Client, distributionID string) error {
+	out, err := svc.GetMonitoringSubscription(context.TODO(), &cloudfront.GetMonitoringSubscriptionInput{
+		DistributionId: aws.String(distributionID),
+	})
+	if err != nil {
+		return err
+	}
+	if out.MonitoringSubscription == nil || out.MonitoringSubscription.RealtimeMetricsSubscriptionConfig == nil {
+		return nil
+	}
+	status := string(out.MonitoringSubscription.RealtimeMetricsSubscriptionConfig.RealtimeMetricsSubscriptionStatus)
+	if status == "" {
+		return nil
+	}
+	g.Resources = append(g.Resources, terraformutils.NewResource(
+		distributionID,
+		distributionID,
+		"aws_cloudfront_monitoring_subscription",
+		"aws",
+		map[string]string{
+			"distribution_id": distributionID,
+		},
+		cloudFrontAllowEmptyValues,
+		map[string]interface{}{},
+	))
 	return nil
 }
 
@@ -68,10 +145,20 @@ func (g *CloudFrontGenerator) loadCachePolicy(svc *cloudfront.Client) error {
 		if err != nil {
 			return err
 		}
+		if out.CachePolicyList == nil {
+			return nil
+		}
 		for _, cachePolicy := range out.CachePolicyList.Items {
+			if cachePolicy.CachePolicy == nil {
+				continue
+			}
+			id := StringValue(cachePolicy.CachePolicy.Id)
+			if id == "" {
+				continue
+			}
 			g.Resources = append(g.Resources, terraformutils.NewSimpleResource(
-				StringValue(cachePolicy.CachePolicy.Id),
-				StringValue(cachePolicy.CachePolicy.Id),
+				id,
+				id,
 				"aws_cloudfront_cache_policy",
 				"aws",
 				cloudFrontAllowEmptyValues,
@@ -85,31 +172,534 @@ func (g *CloudFrontGenerator) loadCachePolicy(svc *cloudfront.Client) error {
 	return nil
 }
 
+func (g *CloudFrontGenerator) loadOriginAccessControls(svc *cloudfront.Client) error {
+	var marker *string
+	for {
+		out, err := svc.ListOriginAccessControls(context.TODO(), &cloudfront.ListOriginAccessControlsInput{Marker: marker})
+		if err != nil {
+			return err
+		}
+		if out.OriginAccessControlList == nil {
+			return nil
+		}
+		for _, control := range out.OriginAccessControlList.Items {
+			id := StringValue(control.Id)
+			if id == "" {
+				continue
+			}
+			g.Resources = append(g.Resources, terraformutils.NewSimpleResource(
+				id,
+				id,
+				"aws_cloudfront_origin_access_control",
+				"aws",
+				cloudFrontAllowEmptyValues,
+			))
+		}
+		marker = out.OriginAccessControlList.NextMarker
+		if marker == nil {
+			break
+		}
+	}
+	return nil
+}
+
+func (g *CloudFrontGenerator) loadOriginAccessIdentities(svc *cloudfront.Client) error {
+	p := cloudfront.NewListCloudFrontOriginAccessIdentitiesPaginator(svc, &cloudfront.ListCloudFrontOriginAccessIdentitiesInput{})
+	for p.HasMorePages() {
+		page, err := p.NextPage(context.TODO())
+		if err != nil {
+			return err
+		}
+		if page.CloudFrontOriginAccessIdentityList == nil {
+			continue
+		}
+		for _, identity := range page.CloudFrontOriginAccessIdentityList.Items {
+			id := StringValue(identity.Id)
+			if id == "" {
+				continue
+			}
+			g.Resources = append(g.Resources, terraformutils.NewSimpleResource(
+				id,
+				id,
+				"aws_cloudfront_origin_access_identity",
+				"aws",
+				cloudFrontAllowEmptyValues,
+			))
+		}
+	}
+	return nil
+}
+
+func (g *CloudFrontGenerator) loadOriginRequestPolicies(svc *cloudfront.Client) error {
+	var marker *string
+	for {
+		out, err := svc.ListOriginRequestPolicies(context.TODO(), &cloudfront.ListOriginRequestPoliciesInput{Marker: marker})
+		if err != nil {
+			return err
+		}
+		if out.OriginRequestPolicyList == nil {
+			return nil
+		}
+		for _, policy := range out.OriginRequestPolicyList.Items {
+			if policy.OriginRequestPolicy == nil {
+				continue
+			}
+			id := StringValue(policy.OriginRequestPolicy.Id)
+			if id == "" {
+				continue
+			}
+			g.Resources = append(g.Resources, terraformutils.NewSimpleResource(
+				id,
+				id,
+				"aws_cloudfront_origin_request_policy",
+				"aws",
+				cloudFrontAllowEmptyValues,
+			))
+		}
+		marker = out.OriginRequestPolicyList.NextMarker
+		if marker == nil {
+			break
+		}
+	}
+	return nil
+}
+
+func (g *CloudFrontGenerator) loadResponseHeadersPolicies(svc *cloudfront.Client) error {
+	var marker *string
+	for {
+		out, err := svc.ListResponseHeadersPolicies(context.TODO(), &cloudfront.ListResponseHeadersPoliciesInput{Marker: marker})
+		if err != nil {
+			return err
+		}
+		if out.ResponseHeadersPolicyList == nil {
+			return nil
+		}
+		for _, policy := range out.ResponseHeadersPolicyList.Items {
+			if policy.ResponseHeadersPolicy == nil {
+				continue
+			}
+			id := StringValue(policy.ResponseHeadersPolicy.Id)
+			if id == "" {
+				continue
+			}
+			g.Resources = append(g.Resources, terraformutils.NewSimpleResource(
+				id,
+				id,
+				"aws_cloudfront_response_headers_policy",
+				"aws",
+				cloudFrontAllowEmptyValues,
+			))
+		}
+		marker = out.ResponseHeadersPolicyList.NextMarker
+		if marker == nil {
+			break
+		}
+	}
+	return nil
+}
+
+func (g *CloudFrontGenerator) loadRealtimeLogConfigs(svc *cloudfront.Client) error {
+	var marker *string
+	for {
+		out, err := svc.ListRealtimeLogConfigs(context.TODO(), &cloudfront.ListRealtimeLogConfigsInput{Marker: marker})
+		if err != nil {
+			return err
+		}
+		if out.RealtimeLogConfigs == nil {
+			return nil
+		}
+		for _, config := range out.RealtimeLogConfigs.Items {
+			arn := StringValue(config.ARN)
+			if arn == "" {
+				continue
+			}
+			g.Resources = append(g.Resources, terraformutils.NewSimpleResource(
+				arn,
+				cloudFrontResourceName(arn, StringValue(config.Name)),
+				"aws_cloudfront_realtime_log_config",
+				"aws",
+				cloudFrontAllowEmptyValues,
+			))
+		}
+		marker = out.RealtimeLogConfigs.NextMarker
+		if marker == nil {
+			break
+		}
+	}
+	return nil
+}
+
+func (g *CloudFrontGenerator) loadFunctions(svc *cloudfront.Client) error {
+	var marker *string
+	seen := map[string]struct{}{}
+	for {
+		out, err := svc.ListFunctions(context.TODO(), &cloudfront.ListFunctionsInput{Marker: marker})
+		if err != nil {
+			return err
+		}
+		if out.FunctionList == nil {
+			return nil
+		}
+		for _, function := range out.FunctionList.Items {
+			name := StringValue(function.Name)
+			if name == "" {
+				continue
+			}
+			if _, ok := seen[name]; ok {
+				continue
+			}
+			seen[name] = struct{}{}
+			g.Resources = append(g.Resources, terraformutils.NewSimpleResource(
+				name,
+				name,
+				"aws_cloudfront_function",
+				"aws",
+				cloudFrontAllowEmptyValues,
+			))
+		}
+		marker = out.FunctionList.NextMarker
+		if marker == nil {
+			break
+		}
+	}
+	return nil
+}
+
+func (g *CloudFrontGenerator) loadPublicKeys(svc *cloudfront.Client) error {
+	p := cloudfront.NewListPublicKeysPaginator(svc, &cloudfront.ListPublicKeysInput{})
+	for p.HasMorePages() {
+		page, err := p.NextPage(context.TODO())
+		if err != nil {
+			return err
+		}
+		if page.PublicKeyList == nil {
+			continue
+		}
+		for _, publicKey := range page.PublicKeyList.Items {
+			id := StringValue(publicKey.Id)
+			if id == "" {
+				continue
+			}
+			g.Resources = append(g.Resources, terraformutils.NewSimpleResource(
+				id,
+				id,
+				"aws_cloudfront_public_key",
+				"aws",
+				cloudFrontAllowEmptyValues,
+			))
+		}
+	}
+	return nil
+}
+
+func (g *CloudFrontGenerator) loadKeyGroups(svc *cloudfront.Client) error {
+	var marker *string
+	for {
+		out, err := svc.ListKeyGroups(context.TODO(), &cloudfront.ListKeyGroupsInput{Marker: marker})
+		if err != nil {
+			return err
+		}
+		if out.KeyGroupList == nil {
+			return nil
+		}
+		for _, keyGroup := range out.KeyGroupList.Items {
+			if keyGroup.KeyGroup == nil {
+				continue
+			}
+			id := StringValue(keyGroup.KeyGroup.Id)
+			if id == "" {
+				continue
+			}
+			g.Resources = append(g.Resources, terraformutils.NewSimpleResource(
+				id,
+				id,
+				"aws_cloudfront_key_group",
+				"aws",
+				cloudFrontAllowEmptyValues,
+			))
+		}
+		marker = out.KeyGroupList.NextMarker
+		if marker == nil {
+			break
+		}
+	}
+	return nil
+}
+
+func (g *CloudFrontGenerator) loadFieldLevelEncryptionConfigs(svc *cloudfront.Client) error {
+	var marker *string
+	for {
+		out, err := svc.ListFieldLevelEncryptionConfigs(context.TODO(), &cloudfront.ListFieldLevelEncryptionConfigsInput{Marker: marker})
+		if err != nil {
+			return err
+		}
+		if out.FieldLevelEncryptionList == nil {
+			return nil
+		}
+		for _, config := range out.FieldLevelEncryptionList.Items {
+			id := StringValue(config.Id)
+			if id == "" {
+				continue
+			}
+			g.Resources = append(g.Resources, terraformutils.NewSimpleResource(
+				id,
+				id,
+				"aws_cloudfront_field_level_encryption_config",
+				"aws",
+				cloudFrontAllowEmptyValues,
+			))
+		}
+		marker = out.FieldLevelEncryptionList.NextMarker
+		if marker == nil {
+			break
+		}
+	}
+	return nil
+}
+
+func (g *CloudFrontGenerator) loadFieldLevelEncryptionProfiles(svc *cloudfront.Client) error {
+	var marker *string
+	for {
+		out, err := svc.ListFieldLevelEncryptionProfiles(context.TODO(), &cloudfront.ListFieldLevelEncryptionProfilesInput{Marker: marker})
+		if err != nil {
+			return err
+		}
+		if out.FieldLevelEncryptionProfileList == nil {
+			return nil
+		}
+		for _, profile := range out.FieldLevelEncryptionProfileList.Items {
+			id := StringValue(profile.Id)
+			if id == "" {
+				continue
+			}
+			g.Resources = append(g.Resources, terraformutils.NewSimpleResource(
+				id,
+				cloudFrontResourceName(id, StringValue(profile.Name)),
+				"aws_cloudfront_field_level_encryption_profile",
+				"aws",
+				cloudFrontAllowEmptyValues,
+			))
+		}
+		marker = out.FieldLevelEncryptionProfileList.NextMarker
+		if marker == nil {
+			break
+		}
+	}
+	return nil
+}
+
+func (g *CloudFrontGenerator) loadContinuousDeploymentPolicies(svc *cloudfront.Client) error {
+	var marker *string
+	for {
+		out, err := svc.ListContinuousDeploymentPolicies(context.TODO(), &cloudfront.ListContinuousDeploymentPoliciesInput{Marker: marker})
+		if err != nil {
+			return err
+		}
+		if out.ContinuousDeploymentPolicyList == nil {
+			return nil
+		}
+		for _, policy := range out.ContinuousDeploymentPolicyList.Items {
+			if policy.ContinuousDeploymentPolicy == nil {
+				continue
+			}
+			id := StringValue(policy.ContinuousDeploymentPolicy.Id)
+			if id == "" {
+				continue
+			}
+			g.Resources = append(g.Resources, terraformutils.NewSimpleResource(
+				id,
+				id,
+				"aws_cloudfront_continuous_deployment_policy",
+				"aws",
+				cloudFrontAllowEmptyValues,
+			))
+		}
+		marker = out.ContinuousDeploymentPolicyList.NextMarker
+		if marker == nil {
+			break
+		}
+	}
+	return nil
+}
+
+func (g *CloudFrontGenerator) loadVpcOrigins(svc *cloudfront.Client) error {
+	var marker *string
+	for {
+		out, err := svc.ListVpcOrigins(context.TODO(), &cloudfront.ListVpcOriginsInput{Marker: marker})
+		if err != nil {
+			return err
+		}
+		if out.VpcOriginList == nil {
+			return nil
+		}
+		for _, origin := range out.VpcOriginList.Items {
+			id := StringValue(origin.Id)
+			if id == "" {
+				continue
+			}
+			g.Resources = append(g.Resources, terraformutils.NewSimpleResource(
+				id,
+				cloudFrontResourceName(id, StringValue(origin.Name)),
+				"aws_cloudfront_vpc_origin",
+				"aws",
+				cloudFrontAllowEmptyValues,
+			))
+		}
+		marker = out.VpcOriginList.NextMarker
+		if marker == nil {
+			break
+		}
+	}
+	return nil
+}
+
+func (g *CloudFrontGenerator) loadKeyValueStores(svc *cloudfront.Client) error {
+	p := cloudfront.NewListKeyValueStoresPaginator(svc, &cloudfront.ListKeyValueStoresInput{})
+	for p.HasMorePages() {
+		page, err := p.NextPage(context.TODO())
+		if err != nil {
+			return err
+		}
+		if page.KeyValueStoreList == nil {
+			continue
+		}
+		for _, store := range page.KeyValueStoreList.Items {
+			name := StringValue(store.Name)
+			if name == "" {
+				continue
+			}
+			g.Resources = append(g.Resources, terraformutils.NewSimpleResource(
+				name,
+				name,
+				"aws_cloudfront_key_value_store",
+				"aws",
+				cloudFrontAllowEmptyValues,
+			))
+		}
+	}
+	return nil
+}
+
 func (g *CloudFrontGenerator) PostConvertHook() error {
 	for i, r := range g.Resources {
 		if r.InstanceInfo.Type != "aws_cloudfront_distribution" {
 			continue
 		}
 
-		for _, cachePolicy := range g.Resources {
-			if cachePolicy.InstanceInfo.Type != "aws_cloudfront_cache_policy" {
-				continue
-			}
+		g.linkDistributionReferences(i)
+	}
+	return nil
+}
 
-			if defaultCacheBehavior, ok := r.Item["default_cache_behavior"].([]interface{})[0].(map[string]interface{})["cache_policy_id"]; ok {
-				if defaultCacheBehavior.(string) == cachePolicy.InstanceState.Attributes["id"] {
-					g.Resources[i].Item["default_cache_behavior"].([]interface{})[0].(map[string]interface{})["cache_policy_id"] = "${aws_cloudfront_cache_policy." + cachePolicy.ResourceName + ".id}"
-				}
-			}
+func (g *CloudFrontGenerator) linkDistributionReferences(distributionIndex int) {
+	for _, referencedResource := range g.Resources {
+		switch referencedResource.InstanceInfo.Type {
+		case "aws_cloudfront_cache_policy":
+			g.replaceCacheBehaviorID(distributionIndex, "cache_policy_id", referencedResource, "id")
+		case "aws_cloudfront_origin_request_policy":
+			g.replaceCacheBehaviorID(distributionIndex, "origin_request_policy_id", referencedResource, "id")
+		case "aws_cloudfront_response_headers_policy":
+			g.replaceCacheBehaviorID(distributionIndex, "response_headers_policy_id", referencedResource, "id")
+		case "aws_cloudfront_origin_access_control":
+			g.replaceOriginID(distributionIndex, "origin_access_control_id", referencedResource, "id")
+		}
+	}
+}
 
-			if orderedCacheBehavior, ok := r.Item["ordered_cache_behavior"].([]interface{}); ok {
-				for j, behavior := range orderedCacheBehavior {
-					if behavior, ok := behavior.(map[string]interface{})["cache_policy_id"]; ok && behavior.(string) == cachePolicy.InstanceState.Attributes["id"] {
-						g.Resources[i].Item["ordered_cache_behavior"].([]interface{})[j].(map[string]interface{})["cache_policy_id"] = "${aws_cloudfront_cache_policy." + cachePolicy.ResourceName + ".id}"
-					}
-				}
+func (g *CloudFrontGenerator) replaceCacheBehaviorID(distributionIndex int, field string, referencedResource terraformutils.Resource, referencedAttribute string) {
+	distribution := g.Resources[distributionIndex]
+	refID := cloudFrontResourceID(referencedResource)
+	if refID == "" {
+		return
+	}
+	ref := cloudFrontReference(referencedResource, referencedAttribute)
+
+	if defaultCacheBehaviors, ok := distribution.Item["default_cache_behavior"].([]interface{}); ok && len(defaultCacheBehaviors) > 0 {
+		if behavior, ok := defaultCacheBehaviors[0].(map[string]interface{}); ok {
+			cloudFrontReplaceFieldValue(behavior, field, refID, ref)
+		}
+	}
+
+	if orderedCacheBehaviors, ok := distribution.Item["ordered_cache_behavior"].([]interface{}); ok {
+		for _, orderedCacheBehavior := range orderedCacheBehaviors {
+			if behavior, ok := orderedCacheBehavior.(map[string]interface{}); ok {
+				cloudFrontReplaceFieldValue(behavior, field, refID, ref)
 			}
 		}
 	}
-	return nil
+}
+
+func (g *CloudFrontGenerator) replaceOriginID(distributionIndex int, field string, referencedResource terraformutils.Resource, referencedAttribute string) {
+	distribution := g.Resources[distributionIndex]
+	refID := cloudFrontResourceID(referencedResource)
+	if refID == "" {
+		return
+	}
+	ref := cloudFrontReference(referencedResource, referencedAttribute)
+
+	if origins, ok := distribution.Item["origin"].([]interface{}); ok {
+		for _, origin := range origins {
+			if origin, ok := origin.(map[string]interface{}); ok {
+				cloudFrontReplaceFieldValue(origin, field, refID, ref)
+			}
+		}
+	}
+}
+
+func cloudFrontReplaceFieldValue(item map[string]interface{}, field string, oldValue string, newValue string) {
+	value, ok := item[field].(string)
+	if ok && value == oldValue {
+		item[field] = newValue
+	}
+}
+
+func cloudFrontResourceID(resource terraformutils.Resource) string {
+	if id := resource.InstanceState.Attributes["id"]; id != "" {
+		return id
+	}
+	return resource.InstanceState.ID
+}
+
+func cloudFrontReference(resource terraformutils.Resource, attribute string) string {
+	return "$" + "{" + resource.InstanceInfo.Type + "." + resource.ResourceName + "." + attribute + "}"
+}
+
+func cloudFrontResourceName(id string, name string) string {
+	if name != "" {
+		return name
+	}
+	return id
+}
+
+func cloudFrontResourceMissing(err error) bool {
+	var entityNotFound *types.EntityNotFound
+	var noSuchCachePolicy *types.NoSuchCachePolicy
+	var noSuchOriginAccessIdentity *types.NoSuchCloudFrontOriginAccessIdentity
+	var noSuchContinuousDeploymentPolicy *types.NoSuchContinuousDeploymentPolicy
+	var noSuchDistribution *types.NoSuchDistribution
+	var noSuchFieldLevelEncryptionConfig *types.NoSuchFieldLevelEncryptionConfig
+	var noSuchFieldLevelEncryptionProfile *types.NoSuchFieldLevelEncryptionProfile
+	var noSuchFunction *types.NoSuchFunctionExists
+	var noSuchMonitoringSubscription *types.NoSuchMonitoringSubscription
+	var noSuchOriginAccessControl *types.NoSuchOriginAccessControl
+	var noSuchOriginRequestPolicy *types.NoSuchOriginRequestPolicy
+	var noSuchPublicKey *types.NoSuchPublicKey
+	var noSuchRealtimeLogConfig *types.NoSuchRealtimeLogConfig
+	var noSuchResource *types.NoSuchResource
+	var noSuchResponseHeadersPolicy *types.NoSuchResponseHeadersPolicy
+	return errors.As(err, &entityNotFound) ||
+		errors.As(err, &noSuchCachePolicy) ||
+		errors.As(err, &noSuchOriginAccessIdentity) ||
+		errors.As(err, &noSuchContinuousDeploymentPolicy) ||
+		errors.As(err, &noSuchDistribution) ||
+		errors.As(err, &noSuchFieldLevelEncryptionConfig) ||
+		errors.As(err, &noSuchFieldLevelEncryptionProfile) ||
+		errors.As(err, &noSuchFunction) ||
+		errors.As(err, &noSuchMonitoringSubscription) ||
+		errors.As(err, &noSuchOriginAccessControl) ||
+		errors.As(err, &noSuchOriginRequestPolicy) ||
+		errors.As(err, &noSuchPublicKey) ||
+		errors.As(err, &noSuchRealtimeLogConfig) ||
+		errors.As(err, &noSuchResource) ||
+		errors.As(err, &noSuchResponseHeadersPolicy)
 }

--- a/providers/aws/cloud_front_test.go
+++ b/providers/aws/cloud_front_test.go
@@ -1,0 +1,109 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package aws
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/service/cloudfront/types"
+	"github.com/chenrui333/terraformer/terraformutils"
+)
+
+func TestCloudFrontResourceName(t *testing.T) {
+	if got, want := cloudFrontResourceName("resource-id", "friendly-name"), "friendly-name"; got != want {
+		t.Fatalf("cloudFrontResourceName() = %q, want %q", got, want)
+	}
+	if got, want := cloudFrontResourceName("resource-id", ""), "resource-id"; got != want {
+		t.Fatalf("cloudFrontResourceName() = %q, want %q", got, want)
+	}
+}
+
+func TestCloudFrontResourceMissing(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{name: "nil", err: nil, want: false},
+		{name: "generic", err: errors.New("boom"), want: false},
+		{name: "distribution missing", err: &types.NoSuchDistribution{}, want: true},
+		{name: "monitoring subscription missing", err: &types.NoSuchMonitoringSubscription{}, want: true},
+		{name: "origin access control missing", err: &types.NoSuchOriginAccessControl{}, want: true},
+		{name: "resource missing", err: &types.NoSuchResource{}, want: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := cloudFrontResourceMissing(tt.err); got != tt.want {
+				t.Fatalf("cloudFrontResourceMissing() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestCloudFrontPostConvertHookLinksDistributionReferences(t *testing.T) {
+	distribution := terraformutils.NewSimpleResource("distribution-1", "distribution-1", "aws_cloudfront_distribution", "aws", cloudFrontAllowEmptyValues)
+	distribution.Item = map[string]interface{}{
+		"default_cache_behavior": []interface{}{
+			map[string]interface{}{
+				"cache_policy_id":            "cache-1",
+				"origin_request_policy_id":   "origin-request-1",
+				"response_headers_policy_id": "response-headers-1",
+			},
+		},
+		"ordered_cache_behavior": []interface{}{
+			map[string]interface{}{
+				"cache_policy_id":            "cache-1",
+				"origin_request_policy_id":   "origin-request-1",
+				"response_headers_policy_id": "response-headers-1",
+			},
+		},
+		"origin": []interface{}{
+			map[string]interface{}{
+				"origin_access_control_id": "origin-access-control-1",
+			},
+		},
+	}
+
+	cachePolicy := terraformutils.NewSimpleResource("cache-1", "cache-1", "aws_cloudfront_cache_policy", "aws", cloudFrontAllowEmptyValues)
+	originRequestPolicy := terraformutils.NewSimpleResource("origin-request-1", "origin-request-1", "aws_cloudfront_origin_request_policy", "aws", cloudFrontAllowEmptyValues)
+	responseHeadersPolicy := terraformutils.NewSimpleResource("response-headers-1", "response-headers-1", "aws_cloudfront_response_headers_policy", "aws", cloudFrontAllowEmptyValues)
+	originAccessControl := terraformutils.NewSimpleResource("origin-access-control-1", "origin-access-control-1", "aws_cloudfront_origin_access_control", "aws", cloudFrontAllowEmptyValues)
+
+	g := &CloudFrontGenerator{}
+	g.Resources = []terraformutils.Resource{
+		distribution,
+		cachePolicy,
+		originRequestPolicy,
+		responseHeadersPolicy,
+		originAccessControl,
+	}
+	if err := g.PostConvertHook(); err != nil {
+		t.Fatalf("PostConvertHook() error = %v", err)
+	}
+
+	defaultBehavior := g.Resources[0].Item["default_cache_behavior"].([]interface{})[0].(map[string]interface{})
+	orderedBehavior := g.Resources[0].Item["ordered_cache_behavior"].([]interface{})[0].(map[string]interface{})
+	origin := g.Resources[0].Item["origin"].([]interface{})[0].(map[string]interface{})
+
+	wantCacheRef := "$" + "{aws_cloudfront_cache_policy." + cachePolicy.ResourceName + ".id}"
+	wantOriginRequestRef := "$" + "{aws_cloudfront_origin_request_policy." + originRequestPolicy.ResourceName + ".id}"
+	wantResponseHeadersRef := "$" + "{aws_cloudfront_response_headers_policy." + responseHeadersPolicy.ResourceName + ".id}"
+	wantOriginAccessControlRef := "$" + "{aws_cloudfront_origin_access_control." + originAccessControl.ResourceName + ".id}"
+
+	if got := defaultBehavior["cache_policy_id"]; got != wantCacheRef {
+		t.Fatalf("default cache_policy_id = %q, want %q", got, wantCacheRef)
+	}
+	if got := defaultBehavior["origin_request_policy_id"]; got != wantOriginRequestRef {
+		t.Fatalf("default origin_request_policy_id = %q, want %q", got, wantOriginRequestRef)
+	}
+	if got := defaultBehavior["response_headers_policy_id"]; got != wantResponseHeadersRef {
+		t.Fatalf("default response_headers_policy_id = %q, want %q", got, wantResponseHeadersRef)
+	}
+	if got := orderedBehavior["cache_policy_id"]; got != wantCacheRef {
+		t.Fatalf("ordered cache_policy_id = %q, want %q", got, wantCacheRef)
+	}
+	if got := origin["origin_access_control_id"]; got != wantOriginAccessControlRef {
+		t.Fatalf("origin_access_control_id = %q, want %q", got, wantOriginAccessControlRef)
+	}
+}

--- a/providers/aws/cloud_front_test.go
+++ b/providers/aws/cloud_front_test.go
@@ -27,10 +27,21 @@ func TestCloudFrontResourceMissing(t *testing.T) {
 	}{
 		{name: "nil", err: nil, want: false},
 		{name: "generic", err: errors.New("boom"), want: false},
+		{name: "entity missing", err: &types.EntityNotFound{}, want: true},
+		{name: "cache policy missing", err: &types.NoSuchCachePolicy{}, want: true},
+		{name: "origin access identity missing", err: &types.NoSuchCloudFrontOriginAccessIdentity{}, want: true},
+		{name: "continuous deployment policy missing", err: &types.NoSuchContinuousDeploymentPolicy{}, want: true},
 		{name: "distribution missing", err: &types.NoSuchDistribution{}, want: true},
+		{name: "field-level encryption config missing", err: &types.NoSuchFieldLevelEncryptionConfig{}, want: true},
+		{name: "field-level encryption profile missing", err: &types.NoSuchFieldLevelEncryptionProfile{}, want: true},
+		{name: "function missing", err: &types.NoSuchFunctionExists{}, want: true},
 		{name: "monitoring subscription missing", err: &types.NoSuchMonitoringSubscription{}, want: true},
 		{name: "origin access control missing", err: &types.NoSuchOriginAccessControl{}, want: true},
+		{name: "origin request policy missing", err: &types.NoSuchOriginRequestPolicy{}, want: true},
+		{name: "public key missing", err: &types.NoSuchPublicKey{}, want: true},
+		{name: "realtime log config missing", err: &types.NoSuchRealtimeLogConfig{}, want: true},
 		{name: "resource missing", err: &types.NoSuchResource{}, want: true},
+		{name: "response headers policy missing", err: &types.NoSuchResponseHeadersPolicy{}, want: true},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
## Summary

- add CloudFront discovery for standalone policies, access controls, identities, functions, keys, VPC origins, key value stores, and monitoring subscriptions
- keep the new standalone CloudFront lookups best-effort so distribution imports still work with narrower permissions
- link imported distributions to discovered cache, origin request, response headers, and origin access control resources

## Notes

- distribution and cache policy discovery keep their existing fail-fast behavior
- CloudFront key-value-store item resources are not included; this PR covers the store resource exposed by the CloudFront list API
