### PR TITLE
feat(kubernetes): import more api resources

### DIFF
--- a/docs/kubernetes.md
+++ b/docs/kubernetes.md
@@ -7,10 +7,14 @@ Example:
  terraformer import kubernetes --resources=deployments,services,storageclasses --filter=deployment=name1:name2:name3
 ```
 
-Terraformer discovers Kubernetes API resources from the active cluster and imports resources that are available through both the typed Kubernetes client and the installed Terraform Kubernetes provider schema.
+Terraformer discovers Kubernetes API resources from the active cluster and imports resources that are available through either the typed Kubernetes client or an explicit dynamic-client import path, and the installed Terraform Kubernetes provider schema.
 
 Common supported resources include:
 
+*   `apiservices`
+    * `kubernetes_api_service_v1`
+*   `certificatesigningrequests`
+    * `kubernetes_certificate_signing_request_v1`
 *   `clusterroles`
     * `kubernetes_cluster_role_v1`
 *   `clusterrolebindings`
@@ -31,6 +35,7 @@ Common supported resources include:
     * `kubernetes_endpoint_slice_v1`
 *   `horizontalpodautoscalers`
     * `kubernetes_horizontal_pod_autoscaler_v2`
+    * `kubernetes_horizontal_pod_autoscaler_v2beta2`
 *   `ingressclasses`
     * `kubernetes_ingress_class_v1`
 *   `ingresses`
@@ -51,6 +56,8 @@ Common supported resources include:
     * `kubernetes_persistent_volume_claim_v1`
 *   `pods`
     * `kubernetes_pod_v1`
+*   `podsecuritypolicies`
+    * `kubernetes_pod_security_policy`
 *   `poddisruptionbudgets`
     * `kubernetes_pod_disruption_budget_v1`
 *   `priorityclasses`

--- a/providers/kubernetes/kind.go
+++ b/providers/kubernetes/kind.go
@@ -4,21 +4,26 @@ package kubernetes
 
 import (
 	"context"
+	"fmt"
 	"reflect"
 
 	"github.com/chenrui333/terraformer/terraformutils"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/kubernetes"
 )
 
 type Kind struct {
 	KubernetesService
-	Name          string
-	Group         string
-	Version       string
-	Namespaced    bool
-	TerraformType string
+	Name             string
+	ResourceName     string
+	Group            string
+	Version          string
+	Namespaced       bool
+	TerraformType    string
+	UseDynamicClient bool
 }
 
 // Generate TerraformResources from Kubernetes API,
@@ -30,11 +35,23 @@ func (k *Kind) InitResources() error {
 		return err
 	}
 
+	if k.UseDynamicClient {
+		client, err := dynamic.NewForConfig(config)
+		if err != nil {
+			return err
+		}
+		return k.initDynamicResources(client)
+	}
+
 	clientset, err := kubernetes.NewForConfig(config)
 	if err != nil {
 		return err
 	}
 
+	return k.initTypedResources(clientset)
+}
+
+func (k *Kind) initTypedResources(clientset kubernetes.Interface) error {
 	group := reflect.ValueOf(clientset).MethodByName(
 		extractClientSetFuncGroupName(k.Group, k.Version)).Call(
 		[]reflect.Value{})[0]
@@ -54,11 +71,7 @@ func (k *Kind) InitResources() error {
 		return results[1].Interface().(error)
 	}
 	items := reflect.Indirect(results[0]).FieldByName("Items")
-
-	terraformType := k.TerraformType
-	if terraformType == "" {
-		terraformType = extractTfResourceName(k.Name)
-	}
+	terraformType := k.terraformType()
 
 	for i := 0; i < items.Len(); i++ {
 		item := items.Index(i)
@@ -83,4 +96,58 @@ func (k *Kind) InitResources() error {
 		))
 	}
 	return nil
+}
+
+func (k *Kind) initDynamicResources(client dynamic.Interface) error {
+	if k.ResourceName == "" {
+		return fmt.Errorf("kubernetes: resource name is required for dynamic resource %s", k.Name)
+	}
+
+	resource := client.Resource(schema.GroupVersionResource{
+		Group:    k.Group,
+		Version:  k.Version,
+		Resource: k.ResourceName,
+	})
+
+	listClient := dynamic.ResourceInterface(resource)
+	if k.Namespaced {
+		listClient = resource.Namespace(metav1.NamespaceAll)
+	}
+
+	results, err := listClient.List(context.Background(), metav1.ListOptions{})
+	if err != nil {
+		return err
+	}
+
+	terraformType := k.terraformType()
+	for i := range results.Items {
+		item := results.Items[i]
+		// Filter to resources that aren't owned by any other resource.
+		if len(item.GetOwnerReferences()) > 0 {
+			continue
+		}
+
+		name := ""
+		if k.Namespaced {
+			name = item.GetNamespace() + "/" + item.GetName()
+		} else {
+			name = item.GetName()
+		}
+
+		k.Resources = append(k.Resources, terraformutils.NewSimpleResource(
+			name,
+			name,
+			terraformType,
+			"kubernetes",
+			[]string{},
+		))
+	}
+	return nil
+}
+
+func (k *Kind) terraformType() string {
+	if k.TerraformType != "" {
+		return k.TerraformType
+	}
+	return extractTfResourceName(k.Name)
 }

--- a/providers/kubernetes/kind_test.go
+++ b/providers/kubernetes/kind_test.go
@@ -1,0 +1,112 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package kubernetes
+
+import (
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	dynamicfake "k8s.io/client-go/dynamic/fake"
+)
+
+func TestInitDynamicResources(t *testing.T) {
+	gvr := schema.GroupVersionResource{
+		Group:    "apiregistration.k8s.io",
+		Version:  "v1",
+		Resource: "apiservices",
+	}
+	apiService := newUnstructured("apiregistration.k8s.io/v1", "APIService", "v1.apps.example.com", "")
+	ownedAPIService := newUnstructured("apiregistration.k8s.io/v1", "APIService", "owned.example.com", "")
+	ownedAPIService.SetOwnerReferences([]metav1.OwnerReference{{
+		APIVersion: "v1",
+		Kind:       "ConfigMap",
+		Name:       "owner",
+		UID:        "owner-uid",
+	}})
+
+	client := dynamicfake.NewSimpleDynamicClientWithCustomListKinds(
+		runtime.NewScheme(),
+		map[schema.GroupVersionResource]string{gvr: "APIServiceList"},
+		apiService,
+		ownedAPIService,
+	)
+
+	kind := &Kind{
+		Group:         "apiregistration.k8s.io",
+		Version:       "v1",
+		Name:          "APIService",
+		ResourceName:  "apiservices",
+		TerraformType: "kubernetes_api_service_v1",
+	}
+	if err := kind.initDynamicResources(client); err != nil {
+		t.Fatalf("initDynamicResources() error = %v", err)
+	}
+
+	if len(kind.Resources) != 1 {
+		t.Fatalf("Resources len = %d, want 1", len(kind.Resources))
+	}
+	resource := kind.Resources[0]
+	if resource.InstanceState.ID != "v1.apps.example.com" {
+		t.Fatalf("resource ID = %q, want %q", resource.InstanceState.ID, "v1.apps.example.com")
+	}
+	if resource.InstanceInfo.Type != "kubernetes_api_service_v1" {
+		t.Fatalf("resource type = %q, want %q", resource.InstanceInfo.Type, "kubernetes_api_service_v1")
+	}
+}
+
+func TestInitDynamicResourcesNamespaced(t *testing.T) {
+	gvr := schema.GroupVersionResource{
+		Group:    "example.com",
+		Version:  "v1",
+		Resource: "widgets",
+	}
+	widget := newUnstructured("example.com/v1", "Widget", "sample", "default")
+	client := dynamicfake.NewSimpleDynamicClientWithCustomListKinds(
+		runtime.NewScheme(),
+		map[schema.GroupVersionResource]string{gvr: "WidgetList"},
+		widget,
+	)
+
+	kind := &Kind{
+		Group:        "example.com",
+		Version:      "v1",
+		Name:         "Widget",
+		ResourceName: "widgets",
+		Namespaced:   true,
+	}
+	if err := kind.initDynamicResources(client); err != nil {
+		t.Fatalf("initDynamicResources() error = %v", err)
+	}
+
+	if len(kind.Resources) != 1 {
+		t.Fatalf("Resources len = %d, want 1", len(kind.Resources))
+	}
+	resource := kind.Resources[0]
+	if resource.InstanceState.ID != "default/sample" {
+		t.Fatalf("resource ID = %q, want %q", resource.InstanceState.ID, "default/sample")
+	}
+	if resource.InstanceInfo.Type != "kubernetes_widget" {
+		t.Fatalf("resource type = %q, want %q", resource.InstanceInfo.Type, "kubernetes_widget")
+	}
+}
+
+func TestInitDynamicResourcesRequiresResourceName(t *testing.T) {
+	client := dynamicfake.NewSimpleDynamicClient(runtime.NewScheme())
+	kind := &Kind{Name: "APIService"}
+
+	if err := kind.initDynamicResources(client); err == nil {
+		t.Fatal("initDynamicResources() error = nil, want error")
+	}
+}
+
+func newUnstructured(apiVersion, kind, name, namespace string) *unstructured.Unstructured {
+	resource := &unstructured.Unstructured{}
+	resource.SetAPIVersion(apiVersion)
+	resource.SetKind(kind)
+	resource.SetName(name)
+	resource.SetNamespace(namespace)
+	return resource
+}

--- a/providers/kubernetes/kubernetes_provider.go
+++ b/providers/kubernetes/kubernetes_provider.go
@@ -121,17 +121,22 @@ func (p *KubernetesProvider) GetSupportedService() map[string]terraformutils.Ser
 				continue
 			}
 
-			// filter to resources available through the typed client-go Clientset
+			useDynamicClient := false
 			if !supportsTypedClientResource(clientset, gv.Group, gv.Version, resource.Kind) {
-				continue
+				if !supportsDynamicClientResource(gv.Group, gv.Version, resource.Kind) {
+					continue
+				}
+				useDynamicClient = true
 			}
 
 			resources[resource.Name] = &Kind{
-				Group:         gv.Group,
-				Version:       gv.Version,
-				Name:          resource.Kind,
-				Namespaced:    resource.Namespaced,
-				TerraformType: terraformResourceName,
+				Group:            gv.Group,
+				Version:          gv.Version,
+				Name:             resource.Kind,
+				ResourceName:     resource.Name,
+				Namespaced:       resource.Namespaced,
+				TerraformType:    terraformResourceName,
+				UseDynamicClient: useDynamicClient,
 			}
 		}
 	}

--- a/providers/kubernetes/utils.go
+++ b/providers/kubernetes/utils.go
@@ -18,6 +18,8 @@ type kubernetesResourceID struct {
 }
 
 var preferredTerraformResourceNames = map[kubernetesResourceID][]string{
+	{group: "apiregistration.k8s.io", version: "v1", kind: "APIService"}:                                {"kubernetes_api_service_v1", "kubernetes_api_service"},
+	{group: "apiregistration.k8s.io", version: "v1beta1", kind: "APIService"}:                           {"kubernetes_api_service"},
 	{group: "apps", version: "v1", kind: "DaemonSet"}:                                                   {"kubernetes_daemon_set_v1", "kubernetes_daemonset"},
 	{group: "apps", version: "v1", kind: "Deployment"}:                                                  {"kubernetes_deployment_v1", "kubernetes_deployment"},
 	{group: "apps", version: "v1", kind: "StatefulSet"}:                                                 {"kubernetes_stateful_set_v1", "kubernetes_stateful_set"},
@@ -25,9 +27,12 @@ var preferredTerraformResourceNames = map[kubernetesResourceID][]string{
 	{group: "apps", version: "v1beta2", kind: "DaemonSet"}:                                              {"kubernetes_daemonset"},
 	{group: "autoscaling", version: "v1", kind: "HorizontalPodAutoscaler"}:                              {"kubernetes_horizontal_pod_autoscaler_v1", "kubernetes_horizontal_pod_autoscaler"},
 	{group: "autoscaling", version: "v2", kind: "HorizontalPodAutoscaler"}:                              {"kubernetes_horizontal_pod_autoscaler_v2", "kubernetes_horizontal_pod_autoscaler"},
+	{group: "autoscaling", version: "v2beta2", kind: "HorizontalPodAutoscaler"}:                         {"kubernetes_horizontal_pod_autoscaler_v2beta2", "kubernetes_horizontal_pod_autoscaler"},
 	{group: "batch", version: "v1", kind: "CronJob"}:                                                    {"kubernetes_cron_job_v1", "kubernetes_cron_job"},
 	{group: "batch", version: "v1", kind: "Job"}:                                                        {"kubernetes_job_v1", "kubernetes_job"},
 	{group: "batch", version: "v1beta1", kind: "CronJob"}:                                               {"kubernetes_cron_job"},
+	{group: "certificates.k8s.io", version: "v1", kind: "CertificateSigningRequest"}:                    {"kubernetes_certificate_signing_request_v1", "kubernetes_certificate_signing_request"},
+	{group: "certificates.k8s.io", version: "v1beta1", kind: "CertificateSigningRequest"}:               {"kubernetes_certificate_signing_request"},
 	{group: "discovery.k8s.io", version: "v1", kind: "EndpointSlice"}:                                   {"kubernetes_endpoint_slice_v1"},
 	{group: "extensions", version: "v1beta1", kind: "DaemonSet"}:                                        {"kubernetes_daemonset"},
 	{group: "extensions", version: "v1beta1", kind: "Ingress"}:                                          {"kubernetes_ingress"},
@@ -44,6 +49,7 @@ var preferredTerraformResourceNames = map[kubernetesResourceID][]string{
 	{group: "node.k8s.io", version: "v1", kind: "RuntimeClass"}:                                         {"kubernetes_runtime_class_v1"},
 	{group: "policy", version: "v1", kind: "PodDisruptionBudget"}:                                       {"kubernetes_pod_disruption_budget_v1", "kubernetes_pod_disruption_budget"},
 	{group: "policy", version: "v1beta1", kind: "PodDisruptionBudget"}:                                  {"kubernetes_pod_disruption_budget"},
+	{group: "policy", version: "v1beta1", kind: "PodSecurityPolicy"}:                                    {"kubernetes_pod_security_policy"},
 	{group: "scheduling.k8s.io", version: "v1", kind: "PriorityClass"}:                                  {"kubernetes_priority_class_v1", "kubernetes_priority_class"},
 	{group: "scheduling.k8s.io", version: "v1beta1", kind: "PriorityClass"}:                             {"kubernetes_priority_class"},
 	{group: "storage.k8s.io", version: "v1", kind: "CSIDriver"}:                                         {"kubernetes_csi_driver_v1", "kubernetes_csi_driver"},
@@ -66,6 +72,15 @@ var preferredTerraformResourceNames = map[kubernetesResourceID][]string{
 	{group: "admissionregistration.k8s.io", version: "v1", kind: "ValidatingWebhookConfiguration"}:      {"kubernetes_validating_webhook_configuration_v1", "kubernetes_validating_webhook_configuration"},
 	{group: "admissionregistration.k8s.io", version: "v1beta1", kind: "MutatingWebhookConfiguration"}:   {"kubernetes_mutating_webhook_configuration"},
 	{group: "admissionregistration.k8s.io", version: "v1beta1", kind: "ValidatingWebhookConfiguration"}: {"kubernetes_validating_webhook_configuration"},
+}
+
+// Dynamic imports are limited to provider resources that are importable but not
+// exposed through kubernetes.Interface in the pinned client-go version.
+var dynamicClientResources = map[kubernetesResourceID]struct{}{
+	{group: "apiregistration.k8s.io", version: "v1", kind: "APIService"}:        {},
+	{group: "apiregistration.k8s.io", version: "v1beta1", kind: "APIService"}:   {},
+	{group: "autoscaling", version: "v2beta2", kind: "HorizontalPodAutoscaler"}: {},
+	{group: "policy", version: "v1beta1", kind: "PodSecurityPolicy"}:            {},
 }
 
 func extractClientSetFuncGroupName(group, version string) string {
@@ -112,6 +127,11 @@ func selectTerraformResourceName(group, version, kind string, hasResourceType fu
 		}
 	}
 	return "", false
+}
+
+func supportsDynamicClientResource(group, version, kind string) bool {
+	_, ok := dynamicClientResources[kubernetesResourceID{group: group, version: version, kind: kind}]
+	return ok
 }
 
 func supportsTypedClientResource(clientset kubernetes.Interface, group, version, kind string) (ok bool) {

--- a/providers/kubernetes/utils_test.go
+++ b/providers/kubernetes/utils_test.go
@@ -52,11 +52,32 @@ func TestTerraformResourceNameCandidates(t *testing.T) {
 			want:    []string{"kubernetes_pod_disruption_budget"},
 		},
 		{
+			name:    "uses legacy pod security policy name for policy beta",
+			group:   "policy",
+			version: "v1beta1",
+			kind:    "PodSecurityPolicy",
+			want:    []string{"kubernetes_pod_security_policy"},
+		},
+		{
 			name:    "prefers autoscaling v2 hpa name",
 			group:   "autoscaling",
 			version: "v2",
 			kind:    "HorizontalPodAutoscaler",
 			want:    []string{"kubernetes_horizontal_pod_autoscaler_v2", "kubernetes_horizontal_pod_autoscaler"},
+		},
+		{
+			name:    "prefers autoscaling v2beta2 hpa name",
+			group:   "autoscaling",
+			version: "v2beta2",
+			kind:    "HorizontalPodAutoscaler",
+			want:    []string{"kubernetes_horizontal_pod_autoscaler_v2beta2", "kubernetes_horizontal_pod_autoscaler"},
+		},
+		{
+			name:    "prefers certificate signing request v1 name",
+			group:   "certificates.k8s.io",
+			version: "v1",
+			kind:    "CertificateSigningRequest",
+			want:    []string{"kubernetes_certificate_signing_request_v1", "kubernetes_certificate_signing_request"},
 		},
 		{
 			name:    "prefers csi driver v1 name",
@@ -85,6 +106,20 @@ func TestTerraformResourceNameCandidates(t *testing.T) {
 			version: "v1",
 			kind:    "RuntimeClass",
 			want:    []string{"kubernetes_runtime_class_v1", "kubernetes_runtime_class"},
+		},
+		{
+			name:    "prefers api service v1 name",
+			group:   "apiregistration.k8s.io",
+			version: "v1",
+			kind:    "APIService",
+			want:    []string{"kubernetes_api_service_v1", "kubernetes_api_service"},
+		},
+		{
+			name:    "prefers legacy api service name for beta API",
+			group:   "apiregistration.k8s.io",
+			version: "v1beta1",
+			kind:    "APIService",
+			want:    []string{"kubernetes_api_service"},
 		},
 	}
 
@@ -190,6 +225,17 @@ func TestSelectTerraformResourceName(t *testing.T) {
 			wantOK: true,
 		},
 		{
+			name:    "selects pod security policy for policy beta API",
+			group:   "policy",
+			version: "v1beta1",
+			kind:    "PodSecurityPolicy",
+			supportedTypes: map[string]struct{}{
+				"kubernetes_pod_security_policy": {},
+			},
+			want:   "kubernetes_pod_security_policy",
+			wantOK: true,
+		},
+		{
 			name:    "prefers legacy cron job for beta API",
 			group:   "batch",
 			version: "v1beta1",
@@ -211,6 +257,42 @@ func TestSelectTerraformResourceName(t *testing.T) {
 				"kubernetes_horizontal_pod_autoscaler_v2": {},
 			},
 			want:   "kubernetes_horizontal_pod_autoscaler_v2",
+			wantOK: true,
+		},
+		{
+			name:    "selects autoscaling v2beta2 hpa for v2beta2 API",
+			group:   "autoscaling",
+			version: "v2beta2",
+			kind:    "HorizontalPodAutoscaler",
+			supportedTypes: map[string]struct{}{
+				"kubernetes_horizontal_pod_autoscaler":         {},
+				"kubernetes_horizontal_pod_autoscaler_v2beta2": {},
+			},
+			want:   "kubernetes_horizontal_pod_autoscaler_v2beta2",
+			wantOK: true,
+		},
+		{
+			name:    "selects certificate signing request v1 for certificates v1 API",
+			group:   "certificates.k8s.io",
+			version: "v1",
+			kind:    "CertificateSigningRequest",
+			supportedTypes: map[string]struct{}{
+				"kubernetes_certificate_signing_request":    {},
+				"kubernetes_certificate_signing_request_v1": {},
+			},
+			want:   "kubernetes_certificate_signing_request_v1",
+			wantOK: true,
+		},
+		{
+			name:    "prefers legacy certificate signing request for certificates beta API",
+			group:   "certificates.k8s.io",
+			version: "v1beta1",
+			kind:    "CertificateSigningRequest",
+			supportedTypes: map[string]struct{}{
+				"kubernetes_certificate_signing_request":    {},
+				"kubernetes_certificate_signing_request_v1": {},
+			},
+			want:   "kubernetes_certificate_signing_request",
 			wantOK: true,
 		},
 		{
@@ -270,6 +352,30 @@ func TestSelectTerraformResourceName(t *testing.T) {
 				"kubernetes_validating_admission_policy_v1": {},
 			},
 			want:   "kubernetes_validating_admission_policy_v1",
+			wantOK: true,
+		},
+		{
+			name:    "selects api service v1 for apiregistration v1 API",
+			group:   "apiregistration.k8s.io",
+			version: "v1",
+			kind:    "APIService",
+			supportedTypes: map[string]struct{}{
+				"kubernetes_api_service":    {},
+				"kubernetes_api_service_v1": {},
+			},
+			want:   "kubernetes_api_service_v1",
+			wantOK: true,
+		},
+		{
+			name:    "prefers legacy api service for apiregistration beta API",
+			group:   "apiregistration.k8s.io",
+			version: "v1beta1",
+			kind:    "APIService",
+			supportedTypes: map[string]struct{}{
+				"kubernetes_api_service":    {},
+				"kubernetes_api_service_v1": {},
+			},
+			want:   "kubernetes_api_service",
 			wantOK: true,
 		},
 		{
@@ -360,6 +466,32 @@ func TestSelectTerraformResourceNameStableV1Aliases(t *testing.T) {
 	}
 }
 
+func TestSupportsDynamicClientResource(t *testing.T) {
+	tests := []struct {
+		name    string
+		group   string
+		version string
+		kind    string
+		want    bool
+	}{
+		{name: "api service v1", group: "apiregistration.k8s.io", version: "v1", kind: "APIService", want: true},
+		{name: "api service beta", group: "apiregistration.k8s.io", version: "v1beta1", kind: "APIService", want: true},
+		{name: "autoscaling v2beta2 hpa", group: "autoscaling", version: "v2beta2", kind: "HorizontalPodAutoscaler", want: true},
+		{name: "pod security policy beta", group: "policy", version: "v1beta1", kind: "PodSecurityPolicy", want: true},
+		{name: "typed core resource", version: "v1", kind: "Service", want: false},
+		{name: "unknown resource", group: "example.com", version: "v1", kind: "Widget", want: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := supportsDynamicClientResource(tt.group, tt.version, tt.kind)
+			if got != tt.want {
+				t.Fatalf("supportsDynamicClientResource(%q, %q, %q) = %t, want %t", tt.group, tt.version, tt.kind, got, tt.want)
+			}
+		})
+	}
+}
+
 func TestSupportsTypedClientResource(t *testing.T) {
 	clientset := fake.NewSimpleClientset()
 
@@ -374,6 +506,8 @@ func TestSupportsTypedClientResource(t *testing.T) {
 		{name: "core endpoints", version: "v1", kind: "Endpoints", want: true},
 		{name: "apps daemon set", group: "apps", version: "v1", kind: "DaemonSet", want: true},
 		{name: "autoscaling hpa", group: "autoscaling", version: "v2", kind: "HorizontalPodAutoscaler", want: true},
+		{name: "autoscaling v2beta2 hpa is not exposed by kubernetes clientset", group: "autoscaling", version: "v2beta2", kind: "HorizontalPodAutoscaler", want: false},
+		{name: "certificate signing request", group: "certificates.k8s.io", version: "v1", kind: "CertificateSigningRequest", want: true},
 		{name: "storage csi driver", group: "storage.k8s.io", version: "v1", kind: "CSIDriver", want: true},
 		{name: "scheduling priority class", group: "scheduling.k8s.io", version: "v1", kind: "PriorityClass", want: true},
 		{name: "admission validating policy", group: "admissionregistration.k8s.io", version: "v1", kind: "ValidatingAdmissionPolicy", want: true},
@@ -381,6 +515,7 @@ func TestSupportsTypedClientResource(t *testing.T) {
 		{name: "discovery endpoint slice", group: "discovery.k8s.io", version: "v1", kind: "EndpointSlice", want: true},
 		{name: "node runtime class", group: "node.k8s.io", version: "v1", kind: "RuntimeClass", want: true},
 		{name: "api service is not exposed by kubernetes clientset", group: "apiregistration.k8s.io", version: "v1", kind: "APIService", want: false},
+		{name: "pod security policy is not exposed by kubernetes clientset", group: "policy", version: "v1beta1", kind: "PodSecurityPolicy", want: false},
 		{name: "unknown group", group: "example.com", version: "v1", kind: "Widget", want: false},
 	}
 


### PR DESCRIPTION
Summary
- add a dynamic-client import path for Kubernetes resources not exposed through the typed client-go Clientset
- enable APIService, autoscaling v2beta2 HPA, and PodSecurityPolicy discovery/import when the cluster and provider schema support them
- prefer v1 Terraform types for CertificateSigningRequest and APIService while preserving beta/legacy fallbacks
- document the newly covered Kubernetes resources

References
- Continues the Kubernetes resource gap work from #225
