### PR TITLE
fix(ibm): return missing api key errors

### DIFF
--- a/cmd/import.go
+++ b/cmd/import.go
@@ -50,6 +50,10 @@ type importResourcesPostProcessor interface {
 	PostProcessImportResources(map[string][]terraformutils.Resource) map[string][]terraformutils.Resource
 }
 
+type importValidator interface {
+	ValidateImport() error
+}
+
 const DefaultPathPattern = "{output}/{provider}/{service}/"
 const DefaultPathOutput = "generated"
 const DefaultState = "local"
@@ -112,6 +116,9 @@ func initOptionsAndWrapper(provider terraformutils.ProviderGenerator, options Im
 	if err != nil {
 		return nil, options, err
 	}
+	if err := validateImport(provider); err != nil {
+		return nil, options, err
+	}
 
 	if terraformerstring.ContainsString(options.Resources, "*") {
 		log.Println("Attempting an import of ALL resources in " + provider.GetName())
@@ -141,6 +148,13 @@ func initOptionsAndWrapper(provider terraformutils.ProviderGenerator, options Im
 	}
 
 	return providerWrapper, options, nil
+}
+
+func validateImport(provider terraformutils.ProviderGenerator) error {
+	if validator, ok := provider.(importValidator); ok {
+		return validator.ValidateImport()
+	}
+	return nil
 }
 
 func initAllServicesResources(providersMapping *terraformutils.ProvidersMapping, options ImportOptions, args []string, providerWrapper *providerwrapper.ProviderWrapper) error {

--- a/cmd/import_test.go
+++ b/cmd/import_test.go
@@ -3,6 +3,7 @@
 package cmd
 
 import (
+	"errors"
 	"testing"
 
 	"github.com/chenrui333/terraformer/terraformutils"
@@ -28,6 +29,15 @@ func (p *testProvider) GenerateFiles()                                         {
 func (p *testProvider) GetProviderData(_ ...string) map[string]interface{}     { return nil }
 func (p *testProvider) GenerateOutputPath() error                              { return nil }
 func (p *testProvider) GetResourceConnections() map[string]map[string][]string { return nil }
+
+type validatingTestProvider struct {
+	testProvider
+	err error
+}
+
+func (p *validatingTestProvider) ValidateImport() error {
+	return p.err
+}
 
 func TestPath(t *testing.T) {
 	tests := []struct {
@@ -83,6 +93,18 @@ func TestProviderServices(t *testing.T) {
 				}
 			}
 		})
+	}
+}
+
+func TestValidateImport(t *testing.T) {
+	if err := validateImport(&testProvider{}); err != nil {
+		t.Fatalf("expected provider without validator to pass, got %v", err)
+	}
+
+	wantErr := errors.New("validation failed")
+	provider := &validatingTestProvider{err: wantErr}
+	if err := validateImport(provider); !errors.Is(err, wantErr) {
+		t.Fatalf("expected validation error %v, got %v", wantErr, err)
 	}
 }
 

--- a/providers/ibm/ibm_cd_toolchain.go
+++ b/providers/ibm/ibm_cd_toolchain.go
@@ -336,7 +336,7 @@ func (g *ToolchainGenerator) InitResources() error {
 
 	apiKey := os.Getenv("IC_API_KEY")
 	if apiKey == "" {
-		log.Fatal("No API key set")
+		return errMissingICAPIKey
 	}
 
 	bmxConfig := &bluemix.Config{

--- a/providers/ibm/ibm_is_floating_ip.go
+++ b/providers/ibm/ibm_is_floating_ip.go
@@ -4,7 +4,6 @@ package ibm
 
 import (
 	"fmt"
-	"log"
 	"os"
 
 	"github.com/IBM/go-sdk-core/v4/core"
@@ -39,7 +38,7 @@ func (g *FloatingIPGenerator) InitResources() error {
 	region := g.Args["region"].(string)
 	apiKey := os.Getenv("IC_API_KEY")
 	if apiKey == "" {
-		log.Fatal("No API key set")
+		return errMissingICAPIKey
 	}
 
 	isURL := GetVPCEndPoint(region)

--- a/providers/ibm/ibm_is_flow_log.go
+++ b/providers/ibm/ibm_is_flow_log.go
@@ -4,7 +4,6 @@ package ibm
 
 import (
 	"fmt"
-	"log"
 	"os"
 
 	"github.com/IBM/go-sdk-core/v4/core"
@@ -32,7 +31,7 @@ func (g *FlowLogGenerator) InitResources() error {
 	region := g.Args["region"].(string)
 	apiKey := os.Getenv("IC_API_KEY")
 	if apiKey == "" {
-		log.Fatal("No API key set")
+		return errMissingICAPIKey
 	}
 
 	isURL := GetVPCEndPoint(region)

--- a/providers/ibm/ibm_is_ike_policy.go
+++ b/providers/ibm/ibm_is_ike_policy.go
@@ -4,7 +4,6 @@ package ibm
 
 import (
 	"fmt"
-	"log"
 	"os"
 
 	"github.com/IBM/go-sdk-core/v4/core"
@@ -32,7 +31,7 @@ func (g *IkeGenerator) InitResources() error {
 	region := g.Args["region"].(string)
 	apiKey := os.Getenv("IC_API_KEY")
 	if apiKey == "" {
-		log.Fatal("No API key set")
+		return errMissingICAPIKey
 	}
 
 	isURL := GetVPCEndPoint(region)

--- a/providers/ibm/ibm_is_image.go
+++ b/providers/ibm/ibm_is_image.go
@@ -4,7 +4,6 @@ package ibm
 
 import (
 	"fmt"
-	"log"
 	"os"
 
 	"github.com/IBM/go-sdk-core/v4/core"
@@ -32,7 +31,7 @@ func (g *ImageGenerator) InitResources() error {
 	region := g.Args["region"].(string)
 	apiKey := os.Getenv("IC_API_KEY")
 	if apiKey == "" {
-		log.Fatal("No API key set")
+		return errMissingICAPIKey
 	}
 
 	isURL := GetVPCEndPoint(region)

--- a/providers/ibm/ibm_is_ipsec_policy.go
+++ b/providers/ibm/ibm_is_ipsec_policy.go
@@ -4,7 +4,6 @@ package ibm
 
 import (
 	"fmt"
-	"log"
 	"os"
 
 	"github.com/IBM/go-sdk-core/v4/core"
@@ -37,7 +36,7 @@ func (g *IpsecGenerator) InitResources() error {
 	region := g.Args["region"].(string)
 	apiKey := os.Getenv("IC_API_KEY")
 	if apiKey == "" {
-		log.Fatal("No API key set")
+		return errMissingICAPIKey
 	}
 
 	isURL := GetVPCEndPoint(region)

--- a/providers/ibm/ibm_is_network_acl.go
+++ b/providers/ibm/ibm_is_network_acl.go
@@ -4,7 +4,6 @@ package ibm
 
 import (
 	"fmt"
-	"log"
 	"os"
 
 	"github.com/IBM/go-sdk-core/v4/core"
@@ -32,7 +31,7 @@ func (g *NetworkACLGenerator) InitResources() error {
 	region := g.Args["region"].(string)
 	apiKey := os.Getenv("IC_API_KEY")
 	if apiKey == "" {
-		log.Fatal("No API key set")
+		return errMissingICAPIKey
 	}
 
 	isURL := GetVPCEndPoint(region)

--- a/providers/ibm/ibm_is_public_gateway.go
+++ b/providers/ibm/ibm_is_public_gateway.go
@@ -4,7 +4,6 @@ package ibm
 
 import (
 	"fmt"
-	"log"
 	"os"
 
 	"github.com/IBM/go-sdk-core/v4/core"
@@ -32,7 +31,7 @@ func (g *PublicGatewayGenerator) InitResources() error {
 	region := g.Args["region"].(string)
 	apiKey := os.Getenv("IC_API_KEY")
 	if apiKey == "" {
-		log.Fatal("No API key set")
+		return errMissingICAPIKey
 	}
 
 	isURL := GetVPCEndPoint(region)

--- a/providers/ibm/ibm_is_ssh_key.go
+++ b/providers/ibm/ibm_is_ssh_key.go
@@ -4,7 +4,6 @@ package ibm
 
 import (
 	"fmt"
-	"log"
 	"os"
 
 	"github.com/IBM/go-sdk-core/v4/core"
@@ -32,7 +31,7 @@ func (g *SSHKeyGenerator) InitResources() error {
 	region := g.Args["region"].(string)
 	apiKey := os.Getenv("IC_API_KEY")
 	if apiKey == "" {
-		log.Fatal("No API key set")
+		return errMissingICAPIKey
 	}
 
 	isURL := GetVPCEndPoint(region)

--- a/providers/ibm/ibm_is_volume.go
+++ b/providers/ibm/ibm_is_volume.go
@@ -4,7 +4,6 @@ package ibm
 
 import (
 	"fmt"
-	"log"
 	"os"
 
 	"github.com/IBM/go-sdk-core/v4/core"
@@ -32,7 +31,7 @@ func (g *VolumeGenerator) InitResources() error {
 	region := g.Args["region"].(string)
 	apiKey := os.Getenv("IC_API_KEY")
 	if apiKey == "" {
-		log.Fatal("No API key set")
+		return errMissingICAPIKey
 	}
 
 	isURL := GetVPCEndPoint(region)

--- a/providers/ibm/ibm_provider.go
+++ b/providers/ibm/ibm_provider.go
@@ -13,6 +13,8 @@ import (
 const DefaultRegion = "us-south"
 const NoRegion = ""
 
+var errMissingICAPIKey = errors.New("set IC_API_KEY env var")
+
 var resourceMutex sync.RWMutex // Used for g.Resources
 
 type IBMProvider struct { //nolint
@@ -23,6 +25,10 @@ type IBMProvider struct { //nolint
 }
 
 func (p *IBMProvider) Init(args []string) error {
+	if os.Getenv("IC_API_KEY") == "" {
+		return errMissingICAPIKey
+	}
+
 	p.ResourceGroup = args[0]
 	p.Region = args[1]
 	p.VPC = args[2]

--- a/providers/ibm/ibm_provider.go
+++ b/providers/ibm/ibm_provider.go
@@ -25,10 +25,6 @@ type IBMProvider struct { //nolint
 }
 
 func (p *IBMProvider) Init(args []string) error {
-	if os.Getenv("IC_API_KEY") == "" {
-		return errMissingICAPIKey
-	}
-
 	p.ResourceGroup = args[0]
 	p.Region = args[1]
 	p.VPC = args[2]
@@ -42,6 +38,13 @@ func (p *IBMProvider) Init(args []string) error {
 	}
 	if err != nil {
 		return err
+	}
+	return nil
+}
+
+func (p *IBMProvider) ValidateImport() error {
+	if os.Getenv("IC_API_KEY") == "" {
+		return errMissingICAPIKey
 	}
 	return nil
 }

--- a/providers/ibm/ibm_provider_test.go
+++ b/providers/ibm/ibm_provider_test.go
@@ -1,0 +1,44 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package ibm
+
+import (
+	"errors"
+	"testing"
+)
+
+func TestProviderInitRequiresAPIKey(t *testing.T) {
+	t.Setenv("IC_API_KEY", "")
+
+	provider := &IBMProvider{}
+	err := provider.Init([]string{"", "", ""})
+	if !errors.Is(err, errMissingICAPIKey) {
+		t.Fatalf("expected missing API key error, got %v", err)
+	}
+}
+
+func TestProviderInitDefaultsRegionWithAPIKey(t *testing.T) {
+	t.Setenv("IC_API_KEY", "api-key")
+
+	provider := &IBMProvider{}
+	if err := provider.Init([]string{"", "", ""}); err != nil {
+		t.Fatalf("expected provider initialization to succeed: %v", err)
+	}
+	if provider.Region != DefaultRegion {
+		t.Fatalf("expected default region %q, got %q", DefaultRegion, provider.Region)
+	}
+}
+
+func TestImageGeneratorReturnsMissingAPIKeyError(t *testing.T) {
+	t.Setenv("IC_API_KEY", "")
+
+	generator := &ImageGenerator{}
+	generator.SetArgs(map[string]interface{}{
+		"region": DefaultRegion,
+	})
+
+	err := generator.InitResources()
+	if !errors.Is(err, errMissingICAPIKey) {
+		t.Fatalf("expected missing API key error, got %v", err)
+	}
+}

--- a/providers/ibm/ibm_provider_test.go
+++ b/providers/ibm/ibm_provider_test.go
@@ -7,11 +7,26 @@ import (
 	"testing"
 )
 
-func TestProviderInitRequiresAPIKey(t *testing.T) {
+func TestProviderInitDoesNotRequireAPIKey(t *testing.T) {
 	t.Setenv("IC_API_KEY", "")
 
 	provider := &IBMProvider{}
-	err := provider.Init([]string{"", "", ""})
+	if err := provider.Init([]string{"", "", ""}); err != nil {
+		t.Fatalf("expected provider initialization to succeed without API key: %v", err)
+	}
+	if provider.Region != DefaultRegion {
+		t.Fatalf("expected default region %q, got %q", DefaultRegion, provider.Region)
+	}
+	if err := provider.InitService("ibm_is_image", false); err != nil {
+		t.Fatalf("expected plan replay service initialization to succeed without API key: %v", err)
+	}
+}
+
+func TestProviderValidateImportRequiresAPIKey(t *testing.T) {
+	t.Setenv("IC_API_KEY", "")
+
+	provider := &IBMProvider{}
+	err := provider.ValidateImport()
 	if !errors.Is(err, errMissingICAPIKey) {
 		t.Fatalf("expected missing API key error, got %v", err)
 	}


### PR DESCRIPTION
## Summary

- Fail IBM live imports early when `IC_API_KEY` is missing, before service fan-out can swallow missing credential errors.
- Keep IBM provider initialization and service initialization usable for offline plan replay from saved plan files.
- Replace remaining IBM VPC-style missing API key `log.Fatal` calls with returned errors.
- Add focused tests for IBM live-import validation, offline initialization, default region initialization, and a representative generator guard.
