### PR TITLE
feat(datadog): add team permission setting import

### DIFF
--- a/docs/datadog.md
+++ b/docs/datadog.md
@@ -156,6 +156,10 @@ Tag filters are order specific. For example, if your monitor has tags (in the or
 *   `team_membership`
     * `datadog_team_membership`
         * **_NOTE:_** Importing a single membership by ID requires quoting the `team_id:user_id` filter value, for example `--filter="team_membership='team-id:user-id'"`; memberships can also be filtered by `team_id`
+*   `team_permission_setting`
+    * `datadog_team_permission_setting`
+        * **_NOTE:_** Requires DataDog/datadog provider 3.90.0 or newer.
+        * **_NOTE:_** Importing a single permission setting by ID requires quoting the `team_id:action` filter value, for example `--filter="team_permission_setting='team-id:manage_membership'"`; permission settings can also be filtered by `team_id`
 *   `user`
     * `datadog_user`
 

--- a/providers/datadog/datadog_provider.go
+++ b/providers/datadog/datadog_provider.go
@@ -179,6 +179,7 @@ func (p *DatadogProvider) GetSupportedService() map[string]terraformutils.Servic
 		"team":                                 &TeamGenerator{},
 		"team_link":                            &TeamLinkGenerator{},
 		"team_membership":                      &TeamMembershipGenerator{},
+		"team_permission_setting":              &TeamPermissionSettingGenerator{},
 		"user":                                 &UserGenerator{},
 		"role":                                 &RoleGenerator{},
 	}

