### PR TITLE
feat(datadog): add team import

### DIFF
--- a/docs/datadog.md
+++ b/docs/datadog.md
@@ -148,6 +148,8 @@ Tag filters are order specific. For example, if your monitor has tags (in the or
     * `datadog_synthetics_private_location`
 *   `synthetics_test`
     * `datadog_synthetics_test`
+*   `team`
+    * `datadog_team`
 *   `user`
     * `datadog_user`
 

--- a/providers/datadog/datadog_provider.go
+++ b/providers/datadog/datadog_provider.go
@@ -176,6 +176,7 @@ func (p *DatadogProvider) GetSupportedService() map[string]terraformutils.Servic
 		"synthetics_test":                      &SyntheticsTestGenerator{},
 		"synthetics_global_variable":           &SyntheticsGlobalVariableGenerator{},
 		"synthetics_private_location":          &SyntheticsPrivateLocationGenerator{},
+		"team":                                 &TeamGenerator{},
 		"user":                                 &UserGenerator{},
 		"role":                                 &RoleGenerator{},
 	}

--- a/providers/datadog/team.go
+++ b/providers/datadog/team.go
@@ -14,7 +14,7 @@ import (
 
 var (
 	// TeamAllowEmptyValues ...
-	TeamAllowEmptyValues = []string{}
+	TeamAllowEmptyValues = []string{"description"}
 )
 
 // TeamGenerator ...

--- a/providers/datadog/team.go
+++ b/providers/datadog/team.go
@@ -4,6 +4,7 @@ package datadog
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 
 	"github.com/DataDog/datadog-api-client-go/v2/api/datadog"
@@ -50,13 +51,44 @@ func (g *TeamGenerator) createResource(team datadogV2.Team) terraformutils.Resou
 
 func (g *TeamGenerator) PostConvertHook() error {
 	for i := range g.Resources {
-		if g.Resources[i].Item == nil {
-			g.Resources[i].Item = map[string]interface{}{}
+		resource := &g.Resources[i]
+		if resource.Item == nil {
+			resource.Item = map[string]interface{}{}
 		}
-		if description, ok := g.Resources[i].Item["description"]; !ok || description == nil {
-			g.Resources[i].Item["description"] = ""
+		if description, ok := resource.Item["description"]; !ok || description == nil {
+			resource.Item["description"] = ""
+			if err := defaultTeamDescriptionState(resource); err != nil {
+				return err
+			}
 		}
 	}
+	return nil
+}
+
+func defaultTeamDescriptionState(resource *terraformutils.Resource) error {
+	if resource.InstanceState == nil {
+		return nil
+	}
+	if resource.InstanceState.Attributes == nil {
+		resource.InstanceState.Attributes = map[string]string{}
+	}
+	resource.InstanceState.Attributes["description"] = ""
+
+	if len(resource.InstanceState.TypedAttributes) == 0 {
+		return nil
+	}
+
+	typedAttributes := map[string]json.RawMessage{}
+	if err := json.Unmarshal(resource.InstanceState.TypedAttributes, &typedAttributes); err != nil {
+		return fmt.Errorf("decode team typed attributes: %w", err)
+	}
+	typedAttributes["description"] = json.RawMessage{'"', '"'}
+
+	rawTypedAttributes, err := json.Marshal(typedAttributes)
+	if err != nil {
+		return fmt.Errorf("encode team typed attributes: %w", err)
+	}
+	resource.InstanceState.SetTypedAttributes(rawTypedAttributes)
 	return nil
 }
 

--- a/providers/datadog/team.go
+++ b/providers/datadog/team.go
@@ -48,6 +48,18 @@ func (g *TeamGenerator) createResource(team datadogV2.Team) terraformutils.Resou
 	)
 }
 
+func (g *TeamGenerator) PostConvertHook() error {
+	for i := range g.Resources {
+		if g.Resources[i].Item == nil {
+			g.Resources[i].Item = map[string]interface{}{}
+		}
+		if description, ok := g.Resources[i].Item["description"]; !ok || description == nil {
+			g.Resources[i].Item["description"] = ""
+		}
+	}
+	return nil
+}
+
 // InitResources Generate TerraformResources from Datadog API,
 // from each team create 1 TerraformResource.
 // Need Team ID as ID for terraform resource.

--- a/providers/datadog/team.go
+++ b/providers/datadog/team.go
@@ -60,16 +60,12 @@ func (g *TeamGenerator) InitResources() error {
 	for _, filter := range g.Filter {
 		if filter.FieldPath == "id" && filter.IsApplicable("team") {
 			for _, value := range filter.AcceptableValues {
-				teamResponse, _, err := api.GetTeam(auth, value)
+				team, err := getTeam(auth, api, value)
 				if err != nil {
 					return err
 				}
-				team, ok := teamResponse.GetDataOk()
-				if !ok {
-					return fmt.Errorf("team %q not found", value)
-				}
 
-				resources = append(resources, g.createResource(*team))
+				resources = append(resources, g.createResource(team))
 			}
 		}
 	}
@@ -85,6 +81,23 @@ func (g *TeamGenerator) InitResources() error {
 	}
 	g.Resources = g.createResources(teams)
 	return nil
+}
+
+func getTeam(auth context.Context, api *datadogV2.TeamsApi, teamID string) (datadogV2.Team, error) {
+	teamResponse, httpResponse, err := api.GetTeam(auth, teamID)
+	if httpResponse != nil && httpResponse.Body != nil {
+		defer httpResponse.Body.Close()
+	}
+	if err != nil {
+		return datadogV2.Team{}, err
+	}
+
+	team, ok := teamResponse.GetDataOk()
+	if !ok {
+		return datadogV2.Team{}, fmt.Errorf("team %q not found", teamID)
+	}
+
+	return *team, nil
 }
 
 func listTeams(auth context.Context, api *datadogV2.TeamsApi) ([]datadogV2.Team, error) {

--- a/providers/datadog/team.go
+++ b/providers/datadog/team.go
@@ -1,0 +1,104 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package datadog
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/DataDog/datadog-api-client-go/v2/api/datadog"
+	"github.com/DataDog/datadog-api-client-go/v2/api/datadogV2"
+
+	"github.com/chenrui333/terraformer/terraformutils"
+)
+
+var (
+	// TeamAllowEmptyValues ...
+	TeamAllowEmptyValues = []string{}
+)
+
+// TeamGenerator ...
+type TeamGenerator struct {
+	DatadogService
+}
+
+func (g *TeamGenerator) createResources(teams []datadogV2.Team) []terraformutils.Resource {
+	resources := []terraformutils.Resource{}
+	for _, team := range teams {
+		resources = append(resources, g.createResource(team))
+	}
+
+	return resources
+}
+
+func (g *TeamGenerator) createResource(team datadogV2.Team) terraformutils.Resource {
+	teamID := team.GetId()
+	resourceName := teamID
+	attributes := team.GetAttributes()
+	if handle := attributes.GetHandle(); handle != "" {
+		resourceName = fmt.Sprintf("%s_%s", handle, teamID)
+	}
+
+	return terraformutils.NewSimpleResource(
+		teamID,
+		fmt.Sprintf("team_%s", resourceName),
+		"datadog_team",
+		"datadog",
+		TeamAllowEmptyValues,
+	)
+}
+
+// InitResources Generate TerraformResources from Datadog API,
+// from each team create 1 TerraformResource.
+// Need Team ID as ID for terraform resource.
+func (g *TeamGenerator) InitResources() error {
+	datadogClient := g.Args["datadogClient"].(*datadog.APIClient)
+	auth := g.Args["auth"].(context.Context)
+	api := datadogV2.NewTeamsApi(datadogClient)
+
+	resources := []terraformutils.Resource{}
+	for _, filter := range g.Filter {
+		if filter.FieldPath == "id" && filter.IsApplicable("team") {
+			for _, value := range filter.AcceptableValues {
+				teamResponse, _, err := api.GetTeam(auth, value)
+				if err != nil {
+					return err
+				}
+				team, ok := teamResponse.GetDataOk()
+				if !ok {
+					return fmt.Errorf("team %q not found", value)
+				}
+
+				resources = append(resources, g.createResource(*team))
+			}
+		}
+	}
+
+	if len(resources) > 0 {
+		g.Resources = resources
+		return nil
+	}
+
+	teams, err := listTeams(auth, api)
+	if err != nil {
+		return err
+	}
+	g.Resources = g.createResources(teams)
+	return nil
+}
+
+func listTeams(auth context.Context, api *datadogV2.TeamsApi) ([]datadogV2.Team, error) {
+	pageSize := int64(100)
+	items, cancel := api.ListTeamsWithPagination(auth, *datadogV2.NewListTeamsOptionalParameters().WithPageSize(pageSize))
+	defer cancel()
+
+	teams := []datadogV2.Team{}
+	for item := range items {
+		if item.Error != nil {
+			return nil, item.Error
+		}
+		teams = append(teams, item.Item)
+	}
+
+	return teams, nil
+}

--- a/providers/datadog/team_test.go
+++ b/providers/datadog/team_test.go
@@ -7,11 +7,50 @@ import (
 	"testing"
 
 	"github.com/DataDog/datadog-api-client-go/v2/api/datadogV2"
+
+	"github.com/chenrui333/terraformer/terraformutils"
 )
 
 func TestTeamAllowEmptyValuesIncludesDescription(t *testing.T) {
 	if !slices.Contains(TeamAllowEmptyValues, "description") {
 		t.Fatal("TeamAllowEmptyValues must include description")
+	}
+}
+
+func TestTeamPostConvertHookCoercesMissingDescription(t *testing.T) {
+	generator := TeamGenerator{}
+	generator.Resources = []terraformutils.Resource{
+		{
+			Item: map[string]interface{}{},
+		},
+		{
+			Item: map[string]interface{}{
+				"description": nil,
+			},
+		},
+		{
+			Item: map[string]interface{}{
+				"description": "owned by platform",
+			},
+		},
+		{},
+	}
+
+	if err := generator.PostConvertHook(); err != nil {
+		t.Fatalf("PostConvertHook() error = %v", err)
+	}
+
+	if got := generator.Resources[0].Item["description"]; got != "" {
+		t.Fatalf("missing description = %v, want empty string", got)
+	}
+	if got := generator.Resources[1].Item["description"]; got != "" {
+		t.Fatalf("nil description = %v, want empty string", got)
+	}
+	if got := generator.Resources[2].Item["description"]; got != "owned by platform" {
+		t.Fatalf("existing description = %v, want owned by platform", got)
+	}
+	if got := generator.Resources[3].Item["description"]; got != "" {
+		t.Fatalf("nil item description = %v, want empty string", got)
 	}
 }
 

--- a/providers/datadog/team_test.go
+++ b/providers/datadog/team_test.go
@@ -3,12 +3,14 @@
 package datadog
 
 import (
+	"encoding/json"
 	"slices"
 	"testing"
 
 	"github.com/DataDog/datadog-api-client-go/v2/api/datadogV2"
 
 	"github.com/chenrui333/terraformer/terraformutils"
+	"github.com/chenrui333/terraformer/terraformutils/tfcompat"
 )
 
 func TestTeamAllowEmptyValuesIncludesDescription(t *testing.T) {
@@ -22,15 +24,35 @@ func TestTeamPostConvertHookCoercesMissingDescription(t *testing.T) {
 	generator.Resources = []terraformutils.Resource{
 		{
 			Item: map[string]interface{}{},
+			InstanceState: &tfcompat.InstanceState{
+				Attributes: map[string]string{},
+			},
 		},
 		{
 			Item: map[string]interface{}{
 				"description": nil,
 			},
+			InstanceState: &tfcompat.InstanceState{
+				Attributes: map[string]string{
+					"id": "team-with-null-description",
+				},
+				TypedAttributes: typedAttributes(t, map[string]interface{}{
+					"description": nil,
+					"id":          "team-with-null-description",
+				}),
+			},
 		},
 		{
 			Item: map[string]interface{}{
 				"description": "owned by platform",
+			},
+			InstanceState: &tfcompat.InstanceState{
+				Attributes: map[string]string{
+					"description": "owned by platform",
+				},
+				TypedAttributes: typedAttributes(t, map[string]interface{}{
+					"description": "owned by platform",
+				}),
 			},
 		},
 		{},
@@ -43,15 +65,50 @@ func TestTeamPostConvertHookCoercesMissingDescription(t *testing.T) {
 	if got := generator.Resources[0].Item["description"]; got != "" {
 		t.Fatalf("missing description = %v, want empty string", got)
 	}
+	if got := generator.Resources[0].InstanceState.Attributes["description"]; got != "" {
+		t.Fatalf("missing description state = %v, want empty string", got)
+	}
 	if got := generator.Resources[1].Item["description"]; got != "" {
 		t.Fatalf("nil description = %v, want empty string", got)
+	}
+	if got := generator.Resources[1].InstanceState.Attributes["description"]; got != "" {
+		t.Fatalf("nil description state = %v, want empty string", got)
+	}
+	if got := typedDescription(t, generator.Resources[1].InstanceState.TypedAttributes); got != "" {
+		t.Fatalf("typed description = %q, want empty string", got)
 	}
 	if got := generator.Resources[2].Item["description"]; got != "owned by platform" {
 		t.Fatalf("existing description = %v, want owned by platform", got)
 	}
+	if got := generator.Resources[2].InstanceState.Attributes["description"]; got != "owned by platform" {
+		t.Fatalf("existing description state = %v, want owned by platform", got)
+	}
+	if got := typedDescription(t, generator.Resources[2].InstanceState.TypedAttributes); got != "owned by platform" {
+		t.Fatalf("existing typed description = %q, want owned by platform", got)
+	}
 	if got := generator.Resources[3].Item["description"]; got != "" {
 		t.Fatalf("nil item description = %v, want empty string", got)
 	}
+}
+
+func typedAttributes(t *testing.T, attributes map[string]interface{}) json.RawMessage {
+	t.Helper()
+
+	raw, err := json.Marshal(attributes)
+	if err != nil {
+		t.Fatalf("Marshal typed attributes = %v", err)
+	}
+	return raw
+}
+
+func typedDescription(t *testing.T, raw json.RawMessage) string {
+	t.Helper()
+
+	attributes := map[string]string{}
+	if err := json.Unmarshal(raw, &attributes); err != nil {
+		t.Fatalf("Unmarshal typed attributes = %v", err)
+	}
+	return attributes["description"]
 }
 
 func TestTeamCreateResource(t *testing.T) {

--- a/providers/datadog/team_test.go
+++ b/providers/datadog/team_test.go
@@ -3,10 +3,17 @@
 package datadog
 
 import (
+	"slices"
 	"testing"
 
 	"github.com/DataDog/datadog-api-client-go/v2/api/datadogV2"
 )
+
+func TestTeamAllowEmptyValuesIncludesDescription(t *testing.T) {
+	if !slices.Contains(TeamAllowEmptyValues, "description") {
+		t.Fatal("TeamAllowEmptyValues must include description")
+	}
+}
 
 func TestTeamCreateResource(t *testing.T) {
 	tests := []struct {

--- a/providers/datadog/team_test.go
+++ b/providers/datadog/team_test.go
@@ -1,0 +1,83 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package datadog
+
+import (
+	"testing"
+
+	"github.com/DataDog/datadog-api-client-go/v2/api/datadogV2"
+)
+
+func TestTeamCreateResource(t *testing.T) {
+	tests := []struct {
+		name     string
+		team     datadogV2.Team
+		wantID   string
+		wantName string
+		wantType string
+	}{
+		{
+			name: "uses handle and id in resource name",
+			team: datadogV2.Team{
+				Id: "bf064c56-edb0-11ed-ae91-da7ad0900002",
+				Attributes: datadogV2.TeamAttributes{
+					Handle: "platform",
+					Name:   "Platform",
+				},
+			},
+			wantID:   "bf064c56-edb0-11ed-ae91-da7ad0900002",
+			wantName: "tfer--team_platform_bf064c56-edb0-11ed-ae91-da7ad0900002",
+			wantType: "datadog_team",
+		},
+		{
+			name: "falls back to id in resource name",
+			team: datadogV2.Team{
+				Id: "bf064c56-edb0-11ed-ae91-da7ad0900002",
+			},
+			wantID:   "bf064c56-edb0-11ed-ae91-da7ad0900002",
+			wantName: "tfer--team_bf064c56-edb0-11ed-ae91-da7ad0900002",
+			wantType: "datadog_team",
+		},
+	}
+
+	generator := TeamGenerator{}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			resource := generator.createResource(tt.team)
+			if resource.InstanceState.ID != tt.wantID {
+				t.Fatalf("resource ID = %q, want %q", resource.InstanceState.ID, tt.wantID)
+			}
+			if resource.ResourceName != tt.wantName {
+				t.Fatalf("resource name = %q, want %q", resource.ResourceName, tt.wantName)
+			}
+			if resource.InstanceInfo.Type != tt.wantType {
+				t.Fatalf("resource type = %q, want %q", resource.InstanceInfo.Type, tt.wantType)
+			}
+		})
+	}
+}
+
+func TestTeamCreateResourcesAllowsSharedHandles(t *testing.T) {
+	generator := TeamGenerator{}
+	resources := generator.createResources([]datadogV2.Team{
+		{
+			Id: "bf064c56-edb0-11ed-ae91-da7ad0900002",
+			Attributes: datadogV2.TeamAttributes{
+				Handle: "platform",
+			},
+		},
+		{
+			Id: "cf064c56-edb0-11ed-ae91-da7ad0900003",
+			Attributes: datadogV2.TeamAttributes{
+				Handle: "platform",
+			},
+		},
+	})
+
+	if got, want := len(resources), 2; got != want {
+		t.Fatalf("len(resources) = %d, want %d", got, want)
+	}
+	if resources[0].ResourceName == resources[1].ResourceName {
+		t.Fatalf("resource names should be unique, got %q", resources[0].ResourceName)
+	}
+}


### PR DESCRIPTION
## Summary

- Add Datadog `team` import support using the v2 Teams API list/get endpoints.
- Generate stable team resource names from handle plus ID to avoid name collisions.
- Register and document `team` as `datadog_team`.

## Notes

Team child resources such as memberships, links, hierarchy links, and permission settings remain separate follow-up gaps.
