### PR TITLE
feat(datadog): add team membership import

### DIFF
--- a/docs/datadog.md
+++ b/docs/datadog.md
@@ -150,6 +150,9 @@ Tag filters are order specific. For example, if your monitor has tags (in the or
     * `datadog_synthetics_test`
 *   `team`
     * `datadog_team`
+*   `team_membership`
+    * `datadog_team_membership`
+        * **_NOTE:_** Importing a single membership by ID requires quoting the `team_id:user_id` filter value, for example `--filter="team_membership='team-id:user-id'"`; memberships can also be filtered by `team_id`
 *   `user`
     * `datadog_user`
 

--- a/providers/datadog/datadog_provider.go
+++ b/providers/datadog/datadog_provider.go
@@ -177,6 +177,7 @@ func (p *DatadogProvider) GetSupportedService() map[string]terraformutils.Servic
 		"synthetics_global_variable":           &SyntheticsGlobalVariableGenerator{},
 		"synthetics_private_location":          &SyntheticsPrivateLocationGenerator{},
 		"team":                                 &TeamGenerator{},
+		"team_membership":                      &TeamMembershipGenerator{},
 		"user":                                 &UserGenerator{},
 		"role":                                 &RoleGenerator{},
 	}

--- a/providers/datadog/team_membership.go
+++ b/providers/datadog/team_membership.go
@@ -47,12 +47,17 @@ func (g *TeamMembershipGenerator) createResource(teamID string, teamMembership d
 	}
 
 	resourceID := fmt.Sprintf("%s:%s", teamID, userID)
-	return terraformutils.NewSimpleResource(
+	return terraformutils.NewResource(
 		resourceID,
 		fmt.Sprintf("team_membership_%s_%s", teamID, userID),
 		"datadog_team_membership",
 		"datadog",
+		map[string]string{
+			"team_id": teamID,
+			"user_id": userID,
+		},
 		TeamMembershipAllowEmptyValues,
+		map[string]interface{}{},
 	), nil
 }
 