--- a/providers/datadog/team_permission_setting.go
+++ b/providers/datadog/team_permission_setting.go
@@ -1,0 +1,209 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package datadog
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/DataDog/datadog-api-client-go/v2/api/datadog"
+	"github.com/DataDog/datadog-api-client-go/v2/api/datadogV2"
+
+	"github.com/chenrui333/terraformer/terraformutils"
+)
+
+var (
+	// TeamPermissionSettingAllowEmptyValues ...
+	TeamPermissionSettingAllowEmptyValues = []string{}
+)
+
+// TeamPermissionSettingGenerator ...
+type TeamPermissionSettingGenerator struct {
+	DatadogService
+}
+
+func (g *TeamPermissionSettingGenerator) createResources(teamID string, teamPermissionSettings []datadogV2.TeamPermissionSetting) ([]terraformutils.Resource, error) {
+	resources := []terraformutils.Resource{}
+	for _, teamPermissionSetting := range teamPermissionSettings {
+		resource, err := g.createResource(teamID, teamPermissionSetting)
+		if err != nil {
+			return nil, err
+		}
+		resources = append(resources, resource)
+	}
+
+	return resources, nil
+}
+
+func (g *TeamPermissionSettingGenerator) createResource(teamID string, teamPermissionSetting datadogV2.TeamPermissionSetting) (terraformutils.Resource, error) {
+	permissionID := teamPermissionSetting.GetId()
+	if permissionID == "" {
+		return terraformutils.Resource{}, fmt.Errorf("team permission setting missing id")
+	}
+	if teamID == "" {
+		return terraformutils.Resource{}, fmt.Errorf("team permission setting %q missing team id", permissionID)
+	}
+
+	attributes := teamPermissionSetting.GetAttributes()
+	action := string(attributes.GetAction())
+	if action == "" {
+		return terraformutils.Resource{}, fmt.Errorf("team permission setting %q missing action", permissionID)
+	}
+	value := string(attributes.GetValue())
+	if value == "" {
+		return terraformutils.Resource{}, fmt.Errorf("team permission setting %q missing value", permissionID)
+	}
+
+	return terraformutils.NewResource(
+		permissionID,
+		fmt.Sprintf("team_permission_setting_%s_%s", teamID, action),
+		"datadog_team_permission_setting",
+		"datadog",
+		map[string]string{
+			"team_id": teamID,
+			"action":  action,
+			"value":   value,
+		},
+		TeamPermissionSettingAllowEmptyValues,
+		map[string]interface{}{},
+	), nil
+}
+
+// InitResources Generate TerraformResources from Datadog API,
+// from each team permission setting create 1 TerraformResource.
+// Need Team Permission Setting ID formatted as '<team_id>:<action>' for filter lookup.
+func (g *TeamPermissionSettingGenerator) InitResources() error {
+	datadogClient := g.Args["datadogClient"].(*datadog.APIClient)
+	auth := g.Args["auth"].(context.Context)
+	api := datadogV2.NewTeamsApi(datadogClient)
+
+	resources, filtered, err := g.filteredResources(auth, api)
+	if err != nil {
+		return err
+	}
+	if filtered {
+		g.Resources = resources
+		return nil
+	}
+
+	teams, err := listTeams(auth, api)
+	if err != nil {
+		return err
+	}
+	for _, team := range teams {
+		teamID := team.GetId()
+		teamPermissionSettings, err := listTeamPermissionSettings(auth, api, teamID)
+		if err != nil {
+			return err
+		}
+		teamResources, err := g.createResources(teamID, teamPermissionSettings)
+		if err != nil {
+			return err
+		}
+		resources = append(resources, teamResources...)
+	}
+
+	g.Resources = resources
+	return nil
+}
+
+func (g *TeamPermissionSettingGenerator) filteredResources(auth context.Context, api *datadogV2.TeamsApi) ([]terraformutils.Resource, bool, error) {
+	resources := []terraformutils.Resource{}
+	filtered := false
+
+	for filterIndex, filter := range g.Filter {
+		if !filter.IsApplicable("team_permission_setting") {
+			continue
+		}
+
+		switch filter.FieldPath {
+		case "id":
+			filtered = true
+			filterIDs, err := parseTeamPermissionSettingImportIDs(filter.AcceptableValues)
+			if err != nil {
+				return nil, true, err
+			}
+			permissionIDs := []string{}
+			for _, filterID := range filterIDs {
+				teamPermissionSetting, err := getTeamPermissionSetting(auth, api, filterID.teamID, filterID.action)
+				if err != nil {
+					return nil, true, err
+				}
+				resource, err := g.createResource(filterID.teamID, teamPermissionSetting)
+				if err != nil {
+					return nil, true, err
+				}
+				permissionIDs = append(permissionIDs, resource.InstanceState.ID)
+				resources = append(resources, resource)
+			}
+			g.Filter[filterIndex].AcceptableValues = permissionIDs
+		case "team_id":
+			filtered = true
+			for _, teamID := range filter.AcceptableValues {
+				teamPermissionSettings, err := listTeamPermissionSettings(auth, api, teamID)
+				if err != nil {
+					return nil, true, err
+				}
+				teamResources, err := g.createResources(teamID, teamPermissionSettings)
+				if err != nil {
+					return nil, true, err
+				}
+				resources = append(resources, teamResources...)
+			}
+		}
+	}
+
+	return resources, filtered, nil
+}
+
+type teamPermissionSettingFilterID struct {
+	teamID string
+	action string
+}
+
+func parseTeamPermissionSettingImportIDs(importIDs []string) ([]teamPermissionSettingFilterID, error) {
+	filterIDs := []teamPermissionSettingFilterID{}
+	for _, importID := range importIDs {
+		teamID, action, err := parseTeamPermissionSettingImportID(importID)
+		if err != nil {
+			return nil, err
+		}
+		filterIDs = append(filterIDs, teamPermissionSettingFilterID{teamID: teamID, action: action})
+	}
+	return filterIDs, nil
+}
+
+func parseTeamPermissionSettingImportID(importID string) (string, string, error) {
+	parts := strings.SplitN(importID, ":", 2)
+	if len(parts) != 2 || parts[0] == "" || parts[1] == "" {
+		return "", "", fmt.Errorf("team permission setting import ID %q must be formatted as team_id:action", importID)
+	}
+	return parts[0], parts[1], nil
+}
+
+func getTeamPermissionSetting(auth context.Context, api *datadogV2.TeamsApi, teamID string, action string) (datadogV2.TeamPermissionSetting, error) {
+	teamPermissionSettings, err := listTeamPermissionSettings(auth, api, teamID)
+	if err != nil {
+		return datadogV2.TeamPermissionSetting{}, err
+	}
+
+	for _, teamPermissionSetting := range teamPermissionSettings {
+		attributes := teamPermissionSetting.GetAttributes()
+		if string(attributes.GetAction()) == action {
+			return teamPermissionSetting, nil
+		}
+	}
+	return datadogV2.TeamPermissionSetting{}, fmt.Errorf("team permission setting %q not found", fmt.Sprintf("%s:%s", teamID, action))
+}
+
+func listTeamPermissionSettings(auth context.Context, api *datadogV2.TeamsApi, teamID string) ([]datadogV2.TeamPermissionSetting, error) {
+	teamPermissionSettingsResponse, httpResponse, err := api.GetTeamPermissionSettings(auth, teamID)
+	if httpResponse != nil && httpResponse.Body != nil {
+		defer httpResponse.Body.Close()
+	}
+	if err != nil {
+		return nil, err
+	}
+	return teamPermissionSettingsResponse.GetData(), nil
+}

