### PR TITLE
feat(launchdarkly): add integration resources

### DIFF
--- a/docs/launchdarkly.md
+++ b/docs/launchdarkly.md
@@ -4,7 +4,7 @@ Example:
 
 ```
 export LAUNCHDARKLY_ACCESS_TOKEN=[LAUNCHDARKLY_ACCESS_TOKEN]
-./terraformer import launchdarkly -r customRole,environment,featureFlag,flagTemplates,metric,relayProxyConfiguration,segment,team,teamMember,webhook
+./terraformer import launchdarkly -r auditLogSubscription,customRole,destination,environment,featureFlag,flagTemplates,flagTrigger,metric,relayProxyConfiguration,segment,team,teamMember,webhook
 ```
 
 Use `project` separately when you want LaunchDarkly environments managed as nested
@@ -14,8 +14,12 @@ environments.
 
 List of supported LaunchDarkly resources:
 
+*   `auditLogSubscription`
+    * `launchdarkly_audit_log_subscription`
 *   `customRole`
     * `launchdarkly_custom_role`
+*   `destination`
+    * `launchdarkly_destination`
 *   `project`
     * `launchdarkly_project`
 *   `environment`
@@ -25,6 +29,8 @@ List of supported LaunchDarkly resources:
     * `launchdarkly_feature_flag_environment`
 *   `flagTemplates`
     * `launchdarkly_flag_templates`
+*   `flagTrigger`
+    * `launchdarkly_flag_trigger`
 *   `metric`
     * `launchdarkly_metric`
 *   `relayProxyConfiguration`