--- a/providers/datadog/team_membership.go
+++ b/providers/datadog/team_membership.go
@@ -1,0 +1,195 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package datadog
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/DataDog/datadog-api-client-go/v2/api/datadog"
+	"github.com/DataDog/datadog-api-client-go/v2/api/datadogV2"
+
+	"github.com/chenrui333/terraformer/terraformutils"
+)
+
+var (
+	// TeamMembershipAllowEmptyValues ...
+	TeamMembershipAllowEmptyValues = []string{}
+)
+
+// TeamMembershipGenerator ...
+type TeamMembershipGenerator struct {
+	DatadogService
+}
+
+func (g *TeamMembershipGenerator) createResources(teamID string, teamMemberships []datadogV2.UserTeam) ([]terraformutils.Resource, error) {
+	resources := []terraformutils.Resource{}
+	for _, teamMembership := range teamMemberships {
+		resource, err := g.createResource(teamID, teamMembership)
+		if err != nil {
+			return nil, err
+		}
+		resources = append(resources, resource)
+	}
+
+	return resources, nil
+}
+
+func (g *TeamMembershipGenerator) createResource(teamID string, teamMembership datadogV2.UserTeam) (terraformutils.Resource, error) {
+	teamID = teamIDFromTeamMembership(teamID, teamMembership)
+	if teamID == "" {
+		return terraformutils.Resource{}, fmt.Errorf("team membership %q missing team relationship id", teamMembership.GetId())
+	}
+	userID := userIDFromTeamMembership(teamMembership)
+	if userID == "" {
+		return terraformutils.Resource{}, fmt.Errorf("team membership %q missing user relationship id", teamMembership.GetId())
+	}
+
+	resourceID := fmt.Sprintf("%s:%s", teamID, userID)
+	return terraformutils.NewSimpleResource(
+		resourceID,
+		fmt.Sprintf("team_membership_%s_%s", teamID, userID),
+		"datadog_team_membership",
+		"datadog",
+		TeamMembershipAllowEmptyValues,
+	), nil
+}
+
+// InitResources Generate TerraformResources from Datadog API,
+// from each team membership create 1 TerraformResource.
+// Need Team Membership ID formatted as '<team_id>:<user_id>' as ID for terraform resource.
+func (g *TeamMembershipGenerator) InitResources() error {
+	datadogClient := g.Args["datadogClient"].(*datadog.APIClient)
+	auth := g.Args["auth"].(context.Context)
+	api := datadogV2.NewTeamsApi(datadogClient)
+
+	resources, filtered, err := g.filteredResources(auth, api)
+	if err != nil {
+		return err
+	}
+	if filtered {
+		g.Resources = resources
+		return nil
+	}
+
+	teams, err := listTeams(auth, api)
+	if err != nil {
+		return err
+	}
+	for _, team := range teams {
+		teamID := team.GetId()
+		teamMemberships, err := listTeamMemberships(auth, api, teamID)
+		if err != nil {
+			return err
+		}
+		teamResources, err := g.createResources(teamID, teamMemberships)
+		if err != nil {
+			return err
+		}
+		resources = append(resources, teamResources...)
+	}
+
+	g.Resources = resources
+	return nil
+}
+
+func (g *TeamMembershipGenerator) filteredResources(auth context.Context, api *datadogV2.TeamsApi) ([]terraformutils.Resource, bool, error) {
+	resources := []terraformutils.Resource{}
+	filtered := false
+
+	for _, filter := range g.Filter {
+		if !filter.IsApplicable("team_membership") {
+			continue
+		}
+
+		switch filter.FieldPath {
+		case "id":
+			filtered = true
+			for _, value := range filter.AcceptableValues {
+				teamID, userID, err := parseTeamMembershipImportID(value)
+				if err != nil {
+					return nil, true, err
+				}
+				teamMembership, err := getTeamMembership(auth, api, teamID, userID)
+				if err != nil {
+					return nil, true, err
+				}
+				resource, err := g.createResource(teamID, teamMembership)
+				if err != nil {
+					return nil, true, err
+				}
+				resources = append(resources, resource)
+			}
+		case "team_id":
+			filtered = true
+			for _, teamID := range filter.AcceptableValues {
+				teamMemberships, err := listTeamMemberships(auth, api, teamID)
+				if err != nil {
+					return nil, true, err
+				}
+				teamResources, err := g.createResources(teamID, teamMemberships)
+				if err != nil {
+					return nil, true, err
+				}
+				resources = append(resources, teamResources...)
+			}
+		}
+	}
+
+	return resources, filtered, nil
+}
+
+func parseTeamMembershipImportID(importID string) (string, string, error) {
+	parts := strings.SplitN(importID, ":", 2)
+	if len(parts) != 2 || parts[0] == "" || parts[1] == "" {
+		return "", "", fmt.Errorf("team membership import ID %q must be formatted as team_id:user_id", importID)
+	}
+	return parts[0], parts[1], nil
+}
+
+func getTeamMembership(auth context.Context, api *datadogV2.TeamsApi, teamID string, userID string) (datadogV2.UserTeam, error) {
+	teamMemberships, err := listTeamMemberships(auth, api, teamID)
+	if err != nil {
+		return datadogV2.UserTeam{}, err
+	}
+	for _, teamMembership := range teamMemberships {
+		if userIDFromTeamMembership(teamMembership) == userID {
+			return teamMembership, nil
+		}
+	}
+	return datadogV2.UserTeam{}, fmt.Errorf("team membership %q not found", fmt.Sprintf("%s:%s", teamID, userID))
+}
+
+func listTeamMemberships(auth context.Context, api *datadogV2.TeamsApi, teamID string) ([]datadogV2.UserTeam, error) {
+	pageSize := int64(100)
+	items, cancel := api.GetTeamMembershipsWithPagination(auth, teamID, *datadogV2.NewGetTeamMembershipsOptionalParameters().WithPageSize(pageSize))
+	defer cancel()
+
+	teamMemberships := []datadogV2.UserTeam{}
+	for item := range items {
+		if item.Error != nil {
+			return nil, item.Error
+		}
+		teamMemberships = append(teamMemberships, item.Item)
+	}
+
+	return teamMemberships, nil
+}
+
+func teamIDFromTeamMembership(defaultTeamID string, teamMembership datadogV2.UserTeam) string {
+	relationships := teamMembership.GetRelationships()
+	teamRelationship := relationships.GetTeam()
+	teamData := teamRelationship.GetData()
+	if teamID := teamData.GetId(); teamID != "" {
+		return teamID
+	}
+	return defaultTeamID
+}
+
+func userIDFromTeamMembership(teamMembership datadogV2.UserTeam) string {
+	relationships := teamMembership.GetRelationships()
+	userRelationship := relationships.GetUser()
+	userData := userRelationship.GetData()
+	return userData.GetId()
+}

