### PR TITLE
feat(datadog): add team link import

### DIFF
--- a/docs/datadog.md
+++ b/docs/datadog.md
@@ -150,6 +150,9 @@ Tag filters are order specific. For example, if your monitor has tags (in the or
     * `datadog_synthetics_test`
 *   `team`
     * `datadog_team`
+*   `team_link`
+    * `datadog_team_link`
+        * **_NOTE:_** Importing a single team link by ID requires quoting the `team_id:link_id` filter value, for example `--filter="team_link='team-id:link-id'"`; links can also be filtered by `team_id`
 *   `team_membership`
     * `datadog_team_membership`
         * **_NOTE:_** Importing a single membership by ID requires quoting the `team_id:user_id` filter value, for example `--filter="team_membership='team-id:user-id'"`; memberships can also be filtered by `team_id`

--- a/providers/datadog/datadog_provider.go
+++ b/providers/datadog/datadog_provider.go
@@ -177,6 +177,7 @@ func (p *DatadogProvider) GetSupportedService() map[string]terraformutils.Servic
 		"synthetics_global_variable":           &SyntheticsGlobalVariableGenerator{},
 		"synthetics_private_location":          &SyntheticsPrivateLocationGenerator{},
 		"team":                                 &TeamGenerator{},
+		"team_link":                            &TeamLinkGenerator{},
 		"team_membership":                      &TeamMembershipGenerator{},
 		"user":                                 &UserGenerator{},
 		"role":                                 &RoleGenerator{},

--- a/providers/datadog/team_link.go
+++ b/providers/datadog/team_link.go
@@ -105,7 +105,7 @@ func (g *TeamLinkGenerator) filteredResources(auth context.Context, api *datadog
 	resources := []terraformutils.Resource{}
 	filtered := false
 
-	for _, filter := range g.Filter {
+	for filterIndex, filter := range g.Filter {
 		if !filter.IsApplicable("team_link") {
 			continue
 		}
@@ -113,21 +113,22 @@ func (g *TeamLinkGenerator) filteredResources(auth context.Context, api *datadog
 		switch filter.FieldPath {
 		case "id":
 			filtered = true
-			for _, value := range filter.AcceptableValues {
-				teamID, linkID, err := parseTeamLinkImportID(value)
+			filterIDs, err := parseTeamLinkImportIDs(filter.AcceptableValues)
+			if err != nil {
+				return nil, true, err
+			}
+			for _, filterID := range filterIDs {
+				teamLink, err := getTeamLink(auth, api, filterID.teamID, filterID.linkID)
 				if err != nil {
 					return nil, true, err
 				}
-				teamLink, err := getTeamLink(auth, api, teamID, linkID)
-				if err != nil {
-					return nil, true, err
-				}
-				resource, err := g.createResource(teamID, teamLink)
+				resource, err := g.createResource(filterID.teamID, teamLink)
 				if err != nil {
 					return nil, true, err
 				}
 				resources = append(resources, resource)
 			}
+			g.Filter[filterIndex].AcceptableValues = teamLinkIDs(filterIDs)
 		case "team_id":
 			filtered = true
 			for _, teamID := range filter.AcceptableValues {
@@ -145,6 +146,31 @@ func (g *TeamLinkGenerator) filteredResources(auth context.Context, api *datadog
 	}
 
 	return resources, filtered, nil
+}
+
+type teamLinkFilterID struct {
+	teamID string
+	linkID string
+}
+
+func parseTeamLinkImportIDs(importIDs []string) ([]teamLinkFilterID, error) {
+	filterIDs := []teamLinkFilterID{}
+	for _, importID := range importIDs {
+		teamID, linkID, err := parseTeamLinkImportID(importID)
+		if err != nil {
+			return nil, err
+		}
+		filterIDs = append(filterIDs, teamLinkFilterID{teamID: teamID, linkID: linkID})
+	}
+	return filterIDs, nil
+}
+
+func teamLinkIDs(filterIDs []teamLinkFilterID) []string {
+	linkIDs := []string{}
+	for _, filterID := range filterIDs {
+		linkIDs = append(linkIDs, filterID.linkID)
+	}
+	return linkIDs
 }
 
 func parseTeamLinkImportID(importID string) (string, string, error) {

--- a/providers/datadog/team_link.go
+++ b/providers/datadog/team_link.go
@@ -1,0 +1,183 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package datadog
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/DataDog/datadog-api-client-go/v2/api/datadog"
+	"github.com/DataDog/datadog-api-client-go/v2/api/datadogV2"
+
+	"github.com/chenrui333/terraformer/terraformutils"
+)
+
+var (
+	// TeamLinkAllowEmptyValues ...
+	TeamLinkAllowEmptyValues = []string{}
+)
+
+// TeamLinkGenerator ...
+type TeamLinkGenerator struct {
+	DatadogService
+}
+
+func (g *TeamLinkGenerator) createResources(teamID string, teamLinks []datadogV2.TeamLink) ([]terraformutils.Resource, error) {
+	resources := []terraformutils.Resource{}
+	for _, teamLink := range teamLinks {
+		resource, err := g.createResource(teamID, teamLink)
+		if err != nil {
+			return nil, err
+		}
+		resources = append(resources, resource)
+	}
+
+	return resources, nil
+}
+
+func (g *TeamLinkGenerator) createResource(teamID string, teamLink datadogV2.TeamLink) (terraformutils.Resource, error) {
+	linkID := teamLink.GetId()
+	if linkID == "" {
+		return terraformutils.Resource{}, fmt.Errorf("team link missing id")
+	}
+
+	attributes := teamLink.GetAttributes()
+	if attributeTeamID := attributes.GetTeamId(); attributeTeamID != "" {
+		teamID = attributeTeamID
+	}
+	if teamID == "" {
+		return terraformutils.Resource{}, fmt.Errorf("team link %q missing team id", linkID)
+	}
+
+	return terraformutils.NewResource(
+		linkID,
+		fmt.Sprintf("team_link_%s_%s", teamID, linkID),
+		"datadog_team_link",
+		"datadog",
+		map[string]string{
+			"team_id": teamID,
+		},
+		TeamLinkAllowEmptyValues,
+		map[string]interface{}{},
+	), nil
+}
+
+// InitResources Generate TerraformResources from Datadog API,
+// from each team link create 1 TerraformResource.
+// Need Team Link ID formatted as '<team_id>:<link_id>' for filter lookup.
+func (g *TeamLinkGenerator) InitResources() error {
+	datadogClient := g.Args["datadogClient"].(*datadog.APIClient)
+	auth := g.Args["auth"].(context.Context)
+	api := datadogV2.NewTeamsApi(datadogClient)
+
+	resources, filtered, err := g.filteredResources(auth, api)
+	if err != nil {
+		return err
+	}
+	if filtered {
+		g.Resources = resources
+		return nil
+	}
+
+	teams, err := listTeams(auth, api)
+	if err != nil {
+		return err
+	}
+	for _, team := range teams {
+		teamID := team.GetId()
+		teamLinks, err := listTeamLinks(auth, api, teamID)
+		if err != nil {
+			return err
+		}
+		teamResources, err := g.createResources(teamID, teamLinks)
+		if err != nil {
+			return err
+		}
+		resources = append(resources, teamResources...)
+	}
+
+	g.Resources = resources
+	return nil
+}
+
+func (g *TeamLinkGenerator) filteredResources(auth context.Context, api *datadogV2.TeamsApi) ([]terraformutils.Resource, bool, error) {
+	resources := []terraformutils.Resource{}
+	filtered := false
+
+	for _, filter := range g.Filter {
+		if !filter.IsApplicable("team_link") {
+			continue
+		}
+
+		switch filter.FieldPath {
+		case "id":
+			filtered = true
+			for _, value := range filter.AcceptableValues {
+				teamID, linkID, err := parseTeamLinkImportID(value)
+				if err != nil {
+					return nil, true, err
+				}
+				teamLink, err := getTeamLink(auth, api, teamID, linkID)
+				if err != nil {
+					return nil, true, err
+				}
+				resource, err := g.createResource(teamID, teamLink)
+				if err != nil {
+					return nil, true, err
+				}
+				resources = append(resources, resource)
+			}
+		case "team_id":
+			filtered = true
+			for _, teamID := range filter.AcceptableValues {
+				teamLinks, err := listTeamLinks(auth, api, teamID)
+				if err != nil {
+					return nil, true, err
+				}
+				teamResources, err := g.createResources(teamID, teamLinks)
+				if err != nil {
+					return nil, true, err
+				}
+				resources = append(resources, teamResources...)
+			}
+		}
+	}
+
+	return resources, filtered, nil
+}
+
+func parseTeamLinkImportID(importID string) (string, string, error) {
+	parts := strings.SplitN(importID, ":", 2)
+	if len(parts) != 2 || parts[0] == "" || parts[1] == "" {
+		return "", "", fmt.Errorf("team link import ID %q must be formatted as team_id:link_id", importID)
+	}
+	return parts[0], parts[1], nil
+}
+
+func getTeamLink(auth context.Context, api *datadogV2.TeamsApi, teamID string, linkID string) (datadogV2.TeamLink, error) {
+	teamLinkResponse, httpResponse, err := api.GetTeamLink(auth, teamID, linkID)
+	if httpResponse != nil && httpResponse.Body != nil {
+		defer httpResponse.Body.Close()
+	}
+	if err != nil {
+		return datadogV2.TeamLink{}, err
+	}
+
+	teamLink, ok := teamLinkResponse.GetDataOk()
+	if !ok {
+		return datadogV2.TeamLink{}, fmt.Errorf("team link %q not found", fmt.Sprintf("%s:%s", teamID, linkID))
+	}
+	return *teamLink, nil
+}
+
+func listTeamLinks(auth context.Context, api *datadogV2.TeamsApi, teamID string) ([]datadogV2.TeamLink, error) {
+	teamLinksResponse, httpResponse, err := api.GetTeamLinks(auth, teamID)
+	if httpResponse != nil && httpResponse.Body != nil {
+		defer httpResponse.Body.Close()
+	}
+	if err != nil {
+		return nil, err
+	}
+	return teamLinksResponse.GetData(), nil
+}

--- a/providers/datadog/team_link_test.go
+++ b/providers/datadog/team_link_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/DataDog/datadog-api-client-go/v2/api/datadogV2"
+	"github.com/chenrui333/terraformer/terraformutils"
 )
 
 func TestTeamLinkCreateResource(t *testing.T) {
@@ -153,6 +154,41 @@ func TestParseTeamLinkImportID(t *testing.T) {
 				t.Fatalf("linkID = %q, want %q", linkID, tt.wantLinkID)
 			}
 		})
+	}
+}
+
+func TestTeamLinkNormalizeIDFilterValues(t *testing.T) {
+	filterIDs, err := parseTeamLinkImportIDs([]string{"team-1:link-1", "team-2:link-2"})
+	if err != nil {
+		t.Fatalf("parseTeamLinkImportIDs() error = %v", err)
+	}
+
+	resource, err := (&TeamLinkGenerator{}).createResource("team-1", datadogV2.TeamLink{Id: "link-1"})
+	if err != nil {
+		t.Fatalf("createResource() error = %v", err)
+	}
+
+	compositeFilter := terraformutils.ResourceFilter{
+		ServiceName:      "team_link",
+		FieldPath:        "id",
+		AcceptableValues: []string{"team-1:link-1", "team-2:link-2"},
+	}
+	if compositeFilter.Filter(resource) {
+		t.Fatal("composite id filter should not match resource whose state ID is the link ID")
+	}
+
+	generator := TeamLinkGenerator{}
+	generator.Filter = []terraformutils.ResourceFilter{
+		{
+			ServiceName:      "team_link",
+			FieldPath:        "id",
+			AcceptableValues: []string{"team-1:link-1", "team-2:link-2"},
+		},
+	}
+	generator.Filter[0].AcceptableValues = teamLinkIDs(filterIDs)
+
+	if !generator.Filter[0].Filter(resource) {
+		t.Fatal("normalized id filter should keep resource whose state ID is the link ID")
 	}
 }
 

--- a/providers/datadog/team_link_test.go
+++ b/providers/datadog/team_link_test.go
@@ -1,0 +1,161 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package datadog
+
+import (
+	"testing"
+
+	"github.com/DataDog/datadog-api-client-go/v2/api/datadogV2"
+)
+
+func TestTeamLinkCreateResource(t *testing.T) {
+	tests := []struct {
+		name     string
+		teamID   string
+		teamLink datadogV2.TeamLink
+		wantID   string
+		wantTeam string
+		wantName string
+		wantType string
+	}{
+		{
+			name:   "uses team id from attributes",
+			teamID: "fallback-team-id",
+			teamLink: datadogV2.TeamLink{
+				Id: "link-id",
+				Attributes: datadogV2.TeamLinkAttributes{
+					TeamId: stringPtr("team-id"),
+				},
+			},
+			wantID:   "link-id",
+			wantTeam: "team-id",
+			wantName: "tfer--team_link_team-id_link-id",
+			wantType: "datadog_team_link",
+		},
+		{
+			name:   "falls back to supplied team id",
+			teamID: "team-id",
+			teamLink: datadogV2.TeamLink{
+				Id: "link-id",
+			},
+			wantID:   "link-id",
+			wantTeam: "team-id",
+			wantName: "tfer--team_link_team-id_link-id",
+			wantType: "datadog_team_link",
+		},
+	}
+
+	generator := TeamLinkGenerator{}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			resource, err := generator.createResource(tt.teamID, tt.teamLink)
+			if err != nil {
+				t.Fatalf("createResource() error = %v", err)
+			}
+			if resource.InstanceState.ID != tt.wantID {
+				t.Fatalf("resource ID = %q, want %q", resource.InstanceState.ID, tt.wantID)
+			}
+			if resource.InstanceState.Attributes["team_id"] != tt.wantTeam {
+				t.Fatalf("team_id attribute = %q, want %q", resource.InstanceState.Attributes["team_id"], tt.wantTeam)
+			}
+			if resource.ResourceName != tt.wantName {
+				t.Fatalf("resource name = %q, want %q", resource.ResourceName, tt.wantName)
+			}
+			if resource.InstanceInfo.Type != tt.wantType {
+				t.Fatalf("resource type = %q, want %q", resource.InstanceInfo.Type, tt.wantType)
+			}
+		})
+	}
+}
+
+func TestTeamLinkCreateResourceMissingID(t *testing.T) {
+	generator := TeamLinkGenerator{}
+	_, err := generator.createResource("team-id", datadogV2.TeamLink{})
+	if err == nil {
+		t.Fatal("createResource() error = nil, want error")
+	}
+}
+
+func TestTeamLinkCreateResourceMissingTeam(t *testing.T) {
+	generator := TeamLinkGenerator{}
+	_, err := generator.createResource("", datadogV2.TeamLink{Id: "link-id"})
+	if err == nil {
+		t.Fatal("createResource() error = nil, want error")
+	}
+}
+
+func TestTeamLinkCreateResourcesAllowsSharedLinkIDs(t *testing.T) {
+	generator := TeamLinkGenerator{}
+	teamLink := datadogV2.TeamLink{
+		Id: "link-id",
+	}
+
+	teamOneResources, err := generator.createResources("team-1", []datadogV2.TeamLink{teamLink})
+	if err != nil {
+		t.Fatalf("createResources() team-1 error = %v", err)
+	}
+	teamTwoResources, err := generator.createResources("team-2", []datadogV2.TeamLink{teamLink})
+	if err != nil {
+		t.Fatalf("createResources() team-2 error = %v", err)
+	}
+	if teamOneResources[0].ResourceName == teamTwoResources[0].ResourceName {
+		t.Fatalf("resource names should be unique, got %q", teamOneResources[0].ResourceName)
+	}
+}
+
+func TestParseTeamLinkImportID(t *testing.T) {
+	tests := []struct {
+		name       string
+		importID   string
+		wantTeamID string
+		wantLinkID string
+		wantErr    bool
+	}{
+		{
+			name:       "valid",
+			importID:   "team-id:link-id",
+			wantTeamID: "team-id",
+			wantLinkID: "link-id",
+		},
+		{
+			name:     "missing delimiter",
+			importID: "team-id",
+			wantErr:  true,
+		},
+		{
+			name:     "missing team id",
+			importID: ":link-id",
+			wantErr:  true,
+		},
+		{
+			name:     "missing link id",
+			importID: "team-id:",
+			wantErr:  true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			teamID, linkID, err := parseTeamLinkImportID(tt.importID)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatal("parseTeamLinkImportID() error = nil, want error")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("parseTeamLinkImportID() error = %v", err)
+			}
+			if teamID != tt.wantTeamID {
+				t.Fatalf("teamID = %q, want %q", teamID, tt.wantTeamID)
+			}
+			if linkID != tt.wantLinkID {
+				t.Fatalf("linkID = %q, want %q", linkID, tt.wantLinkID)
+			}
+		})
+	}
+}
+
+func stringPtr(value string) *string {
+	return &value
+}


### PR DESCRIPTION
## Summary

- Add Datadog `team_link` import support using the v2 Teams API link endpoints.
- Seed `team_id` before refresh while keeping the state ID as the link ID for the provider read path.
- Register and document `team_link`, including filter guidance for quoted composite IDs and `team_id` filters.

## Notes

This keeps the Datadog team-family follow-up scoped to links; permission settings, hierarchy links, notification rules, and sync remain separate gaps.
