### PR TITLE
fix(terraformoutput): return file output errors

### DIFF
--- a/cmd/import.go
+++ b/cmd/import.go
@@ -260,8 +260,12 @@ func printService(provider terraformutils.ProviderGenerator, serviceName string,
 			return err
 		}
 		// create Bucket file
-		if bucketStateDataFile, err := terraformutils.Print(bucket.BucketGetTfData(path), map[string]struct{}{}, options.Output, !options.NoSort); err == nil {
-			terraformoutput.PrintFile(path+"/bucket.tf", bucketStateDataFile)
+		bucketStateDataFile, err := terraformutils.Print(bucket.BucketGetTfData(path), map[string]struct{}{}, options.Output, !options.NoSort)
+		if err != nil {
+			return err
+		}
+		if err := terraformoutput.PrintFile(path+"/bucket.tf", bucketStateDataFile); err != nil {
+			return err
 		}
 	} else {
 		if serviceName == "" {
@@ -311,7 +315,9 @@ func printService(provider terraformutils.ProviderGenerator, serviceName string,
 				if err != nil {
 					return err
 				}
-				terraformoutput.PrintFile(path+"/variables."+terraformoutput.GetFileExtension(options.Output), variablesFile)
+				if err := terraformoutput.PrintFile(path+"/variables."+terraformoutput.GetFileExtension(options.Output), variablesFile); err != nil {
+					return err
+				}
 			}
 		}
 	} else {
@@ -341,7 +347,9 @@ func printService(provider terraformutils.ProviderGenerator, serviceName string,
 				if err != nil {
 					return err
 				}
-				terraformoutput.PrintFile(path+"/variables."+terraformoutput.GetFileExtension(options.Output), variablesFile)
+				if err := terraformoutput.PrintFile(path+"/variables."+terraformoutput.GetFileExtension(options.Output), variablesFile); err != nil {
+					return err
+				}
 			}
 		}
 	}

--- a/terraformutils/terraformoutput/bucket.go
+++ b/terraformutils/terraformoutput/bucket.go
@@ -3,7 +3,6 @@ package terraformoutput
 
 import (
 	"context"
-	"log"
 	"strings"
 
 	"cloud.google.com/go/storage"
@@ -38,7 +37,7 @@ func (b BucketState) BucketUpload(path string, file []byte) error {
 	ctx := context.Background()
 	client, err := storage.NewClient(ctx)
 	if err != nil {
-		log.Fatalf("Failed to create client: %v", err)
+		return err
 	}
 	name := strings.ReplaceAll(b.Name, "gs://", "")
 	wc := client.Bucket(name).Object(b.BucketPrefix(path) + "/default.tfstate").NewWriter(ctx)

--- a/terraformutils/terraformoutput/hcl.go
+++ b/terraformutils/terraformoutput/hcl.go
@@ -4,7 +4,6 @@
 package terraformoutput
 
 import (
-	"log"
 	"os"
 	"strings"
 
@@ -39,7 +38,9 @@ func OutputHclFiles(resources []terraformutils.Resource, provider terraformutils
 	if err != nil {
 		return err
 	}
-	PrintFile(path+"/provider."+GetFileExtension(output), providerDataFile)
+	if err := PrintFile(path+"/provider."+GetFileExtension(output), providerDataFile); err != nil {
+		return err
+	}
 
 	// create outputs files
 	outputs := map[string]interface{}{}
@@ -82,7 +83,9 @@ func OutputHclFiles(resources []terraformutils.Resource, provider terraformutils
 		if err != nil {
 			return err
 		}
-		PrintFile(path+"/outputs."+GetFileExtension(output), outputsFile)
+		if err := PrintFile(path+"/outputs."+GetFileExtension(output), outputsFile); err != nil {
+			return err
+		}
 	}
 
 	// group by resource by type
@@ -135,12 +138,8 @@ func printFile(v []terraformutils.Resource, fileName, path, output string, sort 
 	return nil
 }
 
-func PrintFile(path string, data []byte) {
-	err := os.WriteFile(path, data, os.ModePerm)
-	if err != nil {
-		log.Fatal(err)
-		return
-	}
+func PrintFile(path string, data []byte) error {
+	return os.WriteFile(path, data, os.ModePerm)
 }
 
 func GetFileExtension(outputFormat string) string {

--- a/terraformutils/terraformoutput/output_test.go
+++ b/terraformutils/terraformoutput/output_test.go
@@ -2,7 +2,11 @@
 
 package terraformoutput
 
-import "testing"
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
 
 func TestGetFileExtension(t *testing.T) {
 	tests := []struct {
@@ -87,5 +91,28 @@ func TestBucketGetTfData(t *testing.T) {
 				t.Errorf("prefix = %v, want %q", gcs["prefix"], tc.wantPrefix)
 			}
 		})
+	}
+}
+
+func TestPrintFileWritesData(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "provider.tf")
+	want := []byte("terraform {}")
+
+	if err := PrintFile(path, want); err != nil {
+		t.Fatalf("PrintFile() error = %v", err)
+	}
+	got, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("ReadFile() error = %v", err)
+	}
+	if string(got) != string(want) {
+		t.Fatalf("PrintFile() wrote %q, want %q", got, want)
+	}
+}
+
+func TestPrintFileReturnsWriteError(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "missing", "provider.tf")
+	if err := PrintFile(path, []byte("terraform {}")); err == nil {
+		t.Fatal("PrintFile() error = nil, want write error")
 	}
 }


### PR DESCRIPTION
## Summary

- Return file write errors from Terraform output helpers instead of exiting the process.
- Propagate provider, output, bucket, and variables file write failures through the import command.
- Return GCS state client creation errors from bucket upload instead of calling `log.Fatalf`.
