### PR TITLE
feat(launchdarkly): add environment resource support

### DIFF
--- a/docs/launchdarkly.md
+++ b/docs/launchdarkly.md
@@ -4,8 +4,13 @@ Example:
 
 ```
 export LAUNCHDARKLY_ACCESS_TOKEN=[LAUNCHDARKLY_ACCESS_TOKEN]
-./terraformer import launchdarkly -r project,environment,featureFlag,segment
+./terraformer import launchdarkly -r environment,featureFlag,segment
 ```
+
+Use `project` separately when you want LaunchDarkly environments managed as nested
+`launchdarkly_project` blocks. Avoid importing `project` and `environment` together,
+because that can generate both nested and standalone resources for the same
+environments.
 
 List of supported LaunchDarkly resources:
 

--- a/docs/launchdarkly.md
+++ b/docs/launchdarkly.md
@@ -4,13 +4,15 @@ Example:
 
 ```
 export LAUNCHDARKLY_ACCESS_TOKEN=[LAUNCHDARKLY_ACCESS_TOKEN]
-./terraformer import launchdarkly -r project,featureFlag,segment
+./terraformer import launchdarkly -r project,environment,featureFlag,segment
 ```
 
 List of supported LaunchDarkly resources:
 
 *   `project`
     * `launchdarkly_project`
+*   `environment`
+    * `launchdarkly_environment`
 *   `featureFlag`
     * `launchdarkly_feature_flag`
     * `launchdarkly_feature_flag_environment`

--- a/providers/launchdarkly/environment.go
+++ b/providers/launchdarkly/environment.go
@@ -1,0 +1,52 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package launchdarkly
+
+import (
+	"context"
+
+	"github.com/chenrui333/terraformer/terraformutils"
+	ldapi "github.com/launchdarkly/api-client-go/v16"
+)
+
+type EnvironmentGenerator struct {
+	LaunchDarklyService
+}
+
+func (g *EnvironmentGenerator) loadEnvironments(ctx context.Context, client *ldapi.APIClient, projectKey string) error {
+	envs, err := getEnvironments(ctx, client, projectKey)
+	if err != nil {
+		return err
+	}
+	for _, env := range envs {
+		resource := terraformutils.NewResource(
+			projectKey+"/"+env.Key,
+			projectKey+"-"+env.Name,
+			"launchdarkly_environment",
+			"launchdarkly",
+			map[string]string{
+				"key":         env.Key,
+				"project_key": projectKey,
+			},
+			[]string{},
+			map[string]interface{}{})
+		g.Resources = append(g.Resources, resource)
+	}
+	return nil
+}
+
+func (g *EnvironmentGenerator) InitResources() error {
+	ctx := g.GetArgs()["ctx"].(context.Context)
+	client := g.GetArgs()["client"].(*ldapi.APIClient)
+
+	projects, err := getProjects(ctx, client)
+	if err != nil {
+		return err
+	}
+	for _, project := range projects {
+		if err := g.loadEnvironments(ctx, client, project.Key); err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/providers/launchdarkly/launchdarkly_provider.go
+++ b/providers/launchdarkly/launchdarkly_provider.go
@@ -58,6 +58,7 @@ func (LaunchDarklyProvider) GetResourceConnections() map[string]map[string][]str
 func (p *LaunchDarklyProvider) GetSupportedService() map[string]terraformutils.ServiceGenerator {
 	return map[string]terraformutils.ServiceGenerator{
 		"project":     &ProjectGenerator{},
+		"environment": &EnvironmentGenerator{},
 		"featureFlag": &FeatureFlagsGenerator{},
 		"segment":     &SegmentGenerator{},
 	}


### PR DESCRIPTION
## Summary
- Add a LaunchDarkly `environment` import service for `launchdarkly_environment` resources.
- Reuse the existing paginated project and environment discovery helpers.
- Update the LaunchDarkly docs example and supported resource list.

## Notes
- Kept this PR scoped to environment imports; no LaunchDarkly dependency changes.
