### PR TITLE
docs: update LaunchDarkly supported resources

### DIFF
--- a/docs/launchdarkly.md
+++ b/docs/launchdarkly.md
@@ -1,13 +1,18 @@
-### Use with Launchdarkly
+### Use with LaunchDarkly
 
 Example:
 
 ```
 export LAUNCHDARKLY_ACCESS_TOKEN=[LAUNCHDARKLY_ACCESS_TOKEN]
-./terraformer import launchdarkly -r project
+./terraformer import launchdarkly -r project,featureFlag,segment
 ```
 
 List of supported LaunchDarkly resources:
 
 *   `project`
     * `launchdarkly_project`
+*   `featureFlag`
+    * `launchdarkly_feature_flag`
+    * `launchdarkly_feature_flag_environment`
+*   `segment`
+    * `launchdarkly_segment`


### PR DESCRIPTION
## Summary
- Update the LaunchDarkly docs to list all currently supported Terraformer resource groups.
- Include the emitted Terraform resource types for `featureFlag` and `segment`, which are already implemented in the provider.

## Notes
- Docs-only change; no provider behavior changed.