--- a/providers/datadog/team_membership_test.go
+++ b/providers/datadog/team_membership_test.go
@@ -14,6 +14,8 @@ func TestTeamMembershipCreateResource(t *testing.T) {
 		teamID         string
 		teamMembership datadogV2.UserTeam
 		wantID         string
+		wantTeamID     string
+		wantUserID     string
 		wantName       string
 		wantType       string
 	}{
@@ -35,9 +37,11 @@ func TestTeamMembershipCreateResource(t *testing.T) {
 					},
 				},
 			},
-			wantID:   "team-id:user-id",
-			wantName: "tfer--team_membership_team-id_user-id",
-			wantType: "datadog_team_membership",
+			wantID:     "team-id:user-id",
+			wantTeamID: "team-id",
+			wantUserID: "user-id",
+			wantName:   "tfer--team_membership_team-id_user-id",
+			wantType:   "datadog_team_membership",
 		},
 		{
 			name:   "falls back to supplied team id",
@@ -52,9 +56,11 @@ func TestTeamMembershipCreateResource(t *testing.T) {
 					},
 				},
 			},
-			wantID:   "team-id:user-id",
-			wantName: "tfer--team_membership_team-id_user-id",
-			wantType: "datadog_team_membership",
+			wantID:     "team-id:user-id",
+			wantTeamID: "team-id",
+			wantUserID: "user-id",
+			wantName:   "tfer--team_membership_team-id_user-id",
+			wantType:   "datadog_team_membership",
 		},
 	}
 
