### PR TITLE
aws(dynamodb): add additional DynamoDB resources

### DIFF
--- a/docs/aws.md
+++ b/docs/aws.md
@@ -157,7 +157,11 @@ terraformer import aws --resources=sg --regions=us-east-1
     * `aws_docdb_cluster_parameter_group`
     * `aws_docdb_subnet_group`
 *   `dynamodb`
+    * `aws_dynamodb_contributor_insights`
+    * `aws_dynamodb_kinesis_streaming_destination`
+    * `aws_dynamodb_resource_policy`
     * `aws_dynamodb_table`
+    * `aws_dynamodb_table_export`
 *   `ebs`
     * `aws_ebs_volume`
     * `aws_volume_attachment`

--- a/providers/aws/dynamodb.go
+++ b/providers/aws/dynamodb.go
@@ -4,8 +4,13 @@ package aws
 
 import (
 	"context"
+	"errors"
+	"fmt"
+	"log"
+	"strings"
 
 	"github.com/aws/aws-sdk-go-v2/service/dynamodb"
+	dynamodbtypes "github.com/aws/aws-sdk-go-v2/service/dynamodb/types"
 	"github.com/chenrui333/terraformer/terraformutils"
 )
 
@@ -15,23 +20,231 @@ type DynamoDbGenerator struct {
 	AWSService
 }
 
