### PR TITLE
fix(datadog): close API response bodies

### DIFF
--- a/providers/datadog/dashboard.go
+++ b/providers/datadog/dashboard.go
@@ -54,7 +54,10 @@ func (g *DashboardGenerator) InitResources() error {
 	for _, filter := range g.Filter {
 		if filter.FieldPath == "id" && filter.IsApplicable("dashboard") {
 			for _, value := range filter.AcceptableValues {
-				dashboard, _, err := api.GetDashboard(auth, value)
+				dashboard, httpResp, err := api.GetDashboard(auth, value)
+				if httpResp != nil && httpResp.Body != nil {
+					_ = httpResp.Body.Close()
+				}
 				if err != nil {
 					return err
 				}
@@ -69,7 +72,10 @@ func (g *DashboardGenerator) InitResources() error {
 		return nil
 	}
 
-	summary, _, err := api.ListDashboards(auth)
+	summary, httpResp, err := api.ListDashboards(auth)
+	if httpResp != nil && httpResp.Body != nil {
+		_ = httpResp.Body.Close()
+	}
 	if err != nil {
 		return err
 	}

--- a/providers/datadog/dashboard_json.go
+++ b/providers/datadog/dashboard_json.go
@@ -54,7 +54,10 @@ func (g *DashboardJSONGenerator) InitResources() error {
 	for _, filter := range g.Filter {
 		if filter.FieldPath == "id" && filter.IsApplicable("dashboard_json") {
 			for _, value := range filter.AcceptableValues {
-				dashboard, _, err := api.GetDashboard(auth, value)
+				dashboard, httpResp, err := api.GetDashboard(auth, value)
+				if httpResp != nil && httpResp.Body != nil {
+					_ = httpResp.Body.Close()
+				}
 				if err != nil {
 					return err
 				}
@@ -69,7 +72,10 @@ func (g *DashboardJSONGenerator) InitResources() error {
 		return nil
 	}
 
-	summary, _, err := api.ListDashboards(auth)
+	summary, httpResp, err := api.ListDashboards(auth)
+	if httpResp != nil && httpResp.Body != nil {
+		_ = httpResp.Body.Close()
+	}
 	if err != nil {
 		return err
 	}

--- a/providers/datadog/dashboard_list.go
+++ b/providers/datadog/dashboard_list.go
@@ -51,7 +51,10 @@ func (g *DashboardListGenerator) InitResources() error {
 	auth := g.Args["auth"].(context.Context)
 	api := datadogV1.NewDashboardListsApi(datadogClient)
 
-	dlResponse, _, err := api.ListDashboardLists(auth)
+	dlResponse, httpResp, err := api.ListDashboardLists(auth)
+	if httpResp != nil && httpResp.Body != nil {
+		_ = httpResp.Body.Close()
+	}
 	if err != nil {
 		return err
 	}

--- a/providers/datadog/downtime.go
+++ b/providers/datadog/downtime.go
@@ -61,7 +61,10 @@ func (g *DowntimeGenerator) InitResources() error {
 					return err
 				}
 
-				monitor, _, err := api.GetDowntime(auth, i)
+				monitor, httpResp, err := api.GetDowntime(auth, i)
+				if httpResp != nil && httpResp.Body != nil {
+					_ = httpResp.Body.Close()
+				}
 				if err != nil {
 					return err
 				}
@@ -76,7 +79,10 @@ func (g *DowntimeGenerator) InitResources() error {
 		return nil
 	}
 
-	downtimes, _, err := api.ListDowntimes(auth)
+	downtimes, httpResp, err := api.ListDowntimes(auth)
+	if httpResp != nil && httpResp.Body != nil {
+		_ = httpResp.Body.Close()
+	}
 	if err != nil {
 		return err
 	}

--- a/providers/datadog/integration_aws.go
+++ b/providers/datadog/integration_aws.go
@@ -51,7 +51,10 @@ func (g *IntegrationAWSGenerator) InitResources() error {
 	auth := g.Args["auth"].(context.Context)
 	api := datadogV1.NewAWSIntegrationApi(datadogClient)
 
-	integrations, _, err := api.ListAWSAccounts(auth)
+	integrations, httpResp, err := api.ListAWSAccounts(auth)
+	if httpResp != nil && httpResp.Body != nil {
+		_ = httpResp.Body.Close()
+	}
 	if err != nil {
 		return err
 	}

--- a/providers/datadog/integration_aws_lambda_arn.go
+++ b/providers/datadog/integration_aws_lambda_arn.go
@@ -55,7 +55,10 @@ func (g *IntegrationAWSLambdaARNGenerator) InitResources() error {
 	auth := g.Args["auth"].(context.Context)
 	api := datadogV1.NewAWSLogsIntegrationApi(datadogClient)
 
-	logCollections, _, err := api.ListAWSLogsIntegrations(auth)
+	logCollections, httpResp, err := api.ListAWSLogsIntegrations(auth)
+	if httpResp != nil && httpResp.Body != nil {
+		_ = httpResp.Body.Close()
+	}
 	if err != nil {
 		return err
 	}

--- a/providers/datadog/integration_aws_log_collection.go
+++ b/providers/datadog/integration_aws_log_collection.go
@@ -50,7 +50,10 @@ func (g *IntegrationAWSLogCollectionGenerator) InitResources() error {
 	auth := g.Args["auth"].(context.Context)
 	api := datadogV1.NewAWSLogsIntegrationApi(datadogClient)
 
-	logCollections, _, err := api.ListAWSLogsIntegrations(auth)
+	logCollections, httpResp, err := api.ListAWSLogsIntegrations(auth)
+	if httpResp != nil && httpResp.Body != nil {
+		_ = httpResp.Body.Close()
+	}
 	if err != nil {
 		return err
 	}

--- a/providers/datadog/integration_azure.go
+++ b/providers/datadog/integration_azure.go
@@ -50,7 +50,10 @@ func (g *IntegrationAzureGenerator) InitResources() error {
 	auth := g.Args["auth"].(context.Context)
 	api := datadogV1.NewAzureIntegrationApi(datadogClient)
 
-	integrations, _, err := api.ListAzureIntegration(auth)
+	integrations, httpResp, err := api.ListAzureIntegration(auth)
+	if httpResp != nil && httpResp.Body != nil {
+		_ = httpResp.Body.Close()
+	}
 	if err != nil {
 		return err
 	}

--- a/providers/datadog/integration_gcp.go
+++ b/providers/datadog/integration_gcp.go
@@ -51,7 +51,10 @@ func (g *IntegrationGCPGenerator) InitResources() error {
 	auth := g.Args["auth"].(context.Context)
 	api := datadogV1.NewGCPIntegrationApi(datadogClient)
 
-	integrations, _, err := api.ListGCPIntegration(auth)
+	integrations, httpResp, err := api.ListGCPIntegration(auth)
+	if httpResp != nil && httpResp.Body != nil {
+		_ = httpResp.Body.Close()
+	}
 	if err != nil {
 		return err
 	}

--- a/providers/datadog/integration_slack_channel.go
+++ b/providers/datadog/integration_slack_channel.go
@@ -54,7 +54,10 @@ func (g *IntegrationSlackChannelGenerator) InitResources() error {
 	for _, filter := range g.Filter {
 		if filter.FieldPath == "account_name" && filter.IsApplicable("integration_slack_channel") {
 			for _, value := range filter.AcceptableValues {
-				slackChannels, _, err := api.GetSlackIntegrationChannels(auth, value)
+				slackChannels, httpResp, err := api.GetSlackIntegrationChannels(auth, value)
+				if httpResp != nil && httpResp.Body != nil {
+					_ = httpResp.Body.Close()
+				}
 				if err != nil {
 					return err
 				}

--- a/providers/datadog/logs_archive.go
+++ b/providers/datadog/logs_archive.go
@@ -54,7 +54,10 @@ func (g *LogsArchiveGenerator) InitResources() error {
 	for _, filter := range g.Filter {
 		if filter.FieldPath == "id" && filter.IsApplicable("logs_archive") {
 			for _, value := range filter.AcceptableValues {
-				resp, _, err := api.GetLogsArchive(auth, value)
+				resp, httpResp, err := api.GetLogsArchive(auth, value)
+				if httpResp != nil && httpResp.Body != nil {
+					_ = httpResp.Body.Close()
+				}
 				if err != nil {
 					return err
 				}
@@ -69,11 +72,14 @@ func (g *LogsArchiveGenerator) InitResources() error {
 		return nil
 	}
 
-	logsArchiveListResp, _, err := api.ListLogsArchives(auth)
-	logsArchiveList := logsArchiveListResp.GetData()
+	logsArchiveListResp, httpResp, err := api.ListLogsArchives(auth)
+	if httpResp != nil && httpResp.Body != nil {
+		_ = httpResp.Body.Close()
+	}
 	if err != nil {
 		return err
 	}
+	logsArchiveList := logsArchiveListResp.GetData()
 	g.Resources = g.createResources(logsArchiveList)
 	return nil
 }

--- a/providers/datadog/logs_custom_pipeline.go
+++ b/providers/datadog/logs_custom_pipeline.go
@@ -59,7 +59,10 @@ func (g *LogsCustomPipelineGenerator) InitResources() error {
 	for _, filter := range g.Filter {
 		if filter.FieldPath == "id" && filter.IsApplicable("logs_custom_pipeline") {
 			for _, value := range filter.AcceptableValues {
-				logsCustomPipeline, _, err := api.GetLogsPipeline(auth, value)
+				logsCustomPipeline, httpResp, err := api.GetLogsPipeline(auth, value)
+				if httpResp != nil && httpResp.Body != nil {
+					_ = httpResp.Body.Close()
+				}
 				if err != nil {
 					return err
 				}
@@ -74,7 +77,10 @@ func (g *LogsCustomPipelineGenerator) InitResources() error {
 		return nil
 	}
 
-	logsCustomPipelines, _, err := api.ListLogsPipelines(auth)
+	logsCustomPipelines, httpResp, err := api.ListLogsPipelines(auth)
+	if httpResp != nil && httpResp.Body != nil {
+		_ = httpResp.Body.Close()
+	}
 	if err != nil {
 		return err
 	}

--- a/providers/datadog/logs_index.go
+++ b/providers/datadog/logs_index.go
@@ -54,7 +54,10 @@ func (g *LogsIndexGenerator) InitResources() error {
 	for _, filter := range g.Filter {
 		if filter.FieldPath == "id" && filter.IsApplicable("logs_index") {
 			for _, value := range filter.AcceptableValues {
-				logsIndex, _, err := api.GetLogsIndex(auth, value)
+				logsIndex, httpResp, err := api.GetLogsIndex(auth, value)
+				if httpResp != nil && httpResp.Body != nil {
+					_ = httpResp.Body.Close()
+				}
 				if err != nil {
 					return err
 				}
@@ -69,11 +72,14 @@ func (g *LogsIndexGenerator) InitResources() error {
 		return nil
 	}
 
-	logsIndexList, _, err := api.ListLogIndexes(auth)
-	logsIndex := logsIndexList.GetIndexes()
+	logsIndexList, httpResp, err := api.ListLogIndexes(auth)
+	if httpResp != nil && httpResp.Body != nil {
+		_ = httpResp.Body.Close()
+	}
 	if err != nil {
 		return err
 	}
+	logsIndex := logsIndexList.GetIndexes()
 	g.Resources = g.createResources(logsIndex)
 	return nil
 }

--- a/providers/datadog/logs_integration_pipeline.go
+++ b/providers/datadog/logs_integration_pipeline.go
@@ -53,7 +53,10 @@ func (g *LogsIntegrationPipelineGenerator) InitResources() error {
 	auth := g.Args["auth"].(context.Context)
 	api := datadogV1.NewLogsPipelinesApi(datadogClient)
 
-	logsIntegrationPipelines, _, err := api.ListLogsPipelines(auth)
+	logsIntegrationPipelines, httpResp, err := api.ListLogsPipelines(auth)
+	if httpResp != nil && httpResp.Body != nil {
+		_ = httpResp.Body.Close()
+	}
 	if err != nil {
 		return err
 	}

--- a/providers/datadog/logs_metric.go
+++ b/providers/datadog/logs_metric.go
@@ -54,7 +54,10 @@ func (g *LogsMetricGenerator) InitResources() error {
 	for _, filter := range g.Filter {
 		if filter.FieldPath == "id" && filter.IsApplicable("logs_metric") {
 			for _, value := range filter.AcceptableValues {
-				logsMetric, _, err := api.GetLogsMetric(auth, value)
+				logsMetric, httpResp, err := api.GetLogsMetric(auth, value)
+				if httpResp != nil && httpResp.Body != nil {
+					_ = httpResp.Body.Close()
+				}
 				if err != nil {
 					return err
 				}
@@ -69,7 +72,10 @@ func (g *LogsMetricGenerator) InitResources() error {
 		return nil
 	}
 
-	logsMetrics, _, err := api.ListLogsMetrics(auth)
+	logsMetrics, httpResp, err := api.ListLogsMetrics(auth)
+	if httpResp != nil && httpResp.Body != nil {
+		_ = httpResp.Body.Close()
+	}
 	if err != nil {
 		return err
 	}

--- a/providers/datadog/monitor.go
+++ b/providers/datadog/monitor.go
@@ -66,7 +66,10 @@ func (g *MonitorGenerator) InitResources() error {
 					return err
 				}
 
-				monitor, _, err := api.GetMonitor(auth, i)
+				monitor, httpResp, err := api.GetMonitor(auth, i)
+				if httpResp != nil && httpResp.Body != nil {
+					_ = httpResp.Body.Close()
+				}
 				if err != nil {
 					return err
 				}
@@ -88,9 +91,12 @@ func (g *MonitorGenerator) InitResources() error {
 	pageSize := int32(1000)
 	pageNumber := int64(0)
 	for {
-		resp, _, err := api.ListMonitors(auth, *optionalParams.
+		resp, httpResp, err := api.ListMonitors(auth, *optionalParams.
 			WithPageSize(pageSize).
 			WithPage(pageNumber))
+		if httpResp != nil && httpResp.Body != nil {
+			_ = httpResp.Body.Close()
+		}
 		if err != nil {
 			return err
 		}

--- a/providers/datadog/role.go
+++ b/providers/datadog/role.go
@@ -58,9 +58,12 @@ func (g *RoleGenerator) InitResources() error {
 
 	var roles []datadogV2.Role
 	for remaining > int64(0) {
-		resp, _, err := api.ListRoles(auth, *datadogV2.NewListRolesOptionalParameters().
+		resp, httpResp, err := api.ListRoles(auth, *datadogV2.NewListRolesOptionalParameters().
 			WithPageSize(pageSize).
 			WithPageNumber(pageNumber))
+		if httpResp != nil && httpResp.Body != nil {
+			_ = httpResp.Body.Close()
+		}
 		if err != nil {
 			return err
 		}

--- a/providers/datadog/security_monitoring_default_rule.go
+++ b/providers/datadog/security_monitoring_default_rule.go
@@ -68,10 +68,13 @@ func (g *SecurityMonitoringDefaultRuleGenerator) InitResources() error {
 	remaining := int64(1)
 
 	for remaining > int64(0) {
-		resp, _, err := api.ListSecurityMonitoringRules(auth,
+		resp, httpResp, err := api.ListSecurityMonitoringRules(auth,
 			*datadogV2.NewListSecurityMonitoringRulesOptionalParameters().
 				WithPageSize(pageSize).
 				WithPageNumber(pageNumber))
+		if httpResp != nil && httpResp.Body != nil {
+			_ = httpResp.Body.Close()
+		}
 		if err != nil {
 			return err
 		}

--- a/providers/datadog/security_monitoring_rule.go
+++ b/providers/datadog/security_monitoring_rule.go
@@ -72,10 +72,13 @@ func (g *SecurityMonitoringRuleGenerator) InitResources() error {
 	remaining := int64(1)
 
 	for remaining > int64(0) {
-		resp, _, err := api.ListSecurityMonitoringRules(auth,
+		resp, httpResp, err := api.ListSecurityMonitoringRules(auth,
 			*datadogV2.NewListSecurityMonitoringRulesOptionalParameters().
 				WithPageNumber(pageNumber).
 				WithPageSize(pageSize))
+		if httpResp != nil && httpResp.Body != nil {
+			_ = httpResp.Body.Close()
+		}
 		if err != nil {
 			return err
 		}

--- a/providers/datadog/service_level_objective.go
+++ b/providers/datadog/service_level_objective.go
@@ -51,7 +51,10 @@ func (g *ServiceLevelObjectiveGenerator) InitResources() error {
 	api := datadogV1.NewServiceLevelObjectivesApi(datadogClient)
 
 	var slos []datadogV1.ServiceLevelObjective
-	resp, _, err := api.ListSLOs(auth)
+	resp, httpResp, err := api.ListSLOs(auth)
+	if httpResp != nil && httpResp.Body != nil {
+		_ = httpResp.Body.Close()
+	}
 	if err != nil {
 		return err
 	}

--- a/providers/datadog/synthetics_global_variable.go
+++ b/providers/datadog/synthetics_global_variable.go
@@ -55,7 +55,10 @@ func (g *SyntheticsGlobalVariableGenerator) InitResources() error {
 	for _, filter := range g.Filter {
 		if filter.FieldPath == "id" && filter.IsApplicable("synthetics_global_variable") {
 			for _, v := range filter.AcceptableValues {
-				resp, _, err := api.GetGlobalVariable(auth, v)
+				resp, httpResp, err := api.GetGlobalVariable(auth, v)
+				if httpResp != nil && httpResp.Body != nil {
+					_ = httpResp.Body.Close()
+				}
 				if err != nil {
 					log.Printf("error retrieving synthetics gloval variable with id:%s - %s", v, err)
 					continue

--- a/providers/datadog/synthetics_private_location.go
+++ b/providers/datadog/synthetics_private_location.go
@@ -53,7 +53,10 @@ func (g *SyntheticsPrivateLocationGenerator) InitResources() error {
 	auth := g.Args["auth"].(context.Context)
 	api := datadogV1.NewSyntheticsApi(datadogClient)
 
-	data, _, err := api.ListLocations(auth)
+	data, httpResp, err := api.ListLocations(auth)
+	if httpResp != nil && httpResp.Body != nil {
+		_ = httpResp.Body.Close()
+	}
 	if err != nil {
 		return err
 	}

--- a/providers/datadog/synthetics_test_.go
+++ b/providers/datadog/synthetics_test_.go
@@ -54,7 +54,10 @@ func (g *SyntheticsTestGenerator) InitResources() error {
 	for _, filter := range g.Filter {
 		if filter.FieldPath == "id" && filter.IsApplicable("synthetics_test") {
 			for _, value := range filter.AcceptableValues {
-				syntheticsTest, _, err := api.GetTest(auth, value)
+				syntheticsTest, httpResp, err := api.GetTest(auth, value)
+				if httpResp != nil && httpResp.Body != nil {
+					_ = httpResp.Body.Close()
+				}
 				if err != nil {
 					return err
 				}
@@ -69,7 +72,10 @@ func (g *SyntheticsTestGenerator) InitResources() error {
 		return nil
 	}
 
-	syntheticsTests, _, err := api.ListTests(auth)
+	syntheticsTests, httpResp, err := api.ListTests(auth)
+	if httpResp != nil && httpResp.Body != nil {
+		_ = httpResp.Body.Close()
+	}
 	if err != nil {
 		return err
 	}

--- a/providers/datadog/user.go
+++ b/providers/datadog/user.go
@@ -73,9 +73,12 @@ func (g *UserGenerator) InitResources() error {
 	}
 
 	for remaining > int64(0) {
-		resp, _, err := api.ListUsers(auth, *optionalParams.
+		resp, httpResp, err := api.ListUsers(auth, *optionalParams.
 			WithPageSize(pageSize).
 			WithPageNumber(pageNumber))
+		if httpResp != nil && httpResp.Body != nil {
+			_ = httpResp.Body.Close()
+		}
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
## Summary

- Close Datadog API response bodies returned by generated client calls.
- Keep existing Datadog import behavior and error handling unchanged.
- Fix the provider-wide `bodyclose` lint findings found during the main-branch quality audit.