--- a/providers/launchdarkly/audit_log_subscription.go
+++ b/providers/launchdarkly/audit_log_subscription.go
@@ -53,7 +53,7 @@ func (g *AuditLogSubscriptionGenerator) loadAuditLogSubscriptions(ctx context.Co
 	for _, subscription := range subscriptions.GetItems() {
 		subscriptionID := subscription.GetId()
 		resource := terraformutils.NewResource(
-			fmt.Sprintf("%s/%s", integrationKey, subscriptionID),
+			subscriptionID,
 			fmt.Sprintf("%s-%s", integrationKey, resourceName(subscription.GetName(), subscriptionID)),
 			"launchdarkly_audit_log_subscription",
 			"launchdarkly",

--- a/providers/launchdarkly/audit_log_subscription.go
+++ b/providers/launchdarkly/audit_log_subscription.go
@@ -74,9 +74,16 @@ func auditLogSubscriptionAttributes(integrationKey string, config map[string]int
 		"config.%":        strconv.Itoa(len(config)),
 	}
 	for key, value := range config {
-		attributes["config."+strcase.ToSnake(key)] = auditLogSubscriptionConfigValue(value)
+		attributes["config."+auditLogSubscriptionConfigKey(key)] = auditLogSubscriptionConfigValue(value)
 	}
 	return attributes
+}
+
+func auditLogSubscriptionConfigKey(key string) string {
+	if key == "last9" {
+		return key
+	}
+	return strcase.ToSnake(key)
 }
 
 func auditLogSubscriptionConfigValue(value interface{}) string {

--- a/providers/launchdarkly/audit_log_subscription.go
+++ b/providers/launchdarkly/audit_log_subscription.go
@@ -54,7 +54,7 @@ func (g *AuditLogSubscriptionGenerator) loadAuditLogSubscriptions(ctx context.Co
 		subscriptionID := subscription.GetId()
 		resource := terraformutils.NewResource(
 			fmt.Sprintf("%s/%s", integrationKey, subscriptionID),
-			resourceName(subscription.GetName(), subscriptionID),
+			fmt.Sprintf("%s-%s", integrationKey, resourceName(subscription.GetName(), subscriptionID)),
 			"launchdarkly_audit_log_subscription",
 			"launchdarkly",
 			map[string]string{

--- a/providers/launchdarkly/audit_log_subscription.go
+++ b/providers/launchdarkly/audit_log_subscription.go
@@ -4,10 +4,13 @@ package launchdarkly
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"net/http"
+	"strconv"
 
 	"github.com/chenrui333/terraformer/terraformutils"
+	"github.com/iancoleman/strcase"
 	ldapi "github.com/launchdarkly/api-client-go/v16"
 )
 
@@ -57,14 +60,39 @@ func (g *AuditLogSubscriptionGenerator) loadAuditLogSubscriptions(ctx context.Co
 			fmt.Sprintf("%s-%s", integrationKey, resourceName(subscription.GetName(), subscriptionID)),
 			"launchdarkly_audit_log_subscription",
 			"launchdarkly",
-			map[string]string{
-				"integration_key": integrationKey,
-			},
+			auditLogSubscriptionAttributes(integrationKey, subscription.Config),
 			[]string{},
 			map[string]interface{}{})
 		g.Resources = append(g.Resources, resource)
 	}
 	return nil
+}
+
+func auditLogSubscriptionAttributes(integrationKey string, config map[string]interface{}) map[string]string {
+	attributes := map[string]string{
+		"integration_key": integrationKey,
+		"config.%":        strconv.Itoa(len(config)),
+	}
+	for key, value := range config {
+		attributes["config."+strcase.ToSnake(key)] = auditLogSubscriptionConfigValue(value)
+	}
+	return attributes
+}
+
+func auditLogSubscriptionConfigValue(value interface{}) string {
+	switch v := value.(type) {
+	case nil:
+		return ""
+	case string:
+		return v
+	case bool:
+		return strconv.FormatBool(v)
+	default:
+		if data, err := json.Marshal(v); err == nil {
+			return string(data)
+		}
+		return fmt.Sprint(v)
+	}
 }
 
 func (g *AuditLogSubscriptionGenerator) InitResources() error {

--- a/providers/launchdarkly/audit_log_subscription.go
+++ b/providers/launchdarkly/audit_log_subscription.go
@@ -57,7 +57,7 @@ func (g *AuditLogSubscriptionGenerator) loadAuditLogSubscriptions(ctx context.Co
 		subscriptionID := subscription.GetId()
 		resource := terraformutils.NewResource(
 			subscriptionID,
-			fmt.Sprintf("%s-%s", integrationKey, resourceName(subscription.GetName(), subscriptionID)),
+			auditLogSubscriptionResourceName(integrationKey, subscription.GetName(), subscriptionID),
 			"launchdarkly_audit_log_subscription",
 			"launchdarkly",
 			auditLogSubscriptionAttributes(integrationKey, subscription.Config),
@@ -66,6 +66,10 @@ func (g *AuditLogSubscriptionGenerator) loadAuditLogSubscriptions(ctx context.Co
 		g.Resources = append(g.Resources, resource)
 	}
 	return nil
+}
+
+func auditLogSubscriptionResourceName(integrationKey, name, subscriptionID string) string {
+	return fmt.Sprintf("%s-%s", integrationKey, resourceNameWithID(name, subscriptionID))
 }
 
 func auditLogSubscriptionAttributes(integrationKey string, config map[string]interface{}) map[string]string {

--- a/providers/launchdarkly/audit_log_subscription.go
+++ b/providers/launchdarkly/audit_log_subscription.go
@@ -1,0 +1,80 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package launchdarkly
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/chenrui333/terraformer/terraformutils"
+	ldapi "github.com/launchdarkly/api-client-go/v16"
+)
+
+var auditLogSubscriptionIntegrationKeys = []string{
+	"chronosphere",
+	"cloudtrail",
+	"datadog",
+	"dynatrace",
+	"dynatrace-v2",
+	"elastic",
+	"grafana",
+	"honeycomb",
+	"jira",
+	"kosli",
+	"last9",
+	"logdna",
+	"msteams",
+	"new-relic-apm",
+	"pagerduty",
+	"signalfx",
+	"slack",
+	"splunk",
+}
+
+type AuditLogSubscriptionGenerator struct {
+	LaunchDarklyService
+}
+
+func (g *AuditLogSubscriptionGenerator) loadAuditLogSubscriptions(ctx context.Context, client *ldapi.APIClient, integrationKey string) error {
+	subscriptions, resp, err := client.IntegrationAuditLogSubscriptionsApi.GetSubscriptions(ctx, integrationKey).Execute()
+	if resp != nil && resp.Body != nil {
+		_ = resp.Body.Close()
+	}
+	if resp != nil && resp.StatusCode == http.StatusNotFound {
+		return nil
+	}
+	if err != nil {
+		return err
+	}
+	if subscriptions == nil {
+		return nil
+	}
+	for _, subscription := range subscriptions.GetItems() {
+		subscriptionID := subscription.GetId()
+		resource := terraformutils.NewResource(
+			fmt.Sprintf("%s/%s", integrationKey, subscriptionID),
+			resourceName(subscription.GetName(), subscriptionID),
+			"launchdarkly_audit_log_subscription",
+			"launchdarkly",
+			map[string]string{
+				"integration_key": integrationKey,
+			},
+			[]string{},
+			map[string]interface{}{})
+		g.Resources = append(g.Resources, resource)
+	}
+	return nil
+}
+
+func (g *AuditLogSubscriptionGenerator) InitResources() error {
+	ctx := g.GetArgs()["ctx"].(context.Context)
+	client := g.GetArgs()["client"].(*ldapi.APIClient)
+
+	for _, integrationKey := range auditLogSubscriptionIntegrationKeys {
+		if err := g.loadAuditLogSubscriptions(ctx, client, integrationKey); err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/providers/launchdarkly/audit_log_subscription_test.go
+++ b/providers/launchdarkly/audit_log_subscription_test.go
@@ -7,6 +7,14 @@ import (
 	"testing"
 )
 
+func TestAuditLogSubscriptionResourceNameIncludesSubscriptionID(t *testing.T) {
+	got := auditLogSubscriptionResourceName("datadog", "duplicate", "sub-123")
+	want := "datadog-duplicate-sub-123"
+	if got != want {
+		t.Fatalf("auditLogSubscriptionResourceName() = %q, want %q", got, want)
+	}
+}
+
 func TestAuditLogSubscriptionAttributesSeedsConfig(t *testing.T) {
 	got := auditLogSubscriptionAttributes("datadog", map[string]interface{}{
 		"apiKey":          "secret",

--- a/providers/launchdarkly/audit_log_subscription_test.go
+++ b/providers/launchdarkly/audit_log_subscription_test.go
@@ -11,15 +11,17 @@ func TestAuditLogSubscriptionAttributesSeedsConfig(t *testing.T) {
 	got := auditLogSubscriptionAttributes("datadog", map[string]interface{}{
 		"apiKey":          "secret",
 		"hostURL":         "https://api.datadoghq.com",
+		"last9":           "token",
 		"skipHTTPArchive": true,
 		"nested":          map[string]interface{}{"key": "value"},
 	})
 
 	want := map[string]string{
 		"integration_key":          "datadog",
-		"config.%":                 "4",
+		"config.%":                 "5",
 		"config.api_key":           "secret",
 		"config.host_url":          "https://api.datadoghq.com",
+		"config.last9":             "token",
 		"config.skip_http_archive": "true",
 		"config.nested":            `{"key":"value"}`,
 	}

--- a/providers/launchdarkly/audit_log_subscription_test.go
+++ b/providers/launchdarkly/audit_log_subscription_test.go
@@ -1,0 +1,29 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package launchdarkly
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestAuditLogSubscriptionAttributesSeedsConfig(t *testing.T) {
+	got := auditLogSubscriptionAttributes("datadog", map[string]interface{}{
+		"apiKey":          "secret",
+		"hostURL":         "https://api.datadoghq.com",
+		"skipHTTPArchive": true,
+		"nested":          map[string]interface{}{"key": "value"},
+	})
+
+	want := map[string]string{
+		"integration_key":          "datadog",
+		"config.%":                 "4",
+		"config.api_key":           "secret",
+		"config.host_url":          "https://api.datadoghq.com",
+		"config.skip_http_archive": "true",
+		"config.nested":            `{"key":"value"}`,
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("auditLogSubscriptionAttributes() = %#v, want %#v", got, want)
+	}
+}

--- a/providers/launchdarkly/destination.go
+++ b/providers/launchdarkly/destination.go
@@ -52,7 +52,14 @@ func destinationProjectEnv(destination ldapi.Destination) (string, string, error
 	if !ok || self.Href == nil {
 		return "", "", fmt.Errorf("destination %q is missing self link", destination.GetId())
 	}
-	path := strings.TrimPrefix(*self.Href, "/api/v2/destinations/")
+	href := *self.Href
+	if parsed, err := url.Parse(href); err == nil && parsed.Path != "" {
+		href = parsed.Path
+	}
+	path := strings.TrimPrefix(href, "/api/v2/destinations/")
+	if path == href {
+		return "", "", fmt.Errorf("unexpected destination self link %q", *self.Href)
+	}
 	parts := strings.Split(path, "/")
 	if len(parts) < 3 {
 		return "", "", fmt.Errorf("unexpected destination self link %q", *self.Href)

--- a/providers/launchdarkly/destination.go
+++ b/providers/launchdarkly/destination.go
@@ -31,7 +31,7 @@ func (g *DestinationGenerator) loadDestinations(ctx context.Context) error {
 			destinationID := destination.GetId()
 			resource := terraformutils.NewResource(
 				strings.Join([]string{projectKey, envKey, destinationID}, "/"),
-				fmt.Sprintf("%s-%s-%s", projectKey, envKey, resourceName(destination.GetName(), destinationID)),
+				destinationResourceName(projectKey, envKey, destination.GetName(), destinationID),
 				"launchdarkly_destination",
 				"launchdarkly",
 				map[string]string{
@@ -45,6 +45,10 @@ func (g *DestinationGenerator) loadDestinations(ctx context.Context) error {
 		path = nextPagePath(destinations.GetLinks())
 	}
 	return nil
+}
+
+func destinationResourceName(projectKey, envKey, name, destinationID string) string {
+	return fmt.Sprintf("%s-%s-%s", projectKey, envKey, resourceNameWithID(name, destinationID))
 }
 
 func destinationProjectEnv(destination ldapi.Destination) (string, string, error) {

--- a/providers/launchdarkly/destination.go
+++ b/providers/launchdarkly/destination.go
@@ -1,0 +1,73 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package launchdarkly
+
+import (
+	"context"
+	"fmt"
+	"net/url"
+	"strings"
+
+	"github.com/chenrui333/terraformer/terraformutils"
+	ldapi "github.com/launchdarkly/api-client-go/v16"
+)
+
+type DestinationGenerator struct {
+	LaunchDarklyService
+}
+
+func (g *DestinationGenerator) loadDestinations(ctx context.Context) error {
+	for path := "/destinations"; path != ""; {
+		destinations := &ldapi.Destinations{}
+		if err := getLaunchDarklyAPI(ctx, g.GetArgs()["api_key"].(string), path, destinations); err != nil {
+			return err
+		}
+
+		for _, destination := range destinations.GetItems() {
+			projectKey, envKey, err := destinationProjectEnv(destination)
+			if err != nil {
+				return err
+			}
+			destinationID := destination.GetId()
+			resource := terraformutils.NewResource(
+				strings.Join([]string{projectKey, envKey, destinationID}, "/"),
+				fmt.Sprintf("%s-%s-%s", projectKey, envKey, resourceName(destination.GetName(), destinationID)),
+				"launchdarkly_destination",
+				"launchdarkly",
+				map[string]string{
+					"project_key": projectKey,
+					"env_key":     envKey,
+				},
+				[]string{},
+				map[string]interface{}{})
+			g.Resources = append(g.Resources, resource)
+		}
+		path = nextPagePath(destinations.GetLinks())
+	}
+	return nil
+}
+
+func destinationProjectEnv(destination ldapi.Destination) (string, string, error) {
+	self, ok := destination.GetLinks()["self"]
+	if !ok || self.Href == nil {
+		return "", "", fmt.Errorf("destination %q is missing self link", destination.GetId())
+	}
+	path := strings.TrimPrefix(*self.Href, "/api/v2/destinations/")
+	parts := strings.Split(path, "/")
+	if len(parts) < 3 {
+		return "", "", fmt.Errorf("unexpected destination self link %q", *self.Href)
+	}
+	projectKey, err := url.PathUnescape(parts[0])
+	if err != nil {
+		return "", "", err
+	}
+	envKey, err := url.PathUnescape(parts[1])
+	if err != nil {
+		return "", "", err
+	}
+	return projectKey, envKey, nil
+}
+
+func (g *DestinationGenerator) InitResources() error {
+	return g.loadDestinations(g.GetArgs()["ctx"].(context.Context))
+}

--- a/providers/launchdarkly/destination_test.go
+++ b/providers/launchdarkly/destination_test.go
@@ -1,0 +1,13 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package launchdarkly
+
+import "testing"
+
+func TestDestinationResourceNameIncludesDestinationID(t *testing.T) {
+	got := destinationResourceName("proj", "prod", "duplicate", "dest-123")
+	want := "proj-prod-duplicate-dest-123"
+	if got != want {
+		t.Fatalf("destinationResourceName() = %q, want %q", got, want)
+	}
+}

--- a/providers/launchdarkly/flag_trigger.go
+++ b/providers/launchdarkly/flag_trigger.go
@@ -1,0 +1,103 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package launchdarkly
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"strings"
+
+	"github.com/chenrui333/terraformer/terraformutils"
+	ldapi "github.com/launchdarkly/api-client-go/v16"
+)
+
+type FlagTriggerGenerator struct {
+	LaunchDarklyService
+}
+
+func getFeatureFlags(ctx context.Context, client *ldapi.APIClient, projectKey string) ([]ldapi.FeatureFlag, error) {
+	var allFlags []ldapi.FeatureFlag
+	for offset := int64(0); ; offset += pageSize {
+		featureFlags, resp, err := client.FeatureFlagsApi.GetFeatureFlags(ctx, projectKey).
+			Limit(pageSize).
+			Offset(offset).
+			Execute()
+		if resp != nil && resp.Body != nil {
+			_ = resp.Body.Close()
+		}
+		if err != nil {
+			return nil, err
+		}
+		if featureFlags == nil {
+			break
+		}
+		allFlags = append(allFlags, featureFlags.GetItems()...)
+		if featureFlags.TotalCount == nil || int64(len(allFlags)) >= int64(*featureFlags.TotalCount) {
+			break
+		}
+	}
+	return allFlags, nil
+}
+
+func (g *FlagTriggerGenerator) loadFlagTriggers(ctx context.Context, client *ldapi.APIClient, projectKey, envKey, flagKey string) error {
+	triggers, resp, err := client.FlagTriggersApi.GetTriggerWorkflows(ctx, projectKey, envKey, flagKey).Execute()
+	if resp != nil && resp.Body != nil {
+		_ = resp.Body.Close()
+	}
+	if resp != nil && resp.StatusCode == http.StatusNotFound {
+		return nil
+	}
+	if err != nil {
+		return err
+	}
+	if triggers == nil {
+		return nil
+	}
+	for _, trigger := range triggers.GetItems() {
+		triggerID := trigger.GetId()
+		resource := terraformutils.NewResource(
+			strings.Join([]string{projectKey, envKey, flagKey, triggerID}, "/"),
+			fmt.Sprintf("%s-%s-%s-%s", projectKey, envKey, flagKey, triggerID),
+			"launchdarkly_flag_trigger",
+			"launchdarkly",
+			map[string]string{
+				"project_key":     projectKey,
+				"env_key":         envKey,
+				"flag_key":        flagKey,
+				"integration_key": trigger.GetIntegrationKey(),
+			},
+			[]string{},
+			map[string]interface{}{})
+		g.Resources = append(g.Resources, resource)
+	}
+	return nil
+}
+
+func (g *FlagTriggerGenerator) InitResources() error {
+	ctx := g.GetArgs()["ctx"].(context.Context)
+	client := g.GetArgs()["client"].(*ldapi.APIClient)
+
+	projects, err := getProjects(ctx, client)
+	if err != nil {
+		return err
+	}
+	for _, project := range projects {
+		envs, err := getEnvironments(ctx, client, project.Key)
+		if err != nil {
+			return err
+		}
+		flags, err := getFeatureFlags(ctx, client, project.Key)
+		if err != nil {
+			return err
+		}
+		for _, env := range envs {
+			for _, flag := range flags {
+				if err := g.loadFlagTriggers(ctx, client, project.Key, env.Key, flag.Key); err != nil {
+					return err
+				}
+			}
+		}
+	}
+	return nil
+}

--- a/providers/launchdarkly/flag_trigger.go
+++ b/providers/launchdarkly/flag_trigger.go
@@ -6,7 +6,6 @@ import (
 	"context"
 	"fmt"
 	"net/http"
-	"strings"
 
 	"github.com/chenrui333/terraformer/terraformutils"
 	ldapi "github.com/launchdarkly/api-client-go/v16"
@@ -57,7 +56,7 @@ func (g *FlagTriggerGenerator) loadFlagTriggers(ctx context.Context, client *lda
 	for _, trigger := range triggers.GetItems() {
 		triggerID := trigger.GetId()
 		resource := terraformutils.NewResource(
-			strings.Join([]string{projectKey, envKey, flagKey, triggerID}, "/"),
+			triggerID,
 			fmt.Sprintf("%s-%s-%s-%s", projectKey, envKey, flagKey, triggerID),
 			"launchdarkly_flag_trigger",
 			"launchdarkly",

--- a/providers/launchdarkly/flag_trigger.go
+++ b/providers/launchdarkly/flag_trigger.go
@@ -40,7 +40,7 @@ func getFeatureFlags(ctx context.Context, client *ldapi.APIClient, projectKey st
 }
 
 func (g *FlagTriggerGenerator) loadFlagTriggers(ctx context.Context, client *ldapi.APIClient, projectKey, envKey, flagKey string) error {
-	triggers, resp, err := client.FlagTriggersApi.GetTriggerWorkflows(ctx, projectKey, envKey, flagKey).Execute()
+	triggers, resp, err := getTriggerWorkflows(ctx, client, projectKey, envKey, flagKey)
 	if resp != nil && resp.Body != nil {
 		_ = resp.Body.Close()
 	}
@@ -71,6 +71,11 @@ func (g *FlagTriggerGenerator) loadFlagTriggers(ctx context.Context, client *lda
 		g.Resources = append(g.Resources, resource)
 	}
 	return nil
+}
+
+func getTriggerWorkflows(ctx context.Context, client *ldapi.APIClient, projectKey, environmentKey, featureFlagKey string) (*ldapi.TriggerWorkflowCollectionRep, *http.Response, error) {
+	// The generated SDK order is project, environment, flag, even though the REST path renders flag before environment.
+	return client.FlagTriggersApi.GetTriggerWorkflows(ctx, projectKey, environmentKey, featureFlagKey).Execute()
 }
 
 func (g *FlagTriggerGenerator) InitResources() error {

--- a/providers/launchdarkly/flag_trigger_test.go
+++ b/providers/launchdarkly/flag_trigger_test.go
@@ -1,0 +1,40 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package launchdarkly
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	ldapi "github.com/launchdarkly/api-client-go/v16"
+)
+
+func TestGetTriggerWorkflowsUsesSDKArgumentOrder(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		wantPath := "/api/v2/flags/proj/flag-key/triggers/prod"
+		if r.URL.Path != wantPath {
+			t.Fatalf("request path = %q, want %q", r.URL.Path, wantPath)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte("{\"items\":[{\"_id\":\"trigger-1\",\"_integrationKey\":\"generic\"}]}"))
+	}))
+	defer server.Close()
+
+	config := ldapi.NewConfiguration()
+	config.Servers = ldapi.ServerConfigurations{{URL: server.URL}}
+	client := ldapi.NewAPIClient(config)
+
+	triggers, resp, err := getTriggerWorkflows(context.Background(), client, "proj", "prod", "flag-key")
+	if resp != nil && resp.Body != nil {
+		_ = resp.Body.Close()
+	}
+	if err != nil {
+		t.Fatalf("getTriggerWorkflows() error = %v", err)
+	}
+	items := triggers.GetItems()
+	if len(items) != 1 || items[0].GetId() != "trigger-1" {
+		t.Fatalf("getTriggerWorkflows() items = %#v", items)
+	}
+}

--- a/providers/launchdarkly/launchdarkly_provider.go
+++ b/providers/launchdarkly/launchdarkly_provider.go
@@ -57,11 +57,14 @@ func (LaunchDarklyProvider) GetResourceConnections() map[string]map[string][]str
 
 func (p *LaunchDarklyProvider) GetSupportedService() map[string]terraformutils.ServiceGenerator {
 	return map[string]terraformutils.ServiceGenerator{
+		"auditLogSubscription":    &AuditLogSubscriptionGenerator{},
 		"customRole":              &CustomRoleGenerator{},
+		"destination":             &DestinationGenerator{},
 		"project":                 &ProjectGenerator{},
 		"environment":             &EnvironmentGenerator{},
 		"featureFlag":             &FeatureFlagsGenerator{},
 		"flagTemplates":           &FlagTemplatesGenerator{},
+		"flagTrigger":             &FlagTriggerGenerator{},
 		"metric":                  &MetricGenerator{},
 		"relayProxyConfiguration": &RelayProxyConfigurationGenerator{},
 		"segment":                 &SegmentGenerator{},

--- a/providers/launchdarkly/resource_name.go
+++ b/providers/launchdarkly/resource_name.go
@@ -8,3 +8,10 @@ func resourceName(name, fallback string) string {
 	}
 	return fallback
 }
+
+func resourceNameWithID(name, id string) string {
+	if name == "" || id == "" {
+		return resourceName(name, id)
+	}
+	return name + "-" + id
+}


### PR DESCRIPTION
## Summary

- add LaunchDarkly import support for audit log subscriptions, data export destinations, and flag triggers
- register the new resource groups in the LaunchDarkly provider and docs

## Notes

- leaves non-importable access tokens and newer AI/view resources for follow-up PRs
