### PR TITLE
feat(datadog): add cloud inventory sync config import

### DIFF
--- a/docs/datadog.md
+++ b/docs/datadog.md
@@ -89,6 +89,9 @@ Tag filters are order specific. For example, if your monitor has tags (in the or
     * `datadog_dashboard_json`
 *   `dashboard_list`
     * `datadog_dashboard_list`
+*   `cloud_inventory_sync_config`
+    * `datadog_cloud_inventory_sync_config`
+        * **_NOTE:_** Importing resource requires resource ID's to be passed via [Filter][1] option
 *   `downtime`
     * `datadog_downtime`
 *   `integration_aws`

--- a/docs/datadog.md
+++ b/docs/datadog.md
@@ -16,7 +16,7 @@ terraform {
   required_providers {
     datadog = {
       source  = "DataDog/datadog"
-      version = "3.20.0"
+      version = ">= 3.86.0"
     }
   }
 }
@@ -91,6 +91,7 @@ Tag filters are order specific. For example, if your monitor has tags (in the or
     * `datadog_dashboard_list`
 *   `cloud_inventory_sync_config`
     * `datadog_cloud_inventory_sync_config`
+        * **_NOTE:_** Requires DataDog/datadog provider 3.86.0 or newer.
         * **_NOTE:_** Importing resource requires resource ID's to be passed via [Filter][1] option
 *   `downtime`
     * `datadog_downtime`

--- a/providers/datadog/cloud_inventory_sync_config.go
+++ b/providers/datadog/cloud_inventory_sync_config.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"io"
 	"log"
 	"net/http"
 	"net/url"
@@ -152,8 +153,9 @@ func sendCloudInventorySyncConfigRequest(ctx context.Context, client *datadog.AP
 	if response == nil {
 		return nil, fmt.Errorf("cloud inventory sync config request failed: empty response")
 	}
+	defer response.Body.Close()
 
-	body, err := datadog.ReadBody(response)
+	body, err := io.ReadAll(response.Body)
 	if err != nil {
 		return nil, err
 	}

--- a/providers/datadog/cloud_inventory_sync_config.go
+++ b/providers/datadog/cloud_inventory_sync_config.go
@@ -64,7 +64,7 @@ func (d *cloudInventorySyncConfigResponseDataList) UnmarshalJSON(data []byte) er
 func (g *CloudInventorySyncConfigGenerator) createResource(syncConfig cloudInventorySyncConfigResponseData) terraformutils.Resource {
 	resourceName := syncConfig.ID
 	if syncConfig.Attributes.CloudProvider != "" {
-		resourceName = syncConfig.Attributes.CloudProvider
+		resourceName = fmt.Sprintf("%s_%s", syncConfig.Attributes.CloudProvider, syncConfig.ID)
 	}
 
 	return terraformutils.NewSimpleResource(

--- a/providers/datadog/cloud_inventory_sync_config.go
+++ b/providers/datadog/cloud_inventory_sync_config.go
@@ -1,0 +1,169 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package datadog
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log"
+	"net/http"
+	"net/url"
+
+	"github.com/DataDog/datadog-api-client-go/v2/api/datadog"
+
+	"github.com/chenrui333/terraformer/terraformutils"
+)
+
+const (
+	cloudInventorySyncConfigByIDPath = "/api/v2/cloudinventoryservice/syncconfigs/%s"
+)
+
+var (
+	// CloudInventorySyncConfigAllowEmptyValues ...
+	CloudInventorySyncConfigAllowEmptyValues = []string{}
+)
+
+// CloudInventorySyncConfigGenerator ...
+type CloudInventorySyncConfigGenerator struct {
+	DatadogService
+}
+
+type cloudInventorySyncConfigResponse struct {
+	Data cloudInventorySyncConfigResponseDataList `json:"data"`
+}
+
+type cloudInventorySyncConfigResponseDataList []cloudInventorySyncConfigResponseData
+
+type cloudInventorySyncConfigResponseData struct {
+	ID         string                                     `json:"id"`
+	Attributes cloudInventorySyncConfigResponseAttributes `json:"attributes,omitempty"`
+}
+
+type cloudInventorySyncConfigResponseAttributes struct {
+	CloudProvider string `json:"cloud_provider,omitempty"`
+}
+
+func (d *cloudInventorySyncConfigResponseDataList) UnmarshalJSON(data []byte) error {
+	var list []cloudInventorySyncConfigResponseData
+	if err := json.Unmarshal(data, &list); err == nil {
+		*d = list
+		return nil
+	}
+
+	var single cloudInventorySyncConfigResponseData
+	if err := json.Unmarshal(data, &single); err != nil {
+		return err
+	}
+	*d = []cloudInventorySyncConfigResponseData{single}
+	return nil
+}
+
+func (g *CloudInventorySyncConfigGenerator) createResources(syncConfigs []cloudInventorySyncConfigResponseData) []terraformutils.Resource {
+	resources := []terraformutils.Resource{}
+	for _, syncConfig := range syncConfigs {
+		resources = append(resources, g.createResource(syncConfig))
+	}
+
+	return resources
+}
+
+func (g *CloudInventorySyncConfigGenerator) createResource(syncConfig cloudInventorySyncConfigResponseData) terraformutils.Resource {
+	resourceName := syncConfig.ID
+	if syncConfig.Attributes.CloudProvider != "" {
+		resourceName = syncConfig.Attributes.CloudProvider
+	}
+
+	return terraformutils.NewSimpleResource(
+		syncConfig.ID,
+		fmt.Sprintf("cloud_inventory_sync_config_%s", resourceName),
+		"datadog_cloud_inventory_sync_config",
+		"datadog",
+		CloudInventorySyncConfigAllowEmptyValues,
+	)
+}
+
+// InitResources Generate TerraformResources from Datadog API,
+// from each cloud inventory sync config create 1 TerraformResource.
+// Need Cloud Inventory Sync Config ID as ID for terraform resource.
+func (g *CloudInventorySyncConfigGenerator) InitResources() error {
+	datadogClient := g.Args["datadogClient"].(*datadog.APIClient)
+	auth := g.Args["auth"].(context.Context)
+
+	resources := []terraformutils.Resource{}
+	for _, filter := range g.Filter {
+		if filter.FieldPath == "id" && filter.IsApplicable("cloud_inventory_sync_config") {
+			for _, value := range filter.AcceptableValues {
+				syncConfig, err := getCloudInventorySyncConfig(auth, datadogClient, value)
+				if err != nil {
+					return err
+				}
+				resources = append(resources, g.createResource(syncConfig))
+			}
+		}
+	}
+
+	if len(resources) > 0 {
+		g.Resources = resources
+		return nil
+	}
+
+	log.Print("Filter(Cloud Inventory Sync Config IDs) is required for importing datadog_cloud_inventory_sync_config resource")
+	return nil
+}
+
+func getCloudInventorySyncConfig(ctx context.Context, client *datadog.APIClient, id string) (cloudInventorySyncConfigResponseData, error) {
+	body, err := sendCloudInventorySyncConfigRequest(ctx, client, fmt.Sprintf(cloudInventorySyncConfigByIDPath, id))
+	if err != nil {
+		return cloudInventorySyncConfigResponseData{}, err
+	}
+
+	var response cloudInventorySyncConfigResponse
+	if err := json.Unmarshal(body, &response); err != nil {
+		return cloudInventorySyncConfigResponseData{}, err
+	}
+	if len(response.Data) == 0 {
+		return cloudInventorySyncConfigResponseData{}, fmt.Errorf("cloud inventory sync config %q not found", id)
+	}
+	return response.Data[0], nil
+}
+
+func sendCloudInventorySyncConfigRequest(ctx context.Context, client *datadog.APIClient, path string) ([]byte, error) {
+	basePath, err := client.GetConfig().ServerURLWithContext(ctx, "")
+	if err != nil {
+		return nil, err
+	}
+
+	headerParams := map[string]string{
+		"Accept": "application/json",
+	}
+	if client.GetConfig().DelegatedTokenConfig != nil {
+		if err := datadog.UseDelegatedTokenAuth(ctx, &headerParams, client.GetConfig().DelegatedTokenConfig); err != nil {
+			return nil, err
+		}
+	} else {
+		datadog.SetAuthKeys(ctx, &headerParams, [2]string{"apiKeyAuth", "DD-API-KEY"}, [2]string{"appKeyAuth", "DD-APPLICATION-KEY"})
+	}
+
+	request, err := client.PrepareRequest(ctx, basePath+path, http.MethodGet, nil, headerParams, url.Values{}, url.Values{}, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	response, err := client.CallAPI(request)
+	if err != nil {
+		return nil, err
+	}
+	if response == nil {
+		return nil, fmt.Errorf("cloud inventory sync config request failed: empty response")
+	}
+
+	body, err := datadog.ReadBody(response)
+	if err != nil {
+		return nil, err
+	}
+	if response.StatusCode >= 300 {
+		return nil, fmt.Errorf("cloud inventory sync config request failed: %s: %s", response.Status, string(body))
+	}
+	return body, nil
+}

--- a/providers/datadog/cloud_inventory_sync_config.go
+++ b/providers/datadog/cloud_inventory_sync_config.go
@@ -44,6 +44,8 @@ type cloudInventorySyncConfigResponseAttributes struct {
 	CloudProvider string `json:"cloud_provider,omitempty"`
 }
 
+const cloudInventorySyncConfigMaxErrorBody = 512
+
 func (d *cloudInventorySyncConfigResponseDataList) UnmarshalJSON(data []byte) error {
 	var list []cloudInventorySyncConfigResponseData
 	if err := json.Unmarshal(data, &list); err == nil {
@@ -57,15 +59,6 @@ func (d *cloudInventorySyncConfigResponseDataList) UnmarshalJSON(data []byte) er
 	}
 	*d = []cloudInventorySyncConfigResponseData{single}
 	return nil
-}
-
-func (g *CloudInventorySyncConfigGenerator) createResources(syncConfigs []cloudInventorySyncConfigResponseData) []terraformutils.Resource {
-	resources := []terraformutils.Resource{}
-	for _, syncConfig := range syncConfigs {
-		resources = append(resources, g.createResource(syncConfig))
-	}
-
-	return resources
 }
 
 func (g *CloudInventorySyncConfigGenerator) createResource(syncConfig cloudInventorySyncConfigResponseData) terraformutils.Resource {
@@ -113,7 +106,7 @@ func (g *CloudInventorySyncConfigGenerator) InitResources() error {
 }
 
 func getCloudInventorySyncConfig(ctx context.Context, client *datadog.APIClient, id string) (cloudInventorySyncConfigResponseData, error) {
-	body, err := sendCloudInventorySyncConfigRequest(ctx, client, fmt.Sprintf(cloudInventorySyncConfigByIDPath, id))
+	body, err := sendCloudInventorySyncConfigRequest(ctx, client, fmt.Sprintf(cloudInventorySyncConfigByIDPath, url.PathEscape(id)))
 	if err != nil {
 		return cloudInventorySyncConfigResponseData{}, err
 	}
@@ -128,6 +121,8 @@ func getCloudInventorySyncConfig(ctx context.Context, client *datadog.APIClient,
 	return response.Data[0], nil
 }
 
+// The Datadog Go SDK does not generate a typed Cloud Inventory sync config API,
+// so Terraformer mirrors the upstream Terraform provider's raw endpoint request.
 func sendCloudInventorySyncConfigRequest(ctx context.Context, client *datadog.APIClient, path string) ([]byte, error) {
 	basePath, err := client.GetConfig().ServerURLWithContext(ctx, "")
 	if err != nil {
@@ -163,7 +158,14 @@ func sendCloudInventorySyncConfigRequest(ctx context.Context, client *datadog.AP
 		return nil, err
 	}
 	if response.StatusCode >= 300 {
-		return nil, fmt.Errorf("cloud inventory sync config request failed: %s: %s", response.Status, string(body))
+		return nil, fmt.Errorf("cloud inventory sync config request failed: %s: %s", response.Status, truncateCloudInventorySyncConfigErrorBody(body))
 	}
 	return body, nil
+}
+
+func truncateCloudInventorySyncConfigErrorBody(body []byte) string {
+	if len(body) <= cloudInventorySyncConfigMaxErrorBody {
+		return string(body)
+	}
+	return string(body[:cloudInventorySyncConfigMaxErrorBody]) + "...(truncated)"
 }

--- a/providers/datadog/cloud_inventory_sync_config_test.go
+++ b/providers/datadog/cloud_inventory_sync_config_test.go
@@ -1,0 +1,59 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package datadog
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func TestCloudInventorySyncConfigResponseDataListUnmarshal(t *testing.T) {
+	tests := []struct {
+		name string
+		body string
+		want int
+	}{
+		{
+			name: "single data object",
+			body: `{"data":{"id":"3526615b-4d65-4d9b-947a-d89c18faf0dc","attributes":{"cloud_provider":"aws"}}}`,
+			want: 1,
+		},
+		{
+			name: "data list",
+			body: `{"data":[{"id":"aws","attributes":{"cloud_provider":"aws"}},{"id":"azure","attributes":{"cloud_provider":"azure"}}]}`,
+			want: 2,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var response cloudInventorySyncConfigResponse
+			if err := json.Unmarshal([]byte(tt.body), &response); err != nil {
+				t.Fatalf("Unmarshal() error = %v", err)
+			}
+			if got := len(response.Data); got != tt.want {
+				t.Fatalf("len(response.Data) = %d, want %d", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestCloudInventorySyncConfigCreateResource(t *testing.T) {
+	generator := CloudInventorySyncConfigGenerator{}
+	resource := generator.createResource(cloudInventorySyncConfigResponseData{
+		ID: "3526615b-4d65-4d9b-947a-d89c18faf0dc",
+		Attributes: cloudInventorySyncConfigResponseAttributes{
+			CloudProvider: "aws",
+		},
+	})
+
+	if resource.InstanceState.ID != "3526615b-4d65-4d9b-947a-d89c18faf0dc" {
+		t.Fatalf("resource ID = %q, want %q", resource.InstanceState.ID, "3526615b-4d65-4d9b-947a-d89c18faf0dc")
+	}
+	if resource.ResourceName != "tfer--cloud_inventory_sync_config_aws" {
+		t.Fatalf("resource name = %q, want %q", resource.ResourceName, "tfer--cloud_inventory_sync_config_aws")
+	}
+	if resource.InstanceInfo.Type != "datadog_cloud_inventory_sync_config" {
+		t.Fatalf("resource type = %q, want %q", resource.InstanceInfo.Type, "datadog_cloud_inventory_sync_config")
+	}
+}

--- a/providers/datadog/cloud_inventory_sync_config_test.go
+++ b/providers/datadog/cloud_inventory_sync_config_test.go
@@ -55,7 +55,7 @@ func TestCloudInventorySyncConfigCreateResource(t *testing.T) {
 				},
 			},
 			wantID:   "3526615b-4d65-4d9b-947a-d89c18faf0dc",
-			wantName: "tfer--cloud_inventory_sync_config_aws",
+			wantName: "tfer--cloud_inventory_sync_config_aws_3526615b-4d65-4d9b-947a-d89c18faf0dc",
 			wantType: "datadog_cloud_inventory_sync_config",
 		},
 		{

--- a/providers/datadog/cloud_inventory_sync_config_test.go
+++ b/providers/datadog/cloud_inventory_sync_config_test.go
@@ -39,21 +39,49 @@ func TestCloudInventorySyncConfigResponseDataListUnmarshal(t *testing.T) {
 }
 
 func TestCloudInventorySyncConfigCreateResource(t *testing.T) {
-	generator := CloudInventorySyncConfigGenerator{}
-	resource := generator.createResource(cloudInventorySyncConfigResponseData{
-		ID: "3526615b-4d65-4d9b-947a-d89c18faf0dc",
-		Attributes: cloudInventorySyncConfigResponseAttributes{
-			CloudProvider: "aws",
+	tests := []struct {
+		name       string
+		syncConfig cloudInventorySyncConfigResponseData
+		wantID     string
+		wantName   string
+		wantType   string
+	}{
+		{
+			name: "uses cloud provider in resource name",
+			syncConfig: cloudInventorySyncConfigResponseData{
+				ID: "3526615b-4d65-4d9b-947a-d89c18faf0dc",
+				Attributes: cloudInventorySyncConfigResponseAttributes{
+					CloudProvider: "aws",
+				},
+			},
+			wantID:   "3526615b-4d65-4d9b-947a-d89c18faf0dc",
+			wantName: "tfer--cloud_inventory_sync_config_aws",
+			wantType: "datadog_cloud_inventory_sync_config",
 		},
-	})
+		{
+			name: "falls back to id in resource name",
+			syncConfig: cloudInventorySyncConfigResponseData{
+				ID: "3526615b-4d65-4d9b-947a-d89c18faf0dc",
+			},
+			wantID:   "3526615b-4d65-4d9b-947a-d89c18faf0dc",
+			wantName: "tfer--cloud_inventory_sync_config_3526615b-4d65-4d9b-947a-d89c18faf0dc",
+			wantType: "datadog_cloud_inventory_sync_config",
+		},
+	}
 
-	if resource.InstanceState.ID != "3526615b-4d65-4d9b-947a-d89c18faf0dc" {
-		t.Fatalf("resource ID = %q, want %q", resource.InstanceState.ID, "3526615b-4d65-4d9b-947a-d89c18faf0dc")
-	}
-	if resource.ResourceName != "tfer--cloud_inventory_sync_config_aws" {
-		t.Fatalf("resource name = %q, want %q", resource.ResourceName, "tfer--cloud_inventory_sync_config_aws")
-	}
-	if resource.InstanceInfo.Type != "datadog_cloud_inventory_sync_config" {
-		t.Fatalf("resource type = %q, want %q", resource.InstanceInfo.Type, "datadog_cloud_inventory_sync_config")
+	generator := CloudInventorySyncConfigGenerator{}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			resource := generator.createResource(tt.syncConfig)
+			if resource.InstanceState.ID != tt.wantID {
+				t.Fatalf("resource ID = %q, want %q", resource.InstanceState.ID, tt.wantID)
+			}
+			if resource.ResourceName != tt.wantName {
+				t.Fatalf("resource name = %q, want %q", resource.ResourceName, tt.wantName)
+			}
+			if resource.InstanceInfo.Type != tt.wantType {
+				t.Fatalf("resource type = %q, want %q", resource.InstanceInfo.Type, tt.wantType)
+			}
+		})
 	}
 }

--- a/providers/datadog/datadog_provider.go
+++ b/providers/datadog/datadog_provider.go
@@ -147,6 +147,7 @@ func (p *DatadogProvider) InitService(serviceName string, verbose bool) error {
 // GetSupportedService return map of support service for Datadog
 func (p *DatadogProvider) GetSupportedService() map[string]terraformutils.ServiceGenerator {
 	return map[string]terraformutils.ServiceGenerator{
+		"cloud_inventory_sync_config":          &CloudInventorySyncConfigGenerator{},
 		"dashboard_list":                       &DashboardListGenerator{},
 		"dashboard":                            &DashboardGenerator{},
 		"dashboard_json":                       &DashboardJSONGenerator{},


### PR DESCRIPTION
## Summary

- add Datadog `cloud_inventory_sync_config` import support using the Cloud Inventory sync config GET-by-ID endpoint
- document the new resource and note that imports require ID filters
- add unit coverage for response parsing and resource construction

## Notes

This stays filter-only because the upstream Datadog Terraform provider exposes import/read by sync config ID, but does not show a documented list path for sync configs. CI can cover the full build and lint path.
