### PR TITLE
aws(config): add additional Config resources

### DIFF
--- a/docs/aws.md
+++ b/docs/aws.md
@@ -134,9 +134,17 @@ terraformer import aws --resources=sg --regions=us-east-1
     * `aws_cognito_identity_pool`
     * `aws_cognito_user_pool`
 *   `config`
+    * `aws_config_aggregate_authorization`
     * `aws_config_config_rule`
+    * `aws_config_configuration_aggregator`
     * `aws_config_configuration_recorder`
+    * `aws_config_configuration_recorder_status`
     * `aws_config_delivery_channel`
+    * `aws_config_organization_custom_policy_rule`
+    * `aws_config_organization_custom_rule`
+    * `aws_config_organization_managed_rule`
+    * `aws_config_remediation_configuration`
+    * `aws_config_retention_configuration`
 *   `customer_gateway`
     * `aws_customer_gateway`
 *   `datapipeline`

--- a/providers/aws/config.go
+++ b/providers/aws/config.go
@@ -4,15 +4,26 @@ package aws
 
 import (
 	"context"
+	"errors"
+	"fmt"
+	"log"
 
 	"github.com/aws/aws-sdk-go-v2/service/configservice"
+	configtypes "github.com/aws/aws-sdk-go-v2/service/configservice/types"
 	"github.com/chenrui333/terraformer/terraformutils"
 )
 
 var configAllowEmptyValues = []string{"tags."}
 