+type dynamodbOptionalResourceLoader struct {
+	name string
+	load func() error
+}
+
+type dynamodbTableReference struct {
+	name      string
+	tableARN  string
+	streamARN string
+}
+
+func (g *DynamoDbGenerator) loadOptionalResources(loaders []dynamodbOptionalResourceLoader) {
+	for _, loader := range loaders {
+		if err := loader.load(); err != nil {
+			log.Printf("Skipping DynamoDB %s: %v", loader.name, err)
+		}
+	}
+}
+
 func (g *DynamoDbGenerator) InitResources() error {
 	config, e := g.generateConfig()
 	if e != nil {
 		return e
 	}
 	svc := dynamodb.NewFromConfig(config)
+
+	tables, err := g.loadTables(svc)
+	if err != nil {
+		return err
+	}
+
+	loaders := []dynamodbOptionalResourceLoader{
+		{name: "Kinesis streaming destinations", load: func() error { return g.loadKinesisStreamingDestinations(svc, tables) }},
+		{name: "resource policies", load: func() error { return g.loadResourcePolicies(svc, tables) }},
+		{name: "table exports", load: func() error { return g.loadTableExports(svc) }},
+	}
+	if account, err := g.getAccountNumber(config); err != nil {
+		log.Printf("Skipping DynamoDB contributor insights: unable to get account ID: %v", err)
+	} else if accountID := StringValue(account); accountID != "" {
+		loaders = append(loaders, dynamodbOptionalResourceLoader{
+			name: "contributor insights",
+			load: func() error { return g.loadContributorInsights(svc, accountID) },
+		})
+	}
+	g.loadOptionalResources(loaders)
+
+	return nil
+}
+
+func (g *DynamoDbGenerator) loadTables(svc *dynamodb.Client) ([]dynamodbTableReference, error) {
+	var tables []dynamodbTableReference
 	p := dynamodb.NewListTablesPaginator(svc, &dynamodb.ListTablesInput{})
 	for p.HasMorePages() {
 		page, e := p.NextPage(context.TODO())
 		if e != nil {
-			return e
+			return tables, e
 		}
 		for _, tableName := range page.TableNames {
+			if tableName == "" {
+				continue
+			}
 			g.Resources = append(g.Resources, terraformutils.NewSimpleResource(
 				tableName,
 				tableName,
 				"aws_dynamodb_table",
+				"aws",
+				dynamodbAllowEmptyValues,
+			))
+			tables = append(tables, g.tableReference(svc, tableName))
+		}
+	}
+	return tables, nil
+}
+
+func (g *DynamoDbGenerator) tableReference(svc *dynamodb.Client, tableName string) dynamodbTableReference {
+	table := dynamodbTableReference{name: tableName}
+	output, err := svc.DescribeTable(context.TODO(), &dynamodb.DescribeTableInput{TableName: &tableName})
+	if err != nil {
+		log.Printf("Skipping DynamoDB table metadata for %s: %v", tableName, err)
+		return table
+	}
+	if output == nil || output.Table == nil {
+		return table
+	}
+	table.tableARN = StringValue(output.Table.TableArn)
+	table.streamARN = StringValue(output.Table.LatestStreamArn)
+	return table
+}
+
+func (g *DynamoDbGenerator) loadContributorInsights(svc *dynamodb.Client, accountID string) error {
+	p := dynamodb.NewListContributorInsightsPaginator(svc, &dynamodb.ListContributorInsightsInput{})
+	for p.HasMorePages() {
+		page, err := p.NextPage(context.TODO())
+		if err != nil {
+			return err
+		}
+		for _, summary := range page.ContributorInsightsSummaries {
+			tableName := StringValue(summary.TableName)
+			indexName := StringValue(summary.IndexName)
+			if tableName == "" || !dynamodbContributorInsightsImportable(summary) {
+				continue
+			}
+			attributes := map[string]string{"table_name": tableName}
+			if indexName != "" {
+				attributes["index_name"] = indexName
+			}
+			g.Resources = append(g.Resources, terraformutils.NewResource(
+				dynamodbContributorInsightsImportID(tableName, indexName, accountID),
+				dynamodbResourceName(tableName, indexName, "contributor-insights"),
+				"aws_dynamodb_contributor_insights",
+				"aws",
+				attributes,
+				dynamodbAllowEmptyValues,
+				map[string]interface{}{},
+			))
+		}
+	}
+	return nil
+}
+
+func (g *DynamoDbGenerator) loadKinesisStreamingDestinations(svc *dynamodb.Client, tables []dynamodbTableReference) error {
+	for _, table := range tables {
+		output, err := svc.DescribeKinesisStreamingDestination(context.TODO(), &dynamodb.DescribeKinesisStreamingDestinationInput{
+			TableName: &table.name,
+		})
+		if err != nil {
+			log.Printf("Skipping DynamoDB Kinesis streaming destinations for %s: %v", table.name, err)
+			continue
+		}
+		if output == nil {
+			continue
+		}
+		for _, destination := range output.KinesisDataStreamDestinations {
+			streamARN := StringValue(destination.StreamArn)
+			if streamARN == "" || !dynamodbKinesisStreamingDestinationImportable(destination) {
+				continue
+			}
+			attributes := map[string]string{
+				"stream_arn": streamARN,
+				"table_name": table.name,
+			}
+			if precision := string(destination.ApproximateCreationDateTimePrecision); precision != "" {
+				attributes["approximate_creation_date_time_precision"] = precision
+			}
+			g.Resources = append(g.Resources, terraformutils.NewResource(
+				dynamodbKinesisStreamingDestinationImportID(table.name, streamARN),
+				dynamodbResourceName(table.name, arnLastSegment(streamARN, "/")),
+				"aws_dynamodb_kinesis_streaming_destination",
+				"aws",
+				attributes,
+				dynamodbAllowEmptyValues,
+				map[string]interface{}{},
+			))
+		}
+	}
+	return nil
+}
+
+func (g *DynamoDbGenerator) loadResourcePolicies(svc *dynamodb.Client, tables []dynamodbTableReference) error {
+	for _, table := range tables {
+		for _, resource := range table.resourcePolicyTargets() {
+			output, err := svc.GetResourcePolicy(context.TODO(), &dynamodb.GetResourcePolicyInput{ResourceArn: &resource.arn})
+			if err != nil {
+				if dynamodbResourcePolicyMissing(err) {
+					continue
+				}
+				log.Printf("Skipping DynamoDB resource policy for %s: %v", resource.name, err)
+				continue
+			}
+			if output == nil {
+				continue
+			}
+			policy := StringValue(output.Policy)
+			if policy == "" {
+				continue
+			}
+			g.Resources = append(g.Resources, terraformutils.NewResource(
+				resource.arn,
+				dynamodbResourceName(resource.name, "policy"),
+				"aws_dynamodb_resource_policy",
+				"aws",
+				map[string]string{
+					"policy":       policy,
+					"resource_arn": resource.arn,
+				},
+				dynamodbAllowEmptyValues,
+				map[string]interface{}{},
+			))
+		}
+	}
+	return nil
+}
+
+type dynamodbResourcePolicyTarget struct {
+	name string
+	arn  string
+}
+
+func (table dynamodbTableReference) resourcePolicyTargets() []dynamodbResourcePolicyTarget {
+	var targets []dynamodbResourcePolicyTarget
+	if table.tableARN != "" {
+		targets = append(targets, dynamodbResourcePolicyTarget{name: table.name, arn: table.tableARN})
+	}
+	if table.streamARN != "" {
+		targets = append(targets, dynamodbResourcePolicyTarget{name: dynamodbResourceName(table.name, "stream"), arn: table.streamARN})
+	}
+	return targets
+}
+
+func (g *DynamoDbGenerator) loadTableExports(svc *dynamodb.Client) error {
+	p := dynamodb.NewListExportsPaginator(svc, &dynamodb.ListExportsInput{})
+	for p.HasMorePages() {
+		page, err := p.NextPage(context.TODO())
+		if err != nil {
+			return err
+		}
+		for _, export := range page.ExportSummaries {
+			exportARN := StringValue(export.ExportArn)
+			if exportARN == "" || !dynamodbTableExportImportable(export) {
+				continue
+			}
+			g.Resources = append(g.Resources, terraformutils.NewSimpleResource(
+				exportARN,
+				dynamodbResourceName(arnLastSegment(exportARN, "/")),
+				"aws_dynamodb_table_export",
 				"aws",
 				dynamodbAllowEmptyValues,
 			))
@@ -42,12 +255,58 @@ func (g *DynamoDbGenerator) InitResources() error {
 
 func (g *DynamoDbGenerator) PostConvertHook() error {
 	for _, r := range g.Resources {
-		if r.InstanceInfo.Type != "aws_dynamodb_table" {
+		switch r.InstanceInfo.Type {
+		case "aws_dynamodb_table":
+			if val, ok := r.InstanceState.Attributes["ttl.0.enabled"]; ok && val == "false" {
+				delete(r.Item, "ttl")
+			}
+		case "aws_dynamodb_resource_policy":
+			if val, ok := r.Item["policy"]; ok {
+				policy := g.escapeAwsInterpolation(val.(string))
+				r.Item["policy"] = fmt.Sprintf("<<POLICY\n%s\nPOLICY", policy)
+			}
+		default:
 			continue
-		}
-		if val, ok := r.InstanceState.Attributes["ttl.0.enabled"]; ok && val == "false" {
-			delete(r.Item, "ttl")
 		}
 	}
 	return nil
+}
+
+func dynamodbContributorInsightsImportID(tableName, indexName, accountID string) string {
+	return fmt.Sprintf("name:%s/index:%s/%s", tableName, indexName, accountID)
+}
+
+func dynamodbKinesisStreamingDestinationImportID(tableName, streamARN string) string {
+	return strings.Join([]string{tableName, streamARN}, ",")
+}
+
+func dynamodbResourceName(parts ...string) string {
+	var cleanParts []string
+	for _, part := range parts {
+		if part != "" {
+			cleanParts = append(cleanParts, part)
+		}
+	}
+	if len(cleanParts) == 0 {
+		return "dynamodb_resource"
+	}
+	return strings.Join(cleanParts, "_")
+}
+
+func dynamodbContributorInsightsImportable(summary dynamodbtypes.ContributorInsightsSummary) bool {
+	return summary.ContributorInsightsStatus != "" && summary.ContributorInsightsStatus != dynamodbtypes.ContributorInsightsStatusDisabled
+}
+
+func dynamodbKinesisStreamingDestinationImportable(destination dynamodbtypes.KinesisDataStreamDestination) bool {
+	return destination.DestinationStatus != "" && destination.DestinationStatus != dynamodbtypes.DestinationStatusDisabled
+}
+
+func dynamodbTableExportImportable(export dynamodbtypes.ExportSummary) bool {
+	return export.ExportStatus != "" && export.ExportStatus != dynamodbtypes.ExportStatusFailed
+}
+
+func dynamodbResourcePolicyMissing(err error) bool {
+	var policyNotFound *dynamodbtypes.PolicyNotFoundException
+	var resourceNotFound *dynamodbtypes.ResourceNotFoundException
+	return errors.As(err, &policyNotFound) || errors.As(err, &resourceNotFound)
 }

--- a/providers/aws/dynamodb.go
+++ b/providers/aws/dynamodb.go
@@ -290,7 +290,7 @@ func dynamodbResourceName(parts ...string) string {
 	if len(cleanParts) == 0 {
 		return "dynamodb_resource"
 	}
-	return strings.Join(cleanParts, "_")
+	return strings.Join(cleanParts, "/")
 }
 
 func dynamodbContributorInsightsImportable(summary dynamodbtypes.ContributorInsightsSummary) bool {

--- a/providers/aws/dynamodb.go
+++ b/providers/aws/dynamodb.go
@@ -294,15 +294,15 @@ func dynamodbResourceName(parts ...string) string {
 }
 
 func dynamodbContributorInsightsImportable(summary dynamodbtypes.ContributorInsightsSummary) bool {
-	return summary.ContributorInsightsStatus != "" && summary.ContributorInsightsStatus != dynamodbtypes.ContributorInsightsStatusDisabled
+	return summary.ContributorInsightsStatus == dynamodbtypes.ContributorInsightsStatusEnabled
 }
 
 func dynamodbKinesisStreamingDestinationImportable(destination dynamodbtypes.KinesisDataStreamDestination) bool {
-	return destination.DestinationStatus != "" && destination.DestinationStatus != dynamodbtypes.DestinationStatusDisabled
+	return destination.DestinationStatus == dynamodbtypes.DestinationStatusActive
 }
 
 func dynamodbTableExportImportable(export dynamodbtypes.ExportSummary) bool {
-	return export.ExportStatus != "" && export.ExportStatus != dynamodbtypes.ExportStatusFailed
+	return export.ExportStatus != ""
 }
 
 func dynamodbResourcePolicyMissing(err error) bool {

--- a/providers/aws/dynamodb_test.go
+++ b/providers/aws/dynamodb_test.go
@@ -70,6 +70,16 @@ func TestDynamoDBContributorInsightsImportable(t *testing.T) {
 	}) {
 		t.Fatal("disabled contributor insights should not be importable")
 	}
+	if dynamodbContributorInsightsImportable(dynamodbtypes.ContributorInsightsSummary{
+		ContributorInsightsStatus: dynamodbtypes.ContributorInsightsStatusFailed,
+	}) {
+		t.Fatal("failed contributor insights should not be importable")
+	}
+	if dynamodbContributorInsightsImportable(dynamodbtypes.ContributorInsightsSummary{
+		ContributorInsightsStatus: dynamodbtypes.ContributorInsightsStatusDisabling,
+	}) {
+		t.Fatal("disabling contributor insights should not be importable")
+	}
 	if dynamodbContributorInsightsImportable(dynamodbtypes.ContributorInsightsSummary{}) {
 		t.Fatal("empty contributor insights status should not be importable")
 	}
@@ -86,6 +96,16 @@ func TestDynamoDBKinesisStreamingDestinationImportable(t *testing.T) {
 	}) {
 		t.Fatal("disabled Kinesis streaming destination should not be importable")
 	}
+	if dynamodbKinesisStreamingDestinationImportable(dynamodbtypes.KinesisDataStreamDestination{
+		DestinationStatus: dynamodbtypes.DestinationStatusEnableFailed,
+	}) {
+		t.Fatal("enable-failed Kinesis streaming destination should not be importable")
+	}
+	if dynamodbKinesisStreamingDestinationImportable(dynamodbtypes.KinesisDataStreamDestination{
+		DestinationStatus: dynamodbtypes.DestinationStatusDisabling,
+	}) {
+		t.Fatal("disabling Kinesis streaming destination should not be importable")
+	}
 	if dynamodbKinesisStreamingDestinationImportable(dynamodbtypes.KinesisDataStreamDestination{}) {
 		t.Fatal("empty Kinesis streaming destination status should not be importable")
 	}
@@ -95,8 +115,8 @@ func TestDynamoDBTableExportImportable(t *testing.T) {
 	if !dynamodbTableExportImportable(dynamodbtypes.ExportSummary{ExportStatus: dynamodbtypes.ExportStatusCompleted}) {
 		t.Fatal("completed table export should be importable")
 	}
-	if dynamodbTableExportImportable(dynamodbtypes.ExportSummary{ExportStatus: dynamodbtypes.ExportStatusFailed}) {
-		t.Fatal("failed table export should not be importable")
+	if !dynamodbTableExportImportable(dynamodbtypes.ExportSummary{ExportStatus: dynamodbtypes.ExportStatusFailed}) {
+		t.Fatal("failed table export should be importable")
 	}
 	if dynamodbTableExportImportable(dynamodbtypes.ExportSummary{}) {
 		t.Fatal("empty table export status should not be importable")

--- a/providers/aws/dynamodb_test.go
+++ b/providers/aws/dynamodb_test.go
@@ -1,0 +1,192 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package aws
+
+import (
+	"errors"
+	"testing"
+
+	dynamodbtypes "github.com/aws/aws-sdk-go-v2/service/dynamodb/types"
+	"github.com/chenrui333/terraformer/terraformutils"
+)
+
+func TestDynamoDBContributorInsightsImportID(t *testing.T) {
+	tests := []struct {
+		name      string
+		tableName string
+		indexName string
+		accountID string
+		want      string
+	}{
+		{name: "table", tableName: "events", accountID: "123456789012", want: "name:events/index:/123456789012"},
+		{name: "index", tableName: "events", indexName: "by-user", accountID: "123456789012", want: "name:events/index:by-user/123456789012"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := dynamodbContributorInsightsImportID(tt.tableName, tt.indexName, tt.accountID)
+			if got != tt.want {
+				t.Fatalf("dynamodbContributorInsightsImportID() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestDynamoDBKinesisStreamingDestinationImportID(t *testing.T) {
+	got := dynamodbKinesisStreamingDestinationImportID("events", "arn:aws:kinesis:us-east-1:123456789012:stream/events")
+	want := "events,arn:aws:kinesis:us-east-1:123456789012:stream/events"
+	if got != want {
+		t.Fatalf("dynamodbKinesisStreamingDestinationImportID() = %q, want %q", got, want)
+	}
+}
+
+func TestDynamoDBResourceName(t *testing.T) {
+	tests := []struct {
+		name  string
+		parts []string
+		want  string
+	}{
+		{name: "filters empty parts", parts: []string{"", "events", "", "policy"}, want: "events_policy"},
+		{name: "fallback", parts: nil, want: "dynamodb_resource"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := dynamodbResourceName(tt.parts...)
+			if got != tt.want {
+				t.Fatalf("dynamodbResourceName() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestDynamoDBContributorInsightsImportable(t *testing.T) {
+	if !dynamodbContributorInsightsImportable(dynamodbtypes.ContributorInsightsSummary{
+		ContributorInsightsStatus: dynamodbtypes.ContributorInsightsStatusEnabled,
+	}) {
+		t.Fatal("enabled contributor insights should be importable")
+	}
+	if dynamodbContributorInsightsImportable(dynamodbtypes.ContributorInsightsSummary{
+		ContributorInsightsStatus: dynamodbtypes.ContributorInsightsStatusDisabled,
+	}) {
+		t.Fatal("disabled contributor insights should not be importable")
+	}
+	if dynamodbContributorInsightsImportable(dynamodbtypes.ContributorInsightsSummary{}) {
+		t.Fatal("empty contributor insights status should not be importable")
+	}
+}
+
+func TestDynamoDBKinesisStreamingDestinationImportable(t *testing.T) {
+	if !dynamodbKinesisStreamingDestinationImportable(dynamodbtypes.KinesisDataStreamDestination{
+		DestinationStatus: dynamodbtypes.DestinationStatusActive,
+	}) {
+		t.Fatal("active Kinesis streaming destination should be importable")
+	}
+	if dynamodbKinesisStreamingDestinationImportable(dynamodbtypes.KinesisDataStreamDestination{
+		DestinationStatus: dynamodbtypes.DestinationStatusDisabled,
+	}) {
+		t.Fatal("disabled Kinesis streaming destination should not be importable")
+	}
+	if dynamodbKinesisStreamingDestinationImportable(dynamodbtypes.KinesisDataStreamDestination{}) {
+		t.Fatal("empty Kinesis streaming destination status should not be importable")
+	}
+}
+
+func TestDynamoDBTableExportImportable(t *testing.T) {
+	if !dynamodbTableExportImportable(dynamodbtypes.ExportSummary{ExportStatus: dynamodbtypes.ExportStatusCompleted}) {
+		t.Fatal("completed table export should be importable")
+	}
+	if dynamodbTableExportImportable(dynamodbtypes.ExportSummary{ExportStatus: dynamodbtypes.ExportStatusFailed}) {
+		t.Fatal("failed table export should not be importable")
+	}
+	if dynamodbTableExportImportable(dynamodbtypes.ExportSummary{}) {
+		t.Fatal("empty table export status should not be importable")
+	}
+}
+
+func TestDynamoDBResourcePolicyTargets(t *testing.T) {
+	table := dynamodbTableReference{
+		name:      "events",
+		tableARN:  "arn:aws:dynamodb:us-east-1:123456789012:table/events",
+		streamARN: "arn:aws:dynamodb:us-east-1:123456789012:table/events/stream/2026-05-02T00:00:00.000",
+	}
+	targets := table.resourcePolicyTargets()
+	if len(targets) != 2 {
+		t.Fatalf("len(targets) = %d, want 2", len(targets))
+	}
+	if got, want := targets[0].name, "events"; got != want {
+		t.Fatalf("table target name = %q, want %q", got, want)
+	}
+	if got, want := targets[1].name, "events_stream"; got != want {
+		t.Fatalf("stream target name = %q, want %q", got, want)
+	}
+}
+
+func TestDynamoDBResourcePolicyMissing(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{name: "policy not found", err: &dynamodbtypes.PolicyNotFoundException{}, want: true},
+		{name: "resource not found", err: &dynamodbtypes.ResourceNotFoundException{}, want: true},
+		{name: "wrapped", err: &wrappedError{err: &dynamodbtypes.PolicyNotFoundException{}}, want: true},
+		{name: "other", err: errors.New("boom"), want: false},
+		{name: "nil", err: nil, want: false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := dynamodbResourcePolicyMissing(tt.err)
+			if got != tt.want {
+				t.Fatalf("dynamodbResourcePolicyMissing() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestDynamoDBPostConvertHookWrapsResourcePolicy(t *testing.T) {
+	g := &DynamoDbGenerator{}
+	g.Resources = append(g.Resources, terraformutilsNewResourceForTest(
+		"arn:aws:dynamodb:us-east-1:123456789012:table/events",
+		"events_policy",
+		"aws_dynamodb_resource_policy",
+		map[string]interface{}{"policy": "{\"Version\":\"2012-10-17\"}"},
+	))
+	if err := g.PostConvertHook(); err != nil {
+		t.Fatalf("PostConvertHook() error = %v", err)
+	}
+	got := g.Resources[0].Item["policy"]
+	want := "<<POLICY\n{\"Version\":\"2012-10-17\"}\nPOLICY"
+	if got != want {
+		t.Fatalf("policy = %q, want %q", got, want)
+	}
+}
+
+func TestDynamoDBPostConvertHookRemovesDisabledTTL(t *testing.T) {
+	resource := terraformutilsNewResourceForTest("events", "events", "aws_dynamodb_table", map[string]interface{}{"ttl": []interface{}{map[string]interface{}{"enabled": false}}})
+	resource.InstanceState.Attributes["ttl.0.enabled"] = "false"
+	g := &DynamoDbGenerator{}
+	g.Resources = append(g.Resources, resource)
+	if err := g.PostConvertHook(); err != nil {
+		t.Fatalf("PostConvertHook() error = %v", err)
+	}
+	if _, ok := g.Resources[0].Item["ttl"]; ok {
+		t.Fatal("ttl should be removed when disabled")
+	}
+}
+
+type wrappedError struct {
+	err error
+}
+
+func (e *wrappedError) Error() string {
+	return e.err.Error()
+}
+
+func (e *wrappedError) Unwrap() error {
+	return e.err
+}
+
+func terraformutilsNewResourceForTest(id, name, resourceType string, item map[string]interface{}) terraformutils.Resource {
+	resource := terraformutils.NewSimpleResource(id, name, resourceType, "aws", dynamodbAllowEmptyValues)
+	resource.Item = item
+	return resource
+}

--- a/providers/aws/dynamodb_test.go
+++ b/providers/aws/dynamodb_test.go
@@ -45,7 +45,8 @@ func TestDynamoDBResourceName(t *testing.T) {
 		parts []string
 		want  string
 	}{
-		{name: "filters empty parts", parts: []string{"", "events", "", "policy"}, want: "events_policy"},
+		{name: "filters empty parts", parts: []string{"", "events", "", "policy"}, want: "events/policy"},
+		{name: "preserves segment boundaries", parts: []string{"orders", "stream", "policy"}, want: "orders/stream/policy"},
 		{name: "fallback", parts: nil, want: "dynamodb_resource"},
 	}
 	for _, tt := range tests {
@@ -115,8 +116,16 @@ func TestDynamoDBResourcePolicyTargets(t *testing.T) {
 	if got, want := targets[0].name, "events"; got != want {
 		t.Fatalf("table target name = %q, want %q", got, want)
 	}
-	if got, want := targets[1].name, "events_stream"; got != want {
+	if got, want := targets[1].name, "events/stream"; got != want {
 		t.Fatalf("stream target name = %q, want %q", got, want)
+	}
+}
+
+func TestDynamoDBResourceNamesAvoidSegmentCollisions(t *testing.T) {
+	tablePolicy := dynamodbResourceName("orders_stream", "policy")
+	streamPolicy := dynamodbResourceName("orders", "stream", "policy")
+	if tablePolicy == streamPolicy {
+		t.Fatalf("resource names collide: %q", tablePolicy)
 	}
 }
 


### PR DESCRIPTION
## Summary

- add best-effort discovery for DynamoDB contributor insights, Kinesis streaming destinations, resource policies, and table exports
- keep table import as the core hard-fail path while logging/skipping optional resources when permissions or metadata are unavailable
- document the expanded DynamoDB resource coverage and add helper tests for import IDs, filtering, and policy formatting
