### PR TITLE
fix(auth0): return management client errors

### DIFF
--- a/providers/auth0/action.go
+++ b/providers/auth0/action.go
@@ -33,7 +33,10 @@ func (g ActionGenerator) createResources(actions []*management.Action) []terrafo
 }
 
 func (g *ActionGenerator) InitResources() error {
-	m := g.generateClient()
+	m, err := g.generateClient()
+	if err != nil {
+		return err
+	}
 	ctx := context.Background()
 	list := []*management.Action{}
 

--- a/providers/auth0/auth0_provider.go
+++ b/providers/auth0/auth0_provider.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"os"
 
+	"github.com/auth0/go-auth0/management"
 	"github.com/chenrui333/terraformer/terraformutils"
 	"github.com/zclconf/go-cty/cty"
 )
@@ -15,9 +16,12 @@ type Auth0Provider struct { //nolint
 	domain       string
 	clientID     string
 	clientSecret string
+	client       *management.Management
 }
 
 func (p *Auth0Provider) Init(_ []string) error {
+	p.client = nil
+
 	orgName := os.Getenv("AUTH0_DOMAIN")
 	if orgName == "" {
 		return errors.New("set AUTH0_DOMAIN env var")
@@ -35,6 +39,12 @@ func (p *Auth0Provider) Init(_ []string) error {
 		return errors.New("set AUTH0_CLIENT_SECRET env var")
 	}
 	p.clientSecret = apiToken
+
+	client, err := newManagementClient(p.domain, p.clientID, p.clientSecret)
+	if err != nil {
+		return err
+	}
+	p.client = client
 
 	return nil
 }
@@ -65,9 +75,10 @@ func (p *Auth0Provider) InitService(serviceName string, verbose bool) error {
 	p.Service.SetVerbose(verbose)
 	p.Service.SetProviderName(p.GetName())
 	p.Service.SetArgs(map[string]interface{}{
-		"domain":        p.domain,
-		"client_id":     p.clientID,
-		"client_secret": p.clientSecret,
+		"domain":            p.domain,
+		"client_id":         p.clientID,
+		"client_secret":     p.clientSecret,
+		managementClientArg: p.client,
 	})
 	return nil
 }

--- a/providers/auth0/auth0_provider_test.go
+++ b/providers/auth0/auth0_provider_test.go
@@ -1,0 +1,44 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package auth0
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestProviderInitRejectsInvalidDomain(t *testing.T) {
+	t.Setenv("AUTH0_DOMAIN", "%zz")
+	t.Setenv("AUTH0_CLIENT_ID", "client-id")
+	t.Setenv("AUTH0_CLIENT_SECRET", "client-secret")
+
+	provider := &Auth0Provider{}
+	err := provider.Init(nil)
+	if err == nil {
+		t.Fatal("expected invalid domain to fail provider initialization")
+	}
+	if !strings.Contains(err.Error(), "create Auth0 management client") {
+		t.Fatalf("expected management client error, got %q", err)
+	}
+}
+
+func TestProviderInitServiceUsesInitializedClient(t *testing.T) {
+	t.Setenv("AUTH0_DOMAIN", "example.auth0.com")
+	t.Setenv("AUTH0_CLIENT_ID", "client-id")
+	t.Setenv("AUTH0_CLIENT_SECRET", "client-secret")
+
+	provider := &Auth0Provider{}
+	if err := provider.Init(nil); err != nil {
+		t.Fatalf("expected provider initialization to succeed: %v", err)
+	}
+	if provider.client == nil {
+		t.Fatal("expected provider initialization to store management client")
+	}
+
+	if err := provider.InitService("auth0_client", false); err != nil {
+		t.Fatalf("expected service initialization to succeed: %v", err)
+	}
+	if provider.Service.GetArgs()[managementClientArg] != provider.client {
+		t.Fatal("expected service to reuse provider-level management client")
+	}
+}

--- a/providers/auth0/auth0_service.go
+++ b/providers/auth0/auth0_service.go
@@ -14,10 +14,12 @@ type Auth0Service struct { //nolint
 	terraformutils.Service
 }
 
-func (s *Auth0Service) generateClient() (*management.Management, error) {
-	authenticationOption := management.WithClientCredentials(context.Background(), s.Args["client_id"].(string), s.Args["client_secret"].(string))
+const managementClientArg = "management_client"
 
-	apiClient, err := management.New(s.Args["domain"].(string),
+func newManagementClient(domain, clientID, clientSecret string) (*management.Management, error) {
+	authenticationOption := management.WithClientCredentials(context.Background(), clientID, clientSecret)
+
+	apiClient, err := management.New(domain,
 		authenticationOption,
 		management.WithDebug(false),
 	)
@@ -26,4 +28,12 @@ func (s *Auth0Service) generateClient() (*management.Management, error) {
 	}
 
 	return apiClient, nil
+}
+
+func (s *Auth0Service) generateClient() (*management.Management, error) {
+	if apiClient, ok := s.Args[managementClientArg].(*management.Management); ok && apiClient != nil {
+		return apiClient, nil
+	}
+
+	return newManagementClient(s.Args["domain"].(string), s.Args["client_id"].(string), s.Args["client_secret"].(string))
 }

--- a/providers/auth0/auth0_service.go
+++ b/providers/auth0/auth0_service.go
@@ -4,7 +4,7 @@ package auth0
 
 import (
 	"context"
-	"log"
+	"fmt"
 
 	"github.com/auth0/go-auth0/management"
 	"github.com/chenrui333/terraformer/terraformutils"
@@ -14,7 +14,7 @@ type Auth0Service struct { //nolint
 	terraformutils.Service
 }
 
-func (s *Auth0Service) generateClient() *management.Management {
+func (s *Auth0Service) generateClient() (*management.Management, error) {
 	authenticationOption := management.WithClientCredentials(context.Background(), s.Args["client_id"].(string), s.Args["client_secret"].(string))
 
 	apiClient, err := management.New(s.Args["domain"].(string),
@@ -22,8 +22,8 @@ func (s *Auth0Service) generateClient() *management.Management {
 		management.WithDebug(false),
 	)
 	if err != nil {
-		log.Fatalf("%v", err)
+		return nil, fmt.Errorf("create Auth0 management client: %w", err)
 	}
 
-	return apiClient
+	return apiClient, nil
 }

--- a/providers/auth0/branding.go
+++ b/providers/auth0/branding.go
@@ -32,7 +32,10 @@ func (g BrandingGenerator) createResources(branding *management.Branding) []terr
 }
 
 func (g *BrandingGenerator) InitResources() error {
-	m := g.generateClient()
+	m, err := g.generateClient()
+	if err != nil {
+		return err
+	}
 	ctx := context.Background()
 	branding, err := m.Branding.Read(ctx)
 	if err != nil {

--- a/providers/auth0/client.go
+++ b/providers/auth0/client.go
@@ -33,7 +33,10 @@ func (g ClientGenerator) createResources(clients []*management.Client) []terrafo
 }
 
 func (g *ClientGenerator) InitResources() error {
-	m := g.generateClient()
+	m, err := g.generateClient()
+	if err != nil {
+		return err
+	}
 	ctx := context.Background()
 	list := []*management.Client{}
 

--- a/providers/auth0/client_grant.go
+++ b/providers/auth0/client_grant.go
@@ -33,7 +33,10 @@ func (g ClientGrantGenerator) createResources(clientGrantGrants []*management.Cl
 }
 
 func (g *ClientGrantGenerator) InitResources() error {
-	m := g.generateClient()
+	m, err := g.generateClient()
+	if err != nil {
+		return err
+	}
 	ctx := context.Background()
 	list := []*management.ClientGrant{}
 

--- a/providers/auth0/custom_domain.go
+++ b/providers/auth0/custom_domain.go
@@ -33,7 +33,10 @@ func (g CustomDomainGenerator) createResources(customDomains []*management.Custo
 }
 
 func (g *CustomDomainGenerator) InitResources() error {
-	m := g.generateClient()
+	m, err := g.generateClient()
+	if err != nil {
+		return err
+	}
 	ctx := context.Background()
 	list, err := m.CustomDomain.List(ctx)
 	if err != nil {

--- a/providers/auth0/email.go
+++ b/providers/auth0/email.go
@@ -31,7 +31,10 @@ func (g EmailGenerator) createResources(email *management.EmailProvider) []terra
 }
 
 func (g *EmailGenerator) InitResources() error {
-	m := g.generateClient()
+	m, err := g.generateClient()
+	if err != nil {
+		return err
+	}
 	ctx := context.Background()
 	email, err := m.EmailProvider.Read(ctx)
 	if err != nil {

--- a/providers/auth0/hook.go
+++ b/providers/auth0/hook.go
@@ -33,7 +33,10 @@ func (g HookGenerator) createResources(hooks []*management.Hook) []terraformutil
 }
 
 func (g *HookGenerator) InitResources() error {
-	m := g.generateClient()
+	m, err := g.generateClient()
+	if err != nil {
+		return err
+	}
 	ctx := context.Background()
 	list := []*management.Hook{}
 

--- a/providers/auth0/log_stream.go
+++ b/providers/auth0/log_stream.go
@@ -33,7 +33,10 @@ func (g LogStreamGenerator) createResources(logStreams []*management.LogStream) 
 }
 
 func (g *LogStreamGenerator) InitResources() error {
-	m := g.generateClient()
+	m, err := g.generateClient()
+	if err != nil {
+		return err
+	}
 	ctx := context.Background()
 	list, err := m.LogStream.List(ctx)
 	if err != nil {

--- a/providers/auth0/prompt.go
+++ b/providers/auth0/prompt.go
@@ -32,7 +32,10 @@ func (g PromptGenerator) createResources(prompt *management.Prompt) []terraformu
 }
 
 func (g *PromptGenerator) InitResources() error {
-	m := g.generateClient()
+	m, err := g.generateClient()
+	if err != nil {
+		return err
+	}
 	ctx := context.Background()
 	prompt, err := m.Prompt.Read(ctx)
 	if err != nil {

--- a/providers/auth0/resource_server.go
+++ b/providers/auth0/resource_server.go
@@ -33,7 +33,10 @@ func (g ResourceServerGenerator) createResources(resourceServers []*management.R
 }
 
 func (g *ResourceServerGenerator) InitResources() error {
-	m := g.generateClient()
+	m, err := g.generateClient()
+	if err != nil {
+		return err
+	}
 	ctx := context.Background()
 	list := []*management.ResourceServer{}
 

--- a/providers/auth0/role.go
+++ b/providers/auth0/role.go
@@ -33,7 +33,10 @@ func (g RoleGenerator) createResources(roles []*management.Role) []terraformutil
 }
 
 func (g *RoleGenerator) InitResources() error {
-	m := g.generateClient()
+	m, err := g.generateClient()
+	if err != nil {
+		return err
+	}
 	ctx := context.Background()
 	list := []*management.Role{}
 

--- a/providers/auth0/rule.go
+++ b/providers/auth0/rule.go
@@ -33,7 +33,10 @@ func (g RuleGenerator) createResources(rules []*management.Rule) []terraformutil
 }
 
 func (g *RuleGenerator) InitResources() error {
-	m := g.generateClient()
+	m, err := g.generateClient()
+	if err != nil {
+		return err
+	}
 	ctx := context.Background()
 	list := []*management.Rule{}
 

--- a/providers/auth0/rule_config.go
+++ b/providers/auth0/rule_config.go
@@ -33,7 +33,10 @@ func (g RuleConfigGenerator) createResources(ruleConfigConfigs []*management.Rul
 }
 
 func (g *RuleConfigGenerator) InitResources() error {
-	m := g.generateClient()
+	m, err := g.generateClient()
+	if err != nil {
+		return err
+	}
 	ctx := context.Background()
 
 	list, err := m.RuleConfig.List(ctx)

--- a/providers/auth0/tenant.go
+++ b/providers/auth0/tenant.go
@@ -32,7 +32,10 @@ func (g TenantGenerator) createResources(tenant *management.Tenant) []terraformu
 }
 
 func (g *TenantGenerator) InitResources() error {
-	m := g.generateClient()
+	m, err := g.generateClient()
+	if err != nil {
+		return err
+	}
 	ctx := context.Background()
 	Tenant, err := m.Tenant.Read(ctx)
 	if err != nil {

--- a/providers/auth0/trigger_binding.go
+++ b/providers/auth0/trigger_binding.go
@@ -38,7 +38,10 @@ func (g TriggerBindingGenerator) createResources(bindings map[string]*management
 }
 
 func (g *TriggerBindingGenerator) InitResources() error {
-	m := g.generateClient()
+	m, err := g.generateClient()
+	if err != nil {
+		return err
+	}
 	ctx := context.Background()
 	bindings := map[string]*management.ActionBinding{}
 

--- a/providers/auth0/user.go
+++ b/providers/auth0/user.go
@@ -33,7 +33,10 @@ func (g UserGenerator) createResources(users []*management.User) []terraformutil
 }
 
 func (g *UserGenerator) InitResources() error {
-	m := g.generateClient()
+	m, err := g.generateClient()
+	if err != nil {
+		return err
+	}
 	ctx := context.Background()
 	list := []*management.User{}
 


### PR DESCRIPTION
## Summary

- Return Auth0 management client construction errors instead of exiting the process.
- Build the Auth0 management client during provider initialization so provider-wide setup failures propagate instead of being treated as skipped service imports.
- Reuse the initialized management client across Auth0 resource generators.