@@ -67,6 +73,12 @@ func TestTeamMembershipCreateResource(t *testing.T) {
 			}
 			if resource.InstanceState.ID != tt.wantID {
 				t.Fatalf("resource ID = %q, want %q", resource.InstanceState.ID, tt.wantID)
+			}
+			if resource.InstanceState.Attributes["team_id"] != tt.wantTeamID {
+				t.Fatalf("team_id attribute = %q, want %q", resource.InstanceState.Attributes["team_id"], tt.wantTeamID)
+			}
+			if resource.InstanceState.Attributes["user_id"] != tt.wantUserID {
+				t.Fatalf("user_id attribute = %q, want %q", resource.InstanceState.Attributes["user_id"], tt.wantUserID)
 			}
 			if resource.ResourceName != tt.wantName {
 				t.Fatalf("resource name = %q, want %q", resource.ResourceName, tt.wantName)

--- a/providers/datadog/team_membership_test.go
+++ b/providers/datadog/team_membership_test.go
@@ -1,0 +1,183 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package datadog
+
+import (
+	"testing"
+
+	"github.com/DataDog/datadog-api-client-go/v2/api/datadogV2"
+)
+
+func TestTeamMembershipCreateResource(t *testing.T) {
+	tests := []struct {
+		name           string
+		teamID         string
+		teamMembership datadogV2.UserTeam
+		wantID         string
+		wantName       string
+		wantType       string
+	}{
+		{
+			name:   "uses team and user relationship ids",
+			teamID: "fallback-team-id",
+			teamMembership: datadogV2.UserTeam{
+				Id: "membership-id",
+				Relationships: &datadogV2.UserTeamRelationships{
+					Team: &datadogV2.RelationshipToUserTeamTeam{
+						Data: datadogV2.RelationshipToUserTeamTeamData{
+							Id: "team-id",
+						},
+					},
+					User: &datadogV2.RelationshipToUserTeamUser{
+						Data: datadogV2.RelationshipToUserTeamUserData{
+							Id: "user-id",
+						},
+					},
+				},
+			},
+			wantID:   "team-id:user-id",
+			wantName: "tfer--team_membership_team-id_user-id",
+			wantType: "datadog_team_membership",
+		},
+		{
+			name:   "falls back to supplied team id",
+			teamID: "team-id",
+			teamMembership: datadogV2.UserTeam{
+				Id: "membership-id",
+				Relationships: &datadogV2.UserTeamRelationships{
+					User: &datadogV2.RelationshipToUserTeamUser{
+						Data: datadogV2.RelationshipToUserTeamUserData{
+							Id: "user-id",
+						},
+					},
+				},
+			},
+			wantID:   "team-id:user-id",
+			wantName: "tfer--team_membership_team-id_user-id",
+			wantType: "datadog_team_membership",
+		},
+	}
+
+	generator := TeamMembershipGenerator{}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			resource, err := generator.createResource(tt.teamID, tt.teamMembership)
+			if err != nil {
+				t.Fatalf("createResource() error = %v", err)
+			}
+			if resource.InstanceState.ID != tt.wantID {
+				t.Fatalf("resource ID = %q, want %q", resource.InstanceState.ID, tt.wantID)
+			}
+			if resource.ResourceName != tt.wantName {
+				t.Fatalf("resource name = %q, want %q", resource.ResourceName, tt.wantName)
+			}
+			if resource.InstanceInfo.Type != tt.wantType {
+				t.Fatalf("resource type = %q, want %q", resource.InstanceInfo.Type, tt.wantType)
+			}
+		})
+	}
+}
+
+func TestTeamMembershipCreateResourceMissingUser(t *testing.T) {
+	generator := TeamMembershipGenerator{}
+	_, err := generator.createResource("team-id", datadogV2.UserTeam{Id: "membership-id"})
+	if err == nil {
+		t.Fatal("createResource() error = nil, want error")
+	}
+}
+
+func TestTeamMembershipCreateResourceMissingTeam(t *testing.T) {
+	generator := TeamMembershipGenerator{}
+	_, err := generator.createResource("", datadogV2.UserTeam{
+		Id: "membership-id",
+		Relationships: &datadogV2.UserTeamRelationships{
+			User: &datadogV2.RelationshipToUserTeamUser{
+				Data: datadogV2.RelationshipToUserTeamUserData{
+					Id: "user-id",
+				},
+			},
+		},
+	})
+	if err == nil {
+		t.Fatal("createResource() error = nil, want error")
+	}
+}
+
+func TestTeamMembershipCreateResourcesAllowsSharedUsers(t *testing.T) {
+	generator := TeamMembershipGenerator{}
+	membership := datadogV2.UserTeam{
+		Id: "membership-id",
+		Relationships: &datadogV2.UserTeamRelationships{
+			User: &datadogV2.RelationshipToUserTeamUser{
+				Data: datadogV2.RelationshipToUserTeamUserData{
+					Id: "user-id",
+				},
+			},
+		},
+	}
+
+	teamOneResources, err := generator.createResources("team-1", []datadogV2.UserTeam{membership})
+	if err != nil {
+		t.Fatalf("createResources() team-1 error = %v", err)
+	}
+	teamTwoResources, err := generator.createResources("team-2", []datadogV2.UserTeam{membership})
+	if err != nil {
+		t.Fatalf("createResources() team-2 error = %v", err)
+	}
+	if teamOneResources[0].ResourceName == teamTwoResources[0].ResourceName {
+		t.Fatalf("resource names should be unique, got %q", teamOneResources[0].ResourceName)
+	}
+}
+
+func TestParseTeamMembershipImportID(t *testing.T) {
+	tests := []struct {
+		name       string
+		importID   string
+		wantTeamID string
+		wantUserID string
+		wantErr    bool
+	}{
+		{
+			name:       "valid",
+			importID:   "team-id:user-id",
+			wantTeamID: "team-id",
+			wantUserID: "user-id",
+		},
+		{
+			name:     "missing delimiter",
+			importID: "team-id",
+			wantErr:  true,
+		},
+		{
+			name:     "missing team id",
+			importID: ":user-id",
+			wantErr:  true,
+		},
+		{
+			name:     "missing user id",
+			importID: "team-id:",
+			wantErr:  true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			teamID, userID, err := parseTeamMembershipImportID(tt.importID)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatal("parseTeamMembershipImportID() error = nil, want error")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("parseTeamMembershipImportID() error = %v", err)
+			}
+			if teamID != tt.wantTeamID {
+				t.Fatalf("teamID = %q, want %q", teamID, tt.wantTeamID)
+			}
+			if userID != tt.wantUserID {
+				t.Fatalf("userID = %q, want %q", userID, tt.wantUserID)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

- Add Datadog `team_membership` import support using the v2 Teams API membership pagination endpoint.
- Generate stable resources with Terraform's `team_id:user_id` import ID format.
- Register and document `team_membership`, including filter guidance for quoted composite IDs and `team_id` filters.

## Notes

This keeps the Datadog team follow-up scoped to memberships; team links, permission settings, hierarchy links, notification rules, and sync remain separate gaps.