--- a/providers/datadog/team_permission_setting_test.go
+++ b/providers/datadog/team_permission_setting_test.go
@@ -1,0 +1,210 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package datadog
+
+import (
+	"testing"
+
+	"github.com/DataDog/datadog-api-client-go/v2/api/datadogV2"
+	"github.com/chenrui333/terraformer/terraformutils"
+)
+
+func TestTeamPermissionSettingCreateResource(t *testing.T) {
+	action := datadogV2.TEAMPERMISSIONSETTINGSERIALIZERACTION_MANAGE_MEMBERSHIP
+	value := datadogV2.TEAMPERMISSIONSETTINGVALUE_ADMINS
+	teamPermissionSetting := datadogV2.TeamPermissionSetting{
+		Id: "permission-id",
+		Attributes: &datadogV2.TeamPermissionSettingAttributes{
+			Action: &action,
+			Value:  &value,
+		},
+	}
+
+	resource, err := (&TeamPermissionSettingGenerator{}).createResource("team-id", teamPermissionSetting)
+	if err != nil {
+		t.Fatalf("createResource() error = %v", err)
+	}
+	if resource.InstanceState.ID != "permission-id" {
+		t.Fatalf("resource ID = %q, want %q", resource.InstanceState.ID, "permission-id")
+	}
+	if resource.InstanceState.Attributes["team_id"] != "team-id" {
+		t.Fatalf("team_id attribute = %q, want %q", resource.InstanceState.Attributes["team_id"], "team-id")
+	}
+	if resource.InstanceState.Attributes["action"] != "manage_membership" {
+		t.Fatalf("action attribute = %q, want %q", resource.InstanceState.Attributes["action"], "manage_membership")
+	}
+	if resource.InstanceState.Attributes["value"] != "admins" {
+		t.Fatalf("value attribute = %q, want %q", resource.InstanceState.Attributes["value"], "admins")
+	}
+	if resource.ResourceName != "tfer--team_permission_setting_team-id_manage_membership" {
+		t.Fatalf("resource name = %q, want %q", resource.ResourceName, "tfer--team_permission_setting_team-id_manage_membership")
+	}
+	if resource.InstanceInfo.Type != "datadog_team_permission_setting" {
+		t.Fatalf("resource type = %q, want %q", resource.InstanceInfo.Type, "datadog_team_permission_setting")
+	}
+}
+
+func TestTeamPermissionSettingCreateResourceMissingID(t *testing.T) {
+	action := datadogV2.TEAMPERMISSIONSETTINGSERIALIZERACTION_EDIT
+	value := datadogV2.TEAMPERMISSIONSETTINGVALUE_MEMBERS
+	_, err := (&TeamPermissionSettingGenerator{}).createResource("team-id", datadogV2.TeamPermissionSetting{
+		Attributes: &datadogV2.TeamPermissionSettingAttributes{
+			Action: &action,
+			Value:  &value,
+		},
+	})
+	if err == nil {
+		t.Fatal("createResource() error = nil, want error")
+	}
+}
+
+func TestTeamPermissionSettingCreateResourceMissingTeam(t *testing.T) {
+	action := datadogV2.TEAMPERMISSIONSETTINGSERIALIZERACTION_EDIT
+	value := datadogV2.TEAMPERMISSIONSETTINGVALUE_MEMBERS
+	_, err := (&TeamPermissionSettingGenerator{}).createResource("", datadogV2.TeamPermissionSetting{
+		Id: "permission-id",
+		Attributes: &datadogV2.TeamPermissionSettingAttributes{
+			Action: &action,
+			Value:  &value,
+		},
+	})
+	if err == nil {
+		t.Fatal("createResource() error = nil, want error")
+	}
+}
+
+func TestTeamPermissionSettingCreateResourceMissingAction(t *testing.T) {
+	value := datadogV2.TEAMPERMISSIONSETTINGVALUE_MEMBERS
+	_, err := (&TeamPermissionSettingGenerator{}).createResource("team-id", datadogV2.TeamPermissionSetting{
+		Id: "permission-id",
+		Attributes: &datadogV2.TeamPermissionSettingAttributes{
+			Value: &value,
+		},
+	})
+	if err == nil {
+		t.Fatal("createResource() error = nil, want error")
+	}
+}
+
+func TestTeamPermissionSettingCreateResourceMissingValue(t *testing.T) {
+	action := datadogV2.TEAMPERMISSIONSETTINGSERIALIZERACTION_EDIT
+	_, err := (&TeamPermissionSettingGenerator{}).createResource("team-id", datadogV2.TeamPermissionSetting{
+		Id: "permission-id",
+		Attributes: &datadogV2.TeamPermissionSettingAttributes{
+			Action: &action,
+		},
+	})
+	if err == nil {
+		t.Fatal("createResource() error = nil, want error")
+	}
+}
+
+func TestTeamPermissionSettingCreateResourcesAllowsSharedActions(t *testing.T) {
+	action := datadogV2.TEAMPERMISSIONSETTINGSERIALIZERACTION_EDIT
+	value := datadogV2.TEAMPERMISSIONSETTINGVALUE_MEMBERS
+	teamPermissionSetting := datadogV2.TeamPermissionSetting{
+		Id: "permission-id",
+		Attributes: &datadogV2.TeamPermissionSettingAttributes{
+			Action: &action,
+			Value:  &value,
+		},
+	}
+
+	teamOneResources, err := (&TeamPermissionSettingGenerator{}).createResources("team-1", []datadogV2.TeamPermissionSetting{teamPermissionSetting})
+	if err != nil {
+		t.Fatalf("createResources() team-1 error = %v", err)
+	}
+	teamTwoResources, err := (&TeamPermissionSettingGenerator{}).createResources("team-2", []datadogV2.TeamPermissionSetting{teamPermissionSetting})
+	if err != nil {
+		t.Fatalf("createResources() team-2 error = %v", err)
+	}
+	if teamOneResources[0].ResourceName == teamTwoResources[0].ResourceName {
+		t.Fatalf("resource names should be unique, got %q", teamOneResources[0].ResourceName)
+	}
+}
+
+func TestParseTeamPermissionSettingImportID(t *testing.T) {
+	tests := []struct {
+		name       string
+		importID   string
+		wantTeamID string
+		wantAction string
+		wantErr    bool
+	}{
+		{
+			name:       "valid",
+			importID:   "team-id:manage_membership",
+			wantTeamID: "team-id",
+			wantAction: "manage_membership",
+		},
+		{
+			name:     "missing delimiter",
+			importID: "team-id",
+			wantErr:  true,
+		},
+		{
+			name:     "missing team id",
+			importID: ":manage_membership",
+			wantErr:  true,
+		},
+		{
+			name:     "missing action",
+			importID: "team-id:",
+			wantErr:  true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			teamID, action, err := parseTeamPermissionSettingImportID(tt.importID)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatal("parseTeamPermissionSettingImportID() error = nil, want error")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("parseTeamPermissionSettingImportID() error = %v", err)
+			}
+			if teamID != tt.wantTeamID {
+				t.Fatalf("teamID = %q, want %q", teamID, tt.wantTeamID)
+			}
+			if action != tt.wantAction {
+				t.Fatalf("action = %q, want %q", action, tt.wantAction)
+			}
+		})
+	}
+}
+
+func TestTeamPermissionSettingNormalizeIDFilterValues(t *testing.T) {
+	action := datadogV2.TEAMPERMISSIONSETTINGSERIALIZERACTION_MANAGE_MEMBERSHIP
+	value := datadogV2.TEAMPERMISSIONSETTINGVALUE_ADMINS
+	resource, err := (&TeamPermissionSettingGenerator{}).createResource("team-1", datadogV2.TeamPermissionSetting{
+		Id: "permission-1",
+		Attributes: &datadogV2.TeamPermissionSettingAttributes{
+			Action: &action,
+			Value:  &value,
+		},
+	})
+	if err != nil {
+		t.Fatalf("createResource() error = %v", err)
+	}
+
+	compositeFilter := terraformutils.ResourceFilter{
+		ServiceName:      "team_permission_setting",
+		FieldPath:        "id",
+		AcceptableValues: []string{"team-1:manage_membership"},
+	}
+	if compositeFilter.Filter(resource) {
+		t.Fatal("composite id filter should not match resource whose state ID is the permission setting ID")
+	}
+
+	normalizedFilter := terraformutils.ResourceFilter{
+		ServiceName:      "team_permission_setting",
+		FieldPath:        "id",
+		AcceptableValues: []string{resource.InstanceState.ID},
+	}
+	if !normalizedFilter.Filter(resource) {
+		t.Fatal("normalized id filter should keep resource whose state ID is the permission setting ID")
+	}
+}


### PR DESCRIPTION
Summary
- Add Terraformer import support for Datadog team permission settings.
- Support quoted team_id:action filters and team_id-scoped imports.
- Document the provider version requirement and filter syntax.

Notes
- Seeds team_id, action, and value before provider refresh so generated resources can read cleanly.
- Normalizes composite filters to the Datadog permission setting ID before initial cleanup.
