### PR TITLE
feat(launchdarkly): add expanded resource support

### DIFF
--- a/README.md
+++ b/README.md
@@ -263,7 +263,7 @@ Links to download Terraform provider plugins:
 * Cloud
     * DigitalOcean provider >1.9.1 - [here](https://releases.hashicorp.com/terraform-provider-digitalocean/)
     * Heroku provider >2.2.1 - [here](https://releases.hashicorp.com/terraform-provider-heroku/)
-    * LaunchDarkly provider >=2.1.1 - [here](https://releases.hashicorp.com/terraform-provider-launchdarkly/)
+    * LaunchDarkly provider >=2.28.0 - [here](https://releases.hashicorp.com/terraform-provider-launchdarkly/)
     * Linode provider >1.8.0 - [here](https://releases.hashicorp.com/terraform-provider-linode/)
     * OpenStack provider >1.21.1 - [here](https://releases.hashicorp.com/terraform-provider-openstack/)
     * TencentCloud provider >1.50.0 - [here](https://releases.hashicorp.com/terraform-provider-tencentcloud/)

--- a/docs/launchdarkly.md
+++ b/docs/launchdarkly.md
@@ -4,7 +4,7 @@ Example:
 
 ```
 export LAUNCHDARKLY_ACCESS_TOKEN=[LAUNCHDARKLY_ACCESS_TOKEN]
-./terraformer import launchdarkly -r environment,featureFlag,segment
+./terraformer import launchdarkly -r customRole,environment,featureFlag,flagTemplates,metric,relayProxyConfiguration,segment,team,teamMember,webhook
 ```
 
 Use `project` separately when you want LaunchDarkly environments managed as nested
@@ -14,6 +14,8 @@ environments.
 
 List of supported LaunchDarkly resources:
 
+*   `customRole`
+    * `launchdarkly_custom_role`
 *   `project`
     * `launchdarkly_project`
 *   `environment`
@@ -21,5 +23,17 @@ List of supported LaunchDarkly resources:
 *   `featureFlag`
     * `launchdarkly_feature_flag`
     * `launchdarkly_feature_flag_environment`
+*   `flagTemplates`
+    * `launchdarkly_flag_templates`
+*   `metric`
+    * `launchdarkly_metric`
+*   `relayProxyConfiguration`
+    * `launchdarkly_relay_proxy_configuration`
 *   `segment`
     * `launchdarkly_segment`
+*   `team`
+    * `launchdarkly_team`
+*   `teamMember`
+    * `launchdarkly_team_member`
+*   `webhook`
+    * `launchdarkly_webhook`

--- a/providers/launchdarkly/custom_role.go
+++ b/providers/launchdarkly/custom_role.go
@@ -1,0 +1,52 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package launchdarkly
+
+import (
+	"context"
+
+	"github.com/chenrui333/terraformer/terraformutils"
+	ldapi "github.com/launchdarkly/api-client-go/v16"
+)
+
+type CustomRoleGenerator struct {
+	LaunchDarklyService
+}
+
+func (g *CustomRoleGenerator) loadCustomRoles(ctx context.Context, client *ldapi.APIClient) error {
+	var allRoles []ldapi.CustomRole
+	for offset := int64(0); ; offset += pageSize {
+		roles, _, err := client.CustomRolesApi.GetCustomRoles(ctx).
+			Limit(pageSize).
+			Offset(offset).
+			Execute()
+		if err != nil {
+			return err
+		}
+		if roles == nil {
+			break
+		}
+		allRoles = append(allRoles, roles.Items...)
+		if len(roles.Items) < pageSize {
+			break
+		}
+	}
+	for _, role := range allRoles {
+		resource := terraformutils.NewResource(
+			role.Key,
+			role.Key,
+			"launchdarkly_custom_role",
+			"launchdarkly",
+			map[string]string{
+				"key": role.Key,
+			},
+			[]string{},
+			map[string]interface{}{})
+		g.Resources = append(g.Resources, resource)
+	}
+	return nil
+}
+
+func (g *CustomRoleGenerator) InitResources() error {
+	return g.loadCustomRoles(g.GetArgs()["ctx"].(context.Context), g.GetArgs()["client"].(*ldapi.APIClient))
+}

--- a/providers/launchdarkly/custom_role.go
+++ b/providers/launchdarkly/custom_role.go
@@ -16,10 +16,13 @@ type CustomRoleGenerator struct {
 func (g *CustomRoleGenerator) loadCustomRoles(ctx context.Context, client *ldapi.APIClient) error {
 	var allRoles []ldapi.CustomRole
 	for offset := int64(0); ; offset += pageSize {
-		roles, _, err := client.CustomRolesApi.GetCustomRoles(ctx).
+		roles, resp, err := client.CustomRolesApi.GetCustomRoles(ctx).
 			Limit(pageSize).
 			Offset(offset).
 			Execute()
+		if resp != nil && resp.Body != nil {
+			_ = resp.Body.Close()
+		}
 		if err != nil {
 			return err
 		}

--- a/providers/launchdarkly/flag_templates.go
+++ b/providers/launchdarkly/flag_templates.go
@@ -14,7 +14,11 @@ type FlagTemplatesGenerator struct {
 }
 
 func (g *FlagTemplatesGenerator) loadFlagTemplates(ctx context.Context, client *ldapi.APIClient, projectKey string) error {
-	if _, _, err := client.ProjectsApi.GetFlagDefaultsByProject(ctx, projectKey).Execute(); err != nil {
+	_, resp, err := client.ProjectsApi.GetFlagDefaultsByProject(ctx, projectKey).Execute()
+	if resp != nil && resp.Body != nil {
+		_ = resp.Body.Close()
+	}
+	if err != nil {
 		return err
 	}
 	resource := terraformutils.NewResource(

--- a/providers/launchdarkly/flag_templates.go
+++ b/providers/launchdarkly/flag_templates.go
@@ -1,0 +1,48 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package launchdarkly
+
+import (
+	"context"
+
+	"github.com/chenrui333/terraformer/terraformutils"
+	ldapi "github.com/launchdarkly/api-client-go/v16"
+)
+
+type FlagTemplatesGenerator struct {
+	LaunchDarklyService
+}
+
+func (g *FlagTemplatesGenerator) loadFlagTemplates(ctx context.Context, client *ldapi.APIClient, projectKey string) error {
+	if _, _, err := client.ProjectsApi.GetFlagDefaultsByProject(ctx, projectKey).Execute(); err != nil {
+		return err
+	}
+	resource := terraformutils.NewResource(
+		projectKey,
+		projectKey,
+		"launchdarkly_flag_templates",
+		"launchdarkly",
+		map[string]string{
+			"project_key": projectKey,
+		},
+		[]string{},
+		map[string]interface{}{})
+	g.Resources = append(g.Resources, resource)
+	return nil
+}
+
+func (g *FlagTemplatesGenerator) InitResources() error {
+	ctx := g.GetArgs()["ctx"].(context.Context)
+	client := g.GetArgs()["client"].(*ldapi.APIClient)
+
+	projects, err := getProjects(ctx, client)
+	if err != nil {
+		return err
+	}
+	for _, project := range projects {
+		if err := g.loadFlagTemplates(ctx, client, project.Key); err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/providers/launchdarkly/launchdarkly_provider.go
+++ b/providers/launchdarkly/launchdarkly_provider.go
@@ -57,10 +57,17 @@ func (LaunchDarklyProvider) GetResourceConnections() map[string]map[string][]str
 
 func (p *LaunchDarklyProvider) GetSupportedService() map[string]terraformutils.ServiceGenerator {
 	return map[string]terraformutils.ServiceGenerator{
-		"project":     &ProjectGenerator{},
-		"environment": &EnvironmentGenerator{},
-		"featureFlag": &FeatureFlagsGenerator{},
-		"segment":     &SegmentGenerator{},
+		"customRole":              &CustomRoleGenerator{},
+		"project":                 &ProjectGenerator{},
+		"environment":             &EnvironmentGenerator{},
+		"featureFlag":             &FeatureFlagsGenerator{},
+		"flagTemplates":           &FlagTemplatesGenerator{},
+		"metric":                  &MetricGenerator{},
+		"relayProxyConfiguration": &RelayProxyConfigurationGenerator{},
+		"segment":                 &SegmentGenerator{},
+		"team":                    &TeamGenerator{},
+		"teamMember":              &TeamMemberGenerator{},
+		"webhook":                 &WebhookGenerator{},
 	}
 }
 

--- a/providers/launchdarkly/metric.go
+++ b/providers/launchdarkly/metric.go
@@ -4,6 +4,8 @@ package launchdarkly
 
 import (
 	"context"
+	"fmt"
+	"net/url"
 
 	"github.com/chenrui333/terraformer/terraformutils"
 	ldapi "github.com/launchdarkly/api-client-go/v16"
@@ -13,33 +15,36 @@ type MetricGenerator struct {
 	LaunchDarklyService
 }
 
-func (g *MetricGenerator) loadMetrics(ctx context.Context, client *ldapi.APIClient, projectKey string) error {
-	metrics, _, err := client.MetricsApi.GetMetrics(ctx, projectKey).Execute()
-	if err != nil {
-		return err
-	}
-	if metrics == nil {
-		return nil
-	}
-	for _, metric := range metrics.Items {
-		resource := terraformutils.NewResource(
-			projectKey+"/"+metric.Key,
-			projectKey+"-"+metric.Name,
-			"launchdarkly_metric",
-			"launchdarkly",
-			map[string]string{
-				"key":         metric.Key,
-				"project_key": projectKey,
-			},
-			[]string{},
-			map[string]interface{}{})
-		g.Resources = append(g.Resources, resource)
+func (g *MetricGenerator) loadMetrics(ctx context.Context, apiKey, projectKey string) error {
+	path := fmt.Sprintf("/metrics/%s?limit=%d", url.PathEscape(projectKey), launchDarklyDefaultPageSize)
+	for path != "" {
+		metrics := &ldapi.MetricCollectionRep{}
+		if err := getLaunchDarklyAPI(ctx, apiKey, path, metrics); err != nil {
+			return err
+		}
+
+		for _, metric := range metrics.GetItems() {
+			resource := terraformutils.NewResource(
+				projectKey+"/"+metric.Key,
+				projectKey+"-"+metric.Name,
+				"launchdarkly_metric",
+				"launchdarkly",
+				map[string]string{
+					"key":         metric.Key,
+					"project_key": projectKey,
+				},
+				[]string{},
+				map[string]interface{}{})
+			g.Resources = append(g.Resources, resource)
+		}
+		path = nextPagePath(metrics.GetLinks())
 	}
 	return nil
 }
 
 func (g *MetricGenerator) InitResources() error {
 	ctx := g.GetArgs()["ctx"].(context.Context)
+	apiKey := g.GetArgs()["api_key"].(string)
 	client := g.GetArgs()["client"].(*ldapi.APIClient)
 
 	projects, err := getProjects(ctx, client)
@@ -47,7 +52,7 @@ func (g *MetricGenerator) InitResources() error {
 		return err
 	}
 	for _, project := range projects {
-		if err := g.loadMetrics(ctx, client, project.Key); err != nil {
+		if err := g.loadMetrics(ctx, apiKey, project.Key); err != nil {
 			return err
 		}
 	}

--- a/providers/launchdarkly/metric.go
+++ b/providers/launchdarkly/metric.go
@@ -1,0 +1,55 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package launchdarkly
+
+import (
+	"context"
+
+	"github.com/chenrui333/terraformer/terraformutils"
+	ldapi "github.com/launchdarkly/api-client-go/v16"
+)
+
+type MetricGenerator struct {
+	LaunchDarklyService
+}
+
+func (g *MetricGenerator) loadMetrics(ctx context.Context, client *ldapi.APIClient, projectKey string) error {
+	metrics, _, err := client.MetricsApi.GetMetrics(ctx, projectKey).Execute()
+	if err != nil {
+		return err
+	}
+	if metrics == nil {
+		return nil
+	}
+	for _, metric := range metrics.Items {
+		resource := terraformutils.NewResource(
+			projectKey+"/"+metric.Key,
+			projectKey+"-"+metric.Name,
+			"launchdarkly_metric",
+			"launchdarkly",
+			map[string]string{
+				"key":         metric.Key,
+				"project_key": projectKey,
+			},
+			[]string{},
+			map[string]interface{}{})
+		g.Resources = append(g.Resources, resource)
+	}
+	return nil
+}
+
+func (g *MetricGenerator) InitResources() error {
+	ctx := g.GetArgs()["ctx"].(context.Context)
+	client := g.GetArgs()["client"].(*ldapi.APIClient)
+
+	projects, err := getProjects(ctx, client)
+	if err != nil {
+		return err
+	}
+	for _, project := range projects {
+		if err := g.loadMetrics(ctx, client, project.Key); err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/providers/launchdarkly/raw_api.go
+++ b/providers/launchdarkly/raw_api.go
@@ -1,0 +1,61 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package launchdarkly
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strings"
+
+	ldapi "github.com/launchdarkly/api-client-go/v16"
+)
+
+const (
+	launchDarklyAPIBasePath     = "https://app.launchdarkly.com/api/v2"
+	launchDarklyDefaultPageSize = 20
+)
+
+func getLaunchDarklyAPI(ctx context.Context, apiKey, path string, target interface{}) error {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, launchDarklyAPIURL(path), nil)
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Accept", "application/json")
+	req.Header.Set("Authorization", apiKey)
+	req.Header.Set("LD-API-Version", APIVersion)
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode < http.StatusOK || resp.StatusCode >= http.StatusMultipleChoices {
+		return fmt.Errorf("launchdarkly GET %s failed: %s", path, resp.Status)
+	}
+
+	return json.NewDecoder(resp.Body).Decode(target)
+}
+
+func launchDarklyAPIURL(path string) string {
+	switch {
+	case strings.HasPrefix(path, "https://"), strings.HasPrefix(path, "http://"):
+		return path
+	case strings.HasPrefix(path, "/api/v2"):
+		return "https://app.launchdarkly.com" + path
+	case strings.HasPrefix(path, "/"):
+		return launchDarklyAPIBasePath + path
+	default:
+		return launchDarklyAPIBasePath + "/" + path
+	}
+}
+
+func nextPagePath(links map[string]ldapi.Link) string {
+	next, ok := links["next"]
+	if !ok || next.Href == nil {
+		return ""
+	}
+	return *next.Href
+}

--- a/providers/launchdarkly/relay_proxy_configuration.go
+++ b/providers/launchdarkly/relay_proxy_configuration.go
@@ -1,0 +1,40 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package launchdarkly
+
+import (
+	"context"
+
+	"github.com/chenrui333/terraformer/terraformutils"
+	ldapi "github.com/launchdarkly/api-client-go/v16"
+)
+
+type RelayProxyConfigurationGenerator struct {
+	LaunchDarklyService
+}
+
+func (g *RelayProxyConfigurationGenerator) loadRelayProxyConfigurations(ctx context.Context, client *ldapi.APIClient) error {
+	configs, _, err := client.RelayProxyConfigurationsApi.GetRelayProxyConfigs(ctx).Execute()
+	if err != nil {
+		return err
+	}
+	if configs == nil {
+		return nil
+	}
+	for _, config := range configs.Items {
+		resource := terraformutils.NewResource(
+			config.Id,
+			resourceName(config.Name, config.Id),
+			"launchdarkly_relay_proxy_configuration",
+			"launchdarkly",
+			map[string]string{},
+			[]string{},
+			map[string]interface{}{})
+		g.Resources = append(g.Resources, resource)
+	}
+	return nil
+}
+
+func (g *RelayProxyConfigurationGenerator) InitResources() error {
+	return g.loadRelayProxyConfigurations(g.GetArgs()["ctx"].(context.Context), g.GetArgs()["client"].(*ldapi.APIClient))
+}

--- a/providers/launchdarkly/relay_proxy_configuration.go
+++ b/providers/launchdarkly/relay_proxy_configuration.go
@@ -14,7 +14,10 @@ type RelayProxyConfigurationGenerator struct {
 }
 
 func (g *RelayProxyConfigurationGenerator) loadRelayProxyConfigurations(ctx context.Context, client *ldapi.APIClient) error {
-	configs, _, err := client.RelayProxyConfigurationsApi.GetRelayProxyConfigs(ctx).Execute()
+	configs, resp, err := client.RelayProxyConfigurationsApi.GetRelayProxyConfigs(ctx).Execute()
+	if resp != nil && resp.Body != nil {
+		_ = resp.Body.Close()
+	}
 	if err != nil {
 		return err
 	}

--- a/providers/launchdarkly/resource_name.go
+++ b/providers/launchdarkly/resource_name.go
@@ -1,0 +1,10 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package launchdarkly
+
+func resourceName(name, fallback string) string {
+	if name != "" {
+		return name
+	}
+	return fallback
+}

--- a/providers/launchdarkly/team.go
+++ b/providers/launchdarkly/team.go
@@ -1,0 +1,53 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package launchdarkly
+
+import (
+	"context"
+
+	"github.com/chenrui333/terraformer/terraformutils"
+	ldapi "github.com/launchdarkly/api-client-go/v16"
+)
+
+type TeamGenerator struct {
+	LaunchDarklyService
+}
+
+func (g *TeamGenerator) loadTeams(ctx context.Context, client *ldapi.APIClient) error {
+	var allTeams []ldapi.Team
+	for offset := int64(0); ; offset += pageSize {
+		teams, _, err := client.TeamsApi.GetTeams(ctx).
+			Limit(pageSize).
+			Offset(offset).
+			Execute()
+		if err != nil {
+			return err
+		}
+		if teams == nil {
+			break
+		}
+		allTeams = append(allTeams, teams.Items...)
+		if teams.TotalCount == nil || int64(len(allTeams)) >= int64(*teams.TotalCount) {
+			break
+		}
+	}
+	for _, team := range allTeams {
+		teamKey := team.GetKey()
+		resource := terraformutils.NewResource(
+			teamKey,
+			resourceName(team.GetName(), teamKey),
+			"launchdarkly_team",
+			"launchdarkly",
+			map[string]string{
+				"key": teamKey,
+			},
+			[]string{},
+			map[string]interface{}{})
+		g.Resources = append(g.Resources, resource)
+	}
+	return nil
+}
+
+func (g *TeamGenerator) InitResources() error {
+	return g.loadTeams(g.GetArgs()["ctx"].(context.Context), g.GetArgs()["client"].(*ldapi.APIClient))
+}

--- a/providers/launchdarkly/team.go
+++ b/providers/launchdarkly/team.go
@@ -16,10 +16,13 @@ type TeamGenerator struct {
 func (g *TeamGenerator) loadTeams(ctx context.Context, client *ldapi.APIClient) error {
 	var allTeams []ldapi.Team
 	for offset := int64(0); ; offset += pageSize {
-		teams, _, err := client.TeamsApi.GetTeams(ctx).
+		teams, resp, err := client.TeamsApi.GetTeams(ctx).
 			Limit(pageSize).
 			Offset(offset).
 			Execute()
+		if resp != nil && resp.Body != nil {
+			_ = resp.Body.Close()
+		}
 		if err != nil {
 			return err
 		}

--- a/providers/launchdarkly/team_member.go
+++ b/providers/launchdarkly/team_member.go
@@ -1,0 +1,50 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package launchdarkly
+
+import (
+	"context"
+
+	"github.com/chenrui333/terraformer/terraformutils"
+	ldapi "github.com/launchdarkly/api-client-go/v16"
+)
+
+type TeamMemberGenerator struct {
+	LaunchDarklyService
+}
+
+func (g *TeamMemberGenerator) loadTeamMembers(ctx context.Context, client *ldapi.APIClient) error {
+	var allMembers []ldapi.Member
+	for offset := int64(0); ; offset += pageSize {
+		members, _, err := client.AccountMembersApi.GetMembers(ctx).
+			Limit(pageSize).
+			Offset(offset).
+			Execute()
+		if err != nil {
+			return err
+		}
+		if members == nil {
+			break
+		}
+		allMembers = append(allMembers, members.Items...)
+		if members.TotalCount == nil || int64(len(allMembers)) >= int64(*members.TotalCount) {
+			break
+		}
+	}
+	for _, member := range allMembers {
+		resource := terraformutils.NewResource(
+			member.Id,
+			resourceName(member.Email, member.Id),
+			"launchdarkly_team_member",
+			"launchdarkly",
+			map[string]string{},
+			[]string{},
+			map[string]interface{}{})
+		g.Resources = append(g.Resources, resource)
+	}
+	return nil
+}
+
+func (g *TeamMemberGenerator) InitResources() error {
+	return g.loadTeamMembers(g.GetArgs()["ctx"].(context.Context), g.GetArgs()["client"].(*ldapi.APIClient))
+}

--- a/providers/launchdarkly/team_member.go
+++ b/providers/launchdarkly/team_member.go
@@ -16,10 +16,13 @@ type TeamMemberGenerator struct {
 func (g *TeamMemberGenerator) loadTeamMembers(ctx context.Context, client *ldapi.APIClient) error {
 	var allMembers []ldapi.Member
 	for offset := int64(0); ; offset += pageSize {
-		members, _, err := client.AccountMembersApi.GetMembers(ctx).
+		members, resp, err := client.AccountMembersApi.GetMembers(ctx).
 			Limit(pageSize).
 			Offset(offset).
 			Execute()
+		if resp != nil && resp.Body != nil {
+			_ = resp.Body.Close()
+		}
 		if err != nil {
 			return err
 		}

--- a/providers/launchdarkly/webhook.go
+++ b/providers/launchdarkly/webhook.go
@@ -13,28 +13,29 @@ type WebhookGenerator struct {
 	LaunchDarklyService
 }
 
-func (g *WebhookGenerator) loadWebhooks(ctx context.Context, client *ldapi.APIClient) error {
-	webhooks, _, err := client.WebhooksApi.GetAllWebhooks(ctx).Execute()
-	if err != nil {
-		return err
-	}
-	if webhooks == nil {
-		return nil
-	}
-	for _, webhook := range webhooks.Items {
-		resource := terraformutils.NewResource(
-			webhook.Id,
-			resourceName(webhook.GetName(), webhook.Id),
-			"launchdarkly_webhook",
-			"launchdarkly",
-			map[string]string{},
-			[]string{},
-			map[string]interface{}{})
-		g.Resources = append(g.Resources, resource)
+func (g *WebhookGenerator) loadWebhooks(ctx context.Context, apiKey string) error {
+	for path := "/webhooks"; path != ""; {
+		webhooks := &ldapi.Webhooks{}
+		if err := getLaunchDarklyAPI(ctx, apiKey, path, webhooks); err != nil {
+			return err
+		}
+
+		for _, webhook := range webhooks.GetItems() {
+			resource := terraformutils.NewResource(
+				webhook.Id,
+				resourceName(webhook.GetName(), webhook.Id),
+				"launchdarkly_webhook",
+				"launchdarkly",
+				map[string]string{},
+				[]string{},
+				map[string]interface{}{})
+			g.Resources = append(g.Resources, resource)
+		}
+		path = nextPagePath(webhooks.GetLinks())
 	}
 	return nil
 }
 
 func (g *WebhookGenerator) InitResources() error {
-	return g.loadWebhooks(g.GetArgs()["ctx"].(context.Context), g.GetArgs()["client"].(*ldapi.APIClient))
+	return g.loadWebhooks(g.GetArgs()["ctx"].(context.Context), g.GetArgs()["api_key"].(string))
 }

--- a/providers/launchdarkly/webhook.go
+++ b/providers/launchdarkly/webhook.go
@@ -1,0 +1,40 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package launchdarkly
+
+import (
+	"context"
+
+	"github.com/chenrui333/terraformer/terraformutils"
+	ldapi "github.com/launchdarkly/api-client-go/v16"
+)
+
+type WebhookGenerator struct {
+	LaunchDarklyService
+}
+
+func (g *WebhookGenerator) loadWebhooks(ctx context.Context, client *ldapi.APIClient) error {
+	webhooks, _, err := client.WebhooksApi.GetAllWebhooks(ctx).Execute()
+	if err != nil {
+		return err
+	}
+	if webhooks == nil {
+		return nil
+	}
+	for _, webhook := range webhooks.Items {
+		resource := terraformutils.NewResource(
+			webhook.Id,
+			resourceName(webhook.GetName(), webhook.Id),
+			"launchdarkly_webhook",
+			"launchdarkly",
+			map[string]string{},
+			[]string{},
+			map[string]interface{}{})
+		g.Resources = append(g.Resources, resource)
+	}
+	return nil
+}
+
+func (g *WebhookGenerator) InitResources() error {
+	return g.loadWebhooks(g.GetArgs()["ctx"].(context.Context), g.GetArgs()["client"].(*ldapi.APIClient))
+}


### PR DESCRIPTION
## Summary
- Add LaunchDarkly import generators for custom roles, flag templates, metrics, relay proxy configurations, teams, team members, and webhooks.
- Register the new LaunchDarkly services and document their Terraform resource types.
- Keep higher-risk gaps such as destinations, access tokens, audit log subscriptions, flag triggers, AI resources, and views out of this batch.

## Notes
- This branch is based on the latest `main` after PR #225.
- No LaunchDarkly dependency changes are included.