+const configRemediationBatchSize = 25
+
 type ConfigGenerator struct {
 	AWSService
+}
+
+type configOptionalResourceLoader struct {
+	name string
+	load func() error
 }
 
 func (g *ConfigGenerator) InitResources() error {
@@ -26,12 +37,27 @@ func (g *ConfigGenerator) InitResources() error {
 	if err != nil {
 		return err
 	}
-	err = g.addConfigRules(client, configurationRecorderRefs)
+	configRuleNames, err := g.addConfigRules(client, configurationRecorderRefs)
 	if err != nil {
 		return err
 	}
-	err = g.addDeliveryChannels(client, configurationRecorderRefs)
-	return err
+	deliveryChannelRefs, err := g.addDeliveryChannels(client, configurationRecorderRefs)
+	if err != nil {
+		return err
+	}
+	if err := g.addConfigurationRecorderStatuses(client, appendStringSlices(configurationRecorderRefs, deliveryChannelRefs)); err != nil {
+		return err
+	}
+
+	g.loadOptionalResources([]configOptionalResourceLoader{
+		{name: "configuration aggregators", load: func() error { return g.addConfigurationAggregators(client) }},
+		{name: "aggregate authorizations", load: func() error { return g.addAggregateAuthorizations(client) }},
+		{name: "organization config rules", load: func() error { return g.addOrganizationConfigRules(client) }},
+		{name: "remediation configurations", load: func() error { return g.addRemediationConfigurations(client, configRuleNames) }},
+		{name: "retention configurations", load: func() error { return g.addRetentionConfigurations(client) }},
+	})
+
+	return nil
 }
 
 func (g *ConfigGenerator) addConfigurationRecorders(svc *configservice.Client) ([]string, error) {
@@ -43,7 +69,10 @@ func (g *ConfigGenerator) addConfigurationRecorders(svc *configservice.Client) (
 	}
 	var configurationRecorderRefs []string
 	for _, configurationRecorder := range configurationRecorders.ConfigurationRecorders {
-		name := *configurationRecorder.Name
+		name := StringValue(configurationRecorder.Name)
+		if name == "" {
+			continue
+		}
 		g.Resources = append(g.Resources, terraformutils.NewSimpleResource(
 			name,
 			name,
@@ -57,8 +86,9 @@ func (g *ConfigGenerator) addConfigurationRecorders(svc *configservice.Client) (
 	return configurationRecorderRefs, nil
 }
 
-func (g *ConfigGenerator) addConfigRules(svc *configservice.Client, configurationRecorderRefs []string) error {
+func (g *ConfigGenerator) addConfigRules(svc *configservice.Client, configurationRecorderRefs []string) ([]string, error) {
 	var nextToken *string
+	var configRuleNames []string
 
 	for {
 		configRules, err := svc.DescribeConfigRules(
@@ -68,10 +98,14 @@ func (g *ConfigGenerator) addConfigRules(svc *configservice.Client, configuratio
 			})
 
 		if err != nil {
-			return err
+			return nil, err
 		}
 		for _, configRule := range configRules.ConfigRules {
-			name := *configRule.ConfigRuleName
+			name := StringValue(configRule.ConfigRuleName)
+			if name == "" {
+				continue
+			}
+			configRuleNames = append(configRuleNames, name)
 			g.Resources = append(g.Resources, terraformutils.NewResource(
 				name,
 				name,
@@ -89,18 +123,22 @@ func (g *ConfigGenerator) addConfigRules(svc *configservice.Client, configuratio
 			break
 		}
 	}
-	return nil
+	return configRuleNames, nil
 }
 
-func (g *ConfigGenerator) addDeliveryChannels(svc *configservice.Client, configurationRecorderRefs []string) error {
+func (g *ConfigGenerator) addDeliveryChannels(svc *configservice.Client, configurationRecorderRefs []string) ([]string, error) {
 	deliveryChannels, err := svc.DescribeDeliveryChannels(context.TODO(),
 		&configservice.DescribeDeliveryChannelsInput{})
 
 	if err != nil {
-		return err
+		return nil, err
 	}
+	var deliveryChannelRefs []string
 	for _, deliveryChannel := range deliveryChannels.DeliveryChannels {
-		name := *deliveryChannel.Name
+		name := StringValue(deliveryChannel.Name)
+		if name == "" {
+			continue
+		}
 		g.Resources = append(g.Resources, terraformutils.NewResource(
 			name,
 			name,
@@ -112,6 +150,287 @@ func (g *ConfigGenerator) addDeliveryChannels(svc *configservice.Client, configu
 				"depends_on": configurationRecorderRefs,
 			},
 		))
+		deliveryChannelRefs = append(deliveryChannelRefs, "aws_config_delivery_channel.tfer--"+name)
+	}
+	return deliveryChannelRefs, nil
+}
+
+func (g *ConfigGenerator) addConfigurationRecorderStatuses(svc *configservice.Client, dependsOn []string) error {
+	output, err := svc.DescribeConfigurationRecorderStatus(context.TODO(),
+		&configservice.DescribeConfigurationRecorderStatusInput{})
+	if err != nil {
+		return err
+	}
+	for _, recorderStatus := range output.ConfigurationRecordersStatus {
+		name := StringValue(recorderStatus.Name)
+		if name == "" {
+			continue
+		}
+		g.Resources = append(g.Resources, terraformutils.NewResource(
+			name,
+			name,
+			"aws_config_configuration_recorder_status",
+			"aws",
+			map[string]string{
+				"name": name,
+			},
+			configAllowEmptyValues,
+			map[string]interface{}{
+				"depends_on": dependsOn,
+			},
+		))
 	}
 	return nil
+}
+
+func (g *ConfigGenerator) addConfigurationAggregators(svc *configservice.Client) error {
+	p := configservice.NewDescribeConfigurationAggregatorsPaginator(svc,
+		&configservice.DescribeConfigurationAggregatorsInput{})
+	for p.HasMorePages() {
+		page, err := p.NextPage(context.TODO())
+		if err != nil {
+			return err
+		}
+		for _, aggregator := range page.ConfigurationAggregators {
+			name := StringValue(aggregator.ConfigurationAggregatorName)
+			if name == "" {
+				continue
+			}
+			g.Resources = append(g.Resources, terraformutils.NewResource(
+				name,
+				name,
+				"aws_config_configuration_aggregator",
+				"aws",
+				map[string]string{
+					"name": name,
+				},
+				configAllowEmptyValues,
+				map[string]interface{}{},
+			))
+		}
+	}
+	return nil
+}
+
+func (g *ConfigGenerator) addAggregateAuthorizations(svc *configservice.Client) error {
+	p := configservice.NewDescribeAggregationAuthorizationsPaginator(svc,
+		&configservice.DescribeAggregationAuthorizationsInput{})
+	for p.HasMorePages() {
+		page, err := p.NextPage(context.TODO())
+		if err != nil {
+			return err
+		}
+		for _, authorization := range page.AggregationAuthorizations {
+			accountID := StringValue(authorization.AuthorizedAccountId)
+			region := StringValue(authorization.AuthorizedAwsRegion)
+			if accountID == "" || region == "" {
+				continue
+			}
+			id := configAggregateAuthorizationID(accountID, region)
+			g.Resources = append(g.Resources, terraformutils.NewResource(
+				id,
+				id,
+				"aws_config_aggregate_authorization",
+				"aws",
+				map[string]string{
+					"account_id": accountID,
+					"region":     region,
+				},
+				configAllowEmptyValues,
+				map[string]interface{}{},
+			))
+		}
+	}
+	return nil
+}
+
+func (g *ConfigGenerator) addOrganizationConfigRules(svc *configservice.Client) error {
+	p := configservice.NewDescribeOrganizationConfigRulesPaginator(svc,
+		&configservice.DescribeOrganizationConfigRulesInput{})
+	for p.HasMorePages() {
+		page, err := p.NextPage(context.TODO())
+		if err != nil {
+			return err
+		}
+		for _, rule := range page.OrganizationConfigRules {
+			name := StringValue(rule.OrganizationConfigRuleName)
+			resourceType := configOrganizationRuleResourceType(rule)
+			if name == "" || resourceType == "" {
+				continue
+			}
+			attributes, ok := g.organizationConfigRuleAttributes(svc, name, rule)
+			if !ok {
+				continue
+			}
+			g.Resources = append(g.Resources, terraformutils.NewResource(
+				name,
+				name,
+				resourceType,
+				"aws",
+				attributes,
+				configAllowEmptyValues,
+				map[string]interface{}{},
+			))
+		}
+	}
+	return nil
+}
+
+func (g *ConfigGenerator) organizationConfigRuleAttributes(
+	svc *configservice.Client,
+	name string,
+	rule configtypes.OrganizationConfigRule,
+) (map[string]string, bool) {
+	attributes := map[string]string{
+		"name": name,
+	}
+	if rule.OrganizationCustomPolicyRuleMetadata == nil {
+		return attributes, true
+	}
+
+	output, err := svc.GetOrganizationCustomRulePolicy(context.TODO(),
+		&configservice.GetOrganizationCustomRulePolicyInput{
+			OrganizationConfigRuleName: &name,
+		})
+	if err != nil {
+		log.Printf("Skipping AWS Config organization custom policy rule %s: %v", name, err)
+		return nil, false
+	}
+	policyText := StringValue(output.PolicyText)
+	if policyText == "" {
+		return nil, false
+	}
+	attributes["policy_text"] = policyText
+	return attributes, true
+}
+
+func (g *ConfigGenerator) addRemediationConfigurations(svc *configservice.Client, configRuleNames []string) error {
+	for _, configRuleNamesBatch := range chunkStrings(configRuleNames, configRemediationBatchSize) {
+		if err := g.addRemediationConfigurationsBatch(svc, configRuleNamesBatch); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (g *ConfigGenerator) addRemediationConfigurationsBatch(svc *configservice.Client, configRuleNames []string) error {
+	if len(configRuleNames) == 0 {
+		return nil
+	}
+	output, err := svc.DescribeRemediationConfigurations(context.TODO(),
+		&configservice.DescribeRemediationConfigurationsInput{
+			ConfigRuleNames: configRuleNames,
+		})
+	if err != nil {
+		if configRuleMissing(err) && len(configRuleNames) > 1 {
+			for _, configRuleName := range configRuleNames {
+				if err := g.addRemediationConfigurationsBatch(svc, []string{configRuleName}); err != nil {
+					return err
+				}
+			}
+			return nil
+		}
+		if configRuleMissing(err) {
+			return nil
+		}
+		return err
+	}
+	for _, remediationConfiguration := range output.RemediationConfigurations {
+		name := StringValue(remediationConfiguration.ConfigRuleName)
+		if name == "" {
+			continue
+		}
+		g.Resources = append(g.Resources, terraformutils.NewResource(
+			name,
+			name,
+			"aws_config_remediation_configuration",
+			"aws",
+			map[string]string{
+				"config_rule_name": name,
+			},
+			configAllowEmptyValues,
+			map[string]interface{}{
+				"depends_on": []string{"aws_config_config_rule.tfer--" + name},
+			},
+		))
+	}
+	return nil
+}
+
+func (g *ConfigGenerator) addRetentionConfigurations(svc *configservice.Client) error {
+	p := configservice.NewDescribeRetentionConfigurationsPaginator(svc,
+		&configservice.DescribeRetentionConfigurationsInput{})
+	for p.HasMorePages() {
+		page, err := p.NextPage(context.TODO())
+		if err != nil {
+			return err
+		}
+		for _, retentionConfiguration := range page.RetentionConfigurations {
+			name := StringValue(retentionConfiguration.Name)
+			if name == "" {
+				continue
+			}
+			g.Resources = append(g.Resources, terraformutils.NewSimpleResource(
+				name,
+				name,
+				"aws_config_retention_configuration",
+				"aws",
+				configAllowEmptyValues,
+			))
+		}
+	}
+	return nil
+}
+
+func (g *ConfigGenerator) loadOptionalResources(loaders []configOptionalResourceLoader) {
+	for _, loader := range loaders {
+		if err := loader.load(); err != nil {
+			log.Printf("Skipping AWS Config %s: %v", loader.name, err)
+		}
+	}
+}
+
+func configAggregateAuthorizationID(accountID, region string) string {
+	return fmt.Sprintf("%s:%s", accountID, region)
+}
+
+func configOrganizationRuleResourceType(rule configtypes.OrganizationConfigRule) string {
+	switch {
+	case rule.OrganizationManagedRuleMetadata != nil:
+		return "aws_config_organization_managed_rule"
+	case rule.OrganizationCustomRuleMetadata != nil:
+		return "aws_config_organization_custom_rule"
+	case rule.OrganizationCustomPolicyRuleMetadata != nil:
+		return "aws_config_organization_custom_policy_rule"
+	default:
+		return ""
+	}
+}
+
+func configRuleMissing(err error) bool {
+	var notFound *configtypes.NoSuchConfigRuleException
+	return errors.As(err, &notFound)
+}
+
+func appendStringSlices(values ...[]string) []string {
+	var result []string
+	for _, value := range values {
+		result = append(result, value...)
+	}
+	return result
+}
+
+func chunkStrings(values []string, size int) [][]string {
+	if size <= 0 {
+		return nil
+	}
+	var chunks [][]string
+	for start := 0; start < len(values); start += size {
+		end := start + size
+		if end > len(values) {
+			end = len(values)
+		}
+		chunks = append(chunks, values[start:end])
+	}
+	return chunks
 }

--- a/providers/aws/config.go
+++ b/providers/aws/config.go
@@ -323,7 +323,7 @@ func (g *ConfigGenerator) addRemediationConfigurationsBatch(svc *configservice.C
 			ConfigRuleNames: configRuleNames,
 		})
 	if err != nil {
-		if configRuleMissing(err) && len(configRuleNames) > 1 {
+		if configRemediationConfigurationMissing(err) && len(configRuleNames) > 1 {
 			for _, configRuleName := range configRuleNames {
 				if err := g.addRemediationConfigurationsBatch(svc, []string{configRuleName}); err != nil {
 					return err
@@ -331,7 +331,7 @@ func (g *ConfigGenerator) addRemediationConfigurationsBatch(svc *configservice.C
 			}
 			return nil
 		}
-		if configRuleMissing(err) {
+		if configRemediationConfigurationMissing(err) {
 			return nil
 		}
 		return err
@@ -410,9 +410,13 @@ func configOrganizationRuleResourceType(rule configtypes.OrganizationConfigRule)
 	}
 }
 
-func configRuleMissing(err error) bool {
+func configRemediationConfigurationMissing(err error) bool {
 	var notFound *configtypes.NoSuchConfigRuleException
-	return errors.As(err, &notFound)
+	if errors.As(err, &notFound) {
+		return true
+	}
+	var noRemediation *configtypes.NoSuchRemediationConfigurationException
+	return errors.As(err, &noRemediation)
 }
 
 func chunkStrings(values []string, size int) [][]string {

--- a/providers/aws/config.go
+++ b/providers/aws/config.go
@@ -82,7 +82,7 @@ func (g *ConfigGenerator) addConfigurationRecorders(svc *configservice.Client) (
 			configAllowEmptyValues,
 		))
 		configurationRecorderRefs = append(configurationRecorderRefs,
-			"aws_config_configuration_recorder.tfer--"+name)
+			configResourceRef("aws_config_configuration_recorder", name))
 	}
 	return configurationRecorderRefs, nil
 }
@@ -151,7 +151,7 @@ func (g *ConfigGenerator) addDeliveryChannels(svc *configservice.Client, configu
 				"depends_on": configurationRecorderRefs,
 			},
 		))
-		deliveryChannelRefs = append(deliveryChannelRefs, "aws_config_delivery_channel.tfer--"+name)
+		deliveryChannelRefs = append(deliveryChannelRefs, configResourceRef("aws_config_delivery_channel", name))
 	}
 	return deliveryChannelRefs, nil
 }
@@ -395,8 +395,12 @@ func configAggregateAuthorizationID(accountID, region string) string {
 	return fmt.Sprintf("%s:%s", accountID, region)
 }
 
+func configResourceRef(resourceType, name string) string {
+	return resourceType + "." + terraformutils.TfSanitize(name)
+}
+
 func configRuleResourceRef(name string) string {
-	return "aws_config_config_rule." + terraformutils.TfSanitize(name)
+	return configResourceRef("aws_config_config_rule", name)
 }
 
 func configOrganizationRuleResourceType(rule configtypes.OrganizationConfigRule) string {

--- a/providers/aws/config.go
+++ b/providers/aws/config.go
@@ -351,7 +351,7 @@ func (g *ConfigGenerator) addRemediationConfigurationsBatch(svc *configservice.C
 			},
 			configAllowEmptyValues,
 			map[string]interface{}{
-				"depends_on": []string{"aws_config_config_rule.tfer--" + name},
+				"depends_on": []string{configRuleResourceRef(name)},
 			},
 		))
 	}
@@ -393,6 +393,10 @@ func (g *ConfigGenerator) loadOptionalResources(loaders []configOptionalResource
 
 func configAggregateAuthorizationID(accountID, region string) string {
 	return fmt.Sprintf("%s:%s", accountID, region)
+}
+
+func configRuleResourceRef(name string) string {
+	return "aws_config_config_rule." + terraformutils.TfSanitize(name)
 }
 
 func configOrganizationRuleResourceType(rule configtypes.OrganizationConfigRule) string {

--- a/providers/aws/config.go
+++ b/providers/aws/config.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"fmt"
 	"log"
+	"slices"
 
 	"github.com/aws/aws-sdk-go-v2/service/configservice"
 	configtypes "github.com/aws/aws-sdk-go-v2/service/configservice/types"
@@ -45,7 +46,7 @@ func (g *ConfigGenerator) InitResources() error {
 	if err != nil {
 		return err
 	}
-	if err := g.addConfigurationRecorderStatuses(client, appendStringSlices(configurationRecorderRefs, deliveryChannelRefs)); err != nil {
+	if err := g.addConfigurationRecorderStatuses(client, slices.Concat(configurationRecorderRefs, deliveryChannelRefs)); err != nil {
 		return err
 	}
 
@@ -395,6 +396,8 @@ func configAggregateAuthorizationID(accountID, region string) string {
 }
 
 func configOrganizationRuleResourceType(rule configtypes.OrganizationConfigRule) string {
+	// AWS returns exactly one metadata shape, but prefer the managed shape if a
+	// malformed response sets multiple fields so classification stays stable.
 	switch {
 	case rule.OrganizationManagedRuleMetadata != nil:
 		return "aws_config_organization_managed_rule"
@@ -410,14 +413,6 @@ func configOrganizationRuleResourceType(rule configtypes.OrganizationConfigRule)
 func configRuleMissing(err error) bool {
 	var notFound *configtypes.NoSuchConfigRuleException
 	return errors.As(err, &notFound)
-}
-
-func appendStringSlices(values ...[]string) []string {
-	var result []string
-	for _, value := range values {
-		result = append(result, value...)
-	}
-	return result
 }
 
 func chunkStrings(values []string, size int) [][]string {

--- a/providers/aws/config_test.go
+++ b/providers/aws/config_test.go
@@ -1,0 +1,163 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package aws
+
+import (
+	"errors"
+	"reflect"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	configtypes "github.com/aws/aws-sdk-go-v2/service/configservice/types"
+)
+
+func TestConfigAggregateAuthorizationID(t *testing.T) {
+	got := configAggregateAuthorizationID("123456789012", "us-east-1")
+	want := "123456789012:us-east-1"
+	if got != want {
+		t.Fatalf("configAggregateAuthorizationID() = %q, want %q", got, want)
+	}
+}
+
+func TestConfigOrganizationRuleResourceType(t *testing.T) {
+	tests := []struct {
+		name string
+		rule configtypes.OrganizationConfigRule
+		want string
+	}{
+		{
+			name: "managed rule",
+			rule: configtypes.OrganizationConfigRule{
+				OrganizationManagedRuleMetadata: &configtypes.OrganizationManagedRuleMetadata{},
+			},
+			want: "aws_config_organization_managed_rule",
+		},
+		{
+			name: "custom rule",
+			rule: configtypes.OrganizationConfigRule{
+				OrganizationCustomRuleMetadata: &configtypes.OrganizationCustomRuleMetadata{},
+			},
+			want: "aws_config_organization_custom_rule",
+		},
+		{
+			name: "custom policy rule",
+			rule: configtypes.OrganizationConfigRule{
+				OrganizationCustomPolicyRuleMetadata: &configtypes.OrganizationCustomPolicyRuleMetadataNoPolicy{},
+			},
+			want: "aws_config_organization_custom_policy_rule",
+		},
+		{
+			name: "unknown rule shape",
+			rule: configtypes.OrganizationConfigRule{},
+			want: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := configOrganizationRuleResourceType(tt.rule)
+			if got != tt.want {
+				t.Fatalf("configOrganizationRuleResourceType() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestConfigRuleMissing(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{
+			name: "no such config rule",
+			err:  &configtypes.NoSuchConfigRuleException{},
+			want: true,
+		},
+		{
+			name: "wrapped no such config rule",
+			err:  errors.Join(errors.New("lookup failed"), &configtypes.NoSuchConfigRuleException{}),
+			want: true,
+		},
+		{
+			name: "generic error",
+			err:  errors.New("boom"),
+			want: false,
+		},
+		{
+			name: "nil error",
+			err:  nil,
+			want: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := configRuleMissing(tt.err)
+			if got != tt.want {
+				t.Fatalf("configRuleMissing() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestAppendStringSlices(t *testing.T) {
+	got := appendStringSlices([]string{"recorder"}, nil, []string{"channel", "status"})
+	want := []string{"recorder", "channel", "status"}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("appendStringSlices() = %#v, want %#v", got, want)
+	}
+}
+
+func TestChunkStrings(t *testing.T) {
+	tests := []struct {
+		name   string
+		values []string
+		size   int
+		want   [][]string
+	}{
+		{
+			name:   "chunks values",
+			values: []string{"a", "b", "c", "d", "e"},
+			size:   2,
+			want:   [][]string{{"a", "b"}, {"c", "d"}, {"e"}},
+		},
+		{
+			name:   "empty values",
+			values: nil,
+			size:   2,
+			want:   nil,
+		},
+		{
+			name:   "invalid size",
+			values: []string{"a"},
+			size:   0,
+			want:   nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := chunkStrings(tt.values, tt.size)
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Fatalf("chunkStrings() = %#v, want %#v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestConfigOrganizationRuleResourceTypePrefersManagedShape(t *testing.T) {
+	rule := configtypes.OrganizationConfigRule{
+		OrganizationConfigRuleName: aws.String("example"),
+		OrganizationManagedRuleMetadata: &configtypes.OrganizationManagedRuleMetadata{
+			RuleIdentifier: aws.String("S3_BUCKET_VERSIONING_ENABLED"),
+		},
+		OrganizationCustomRuleMetadata: &configtypes.OrganizationCustomRuleMetadata{},
+	}
+
+	got := configOrganizationRuleResourceType(rule)
+	want := "aws_config_organization_managed_rule"
+	if got != want {
+		t.Fatalf("configOrganizationRuleResourceType() = %q, want %q", got, want)
+	}
+}

--- a/providers/aws/config_test.go
+++ b/providers/aws/config_test.go
@@ -101,14 +101,6 @@ func TestConfigRuleMissing(t *testing.T) {
 	}
 }
 
-func TestAppendStringSlices(t *testing.T) {
-	got := appendStringSlices([]string{"recorder"}, nil, []string{"channel", "status"})
-	want := []string{"recorder", "channel", "status"}
-	if !reflect.DeepEqual(got, want) {
-		t.Fatalf("appendStringSlices() = %#v, want %#v", got, want)
-	}
-}
-
 func TestChunkStrings(t *testing.T) {
 	tests := []struct {
 		name   string
@@ -132,6 +124,12 @@ func TestChunkStrings(t *testing.T) {
 			name:   "invalid size",
 			values: []string{"a"},
 			size:   0,
+			want:   nil,
+		},
+		{
+			name:   "negative size",
+			values: []string{"a"},
+			size:   -1,
 			want:   nil,
 		},
 	}

--- a/providers/aws/config_test.go
+++ b/providers/aws/config_test.go
@@ -28,6 +28,37 @@ func TestConfigRuleResourceRef(t *testing.T) {
 	}
 }
 
+func TestConfigResourceRefSanitizesName(t *testing.T) {
+	tests := []struct {
+		name         string
+		resourceType string
+		resourceName string
+		want         string
+	}{
+		{
+			name:         "recorder",
+			resourceType: "aws_config_configuration_recorder",
+			resourceName: "recorder:with/slashes",
+			want:         "aws_config_configuration_recorder.tfer--recorder-003A-with-002F-slashes",
+		},
+		{
+			name:         "delivery channel",
+			resourceType: "aws_config_delivery_channel",
+			resourceName: "channel:with/slashes",
+			want:         "aws_config_delivery_channel.tfer--channel-003A-with-002F-slashes",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := configResourceRef(tt.resourceType, tt.resourceName)
+			if got != tt.want {
+				t.Fatalf("configResourceRef() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
 func TestConfigOrganizationRuleResourceType(t *testing.T) {
 	tests := []struct {
 		name string

--- a/providers/aws/config_test.go
+++ b/providers/aws/config_test.go
@@ -63,7 +63,7 @@ func TestConfigOrganizationRuleResourceType(t *testing.T) {
 	}
 }
 
-func TestConfigRuleMissing(t *testing.T) {
+func TestConfigRemediationConfigurationMissing(t *testing.T) {
 	tests := []struct {
 		name string
 		err  error
@@ -80,6 +80,16 @@ func TestConfigRuleMissing(t *testing.T) {
 			want: true,
 		},
 		{
+			name: "no such remediation configuration",
+			err:  &configtypes.NoSuchRemediationConfigurationException{},
+			want: true,
+		},
+		{
+			name: "wrapped no such remediation configuration",
+			err:  errors.Join(errors.New("lookup failed"), &configtypes.NoSuchRemediationConfigurationException{}),
+			want: true,
+		},
+		{
 			name: "generic error",
 			err:  errors.New("boom"),
 			want: false,
@@ -93,9 +103,9 @@ func TestConfigRuleMissing(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := configRuleMissing(tt.err)
+			got := configRemediationConfigurationMissing(tt.err)
 			if got != tt.want {
-				t.Fatalf("configRuleMissing() = %v, want %v", got, tt.want)
+				t.Fatalf("configRemediationConfigurationMissing() = %v, want %v", got, tt.want)
 			}
 		})
 	}

--- a/providers/aws/config_test.go
+++ b/providers/aws/config_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	configtypes "github.com/aws/aws-sdk-go-v2/service/configservice/types"
+	"github.com/chenrui333/terraformer/terraformutils"
 )
 
 func TestConfigAggregateAuthorizationID(t *testing.T) {
@@ -16,6 +17,14 @@ func TestConfigAggregateAuthorizationID(t *testing.T) {
 	want := "123456789012:us-east-1"
 	if got != want {
 		t.Fatalf("configAggregateAuthorizationID() = %q, want %q", got, want)
+	}
+}
+
+func TestConfigRuleResourceRef(t *testing.T) {
+	got := configRuleResourceRef("rule:with/slashes")
+	want := "aws_config_config_rule.tfer--rule-003A-with-002F-slashes"
+	if got != want {
+		t.Fatalf("configRuleResourceRef() = %q, want %q", got, want)
 	}
 }
 
@@ -167,5 +176,29 @@ func TestConfigOrganizationRuleResourceTypePrefersManagedShape(t *testing.T) {
 	want := "aws_config_organization_managed_rule"
 	if got != want {
 		t.Fatalf("configOrganizationRuleResourceType() = %q, want %q", got, want)
+	}
+}
+
+func TestConfigRemediationConfigurationDependencySanitizesRuleName(t *testing.T) {
+	name := "rule:with/slashes"
+	resource := terraformutils.NewResource(
+		name,
+		name,
+		"aws_config_remediation_configuration",
+		"aws",
+		map[string]string{
+			"config_rule_name": name,
+		},
+		configAllowEmptyValues,
+		map[string]interface{}{"depends_on": []string{configRuleResourceRef(name)}},
+	)
+
+	dependsOn, ok := resource.AdditionalFields["depends_on"].([]string)
+	if !ok {
+		t.Fatalf("depends_on type = %T, want []string", resource.AdditionalFields["depends_on"])
+	}
+	want := configRuleResourceRef(name)
+	if len(dependsOn) != 1 || dependsOn[0] != want {
+		t.Fatalf("depends_on = %#v, want [%q]", dependsOn, want)
 	}
 }


### PR DESCRIPTION
## Summary

- add discovery for AWS Config aggregate authorizations, configuration aggregators, recorder status, organization rules, remediation configurations, and retention configurations
- keep broader account/org Config lookups best-effort so missing IAM permissions do not block existing recorder/rule/channel imports
- document the new Config resource coverage and add focused helper tests

## Notes

Conformance pack resources are intentionally left for a separate pass because the Config describe APIs do not reliably return the original template body or S3 URI needed for valid generated HCL.
