### PR TITLE
feat(kubernetes): map modern resource types

### DIFF
--- a/docs/kubernetes.md
+++ b/docs/kubernetes.md
@@ -35,10 +35,10 @@ Common supported resources include:
     * `kubernetes_job_v1`
 *   `limitranges`
     * `kubernetes_limit_range`
-*   `networkpolicies`
-    * `kubernetes_network_policy_v1`
 *   `namespaces`
     * `kubernetes_namespace`
+*   `networkpolicies`
+    * `kubernetes_network_policy_v1`
 *   `persistentvolumes`
     * `kubernetes_persistent_volume`
 *   `persistentvolumeclaims`

--- a/docs/kubernetes.md
+++ b/docs/kubernetes.md
@@ -7,18 +7,36 @@ Example:
  terraformer import kubernetes --resources=deployments,services,storageclasses --filter=deployment=name1:name2:name3
 ```
 
-All Kubernetes resources that are currently supported by the Kubernetes provider, are also supported by this module. Here is the list of resources which are currently supported by Kubernetes provider v.1.4:
+Terraformer discovers Kubernetes API resources from the active cluster and imports resources that are available through both the typed Kubernetes client and the installed Terraform Kubernetes provider schema.
 
-*   `clusterrolebinding`
+Common supported resources include:
+
+*   `clusterroles`
+    * `kubernetes_cluster_role`
+*   `clusterrolebindings`
     * `kubernetes_cluster_role_binding`
 *   `configmaps`
     * `kubernetes_config_map`
+*   `cronjobs`
+    * `kubernetes_cron_job_v1`
+*   `daemonsets`
+    * `kubernetes_daemon_set_v1`
 *   `deployments`
     * `kubernetes_deployment`
+*   `endpointslices`
+    * `kubernetes_endpoint_slice_v1`
 *   `horizontalpodautoscalers`
     * `kubernetes_horizontal_pod_autoscaler`
+*   `ingressclasses`
+    * `kubernetes_ingress_class_v1`
+*   `ingresses`
+    * `kubernetes_ingress_v1`
+*   `jobs`
+    * `kubernetes_job_v1`
 *   `limitranges`
     * `kubernetes_limit_range`
+*   `networkpolicies`
+    * `kubernetes_network_policy_v1`
 *   `namespaces`
     * `kubernetes_namespace`
 *   `persistentvolumes`
@@ -27,10 +45,18 @@ All Kubernetes resources that are currently supported by the Kubernetes provider
     * `kubernetes_persistent_volume_claim`
 *   `pods`
     * `kubernetes_pod`
+*   `poddisruptionbudgets`
+    * `kubernetes_pod_disruption_budget_v1`
 *   `replicationcontrollers`
     * `kubernetes_replication_controller`
 *   `resourcequotas`
     * `kubernetes_resource_quota`
+*   `roles`
+    * `kubernetes_role`
+*   `rolebindings`
+    * `kubernetes_role_binding`
+*   `runtimeclasses`
+    * `kubernetes_runtime_class_v1`
 *   `secrets`
     * `kubernetes_secret`
 *   `services`

--- a/providers/kubernetes/kind.go
+++ b/providers/kubernetes/kind.go
@@ -14,10 +14,11 @@ import (
 
 type Kind struct {
 	KubernetesService
-	Name       string
-	Group      string
-	Version    string
-	Namespaced bool
+	Name          string
+	Group         string
+	Version       string
+	Namespaced    bool
+	TerraformType string
 }
 
 // Generate TerraformResources from Kubernetes API,
@@ -54,6 +55,11 @@ func (k *Kind) InitResources() error {
 	}
 	items := reflect.Indirect(results[0]).FieldByName("Items")
 
+	terraformType := k.TerraformType
+	if terraformType == "" {
+		terraformType = extractTfResourceName(k.Name)
+	}
+
 	for i := 0; i < items.Len(); i++ {
 		item := items.Index(i)
 		// Filter to resources that aren't owned by any other resource
@@ -71,7 +77,7 @@ func (k *Kind) InitResources() error {
 		k.Resources = append(k.Resources, terraformutils.NewSimpleResource(
 			name,
 			name,
-			extractTfResourceName(k.Name),
+			terraformType,
 			"kubernetes",
 			[]string{},
 		))

--- a/providers/kubernetes/kubernetes_provider.go
+++ b/providers/kubernetes/kubernetes_provider.go
@@ -23,6 +23,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/client-go/discovery"
+	k8sclient "k8s.io/client-go/kubernetes"
 	_ "k8s.io/client-go/plugin/pkg/client/auth/gcp" // GKE support
 )
 
@@ -80,6 +81,11 @@ func (p *KubernetesProvider) GetSupportedService() map[string]terraformutils.Ser
 		log.Println(err)
 		return resources
 	}
+	clientset, err := k8sclient.NewForConfig(config)
+	if err != nil {
+		log.Println(err)
+		return resources
+	}
 	provider, err := providerwrapper.NewProviderWrapper("kubernetes", cty.Value{}, p.verbose == "true")
 	if err != nil {
 		log.Println(err)
@@ -106,16 +112,26 @@ func (p *KubernetesProvider) GetSupportedService() map[string]terraformutils.Ser
 				continue
 			}
 
-			// filter to resource that are supported by terraform kubernetes provider
-			if _, ok := resp.ResourceTypes[extractTfResourceName(resource.Kind)]; !ok {
+			// filter to resources that the Terraform Kubernetes provider can import
+			terraformResourceName, ok := selectTerraformResourceName(resource.Kind, func(name string) bool {
+				_, exists := resp.ResourceTypes[name]
+				return exists
+			})
+			if !ok {
+				continue
+			}
+
+			// filter to resources available through the typed client-go Clientset
+			if !supportsTypedClientResource(clientset, gv.Group, gv.Version, resource.Kind) {
 				continue
 			}
 
 			resources[resource.Name] = &Kind{
-				Group:      gv.Group,
-				Version:    gv.Version,
-				Name:       resource.Kind,
-				Namespaced: resource.Namespaced,
+				Group:         gv.Group,
+				Version:       gv.Version,
+				Name:          resource.Kind,
+				Namespaced:    resource.Namespaced,
+				TerraformType: terraformResourceName,
 			}
 		}
 	}

--- a/providers/kubernetes/kubernetes_provider.go
+++ b/providers/kubernetes/kubernetes_provider.go
@@ -113,7 +113,7 @@ func (p *KubernetesProvider) GetSupportedService() map[string]terraformutils.Ser
 			}
 
 			// filter to resources that the Terraform Kubernetes provider can import
-			terraformResourceName, ok := selectTerraformResourceName(resource.Kind, func(name string) bool {
+			terraformResourceName, ok := selectTerraformResourceName(gv.Group, gv.Version, resource.Kind, func(name string) bool {
 				_, exists := resp.ResourceTypes[name]
 				return exists
 			})

--- a/providers/kubernetes/utils.go
+++ b/providers/kubernetes/utils.go
@@ -11,16 +11,31 @@ import (
 	"k8s.io/client-go/kubernetes"
 )
 
-var preferredTerraformResourceNames = map[string][]string{
-	"CronJob":             {"kubernetes_cron_job_v1", "kubernetes_cron_job"},
-	"DaemonSet":           {"kubernetes_daemon_set_v1", "kubernetes_daemonset"},
-	"EndpointSlice":       {"kubernetes_endpoint_slice_v1"},
-	"Ingress":             {"kubernetes_ingress_v1", "kubernetes_ingress"},
-	"IngressClass":        {"kubernetes_ingress_class_v1", "kubernetes_ingress_class"},
-	"Job":                 {"kubernetes_job_v1", "kubernetes_job"},
-	"NetworkPolicy":       {"kubernetes_network_policy_v1", "kubernetes_network_policy"},
-	"PodDisruptionBudget": {"kubernetes_pod_disruption_budget_v1", "kubernetes_pod_disruption_budget"},
-	"RuntimeClass":        {"kubernetes_runtime_class_v1"},
+type kubernetesResourceID struct {
+	group   string
+	version string
+	kind    string
+}
+
+var preferredTerraformResourceNames = map[kubernetesResourceID][]string{
+	{group: "apps", version: "v1", kind: "DaemonSet"}:                       {"kubernetes_daemon_set_v1", "kubernetes_daemonset"},
+	{group: "apps", version: "v1beta1", kind: "DaemonSet"}:                  {"kubernetes_daemonset"},
+	{group: "apps", version: "v1beta2", kind: "DaemonSet"}:                  {"kubernetes_daemonset"},
+	{group: "batch", version: "v1", kind: "CronJob"}:                        {"kubernetes_cron_job_v1", "kubernetes_cron_job"},
+	{group: "batch", version: "v1", kind: "Job"}:                            {"kubernetes_job_v1", "kubernetes_job"},
+	{group: "batch", version: "v1beta1", kind: "CronJob"}:                   {"kubernetes_cron_job"},
+	{group: "discovery.k8s.io", version: "v1", kind: "EndpointSlice"}:       {"kubernetes_endpoint_slice_v1"},
+	{group: "extensions", version: "v1beta1", kind: "DaemonSet"}:            {"kubernetes_daemonset"},
+	{group: "extensions", version: "v1beta1", kind: "Ingress"}:              {"kubernetes_ingress"},
+	{group: "networking.k8s.io", version: "v1", kind: "Ingress"}:            {"kubernetes_ingress_v1", "kubernetes_ingress"},
+	{group: "networking.k8s.io", version: "v1", kind: "IngressClass"}:       {"kubernetes_ingress_class_v1", "kubernetes_ingress_class"},
+	{group: "networking.k8s.io", version: "v1", kind: "NetworkPolicy"}:      {"kubernetes_network_policy_v1", "kubernetes_network_policy"},
+	{group: "networking.k8s.io", version: "v1beta1", kind: "Ingress"}:       {"kubernetes_ingress"},
+	{group: "networking.k8s.io", version: "v1beta1", kind: "IngressClass"}:  {"kubernetes_ingress_class"},
+	{group: "networking.k8s.io", version: "v1beta1", kind: "NetworkPolicy"}: {"kubernetes_network_policy"},
+	{group: "node.k8s.io", version: "v1", kind: "RuntimeClass"}:             {"kubernetes_runtime_class_v1"},
+	{group: "policy", version: "v1", kind: "PodDisruptionBudget"}:           {"kubernetes_pod_disruption_budget_v1", "kubernetes_pod_disruption_budget"},
+	{group: "policy", version: "v1beta1", kind: "PodDisruptionBudget"}:      {"kubernetes_pod_disruption_budget"},
 }
 
 func extractClientSetFuncGroupName(group, version string) string {
@@ -45,8 +60,8 @@ func extractTfResourceName(kind string) string {
 	return "kubernetes_" + strcase.ToSnake(kind)
 }
 
-func terraformResourceNameCandidates(kind string) []string {
-	candidates := append([]string{}, preferredTerraformResourceNames[kind]...)
+func terraformResourceNameCandidates(group, version, kind string) []string {
+	candidates := append([]string{}, preferredTerraformResourceNames[kubernetesResourceID{group: group, version: version, kind: kind}]...)
 	defaultName := extractTfResourceName(kind)
 	for _, name := range candidates {
 		if name == defaultName {
@@ -56,8 +71,8 @@ func terraformResourceNameCandidates(kind string) []string {
 	return append(candidates, defaultName)
 }
 
-func selectTerraformResourceName(kind string, hasResourceType func(string) bool) (string, bool) {
-	for _, name := range terraformResourceNameCandidates(kind) {
+func selectTerraformResourceName(group, version, kind string, hasResourceType func(string) bool) (string, bool) {
+	for _, name := range terraformResourceNameCandidates(group, version, kind) {
 		if hasResourceType(name) {
 			return name, true
 		}

--- a/providers/kubernetes/utils.go
+++ b/providers/kubernetes/utils.go
@@ -4,10 +4,24 @@
 package kubernetes
 
 import (
+	"reflect"
 	"strings"
 
 	"github.com/iancoleman/strcase"
+	"k8s.io/client-go/kubernetes"
 )
+
+var preferredTerraformResourceNames = map[string][]string{
+	"CronJob":             {"kubernetes_cron_job_v1", "kubernetes_cron_job"},
+	"DaemonSet":           {"kubernetes_daemon_set_v1", "kubernetes_daemonset"},
+	"EndpointSlice":       {"kubernetes_endpoint_slice_v1"},
+	"Ingress":             {"kubernetes_ingress_v1", "kubernetes_ingress"},
+	"IngressClass":        {"kubernetes_ingress_class_v1", "kubernetes_ingress_class"},
+	"Job":                 {"kubernetes_job_v1", "kubernetes_job"},
+	"NetworkPolicy":       {"kubernetes_network_policy_v1", "kubernetes_network_policy"},
+	"PodDisruptionBudget": {"kubernetes_pod_disruption_budget_v1", "kubernetes_pod_disruption_budget"},
+	"RuntimeClass":        {"kubernetes_runtime_class_v1"},
+}
 
 func extractClientSetFuncGroupName(group, version string) string {
 	v := strings.Title(version)
@@ -29,4 +43,46 @@ func extractClientSetFuncTypeName(kind string) string {
 
 func extractTfResourceName(kind string) string {
 	return "kubernetes_" + strcase.ToSnake(kind)
+}
+
+func terraformResourceNameCandidates(kind string) []string {
+	seen := map[string]struct{}{}
+	candidates := []string{}
+	for _, name := range preferredTerraformResourceNames[kind] {
+		if _, ok := seen[name]; ok {
+			continue
+		}
+		seen[name] = struct{}{}
+		candidates = append(candidates, name)
+	}
+
+	defaultName := extractTfResourceName(kind)
+	if _, ok := seen[defaultName]; !ok {
+		candidates = append(candidates, defaultName)
+	}
+	return candidates
+}
+
+func selectTerraformResourceName(kind string, hasResourceType func(string) bool) (string, bool) {
+	for _, name := range terraformResourceNameCandidates(kind) {
+		if hasResourceType(name) {
+			return name, true
+		}
+	}
+	return "", false
+}
+
+func supportsTypedClientResource(clientset kubernetes.Interface, group, version, kind string) bool {
+	groupMethod := reflect.ValueOf(clientset).MethodByName(extractClientSetFuncGroupName(group, version))
+	if !groupMethod.IsValid() {
+		return false
+	}
+
+	groupValues := groupMethod.Call([]reflect.Value{})
+	if len(groupValues) == 0 || !groupValues[0].IsValid() {
+		return false
+	}
+
+	resourceMethod := groupValues[0].MethodByName(extractClientSetFuncTypeName(kind))
+	return resourceMethod.IsValid()
 }

--- a/providers/kubernetes/utils.go
+++ b/providers/kubernetes/utils.go
@@ -46,21 +46,14 @@ func extractTfResourceName(kind string) string {
 }
 
 func terraformResourceNameCandidates(kind string) []string {
-	seen := map[string]struct{}{}
-	candidates := []string{}
-	for _, name := range preferredTerraformResourceNames[kind] {
-		if _, ok := seen[name]; ok {
-			continue
-		}
-		seen[name] = struct{}{}
-		candidates = append(candidates, name)
-	}
-
+	candidates := append([]string{}, preferredTerraformResourceNames[kind]...)
 	defaultName := extractTfResourceName(kind)
-	if _, ok := seen[defaultName]; !ok {
-		candidates = append(candidates, defaultName)
+	for _, name := range candidates {
+		if name == defaultName {
+			return candidates
+		}
 	}
-	return candidates
+	return append(candidates, defaultName)
 }
 
 func selectTerraformResourceName(kind string, hasResourceType func(string) bool) (string, bool) {
@@ -72,7 +65,13 @@ func selectTerraformResourceName(kind string, hasResourceType func(string) bool)
 	return "", false
 }
 
-func supportsTypedClientResource(clientset kubernetes.Interface, group, version, kind string) bool {
+func supportsTypedClientResource(clientset kubernetes.Interface, group, version, kind string) (ok bool) {
+	defer func() {
+		if recover() != nil {
+			ok = false
+		}
+	}()
+
 	groupMethod := reflect.ValueOf(clientset).MethodByName(extractClientSetFuncGroupName(group, version))
 	if !groupMethod.IsValid() {
 		return false

--- a/providers/kubernetes/utils_test.go
+++ b/providers/kubernetes/utils_test.go
@@ -89,6 +89,7 @@ func TestSelectTerraformResourceName(t *testing.T) {
 			supportedTypes: map[string]struct{}{
 				"kubernetes_service": {},
 			},
+			want:   "",
 			wantOK: false,
 		},
 	}

--- a/providers/kubernetes/utils_test.go
+++ b/providers/kubernetes/utils_test.go
@@ -1,0 +1,138 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package kubernetes
+
+import (
+	"reflect"
+	"testing"
+
+	"k8s.io/client-go/kubernetes/fake"
+)
+
+func TestTerraformResourceNameCandidates(t *testing.T) {
+	tests := []struct {
+		name string
+		kind string
+		want []string
+	}{
+		{
+			name: "uses default name for existing core resource",
+			kind: "Service",
+			want: []string{"kubernetes_service"},
+		},
+		{
+			name: "prefers modern daemon set name before legacy provider spelling",
+			kind: "DaemonSet",
+			want: []string{"kubernetes_daemon_set_v1", "kubernetes_daemonset", "kubernetes_daemon_set"},
+		},
+		{
+			name: "uses v1-only endpoint slice name",
+			kind: "EndpointSlice",
+			want: []string{"kubernetes_endpoint_slice_v1", "kubernetes_endpoint_slice"},
+		},
+		{
+			name: "uses v1-only runtime class name",
+			kind: "RuntimeClass",
+			want: []string{"kubernetes_runtime_class_v1", "kubernetes_runtime_class"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := terraformResourceNameCandidates(tt.kind)
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Fatalf("terraformResourceNameCandidates(%q) = %#v, want %#v", tt.kind, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestSelectTerraformResourceName(t *testing.T) {
+	tests := []struct {
+		name           string
+		kind           string
+		supportedTypes map[string]struct{}
+		want           string
+		wantOK         bool
+	}{
+		{
+			name: "selects default name",
+			kind: "Service",
+			supportedTypes: map[string]struct{}{
+				"kubernetes_service": {},
+			},
+			want:   "kubernetes_service",
+			wantOK: true,
+		},
+		{
+			name: "prefers modern mapped name",
+			kind: "DaemonSet",
+			supportedTypes: map[string]struct{}{
+				"kubernetes_daemonset":     {},
+				"kubernetes_daemon_set_v1": {},
+			},
+			want:   "kubernetes_daemon_set_v1",
+			wantOK: true,
+		},
+		{
+			name: "falls back to legacy mapped name",
+			kind: "DaemonSet",
+			supportedTypes: map[string]struct{}{
+				"kubernetes_daemonset": {},
+			},
+			want:   "kubernetes_daemonset",
+			wantOK: true,
+		},
+		{
+			name: "returns false when provider has no matching resource",
+			kind: "EndpointSlice",
+			supportedTypes: map[string]struct{}{
+				"kubernetes_service": {},
+			},
+			wantOK: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, ok := selectTerraformResourceName(tt.kind, func(name string) bool {
+				_, exists := tt.supportedTypes[name]
+				return exists
+			})
+			if ok != tt.wantOK {
+				t.Fatalf("selectTerraformResourceName(%q) ok = %t, want %t", tt.kind, ok, tt.wantOK)
+			}
+			if got != tt.want {
+				t.Fatalf("selectTerraformResourceName(%q) = %q, want %q", tt.kind, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestSupportsTypedClientResource(t *testing.T) {
+	clientset := fake.NewSimpleClientset()
+
+	tests := []struct {
+		name    string
+		group   string
+		version string
+		kind    string
+		want    bool
+	}{
+		{name: "core service", version: "v1", kind: "Service", want: true},
+		{name: "apps daemon set", group: "apps", version: "v1", kind: "DaemonSet", want: true},
+		{name: "discovery endpoint slice", group: "discovery.k8s.io", version: "v1", kind: "EndpointSlice", want: true},
+		{name: "node runtime class", group: "node.k8s.io", version: "v1", kind: "RuntimeClass", want: true},
+		{name: "api service is not exposed by kubernetes clientset", group: "apiregistration.k8s.io", version: "v1", kind: "APIService", want: false},
+		{name: "unknown group", group: "example.com", version: "v1", kind: "Widget", want: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := supportsTypedClientResource(clientset, tt.group, tt.version, tt.kind)
+			if got != tt.want {
+				t.Fatalf("supportsTypedClientResource(%q, %q, %q) = %t, want %t", tt.group, tt.version, tt.kind, got, tt.want)
+			}
+		})
+	}
+}

--- a/providers/kubernetes/utils_test.go
+++ b/providers/kubernetes/utils_test.go
@@ -11,37 +11,67 @@ import (
 
 func TestTerraformResourceNameCandidates(t *testing.T) {
 	tests := []struct {
-		name string
-		kind string
-		want []string
+		name    string
+		group   string
+		version string
+		kind    string
+		want    []string
 	}{
 		{
-			name: "uses default name for existing core resource",
-			kind: "Service",
-			want: []string{"kubernetes_service"},
+			name:    "uses default name for existing core resource",
+			version: "v1",
+			kind:    "Service",
+			want:    []string{"kubernetes_service"},
 		},
 		{
-			name: "prefers modern daemon set name before legacy provider spelling",
-			kind: "DaemonSet",
-			want: []string{"kubernetes_daemon_set_v1", "kubernetes_daemonset", "kubernetes_daemon_set"},
+			name:    "prefers modern daemon set name before legacy provider spelling for apps v1",
+			group:   "apps",
+			version: "v1",
+			kind:    "DaemonSet",
+			want:    []string{"kubernetes_daemon_set_v1", "kubernetes_daemonset", "kubernetes_daemon_set"},
 		},
 		{
-			name: "uses v1-only endpoint slice name",
-			kind: "EndpointSlice",
-			want: []string{"kubernetes_endpoint_slice_v1", "kubernetes_endpoint_slice"},
+			name:    "prefers legacy daemonset name for extensions beta",
+			group:   "extensions",
+			version: "v1beta1",
+			kind:    "DaemonSet",
+			want:    []string{"kubernetes_daemonset", "kubernetes_daemon_set"},
 		},
 		{
-			name: "uses v1-only runtime class name",
-			kind: "RuntimeClass",
-			want: []string{"kubernetes_runtime_class_v1", "kubernetes_runtime_class"},
+			name:    "prefers legacy ingress name for networking beta",
+			group:   "networking.k8s.io",
+			version: "v1beta1",
+			kind:    "Ingress",
+			want:    []string{"kubernetes_ingress"},
+		},
+		{
+			name:    "prefers legacy pod disruption budget name for policy beta",
+			group:   "policy",
+			version: "v1beta1",
+			kind:    "PodDisruptionBudget",
+			want:    []string{"kubernetes_pod_disruption_budget"},
+		},
+		{
+			name:    "uses v1-only endpoint slice name",
+			group:   "discovery.k8s.io",
+			version: "v1",
+			kind:    "EndpointSlice",
+			want:    []string{"kubernetes_endpoint_slice_v1", "kubernetes_endpoint_slice"},
+		},
+		{
+			name:    "uses v1-only runtime class name",
+			group:   "node.k8s.io",
+			version: "v1",
+			kind:    "RuntimeClass",
+			want:    []string{"kubernetes_runtime_class_v1", "kubernetes_runtime_class"},
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := terraformResourceNameCandidates(tt.kind)
+			got := terraformResourceNameCandidates(tt.group, tt.version, tt.kind)
 			if !reflect.DeepEqual(got, tt.want) {
-				t.Fatalf("terraformResourceNameCandidates(%q) = %#v, want %#v", tt.kind, got, tt.want)
+				t.Fatalf("terraformResourceNameCandidates(%q, %q, %q) = %#v, want %#v", tt.group, tt.version, tt.kind, got, tt.want)
 			}
 		})
 	}
@@ -50,14 +80,17 @@ func TestTerraformResourceNameCandidates(t *testing.T) {
 func TestSelectTerraformResourceName(t *testing.T) {
 	tests := []struct {
 		name           string
+		group          string
+		version        string
 		kind           string
 		supportedTypes map[string]struct{}
 		want           string
 		wantOK         bool
 	}{
 		{
-			name: "selects default name",
-			kind: "Service",
+			name:    "selects default name",
+			version: "v1",
+			kind:    "Service",
 			supportedTypes: map[string]struct{}{
 				"kubernetes_service": {},
 			},
@@ -65,8 +98,10 @@ func TestSelectTerraformResourceName(t *testing.T) {
 			wantOK: true,
 		},
 		{
-			name: "prefers modern mapped name",
-			kind: "DaemonSet",
+			name:    "prefers modern mapped name for v1 API",
+			group:   "apps",
+			version: "v1",
+			kind:    "DaemonSet",
 			supportedTypes: map[string]struct{}{
 				"kubernetes_daemonset":     {},
 				"kubernetes_daemon_set_v1": {},
@@ -75,8 +110,10 @@ func TestSelectTerraformResourceName(t *testing.T) {
 			wantOK: true,
 		},
 		{
-			name: "falls back to legacy mapped name",
-			kind: "DaemonSet",
+			name:    "falls back to legacy mapped name for v1 API",
+			group:   "apps",
+			version: "v1",
+			kind:    "DaemonSet",
 			supportedTypes: map[string]struct{}{
 				"kubernetes_daemonset": {},
 			},
@@ -84,8 +121,70 @@ func TestSelectTerraformResourceName(t *testing.T) {
 			wantOK: true,
 		},
 		{
-			name: "returns false when provider has no matching resource",
-			kind: "EndpointSlice",
+			name:    "prefers legacy mapped name for beta API even when v1 type exists",
+			group:   "networking.k8s.io",
+			version: "v1beta1",
+			kind:    "Ingress",
+			supportedTypes: map[string]struct{}{
+				"kubernetes_ingress":    {},
+				"kubernetes_ingress_v1": {},
+			},
+			want:   "kubernetes_ingress",
+			wantOK: true,
+		},
+		{
+			name:    "selects v1 mapped name for v1 API",
+			group:   "networking.k8s.io",
+			version: "v1",
+			kind:    "Ingress",
+			supportedTypes: map[string]struct{}{
+				"kubernetes_ingress":    {},
+				"kubernetes_ingress_v1": {},
+			},
+			want:   "kubernetes_ingress_v1",
+			wantOK: true,
+		},
+		{
+			name:    "prefers legacy pod disruption budget for beta API",
+			group:   "policy",
+			version: "v1beta1",
+			kind:    "PodDisruptionBudget",
+			supportedTypes: map[string]struct{}{
+				"kubernetes_pod_disruption_budget":    {},
+				"kubernetes_pod_disruption_budget_v1": {},
+			},
+			want:   "kubernetes_pod_disruption_budget",
+			wantOK: true,
+		},
+		{
+			name:    "selects v1 pod disruption budget for v1 API",
+			group:   "policy",
+			version: "v1",
+			kind:    "PodDisruptionBudget",
+			supportedTypes: map[string]struct{}{
+				"kubernetes_pod_disruption_budget":    {},
+				"kubernetes_pod_disruption_budget_v1": {},
+			},
+			want:   "kubernetes_pod_disruption_budget_v1",
+			wantOK: true,
+		},
+		{
+			name:    "prefers legacy cron job for beta API",
+			group:   "batch",
+			version: "v1beta1",
+			kind:    "CronJob",
+			supportedTypes: map[string]struct{}{
+				"kubernetes_cron_job":    {},
+				"kubernetes_cron_job_v1": {},
+			},
+			want:   "kubernetes_cron_job",
+			wantOK: true,
+		},
+		{
+			name:    "returns false when provider has no matching resource",
+			group:   "discovery.k8s.io",
+			version: "v1",
+			kind:    "EndpointSlice",
 			supportedTypes: map[string]struct{}{
 				"kubernetes_service": {},
 			},
@@ -96,15 +195,15 @@ func TestSelectTerraformResourceName(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, ok := selectTerraformResourceName(tt.kind, func(name string) bool {
+			got, ok := selectTerraformResourceName(tt.group, tt.version, tt.kind, func(name string) bool {
 				_, exists := tt.supportedTypes[name]
 				return exists
 			})
 			if ok != tt.wantOK {
-				t.Fatalf("selectTerraformResourceName(%q) ok = %t, want %t", tt.kind, ok, tt.wantOK)
+				t.Fatalf("selectTerraformResourceName(%q, %q, %q) ok = %t, want %t", tt.group, tt.version, tt.kind, ok, tt.wantOK)
 			}
 			if got != tt.want {
-				t.Fatalf("selectTerraformResourceName(%q) = %q, want %q", tt.kind, got, tt.want)
+				t.Fatalf("selectTerraformResourceName(%q, %q, %q) = %q, want %q", tt.group, tt.version, tt.kind, got, tt.want)
 			}
 		})
 	}


### PR DESCRIPTION
Summary
- add explicit Terraform resource-name selection for modern Kubernetes resource kinds
- keep discovered resources limited to kinds exposed through the typed client-go Clientset
- refresh Kubernetes docs with the newly mapped common resources

References
- Refs #203
