### PR TITLE
feat(kubernetes): import custom resources as manifests

### DIFF
--- a/docs/kubernetes.md
+++ b/docs/kubernetes.md
@@ -9,6 +9,7 @@ Example:
 
 Terraformer discovers Kubernetes API resources from the active cluster and imports resources that are available through either the typed Kubernetes client or an explicit dynamic-client import path, and the installed Terraform Kubernetes provider schema.
 Discovered CRDs and other untyped API extensions without a first-class Terraform Kubernetes provider type can be imported through `kubernetes_manifest` when the API resource is manageable and the installed provider supports that resource.
+Manifest-backed custom resources use a group/version-qualified resource selector such as `example.com/v1/widgets` to avoid collisions between CRDs that share the same plural name.
 
 Common supported resources include:
 

--- a/docs/kubernetes.md
+++ b/docs/kubernetes.md
@@ -8,6 +8,7 @@ Example:
 ```
 
 Terraformer discovers Kubernetes API resources from the active cluster and imports resources that are available through either the typed Kubernetes client or an explicit dynamic-client import path, and the installed Terraform Kubernetes provider schema.
+Discovered CRDs and other untyped API extensions without a first-class Terraform Kubernetes provider type can be imported through `kubernetes_manifest` when the API resource is manageable and the installed provider supports that resource.
 
 Common supported resources include:
 
@@ -35,6 +36,8 @@ Common supported resources include:
     * `kubernetes_endpoints_v1`
 *   `endpointslices`
     * `kubernetes_endpoint_slice_v1`
+*   discovered CRDs and custom resources
+    * `kubernetes_manifest`
 *   `horizontalpodautoscalers`
     * `kubernetes_horizontal_pod_autoscaler_v2`
     * `kubernetes_horizontal_pod_autoscaler_v2beta2`

--- a/providers/kubernetes/kind.go
+++ b/providers/kubernetes/kind.go
@@ -6,10 +6,12 @@ import (
 	"context"
 	"fmt"
 	"reflect"
+	"strings"
 
 	"github.com/chenrui333/terraformer/terraformutils"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/kubernetes"
@@ -135,7 +137,7 @@ func (k *Kind) initDynamicResources(client dynamic.Interface) error {
 		}
 
 		k.Resources = append(k.Resources, terraformutils.NewSimpleResource(
-			name,
+			k.importID(item),
 			name,
 			terraformType,
 			"kubernetes",
@@ -150,4 +152,31 @@ func (k *Kind) terraformType() string {
 		return k.TerraformType
 	}
 	return extractTfResourceName(k.Name)
+}
+
+func (k *Kind) importID(item unstructured.Unstructured) string {
+	name := item.GetName()
+	if k.terraformType() != manifestTerraformResourceName {
+		if k.Namespaced {
+			return item.GetNamespace() + "/" + name
+		}
+		return name
+	}
+
+	parts := []string{
+		"apiVersion=" + k.apiVersion(),
+		"kind=" + k.Name,
+	}
+	if k.Namespaced {
+		parts = append(parts, "namespace="+item.GetNamespace())
+	}
+	parts = append(parts, "name="+name)
+	return strings.Join(parts, ",")
+}
+
+func (k *Kind) apiVersion() string {
+	if k.Group == "" {
+		return k.Version
+	}
+	return k.Group + "/" + k.Version
 }

--- a/providers/kubernetes/kind.go
+++ b/providers/kubernetes/kind.go
@@ -129,15 +129,10 @@ func (k *Kind) initDynamicResources(client dynamic.Interface) error {
 			continue
 		}
 
-		name := ""
-		if k.Namespaced {
-			name = item.GetNamespace() + "/" + item.GetName()
-		} else {
-			name = item.GetName()
-		}
-
+		name := k.resourceName(item)
+		importID := k.importID(item)
 		k.Resources = append(k.Resources, terraformutils.NewSimpleResource(
-			k.importID(item),
+			importID,
 			name,
 			terraformType,
 			"kubernetes",
@@ -145,6 +140,23 @@ func (k *Kind) initDynamicResources(client dynamic.Interface) error {
 		))
 	}
 	return nil
+}
+
+func (k *Kind) resourceName(item unstructured.Unstructured) string {
+	name := item.GetName()
+	if k.terraformType() != manifestTerraformResourceName {
+		if k.Namespaced {
+			return item.GetNamespace() + "/" + name
+		}
+		return name
+	}
+
+	parts := []string{k.apiVersion(), k.Name}
+	if k.Namespaced {
+		parts = append(parts, item.GetNamespace())
+	}
+	parts = append(parts, name)
+	return strings.Join(parts, "/")
 }
 
 func (k *Kind) terraformType() string {

--- a/providers/kubernetes/kind_test.go
+++ b/providers/kubernetes/kind_test.go
@@ -127,8 +127,9 @@ func TestInitDynamicResourcesManifestImportID(t *testing.T) {
 	if resource.InstanceState.ID != "apiVersion=example.com/v1,kind=Widget,namespace=default,name=sample" {
 		t.Fatalf("resource ID = %q, want %q", resource.InstanceState.ID, "apiVersion=example.com/v1,kind=Widget,namespace=default,name=sample")
 	}
-	if resource.ResourceName != terraformutils.TfSanitize("default/sample") {
-		t.Fatalf("resource name = %q, want %q", resource.ResourceName, terraformutils.TfSanitize("default/sample"))
+	wantResourceName := terraformutils.TfSanitize("example.com/v1/Widget/default/sample")
+	if resource.ResourceName != wantResourceName {
+		t.Fatalf("resource name = %q, want %q", resource.ResourceName, wantResourceName)
 	}
 	if resource.InstanceInfo.Type != manifestTerraformResourceName {
 		t.Fatalf("resource type = %q, want %q", resource.InstanceInfo.Type, manifestTerraformResourceName)
@@ -164,6 +165,35 @@ func TestInitDynamicResourcesManifestImportIDClusterScoped(t *testing.T) {
 	}
 	if kind.Resources[0].InstanceState.ID != "apiVersion=apiextensions.k8s.io/v1,kind=CustomResourceDefinition,name=widgets.example.com" {
 		t.Fatalf("resource ID = %q, want %q", kind.Resources[0].InstanceState.ID, "apiVersion=apiextensions.k8s.io/v1,kind=CustomResourceDefinition,name=widgets.example.com")
+	}
+	wantResourceName := terraformutils.TfSanitize("apiextensions.k8s.io/v1/CustomResourceDefinition/widgets.example.com")
+	if kind.Resources[0].ResourceName != wantResourceName {
+		t.Fatalf("resource name = %q, want %q", kind.Resources[0].ResourceName, wantResourceName)
+	}
+}
+
+func TestManifestResourceNameIncludesKind(t *testing.T) {
+	widget := newUnstructured("example.com/v1", "Widget", "sample", "default")
+	gadget := newUnstructured("example.com/v1", "Gadget", "sample", "default")
+	kind := &Kind{
+		Group:         "example.com",
+		Version:       "v1",
+		Name:          "Widget",
+		Namespaced:    true,
+		TerraformType: manifestTerraformResourceName,
+	}
+	widgetName := kind.resourceName(*widget)
+	kind.Name = "Gadget"
+	gadgetName := kind.resourceName(*gadget)
+
+	if widgetName == gadgetName {
+		t.Fatalf("manifest resource names collided: %q", widgetName)
+	}
+	if widgetName != "example.com/v1/Widget/default/sample" {
+		t.Fatalf("widget resource name = %q, want %q", widgetName, "example.com/v1/Widget/default/sample")
+	}
+	if gadgetName != "example.com/v1/Gadget/default/sample" {
+		t.Fatalf("gadget resource name = %q, want %q", gadgetName, "example.com/v1/Gadget/default/sample")
 	}
 }
 

--- a/providers/kubernetes/kind_test.go
+++ b/providers/kubernetes/kind_test.go
@@ -5,6 +5,8 @@ package kubernetes
 import (
 	"testing"
 
+	"github.com/chenrui333/terraformer/terraformutils"
+
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -90,6 +92,78 @@ func TestInitDynamicResourcesNamespaced(t *testing.T) {
 	}
 	if resource.InstanceInfo.Type != "kubernetes_widget" {
 		t.Fatalf("resource type = %q, want %q", resource.InstanceInfo.Type, "kubernetes_widget")
+	}
+}
+
+func TestInitDynamicResourcesManifestImportID(t *testing.T) {
+	gvr := schema.GroupVersionResource{
+		Group:    "example.com",
+		Version:  "v1",
+		Resource: "widgets",
+	}
+	widget := newUnstructured("example.com/v1", "Widget", "sample", "default")
+	client := dynamicfake.NewSimpleDynamicClientWithCustomListKinds(
+		runtime.NewScheme(),
+		map[schema.GroupVersionResource]string{gvr: "WidgetList"},
+		widget,
+	)
+
+	kind := &Kind{
+		Group:         "example.com",
+		Version:       "v1",
+		Name:          "Widget",
+		ResourceName:  "widgets",
+		Namespaced:    true,
+		TerraformType: manifestTerraformResourceName,
+	}
+	if err := kind.initDynamicResources(client); err != nil {
+		t.Fatalf("initDynamicResources() error = %v", err)
+	}
+
+	if len(kind.Resources) != 1 {
+		t.Fatalf("Resources len = %d, want 1", len(kind.Resources))
+	}
+	resource := kind.Resources[0]
+	if resource.InstanceState.ID != "apiVersion=example.com/v1,kind=Widget,namespace=default,name=sample" {
+		t.Fatalf("resource ID = %q, want %q", resource.InstanceState.ID, "apiVersion=example.com/v1,kind=Widget,namespace=default,name=sample")
+	}
+	if resource.ResourceName != terraformutils.TfSanitize("default/sample") {
+		t.Fatalf("resource name = %q, want %q", resource.ResourceName, terraformutils.TfSanitize("default/sample"))
+	}
+	if resource.InstanceInfo.Type != manifestTerraformResourceName {
+		t.Fatalf("resource type = %q, want %q", resource.InstanceInfo.Type, manifestTerraformResourceName)
+	}
+}
+
+func TestInitDynamicResourcesManifestImportIDClusterScoped(t *testing.T) {
+	gvr := schema.GroupVersionResource{
+		Group:    "apiextensions.k8s.io",
+		Version:  "v1",
+		Resource: "customresourcedefinitions",
+	}
+	crd := newUnstructured("apiextensions.k8s.io/v1", "CustomResourceDefinition", "widgets.example.com", "")
+	client := dynamicfake.NewSimpleDynamicClientWithCustomListKinds(
+		runtime.NewScheme(),
+		map[schema.GroupVersionResource]string{gvr: "CustomResourceDefinitionList"},
+		crd,
+	)
+
+	kind := &Kind{
+		Group:         "apiextensions.k8s.io",
+		Version:       "v1",
+		Name:          "CustomResourceDefinition",
+		ResourceName:  "customresourcedefinitions",
+		TerraformType: manifestTerraformResourceName,
+	}
+	if err := kind.initDynamicResources(client); err != nil {
+		t.Fatalf("initDynamicResources() error = %v", err)
+	}
+
+	if len(kind.Resources) != 1 {
+		t.Fatalf("Resources len = %d, want 1", len(kind.Resources))
+	}
+	if kind.Resources[0].InstanceState.ID != "apiVersion=apiextensions.k8s.io/v1,kind=CustomResourceDefinition,name=widgets.example.com" {
+		t.Fatalf("resource ID = %q, want %q", kind.Resources[0].InstanceState.ID, "apiVersion=apiextensions.k8s.io/v1,kind=CustomResourceDefinition,name=widgets.example.com")
 	}
 }
 

--- a/providers/kubernetes/kubernetes_provider.go
+++ b/providers/kubernetes/kubernetes_provider.go
@@ -20,6 +20,7 @@ import (
 	"github.com/zclconf/go-cty/cty"
 
 	"github.com/pkg/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/client-go/discovery"
@@ -123,15 +124,7 @@ func (p *KubernetesProvider) GetSupportedService() map[string]terraformutils.Ser
 				continue
 			}
 
-			resources[resource.Name] = &Kind{
-				Group:            gv.Group,
-				Version:          gv.Version,
-				Name:             resource.Kind,
-				ResourceName:     resource.Name,
-				Namespaced:       resource.Namespaced,
-				TerraformType:    terraformResourceName,
-				UseDynamicClient: useDynamicClient,
-			}
+			addKubernetesResourceService(resources, gv.Group, gv.Version, resource, terraformResourceName, useDynamicClient)
 		}
 	}
 	addDefaultServiceAccountService(resources, clientset, listableResources, func(name string) bool {
@@ -139,6 +132,35 @@ func (p *KubernetesProvider) GetSupportedService() map[string]terraformutils.Ser
 		return exists
 	})
 	return resources
+}
+
+func addKubernetesResourceService(
+	resources map[string]terraformutils.ServiceGenerator,
+	group string,
+	version string,
+	resource metav1.APIResource,
+	terraformResourceName string,
+	useDynamicClient bool,
+) {
+	resources[kubernetesResourceServiceKey(group, version, resource.Name, terraformResourceName)] = &Kind{
+		Group:            group,
+		Version:          version,
+		Name:             resource.Kind,
+		ResourceName:     resource.Name,
+		Namespaced:       resource.Namespaced,
+		TerraformType:    terraformResourceName,
+		UseDynamicClient: useDynamicClient,
+	}
+}
+
+func kubernetesResourceServiceKey(group, version, resourceName, terraformResourceName string) string {
+	if terraformResourceName != manifestTerraformResourceName {
+		return resourceName
+	}
+	if group == "" {
+		return version + "/" + resourceName
+	}
+	return group + "/" + version + "/" + resourceName
 }
 
 func addDefaultServiceAccountService(

--- a/providers/kubernetes/kubernetes_provider.go
+++ b/providers/kubernetes/kubernetes_provider.go
@@ -114,21 +114,13 @@ func (p *KubernetesProvider) GetSupportedService() map[string]terraformutils.Ser
 			}
 			listableResources[kubernetesResourceID{group: gv.Group, version: gv.Version, kind: resource.Kind}] = struct{}{}
 
-			// filter to resources that the Terraform Kubernetes provider can import
-			terraformResourceName, ok := selectTerraformResourceName(gv.Group, gv.Version, resource.Kind, func(name string) bool {
+			hasResourceType := func(name string) bool {
 				_, exists := resp.ResourceTypes[name]
 				return exists
-			})
+			}
+			terraformResourceName, useDynamicClient, ok := selectImportResourceName(clientset, gv.Group, gv.Version, resource, hasResourceType)
 			if !ok {
 				continue
-			}
-
-			useDynamicClient := false
-			if !supportsTypedClientResource(clientset, gv.Group, gv.Version, resource.Kind) {
-				if !supportsDynamicClientResource(gv.Group, gv.Version, resource.Kind) {
-					continue
-				}
-				useDynamicClient = true
 			}
 
 			resources[resource.Name] = &Kind{

--- a/providers/kubernetes/kubernetes_provider_test.go
+++ b/providers/kubernetes/kubernetes_provider_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/chenrui333/terraformer/terraformutils"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes/fake"
 )
 
@@ -59,6 +60,52 @@ func TestAddDefaultServiceAccountServiceRequiresServiceAccountAPI(t *testing.T) 
 
 	if _, ok := resources[defaultServiceAccountServiceName]; ok {
 		t.Fatalf("resources[%q] was registered without serviceaccounts API support", defaultServiceAccountServiceName)
+	}
+}
+
+func TestAddKubernetesResourceServiceDisambiguatesManifestPluralCollisions(t *testing.T) {
+	resources := map[string]terraformutils.ServiceGenerator{}
+	resource := metav1.APIResource{
+		Name:       "widgets",
+		Kind:       "Widget",
+		Namespaced: true,
+	}
+
+	addKubernetesResourceService(resources, "example.com", "v1", resource, manifestTerraformResourceName, true)
+	addKubernetesResourceService(resources, "other.example.com", "v1", resource, manifestTerraformResourceName, true)
+
+	if len(resources) != 2 {
+		t.Fatalf("resources len = %d, want 2", len(resources))
+	}
+	for _, key := range []string{"example.com/v1/widgets", "other.example.com/v1/widgets"} {
+		service, ok := resources[key]
+		if !ok {
+			t.Fatalf("resources[%q] was not registered", key)
+		}
+		kind := service.(*Kind)
+		if kind.ResourceName != "widgets" {
+			t.Fatalf("ResourceName = %q, want %q", kind.ResourceName, "widgets")
+		}
+		if kind.TerraformType != manifestTerraformResourceName {
+			t.Fatalf("TerraformType = %q, want %q", kind.TerraformType, manifestTerraformResourceName)
+		}
+	}
+}
+
+func TestAddKubernetesResourceServiceKeepsNativePluralKey(t *testing.T) {
+	resources := map[string]terraformutils.ServiceGenerator{}
+	resource := metav1.APIResource{
+		Name: "services",
+		Kind: "Service",
+	}
+
+	addKubernetesResourceService(resources, "", "v1", resource, "kubernetes_service_v1", false)
+
+	if _, ok := resources["services"]; !ok {
+		t.Fatal("native resource was not registered with its plural key")
+	}
+	if _, ok := resources["v1/services"]; ok {
+		t.Fatal("native resource was registered with a manifest-style qualified key")
 	}
 }
 

--- a/providers/kubernetes/utils.go
+++ b/providers/kubernetes/utils.go
@@ -149,6 +149,9 @@ func selectImportResourceName(
 		if supportsDynamicClientResource(group, version, resource.Kind) {
 			return terraformResourceName, true, true
 		}
+		if supportsManifestResource(resource, hasResourceType) {
+			return manifestTerraformResourceName, true, true
+		}
 		return "", false, false
 	}
 

--- a/providers/kubernetes/utils.go
+++ b/providers/kubernetes/utils.go
@@ -88,7 +88,40 @@ var dynamicClientResources = map[kubernetesResourceID]struct{}{
 	{group: "policy", version: "v1beta1", kind: "PodSecurityPolicy"}:            {},
 }
 
+// client-go group accessor names collapse DNS groups to their first label
+// (for example, rbac.authorization.k8s.io -> RbacV1), so require exact API
+// groups before reflection to avoid treating CRDs like apps.example.com as
+// native apps resources.
+var typedClientSetAPIGroups = map[string]struct{}{
+	"":                             {},
+	"admissionregistration.k8s.io": {},
+	"apps":                         {},
+	"authentication.k8s.io":        {},
+	"authorization.k8s.io":         {},
+	"autoscaling":                  {},
+	"batch":                        {},
+	"certificates.k8s.io":          {},
+	"coordination.k8s.io":          {},
+	"discovery.k8s.io":             {},
+	"events.k8s.io":                {},
+	"extensions":                   {},
+	"flowcontrol.apiserver.k8s.io": {},
+	"internal.apiserver.k8s.io":    {},
+	"networking.k8s.io":            {},
+	"node.k8s.io":                  {},
+	"policy":                       {},
+	"rbac.authorization.k8s.io":    {},
+	"resource.k8s.io":              {},
+	"scheduling.k8s.io":            {},
+	"storagemigration.k8s.io":      {},
+	"storage.k8s.io":               {},
+}
+
 func extractClientSetFuncGroupName(group, version string) string {
+	if _, ok := typedClientSetAPIGroups[group]; !ok {
+		return ""
+	}
+
 	v := strings.Title(version)
 	if len(group) > 0 {
 		return strings.Title(strings.Split(group, ".")[0]) + v

--- a/providers/kubernetes/utils.go
+++ b/providers/kubernetes/utils.go
@@ -8,8 +8,12 @@ import (
 	"strings"
 
 	"github.com/iancoleman/strcase"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/client-go/kubernetes"
 )
+
+const manifestTerraformResourceName = "kubernetes_manifest"
 
 type kubernetesResourceID struct {
 	group   string
@@ -130,9 +134,50 @@ func selectTerraformResourceName(group, version, kind string, hasResourceType fu
 	return "", false
 }
 
+func selectImportResourceName(
+	clientset kubernetes.Interface,
+	group string,
+	version string,
+	resource metav1.APIResource,
+	hasResourceType func(string) bool,
+) (string, bool, bool) {
+	terraformResourceName, ok := selectTerraformResourceName(group, version, resource.Kind, hasResourceType)
+	if ok {
+		if supportsTypedClientResource(clientset, group, version, resource.Kind) {
+			return terraformResourceName, false, true
+		}
+		if supportsDynamicClientResource(group, version, resource.Kind) {
+			return terraformResourceName, true, true
+		}
+		return "", false, false
+	}
+
+	// Keep native typed-client resources on explicit provider resources only.
+	// The manifest fallback is for CRDs and other untyped API extensions.
+	if supportsTypedClientResource(clientset, group, version, resource.Kind) {
+		return "", false, false
+	}
+	if !supportsManifestResource(resource, hasResourceType) {
+		return "", false, false
+	}
+	return manifestTerraformResourceName, true, true
+}
+
 func supportsDynamicClientResource(group, version, kind string) bool {
 	_, ok := dynamicClientResources[kubernetesResourceID{group: group, version: version, kind: kind}]
 	return ok
+}
+
+func supportsManifestResource(resource metav1.APIResource, hasResourceType func(string) bool) bool {
+	if !hasResourceType(manifestTerraformResourceName) {
+		return false
+	}
+	if resource.Kind == "" || strings.Contains(resource.Name, "/") {
+		return false
+	}
+
+	verbs := sets.NewString(resource.Verbs...)
+	return verbs.HasAll("create", "delete", "get", "list", "patch")
 }
 
 func supportsTypedClientResource(clientset kubernetes.Interface, group, version, kind string) (ok bool) {

--- a/providers/kubernetes/utils_test.go
+++ b/providers/kubernetes/utils_test.go
@@ -485,6 +485,23 @@ func TestSelectImportResourceName(t *testing.T) {
 			wantOK:      true,
 		},
 		{
+			name:    "falls back to manifest for colliding custom kind",
+			group:   "serving.knative.dev",
+			version: "v1",
+			resource: metav1.APIResource{
+				Name:  "services",
+				Kind:  "Service",
+				Verbs: manageableVerbs,
+			},
+			supportedTypes: map[string]struct{}{
+				"kubernetes_service":          {},
+				manifestTerraformResourceName: {},
+			},
+			want:        manifestTerraformResourceName,
+			wantDynamic: true,
+			wantOK:      true,
+		},
+		{
 			name:    "skips native typed resource without first-class provider type",
 			version: "v1",
 			resource: metav1.APIResource{

--- a/providers/kubernetes/utils_test.go
+++ b/providers/kubernetes/utils_test.go
@@ -502,6 +502,23 @@ func TestSelectImportResourceName(t *testing.T) {
 			wantOK:      true,
 		},
 		{
+			name:    "falls back to manifest for custom group sharing native prefix",
+			group:   "apps.example.com",
+			version: "v1",
+			resource: metav1.APIResource{
+				Name:  "deployments",
+				Kind:  "Deployment",
+				Verbs: manageableVerbs,
+			},
+			supportedTypes: map[string]struct{}{
+				"kubernetes_deployment":       {},
+				manifestTerraformResourceName: {},
+			},
+			want:        manifestTerraformResourceName,
+			wantDynamic: true,
+			wantOK:      true,
+		},
+		{
 			name:    "skips native typed resource without first-class provider type",
 			version: "v1",
 			resource: metav1.APIResource{
@@ -724,6 +741,7 @@ func TestSupportsTypedClientResource(t *testing.T) {
 		{name: "core service", version: "v1", kind: "Service", want: true},
 		{name: "core endpoints", version: "v1", kind: "Endpoints", want: true},
 		{name: "apps daemon set", group: "apps", version: "v1", kind: "DaemonSet", want: true},
+		{name: "custom group sharing native prefix is not typed", group: "apps.example.com", version: "v1", kind: "Deployment", want: false},
 		{name: "autoscaling hpa", group: "autoscaling", version: "v2", kind: "HorizontalPodAutoscaler", want: true},
 		{name: "autoscaling v2beta2 hpa is not exposed by kubernetes clientset", group: "autoscaling", version: "v2beta2", kind: "HorizontalPodAutoscaler", want: false},
 		{name: "certificate signing request", group: "certificates.k8s.io", version: "v1", kind: "CertificateSigningRequest", want: true},

--- a/providers/kubernetes/utils_test.go
+++ b/providers/kubernetes/utils_test.go
@@ -6,6 +6,7 @@ import (
 	"reflect"
 	"testing"
 
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes/fake"
 )
 
@@ -424,6 +425,110 @@ func TestSelectTerraformResourceName(t *testing.T) {
 	}
 }
 
+func TestSelectImportResourceName(t *testing.T) {
+	clientset := fake.NewSimpleClientset()
+	manageableVerbs := []string{"create", "delete", "get", "list", "patch", "update"}
+	tests := []struct {
+		name           string
+		group          string
+		version        string
+		resource       metav1.APIResource
+		supportedTypes map[string]struct{}
+		want           string
+		wantDynamic    bool
+		wantOK         bool
+	}{
+		{
+			name:    "selects first-class typed resource",
+			version: "v1",
+			resource: metav1.APIResource{
+				Name:  "services",
+				Kind:  "Service",
+				Verbs: manageableVerbs,
+			},
+			supportedTypes: map[string]struct{}{
+				"kubernetes_service_v1": {},
+			},
+			want:   "kubernetes_service_v1",
+			wantOK: true,
+		},
+		{
+			name:    "selects explicit dynamic first-class resource",
+			group:   "apiregistration.k8s.io",
+			version: "v1",
+			resource: metav1.APIResource{
+				Name:  "apiservices",
+				Kind:  "APIService",
+				Verbs: manageableVerbs,
+			},
+			supportedTypes: map[string]struct{}{
+				"kubernetes_api_service_v1": {},
+			},
+			want:        "kubernetes_api_service_v1",
+			wantDynamic: true,
+			wantOK:      true,
+		},
+		{
+			name:    "falls back to manifest for untyped API extension",
+			group:   "example.com",
+			version: "v1",
+			resource: metav1.APIResource{
+				Name:  "widgets",
+				Kind:  "Widget",
+				Verbs: manageableVerbs,
+			},
+			supportedTypes: map[string]struct{}{
+				manifestTerraformResourceName: {},
+			},
+			want:        manifestTerraformResourceName,
+			wantDynamic: true,
+			wantOK:      true,
+		},
+		{
+			name:    "skips native typed resource without first-class provider type",
+			version: "v1",
+			resource: metav1.APIResource{
+				Name:  "nodes",
+				Kind:  "Node",
+				Verbs: manageableVerbs,
+			},
+			supportedTypes: map[string]struct{}{
+				manifestTerraformResourceName: {},
+			},
+			wantOK: false,
+		},
+		{
+			name:    "skips untyped resource without manifest provider type",
+			group:   "example.com",
+			version: "v1",
+			resource: metav1.APIResource{
+				Name:  "widgets",
+				Kind:  "Widget",
+				Verbs: manageableVerbs,
+			},
+			wantOK: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, dynamic, ok := selectImportResourceName(clientset, tt.group, tt.version, tt.resource, func(name string) bool {
+				_, exists := tt.supportedTypes[name]
+				return exists
+			})
+			if ok != tt.wantOK {
+				t.Fatalf("selectImportResourceName() ok = %t, want %t", ok, tt.wantOK)
+			}
+			if dynamic != tt.wantDynamic {
+				t.Fatalf("selectImportResourceName() dynamic = %t, want %t", dynamic, tt.wantDynamic)
+			}
+			if got != tt.want {
+				t.Fatalf("selectImportResourceName() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
 func TestSelectTerraformResourceNameStableV1Aliases(t *testing.T) {
 	tests := []struct {
 		name       string
@@ -505,6 +610,85 @@ func TestSupportsDynamicClientResource(t *testing.T) {
 			got := supportsDynamicClientResource(tt.group, tt.version, tt.kind)
 			if got != tt.want {
 				t.Fatalf("supportsDynamicClientResource(%q, %q, %q) = %t, want %t", tt.group, tt.version, tt.kind, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestSupportsManifestResource(t *testing.T) {
+	manageableVerbs := []string{"create", "delete", "get", "list", "patch", "update"}
+	tests := []struct {
+		name           string
+		resource       metav1.APIResource
+		supportedTypes map[string]struct{}
+		want           bool
+	}{
+		{
+			name: "supports manageable custom resource",
+			resource: metav1.APIResource{
+				Name:  "widgets",
+				Kind:  "Widget",
+				Verbs: manageableVerbs,
+			},
+			supportedTypes: map[string]struct{}{
+				manifestTerraformResourceName: {},
+			},
+			want: true,
+		},
+		{
+			name: "requires manifest provider type",
+			resource: metav1.APIResource{
+				Name:  "widgets",
+				Kind:  "Widget",
+				Verbs: manageableVerbs,
+			},
+			want: false,
+		},
+		{
+			name: "rejects subresources",
+			resource: metav1.APIResource{
+				Name:  "widgets/status",
+				Kind:  "Widget",
+				Verbs: manageableVerbs,
+			},
+			supportedTypes: map[string]struct{}{
+				manifestTerraformResourceName: {},
+			},
+			want: false,
+		},
+		{
+			name: "requires manageable verbs",
+			resource: metav1.APIResource{
+				Name:  "podmetrics",
+				Kind:  "PodMetrics",
+				Verbs: []string{"get", "list"},
+			},
+			supportedTypes: map[string]struct{}{
+				manifestTerraformResourceName: {},
+			},
+			want: false,
+		},
+		{
+			name: "requires kind",
+			resource: metav1.APIResource{
+				Name:  "widgets",
+				Verbs: manageableVerbs,
+			},
+			supportedTypes: map[string]struct{}{
+				manifestTerraformResourceName: {},
+			},
+			want: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := supportsManifestResource(tt.resource, func(name string) bool {
+				_, exists := tt.supportedTypes[name]
+				return exists
+			})
+			if got != tt.want {
+				t.Fatalf("supportsManifestResource() = %t, want %t", got, tt.want)
 			}
 		})
 	}

--- a/terraformutils/hcl.go
+++ b/terraformutils/hcl.go
@@ -300,7 +300,7 @@ func hclPrintManifestResources(resources []Resource, sortOutput bool) ([]byte, e
 func manifestConfigAttributes(item map[string]interface{}) map[string]interface{} {
 	attributes := make(map[string]interface{}, len(item))
 	for key, value := range item {
-		if key == "object" {
+		if key == "object" || value == nil {
 			continue
 		}
 		attributes[key] = value

--- a/terraformutils/hcl.go
+++ b/terraformutils/hcl.go
@@ -21,7 +21,18 @@ import (
 
 const safeChars = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789-_"
 
-var unsafeChars = regexp.MustCompile(`[^0-9A-Za-z_\-]`)
+var (
+	unsafeChars       = regexp.MustCompile(`[^0-9A-Za-z_\-]`)
+	hclObjectKeyChars = regexp.MustCompile(`^[A-Za-z_][0-9A-Za-z_-]*$`)
+	hclReservedKeys   = map[string]struct{}{
+		"false": {},
+		"for":   {},
+		"if":    {},
+		"in":    {},
+		"null":  {},
+		"true":  {},
+	}
+)
 
 // make HCL output reproducible by sorting the AST nodes
 func sortHclTree(tree interface{}) {
@@ -232,10 +243,18 @@ func blockSyntaxAdjustments(formatted []byte, mapsObjects map[string]struct{}) [
 }
 
 func formatMapKey(key string) string {
-	if regexp.MustCompile("^[A-Za-z0-9_-]+$").MatchString(key) {
+	if isSafeHCLObjectKey(key) {
 		return key
 	}
 	return quoteHCLLabel(key)
+}
+
+func isSafeHCLObjectKey(key string) bool {
+	if !hclObjectKeyChars.MatchString(key) {
+		return false
+	}
+	_, reserved := hclReservedKeys[key]
+	return !reserved
 }
 
 func quoteHCLLabel(key string) string {

--- a/terraformutils/hcl.go
+++ b/terraformutils/hcl.go
@@ -231,6 +231,142 @@ func blockSyntaxAdjustments(formatted []byte, mapsObjects map[string]struct{}) [
 	return []byte(s)
 }
 
+func formatMapKey(key string) string {
+	if regexp.MustCompile("^[A-Za-z0-9_-]+$").MatchString(key) {
+		return key
+	}
+	return quoteHCLLabel(key)
+}
+
+func quoteHCLLabel(key string) string {
+	raw, err := json.Marshal(key)
+	if err != nil {
+		return "\"" + key + "\""
+	}
+	return string(raw)
+}
+
+func hclPrintManifestResources(resources []Resource, sortOutput bool) ([]byte, error) {
+	if len(resources) == 0 {
+		return []byte{}, nil
+	}
+
+	resources = append([]Resource{}, resources...)
+	if sortOutput {
+		sort.Slice(resources, func(i, j int) bool {
+			return resources[i].ResourceName < resources[j].ResourceName
+		})
+	}
+
+	var b strings.Builder
+	for i, res := range resources {
+		if i > 0 {
+			b.WriteString("\n\n")
+		}
+		fmt.Fprintf(&b, "resource %s %s {\n", quoteHCLLabel(res.InstanceInfo.Type), quoteHCLLabel(res.ResourceName))
+		item := manifestConfigAttributes(res.Item)
+		for _, key := range sortedHCLKeys(item) {
+			b.WriteString("  " + formatMapKey(key) + " = ")
+			if err := hclWriteValue(&b, item[key], 2, sortOutput); err != nil {
+				return nil, err
+			}
+			b.WriteString("\n")
+		}
+		b.WriteString("}")
+	}
+	b.WriteString("\n")
+	return []byte(b.String()), nil
+}
+
+func manifestConfigAttributes(item map[string]interface{}) map[string]interface{} {
+	attributes := make(map[string]interface{}, len(item))
+	for key, value := range item {
+		if key == "object" {
+			continue
+		}
+		attributes[key] = value
+	}
+	return attributes
+}
+
+func hclWriteValue(b *strings.Builder, value interface{}, indent int, sortOutput bool) error {
+	switch value := value.(type) {
+	case map[string]interface{}:
+		return hclWriteMap(b, value, indent, sortOutput)
+	case []interface{}:
+		return hclWriteList(b, value, indent, sortOutput)
+	default:
+		raw, err := json.Marshal(value)
+		if err != nil {
+			return err
+		}
+		b.Write(raw)
+		return nil
+	}
+}
+
+func hclWriteMap(b *strings.Builder, value map[string]interface{}, indent int, sortOutput bool) error {
+	if len(value) == 0 {
+		b.WriteString("{}")
+		return nil
+	}
+
+	b.WriteString("{\n")
+	childIndent := strings.Repeat(" ", indent+2)
+	for _, key := range sortedHCLKeys(value) {
+		b.WriteString(childIndent + formatMapKey(key) + " = ")
+		if err := hclWriteValue(b, value[key], indent+2, sortOutput); err != nil {
+			return err
+		}
+		b.WriteString("\n")
+	}
+	b.WriteString(strings.Repeat(" ", indent) + "}")
+	return nil
+}
+
+func hclWriteList(b *strings.Builder, value []interface{}, indent int, sortOutput bool) error {
+	if len(value) == 0 {
+		b.WriteString("[]")
+		return nil
+	}
+
+	b.WriteString("[\n")
+	childIndent := strings.Repeat(" ", indent+2)
+	for _, item := range value {
+		b.WriteString(childIndent)
+		if err := hclWriteValue(b, item, indent+2, sortOutput); err != nil {
+			return err
+		}
+		b.WriteString(",\n")
+	}
+	b.WriteString(strings.Repeat(" ", indent) + "]")
+	return nil
+}
+
+func sortedHCLKeys(value map[string]interface{}) []string {
+	keys := make([]string, 0, len(value))
+	for key := range value {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	return keys
+}
+
+func appendHCLSection(base []byte, section []byte) []byte {
+	base = bytes.TrimRight(base, "\n")
+	section = bytes.TrimLeft(section, "\n")
+	if len(bytes.TrimSpace(base)) == 0 {
+		return section
+	}
+	if len(bytes.TrimSpace(section)) == 0 {
+		return base
+	}
+	out := append([]byte{}, base...)
+	out = append(out, '\n', '\n')
+	out = append(out, section...)
+	return out
+}
+
 func requiredProvidersObjectAdjustments(formatted []byte) []byte {
 	s := string(formatted)
 	requiredProvidersRe := regexp.MustCompile("required_providers \".*\" {")
@@ -270,8 +406,21 @@ func TfSanitize(name string) string {
 func HclPrintResource(resources []Resource, providerData map[string]interface{}, output string, sort bool) ([]byte, error) {
 	resourcesByType := map[string]map[string]interface{}{}
 	mapsObjects := map[string]struct{}{}
+	manifestResources := make([]Resource, 0)
+	manifestResourceNames := map[string]struct{}{}
 	indexRe := regexp.MustCompile(`\.[0-9]+`)
 	for _, res := range resources {
+		if output == "hcl" && res.InstanceInfo.Type == "kubernetes_manifest" {
+			if _, exists := manifestResourceNames[res.ResourceName]; exists {
+				log.Println(resources)
+				log.Printf("[ERR]: duplicate resource found: %s.%s", res.InstanceInfo.Type, res.ResourceName)
+				continue
+			}
+			manifestResourceNames[res.ResourceName] = struct{}{}
+			manifestResources = append(manifestResources, res)
+			continue
+		}
+
 		r := resourcesByType[res.InstanceInfo.Type]
 		if r == nil {
 			r = make(map[string]interface{})
@@ -303,7 +452,22 @@ func HclPrintResource(resources []Resource, providerData map[string]interface{},
 	}
 	var err error
 
-	hclBytes, err := Print(data, mapsObjects, output, sort)
+	var hclBytes []byte
+	if output == "hcl" && len(manifestResources) > 0 {
+		if len(data) > 0 {
+			hclBytes, err = Print(data, mapsObjects, output, sort)
+			if err != nil {
+				return []byte{}, err
+			}
+		}
+		manifestBytes, err := hclPrintManifestResources(manifestResources, sort)
+		if err != nil {
+			return []byte{}, err
+		}
+		return appendHCLSection(hclBytes, manifestBytes), nil
+	}
+
+	hclBytes, err = Print(data, mapsObjects, output, sort)
 	if err != nil {
 		return []byte{}, err
 	}

--- a/terraformutils/hcl.go
+++ b/terraformutils/hcl.go
@@ -246,7 +246,7 @@ func formatMapKey(key string) string {
 	if isSafeHCLObjectKey(key) {
 		return key
 	}
-	return quoteHCLLabel(key)
+	return quoteHCLString(key)
 }
 
 func isSafeHCLObjectKey(key string) bool {
@@ -263,6 +263,20 @@ func quoteHCLLabel(key string) string {
 		return "\"" + key + "\""
 	}
 	return string(raw)
+}
+
+func quoteHCLString(value string) string {
+	raw, err := json.Marshal(escapeTerraformTemplateMarkers(value))
+	if err != nil {
+		return "\"" + value + "\""
+	}
+	return string(raw)
+}
+
+func escapeTerraformTemplateMarkers(value string) string {
+	value = strings.ReplaceAll(value, "${", "$${")
+	value = strings.ReplaceAll(value, "%{", "%%{")
+	return value
 }
 
 func hclPrintManifestResources(resources []Resource, sortOutput bool) ([]byte, error) {
@@ -314,6 +328,9 @@ func hclWriteValue(b *strings.Builder, value interface{}, indent int, sortOutput
 		return hclWriteMap(b, value, indent, sortOutput)
 	case []interface{}:
 		return hclWriteList(b, value, indent, sortOutput)
+	case string:
+		b.WriteString(quoteHCLString(value))
+		return nil
 	default:
 		raw, err := json.Marshal(value)
 		if err != nil {

--- a/terraformutils/hcl_test.go
+++ b/terraformutils/hcl_test.go
@@ -52,6 +52,7 @@ func TestPrintManifestResourceKeepsNestedMapsRenderable(t *testing.T) {
 		nil,
 	)
 	resource.Item = map[string]interface{}{
+		"field_manager": nil,
 		"manifest": map[string]interface{}{
 			"apiVersion": "example.com/v1",
 			"kind":       "Widget",
@@ -101,6 +102,8 @@ func TestPrintManifestResourceKeepsNestedMapsRenderable(t *testing.T) {
 				"phase": "Ready",
 			},
 		},
+		"timeouts": nil,
+		"wait":     nil,
 	}
 
 	data, err := HclPrintResource([]Resource{resource}, map[string]interface{}{}, "hcl", true)
@@ -130,8 +133,10 @@ func TestPrintManifestResourceKeepsNestedMapsRenderable(t *testing.T) {
 			t.Fatalf("%s rendered as a block:\n%s", block, output)
 		}
 	}
-	if strings.Contains(output, "object =") || strings.Contains(output, "status =") {
-		t.Fatalf("computed object state was rendered:\n%s", output)
+	for _, unwanted := range []string{"object =", "status =", "field_manager =", "timeouts =", "wait ="} {
+		if strings.Contains(output, unwanted) {
+			t.Fatalf("%s was rendered:\n%s", unwanted, output)
+		}
 	}
 	if _, err := hclParser.Parse(data); err != nil {
 		t.Fatalf("generated HCL does not parse: %v\n%s", err, output)

--- a/terraformutils/hcl_test.go
+++ b/terraformutils/hcl_test.go
@@ -5,6 +5,8 @@ package terraformutils
 import (
 	"strings"
 	"testing"
+
+	hclParser "github.com/hashicorp/hcl/hcl/parser"
 )
 
 func TestPrintResource(t *testing.T) {
@@ -38,5 +40,90 @@ func TestPrintResource(t *testing.T) {
 	}
 	if strings.Count(string(data), "map2 = ") != 1 {
 		t.Errorf("failed to parse data %s", string(data))
+	}
+}
+
+func TestPrintManifestResourceKeepsNestedMapsRenderable(t *testing.T) {
+	resource := NewSimpleResource(
+		"apiVersion=example.com/v1,kind=Widget,namespace=default,name=sample",
+		"example.com/v1/Widget/default/sample",
+		"kubernetes_manifest",
+		"kubernetes",
+		nil,
+	)
+	resource.Item = map[string]interface{}{
+		"manifest": map[string]interface{}{
+			"apiVersion": "example.com/v1",
+			"kind":       "Widget",
+			"metadata": map[string]interface{}{
+				"name":      "sample",
+				"namespace": "default",
+				"labels": map[string]interface{}{
+					"app": "sample",
+				},
+			},
+			"spec": map[string]interface{}{
+				"template": map[string]interface{}{
+					"metadata": map[string]interface{}{
+						"labels": map[string]interface{}{
+							"app": "sample",
+						},
+					},
+				},
+				"versions": []interface{}{
+					map[string]interface{}{
+						"name": "v1",
+						"schema": map[string]interface{}{
+							"openAPIV3Schema": map[string]interface{}{
+								"type": "object",
+							},
+						},
+					},
+					map[string]interface{}{
+						"name": "v2",
+						"schema": map[string]interface{}{
+							"openAPIV3Schema": map[string]interface{}{
+								"type": "object",
+							},
+						},
+					},
+				},
+			},
+		},
+		"object": map[string]interface{}{
+			"status": map[string]interface{}{
+				"phase": "Ready",
+			},
+		},
+	}
+
+	data, err := HclPrintResource([]Resource{resource}, map[string]interface{}{}, "hcl", true)
+	if err != nil {
+		t.Fatalf("HclPrintResource() error = %v", err)
+	}
+	output := string(data)
+	for _, want := range []string{
+		"manifest = {",
+		"metadata = {",
+		"labels = {",
+		"template = {",
+		"versions = [",
+		"schema = {",
+		"openAPIV3Schema = {",
+	} {
+		if !strings.Contains(output, want) {
+			t.Fatalf("output does not contain %q:\n%s", want, output)
+		}
+	}
+	for _, block := range []string{"manifest {", "schema {", "openAPIV3Schema {"} {
+		if strings.Contains(output, block) {
+			t.Fatalf("%s rendered as a block:\n%s", block, output)
+		}
+	}
+	if strings.Contains(output, "object =") || strings.Contains(output, "status =") {
+		t.Fatalf("computed object state was rendered:\n%s", output)
+	}
+	if _, err := hclParser.Parse(data); err != nil {
+		t.Fatalf("generated HCL does not parse: %v\n%s", err, output)
 	}
 }

--- a/terraformutils/hcl_test.go
+++ b/terraformutils/hcl_test.go
@@ -56,10 +56,16 @@ func TestPrintManifestResourceKeepsNestedMapsRenderable(t *testing.T) {
 			"apiVersion": "example.com/v1",
 			"kind":       "Widget",
 			"metadata": map[string]interface{}{
+				"annotations": map[string]interface{}{
+					"if":                        "reserved",
+					"kubernetes.io/description": "sample widget",
+				},
 				"name":      "sample",
 				"namespace": "default",
 				"labels": map[string]interface{}{
-					"app": "sample",
+					"123abc": "numeric",
+					"app":    "sample",
+					"for":    "reserved",
 				},
 			},
 			"spec": map[string]interface{}{
@@ -110,6 +116,10 @@ func TestPrintManifestResourceKeepsNestedMapsRenderable(t *testing.T) {
 		"versions = [",
 		"schema = {",
 		"openAPIV3Schema = {",
+		"\"123abc\" = \"numeric\"",
+		"\"for\" = \"reserved\"",
+		"\"if\" = \"reserved\"",
+		"\"kubernetes.io/description\" = \"sample widget\"",
 	} {
 		if !strings.Contains(output, want) {
 			t.Fatalf("output does not contain %q:\n%s", want, output)

--- a/terraformutils/hcl_test.go
+++ b/terraformutils/hcl_test.go
@@ -58,6 +58,8 @@ func TestPrintManifestResourceKeepsNestedMapsRenderable(t *testing.T) {
 			"kind":       "Widget",
 			"metadata": map[string]interface{}{
 				"annotations": map[string]interface{}{
+					"${terraform.io/template}":  "literal ${FOO}",
+					"%{terraform.io/directive}": "literal %{ if true }enabled%{ endif }",
 					"if":                        "reserved",
 					"kubernetes.io/description": "sample widget",
 				},
@@ -120,6 +122,8 @@ func TestPrintManifestResourceKeepsNestedMapsRenderable(t *testing.T) {
 		"schema = {",
 		"openAPIV3Schema = {",
 		"\"123abc\" = \"numeric\"",
+		"\"$${terraform.io/template}\" = \"literal $${FOO}\"",
+		"\"%%{terraform.io/directive}\" = \"literal %%{ if true }enabled%%{ endif }\"",
 		"\"for\" = \"reserved\"",
 		"\"if\" = \"reserved\"",
 		"\"kubernetes.io/description\" = \"sample widget\"",

--- a/terraformutils/kubernetesmanifest/manifest.go
+++ b/terraformutils/kubernetesmanifest/manifest.go
@@ -1,0 +1,51 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package kubernetesmanifest
+
+var serverOwnedMetadataKeys = []string{
+	"creationTimestamp",
+	"deletionGracePeriodSeconds",
+	"deletionTimestamp",
+	"generation",
+	"managedFields",
+	"resourceVersion",
+	"selfLink",
+	"uid",
+}
+
+func ConfigFromObject(object map[string]interface{}) map[string]interface{} {
+	manifest := copyMap(object)
+	delete(manifest, "status")
+
+	metadata, ok := manifest["metadata"].(map[string]interface{})
+	if !ok {
+		return manifest
+	}
+	for _, key := range serverOwnedMetadataKeys {
+		delete(metadata, key)
+	}
+	return manifest
+}
+
+func copyMap(value map[string]interface{}) map[string]interface{} {
+	copyValue := make(map[string]interface{}, len(value))
+	for key, child := range value {
+		copyValue[key] = copyInterface(child)
+	}
+	return copyValue
+}
+
+func copyInterface(value interface{}) interface{} {
+	switch value := value.(type) {
+	case map[string]interface{}:
+		return copyMap(value)
+	case []interface{}:
+		copyValue := make([]interface{}, len(value))
+		for i, child := range value {
+			copyValue[i] = copyInterface(child)
+		}
+		return copyValue
+	default:
+		return value
+	}
+}

--- a/terraformutils/kubernetesmanifest/manifest_test.go
+++ b/terraformutils/kubernetesmanifest/manifest_test.go
@@ -1,0 +1,56 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package kubernetesmanifest
+
+import "testing"
+
+func TestConfigFromObjectStripsServerOwnedFields(t *testing.T) {
+	object := map[string]interface{}{
+		"apiVersion": "example.com/v1",
+		"kind":       "Widget",
+		"metadata": map[string]interface{}{
+			"name":              "sample",
+			"namespace":         "default",
+			"resourceVersion":   "123",
+			"uid":               "uid-123",
+			"managedFields":     []interface{}{map[string]interface{}{"manager": "controller"}},
+			"creationTimestamp": "2026-05-02T00:00:00Z",
+			"labels": map[string]interface{}{
+				"app": "sample",
+			},
+		},
+		"spec": map[string]interface{}{
+			"replicas": float64(1),
+		},
+		"status": map[string]interface{}{
+			"phase": "Ready",
+		},
+	}
+
+	manifest := ConfigFromObject(object)
+
+	if _, ok := manifest["status"]; ok {
+		t.Fatal("status was not stripped")
+	}
+	metadata := manifest["metadata"].(map[string]interface{})
+	for _, key := range []string{"resourceVersion", "uid", "managedFields", "creationTimestamp"} {
+		if _, ok := metadata[key]; ok {
+			t.Fatalf("metadata.%s was not stripped", key)
+		}
+	}
+	if metadata["name"] != "sample" {
+		t.Fatalf("metadata.name = %v, want %q", metadata["name"], "sample")
+	}
+	labels := metadata["labels"].(map[string]interface{})
+	if labels["app"] != "sample" {
+		t.Fatalf("metadata.labels.app = %v, want %q", labels["app"], "sample")
+	}
+
+	originalMetadata := object["metadata"].(map[string]interface{})
+	if _, ok := originalMetadata["uid"]; !ok {
+		t.Fatal("original object metadata.uid was mutated")
+	}
+	if _, ok := object["status"]; !ok {
+		t.Fatal("original object status was mutated")
+	}
+}

--- a/terraformutils/providerwrapper/provider.go
+++ b/terraformutils/providerwrapper/provider.go
@@ -207,15 +207,21 @@ func populateKubernetesManifestFromObject(resourceType string, state *tfcompat.I
 	if err := json.Unmarshal(state.TypedAttributes, &attributes); err != nil {
 		return
 	}
-	if manifestHasValue(attributes["manifest"]) {
-		return
-	}
 
 	object, ok := attributes["object"].(map[string]interface{})
-	if !ok || len(object) == 0 {
+	changed := false
+	if !manifestHasValue(attributes["manifest"]) && ok && len(object) > 0 {
+		attributes["manifest"] = object
+		changed = true
+	}
+
+	if _, ok := attributes["object"]; ok {
+		delete(attributes, "object")
+		changed = true
+	}
+	if !changed {
 		return
 	}
-	attributes["manifest"] = object
 
 	raw, err := json.Marshal(attributes)
 	if err != nil {

--- a/terraformutils/providerwrapper/provider.go
+++ b/terraformutils/providerwrapper/provider.go
@@ -14,6 +14,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/chenrui333/terraformer/terraformutils/kubernetesmanifest"
 	"github.com/chenrui333/terraformer/terraformutils/terraformerstring"
 	"github.com/chenrui333/terraformer/terraformutils/tfcompat"
 	"github.com/chenrui333/terraformer/terraformutils/tfcompat/configschema"
@@ -211,7 +212,7 @@ func populateKubernetesManifestFromObject(resourceType string, state *tfcompat.I
 	object, ok := attributes["object"].(map[string]interface{})
 	changed := false
 	if !manifestHasValue(attributes["manifest"]) && ok && len(object) > 0 {
-		attributes["manifest"] = object
+		attributes["manifest"] = kubernetesmanifest.ConfigFromObject(object)
 		changed = true
 	}
 

--- a/terraformutils/providerwrapper/provider.go
+++ b/terraformutils/providerwrapper/provider.go
@@ -3,6 +3,7 @@
 package providerwrapper
 
 import (
+	"encoding/json"
 	"errors"
 	"fmt"
 	"log"
@@ -26,6 +27,8 @@ import (
 
 // DefaultDataDir is the default directory for storing local data.
 const DefaultDataDir = ".terraform"
+
+const kubernetesManifestResourceType = "kubernetes_manifest"
 
 type ProviderWrapper struct {
 	Provider     *providerproto.GRPCProvider
@@ -190,7 +193,46 @@ func (p *ProviderWrapper) importResourceState(info *tfcompat.InstanceInfo, state
 	if len(importResponse.ImportedResources) == 0 {
 		return nil, errors.New("not able to import resource for a given ID")
 	}
-	return tfcompat.NewInstanceStateShimmedFromValue(importResponse.ImportedResources[0].State, int(schema.ResourceTypes[info.Type].Version)), nil
+	importedState := tfcompat.NewInstanceStateShimmedFromValue(importResponse.ImportedResources[0].State, int(schema.ResourceTypes[info.Type].Version))
+	populateKubernetesManifestFromObject(info.Type, importedState)
+	return importedState, nil
+}
+
+func populateKubernetesManifestFromObject(resourceType string, state *tfcompat.InstanceState) {
+	if resourceType != kubernetesManifestResourceType || state == nil || len(state.TypedAttributes) == 0 {
+		return
+	}
+
+	attributes := map[string]interface{}{}
+	if err := json.Unmarshal(state.TypedAttributes, &attributes); err != nil {
+		return
+	}
+	if manifestHasValue(attributes["manifest"]) {
+		return
+	}
+
+	object, ok := attributes["object"].(map[string]interface{})
+	if !ok || len(object) == 0 {
+		return
+	}
+	attributes["manifest"] = object
+
+	raw, err := json.Marshal(attributes)
+	if err != nil {
+		return
+	}
+	state.SetTypedAttributes(raw)
+}
+
+func manifestHasValue(value interface{}) bool {
+	switch value := value.(type) {
+	case nil:
+		return false
+	case map[string]interface{}:
+		return len(value) > 0
+	default:
+		return true
+	}
 }
 
 func (p *ProviderWrapper) initProvider(verbose bool) error {

--- a/terraformutils/providerwrapper/provider.go
+++ b/terraformutils/providerwrapper/provider.go
@@ -141,7 +141,8 @@ func (p *ProviderWrapper) Refresh(info *tfcompat.InstanceInfo, state *tfcompat.I
 	impliedType := schema.ResourceTypes[info.Type].Block.ImpliedType()
 	priorState, err := state.AttrsAsObjectValue(impliedType)
 	if err != nil {
-		return nil, err
+		log.Printf("Fail prepare prior state for provider read, trying import command: %s", err)
+		return p.importResourceState(info, state, schema)
 	}
 	successReadResource := false
 	resp := providerproto.ReadResourceResponse{}
@@ -163,18 +164,7 @@ func (p *ProviderWrapper) Refresh(info *tfcompat.InstanceInfo, state *tfcompat.I
 
 	if !successReadResource {
 		log.Println("Fail read resource from provider, trying import command")
-		// retry with regular import command - without resource attributes
-		importResponse := p.Provider.ImportResourceState(providerproto.ImportResourceStateRequest{
-			TypeName: info.Type,
-			ID:       state.ID,
-		})
-		if importResponse.Diagnostics.HasErrors() {
-			return nil, resp.Diagnostics.Err()
-		}
-		if len(importResponse.ImportedResources) == 0 {
-			return nil, errors.New("not able to import resource for a given ID")
-		}
-		return tfcompat.NewInstanceStateShimmedFromValue(importResponse.ImportedResources[0].State, int(schema.ResourceTypes[info.Type].Version)), nil
+		return p.importResourceState(info, state, schema)
 	}
 
 	if resp.NewState.IsNull() {
@@ -183,6 +173,24 @@ func (p *ProviderWrapper) Refresh(info *tfcompat.InstanceInfo, state *tfcompat.I
 	}
 
 	return tfcompat.NewInstanceStateShimmedFromValue(resp.NewState, int(schema.ResourceTypes[info.Type].Version)), nil
+}
+
+func (p *ProviderWrapper) importResourceState(info *tfcompat.InstanceInfo, state *tfcompat.InstanceState, schema *providerproto.GetProviderSchemaResponse) (*tfcompat.InstanceState, error) {
+	id := ""
+	if state != nil {
+		id = state.ID
+	}
+	importResponse := p.Provider.ImportResourceState(providerproto.ImportResourceStateRequest{
+		TypeName: info.Type,
+		ID:       id,
+	})
+	if importResponse.Diagnostics.HasErrors() {
+		return nil, importResponse.Diagnostics.Err()
+	}
+	if len(importResponse.ImportedResources) == 0 {
+		return nil, errors.New("not able to import resource for a given ID")
+	}
+	return tfcompat.NewInstanceStateShimmedFromValue(importResponse.ImportedResources[0].State, int(schema.ResourceTypes[info.Type].Version)), nil
 }
 
 func (p *ProviderWrapper) initProvider(verbose bool) error {

--- a/terraformutils/providerwrapper/provider.go
+++ b/terraformutils/providerwrapper/provider.go
@@ -215,10 +215,6 @@ func populateKubernetesManifestFromObject(resourceType string, state *tfcompat.I
 		changed = true
 	}
 
-	if _, ok := attributes["object"]; ok {
-		delete(attributes, "object")
-		changed = true
-	}
 	if !changed {
 		return
 	}

--- a/terraformutils/providerwrapper/provider.go
+++ b/terraformutils/providerwrapper/provider.go
@@ -19,6 +19,7 @@ import (
 	"github.com/chenrui333/terraformer/terraformutils/tfcompat"
 	"github.com/chenrui333/terraformer/terraformutils/tfcompat/configschema"
 	"github.com/chenrui333/terraformer/terraformutils/tfcompat/providerproto"
+	"github.com/chenrui333/terraformer/terraformutils/typedjson"
 
 	"github.com/zclconf/go-cty/cty"
 
@@ -176,7 +177,9 @@ func (p *ProviderWrapper) Refresh(info *tfcompat.InstanceInfo, state *tfcompat.I
 		return nil, errors.New(msg)
 	}
 
-	return tfcompat.NewInstanceStateShimmedFromValue(resp.NewState, int(schema.ResourceTypes[info.Type].Version)), nil
+	refreshedState := tfcompat.NewInstanceStateShimmedFromValue(resp.NewState, int(schema.ResourceTypes[info.Type].Version))
+	preserveKubernetesManifestID(info.Type, refreshedState, state)
+	return refreshedState, nil
 }
 
 func (p *ProviderWrapper) importResourceState(info *tfcompat.InstanceInfo, state *tfcompat.InstanceState, schema *providerproto.GetProviderSchemaResponse) (*tfcompat.InstanceState, error) {
@@ -195,8 +198,16 @@ func (p *ProviderWrapper) importResourceState(info *tfcompat.InstanceInfo, state
 		return nil, errors.New("not able to import resource for a given ID")
 	}
 	importedState := tfcompat.NewInstanceStateShimmedFromValue(importResponse.ImportedResources[0].State, int(schema.ResourceTypes[info.Type].Version))
+	preserveKubernetesManifestID(info.Type, importedState, state)
 	populateKubernetesManifestFromObject(info.Type, importedState)
 	return importedState, nil
+}
+
+func preserveKubernetesManifestID(resourceType string, next *tfcompat.InstanceState, previous *tfcompat.InstanceState) {
+	if resourceType != kubernetesManifestResourceType || next == nil || next.ID != "" || previous == nil {
+		return
+	}
+	next.ID = previous.ID
 }
 
 func populateKubernetesManifestFromObject(resourceType string, state *tfcompat.InstanceState) {
@@ -204,8 +215,8 @@ func populateKubernetesManifestFromObject(resourceType string, state *tfcompat.I
 		return
 	}
 
-	attributes := map[string]interface{}{}
-	if err := json.Unmarshal(state.TypedAttributes, &attributes); err != nil {
+	attributes, err := typedjson.UnmarshalObject(state.TypedAttributes)
+	if err != nil {
 		return
 	}
 

--- a/terraformutils/providerwrapper/provider_test.go
+++ b/terraformutils/providerwrapper/provider_test.go
@@ -112,8 +112,12 @@ func TestPopulateKubernetesManifestFromObject(t *testing.T) {
 	if manifest["kind"] != "Widget" {
 		t.Fatalf("manifest.kind = %v, want %q", manifest["kind"], "Widget")
 	}
-	if _, ok := attributes["object"]; ok {
-		t.Fatal("computed object was not removed from imported state")
+	object, ok := attributes["object"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("object type = %T, want map[string]interface{}", attributes["object"])
+	}
+	if object["kind"] != "Widget" {
+		t.Fatalf("object.kind = %v, want %q", object["kind"], "Widget")
 	}
 	if !state.HasCurrentTypedAttributes() {
 		t.Fatal("typed attributes were not marked current after manifest population")
@@ -154,8 +158,12 @@ func TestPopulateKubernetesManifestFromObjectPreservesExistingManifest(t *testin
 	if metadata["name"] != "configured" {
 		t.Fatalf("manifest.metadata.name = %v, want %q", metadata["name"], "configured")
 	}
-	if _, ok := attributes["object"]; ok {
-		t.Fatal("computed object was not removed from imported state")
+	object, ok := attributes["object"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("object type = %T, want map[string]interface{}", attributes["object"])
+	}
+	if object["kind"] != "Widget" {
+		t.Fatalf("object.kind = %v, want %q", object["kind"], "Widget")
 	}
 }
 

--- a/terraformutils/providerwrapper/provider_test.go
+++ b/terraformutils/providerwrapper/provider_test.go
@@ -1,6 +1,7 @@
 package providerwrapper
 
 import (
+	"encoding/json"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -8,6 +9,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/chenrui333/terraformer/terraformutils/tfcompat"
 	"github.com/chenrui333/terraformer/terraformutils/tfcompat/configschema"
 	"github.com/zclconf/go-cty/cty"
 )
@@ -73,6 +75,84 @@ func TestIgnoredAttributes(t *testing.T) {
 				}
 			}
 		})
+	}
+}
+
+func TestPopulateKubernetesManifestFromObject(t *testing.T) {
+	state := &tfcompat.InstanceState{
+		Attributes: map[string]string{
+			"id": "apiVersion=example.com/v1,kind=Widget,name=sample",
+		},
+		TypedAttributes: json.RawMessage(`{
+			"id": "apiVersion=example.com/v1,kind=Widget,name=sample",
+			"manifest": {},
+			"object": {
+				"apiVersion": "example.com/v1",
+				"kind": "Widget",
+				"metadata": {
+					"name": "sample"
+				}
+			}
+		}`),
+	}
+
+	populateKubernetesManifestFromObject(kubernetesManifestResourceType, state)
+
+	attributes := map[string]interface{}{}
+	if err := json.Unmarshal(state.TypedAttributes, &attributes); err != nil {
+		t.Fatalf("TypedAttributes unmarshal error = %v", err)
+	}
+	manifest, ok := attributes["manifest"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("manifest type = %T, want map[string]interface{}", attributes["manifest"])
+	}
+	if manifest["apiVersion"] != "example.com/v1" {
+		t.Fatalf("manifest.apiVersion = %v, want %q", manifest["apiVersion"], "example.com/v1")
+	}
+	if manifest["kind"] != "Widget" {
+		t.Fatalf("manifest.kind = %v, want %q", manifest["kind"], "Widget")
+	}
+	if _, ok := attributes["object"]; !ok {
+		t.Fatal("object was removed from imported state")
+	}
+	if !state.HasCurrentTypedAttributes() {
+		t.Fatal("typed attributes were not marked current after manifest population")
+	}
+}
+
+func TestPopulateKubernetesManifestFromObjectPreservesExistingManifest(t *testing.T) {
+	state := &tfcompat.InstanceState{
+		Attributes: map[string]string{
+			"id": "apiVersion=example.com/v1,kind=Widget,name=sample",
+		},
+		TypedAttributes: json.RawMessage(`{
+			"manifest": {
+				"apiVersion": "example.com/v1",
+				"kind": "Widget",
+				"metadata": {
+					"name": "configured"
+				}
+			},
+			"object": {
+				"apiVersion": "example.com/v1",
+				"kind": "Widget",
+				"metadata": {
+					"name": "sample"
+				}
+			}
+		}`),
+	}
+
+	populateKubernetesManifestFromObject(kubernetesManifestResourceType, state)
+
+	attributes := map[string]interface{}{}
+	if err := json.Unmarshal(state.TypedAttributes, &attributes); err != nil {
+		t.Fatalf("TypedAttributes unmarshal error = %v", err)
+	}
+	manifest := attributes["manifest"].(map[string]interface{})
+	metadata := manifest["metadata"].(map[string]interface{})
+	if metadata["name"] != "configured" {
+		t.Fatalf("manifest.metadata.name = %v, want %q", metadata["name"], "configured")
 	}
 }
 

--- a/terraformutils/providerwrapper/provider_test.go
+++ b/terraformutils/providerwrapper/provider_test.go
@@ -112,8 +112,8 @@ func TestPopulateKubernetesManifestFromObject(t *testing.T) {
 	if manifest["kind"] != "Widget" {
 		t.Fatalf("manifest.kind = %v, want %q", manifest["kind"], "Widget")
 	}
-	if _, ok := attributes["object"]; !ok {
-		t.Fatal("object was removed from imported state")
+	if _, ok := attributes["object"]; ok {
+		t.Fatal("computed object was not removed from imported state")
 	}
 	if !state.HasCurrentTypedAttributes() {
 		t.Fatal("typed attributes were not marked current after manifest population")
@@ -153,6 +153,9 @@ func TestPopulateKubernetesManifestFromObjectPreservesExistingManifest(t *testin
 	metadata := manifest["metadata"].(map[string]interface{})
 	if metadata["name"] != "configured" {
 		t.Fatalf("manifest.metadata.name = %v, want %q", metadata["name"], "configured")
+	}
+	if _, ok := attributes["object"]; ok {
+		t.Fatal("computed object was not removed from imported state")
 	}
 }
 

--- a/terraformutils/providerwrapper/provider_test.go
+++ b/terraformutils/providerwrapper/provider_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/chenrui333/terraformer/terraformutils/tfcompat"
 	"github.com/chenrui333/terraformer/terraformutils/tfcompat/configschema"
+	"github.com/chenrui333/terraformer/terraformutils/typedjson"
 	"github.com/zclconf/go-cty/cty"
 )
 
@@ -194,6 +195,61 @@ func TestPopulateKubernetesManifestFromObjectPreservesExistingManifest(t *testin
 	}
 	if object["kind"] != "Widget" {
 		t.Fatalf("object.kind = %v, want %q", object["kind"], "Widget")
+	}
+}
+
+func TestPopulateKubernetesManifestFromObjectPreservesJSONNumbers(t *testing.T) {
+	state := &tfcompat.InstanceState{
+		TypedAttributes: json.RawMessage("{\"manifest\":{},\"object\":{\"apiVersion\":\"example.com/v1\",\"kind\":\"Widget\",\"metadata\":{\"name\":\"sample\"},\"spec\":{\"bigInteger\":9007199254740993,\"preciseDecimal\":0.1234567890123456789}}}"),
+	}
+
+	populateKubernetesManifestFromObject(kubernetesManifestResourceType, state)
+
+	attributes, err := typedjson.UnmarshalObject(state.TypedAttributes)
+	if err != nil {
+		t.Fatalf("TypedAttributes unmarshal error = %v", err)
+	}
+	manifest := attributes["manifest"].(map[string]interface{})
+	manifestSpec := manifest["spec"].(map[string]interface{})
+	assertJSONNumber(t, manifestSpec["bigInteger"], "9007199254740993")
+	assertJSONNumber(t, manifestSpec["preciseDecimal"], "0.1234567890123456789")
+
+	object := attributes["object"].(map[string]interface{})
+	objectSpec := object["spec"].(map[string]interface{})
+	assertJSONNumber(t, objectSpec["bigInteger"], "9007199254740993")
+	assertJSONNumber(t, objectSpec["preciseDecimal"], "0.1234567890123456789")
+}
+
+func TestPreserveKubernetesManifestID(t *testing.T) {
+	previous := &tfcompat.InstanceState{ID: "apiVersion=example.com/v1,kind=Widget,name=sample"}
+	next := &tfcompat.InstanceState{}
+
+	preserveKubernetesManifestID(kubernetesManifestResourceType, next, previous)
+	if next.ID != previous.ID {
+		t.Fatalf("manifest ID = %q, want %q", next.ID, previous.ID)
+	}
+
+	next.ID = "provider-id"
+	preserveKubernetesManifestID(kubernetesManifestResourceType, next, previous)
+	if next.ID != "provider-id" {
+		t.Fatalf("manifest ID = %q, want existing provider ID", next.ID)
+	}
+
+	nonManifest := &tfcompat.InstanceState{}
+	preserveKubernetesManifestID("kubernetes_service_v1", nonManifest, previous)
+	if nonManifest.ID != "" {
+		t.Fatalf("non-manifest ID = %q, want empty", nonManifest.ID)
+	}
+}
+
+func assertJSONNumber(t *testing.T, value interface{}, want string) {
+	t.Helper()
+	number, ok := value.(json.Number)
+	if !ok {
+		t.Fatalf("number type = %T, want json.Number", value)
+	}
+	if number.String() != want {
+		t.Fatalf("number = %s, want %s", number.String(), want)
 	}
 }
 

--- a/terraformutils/providerwrapper/provider_test.go
+++ b/terraformutils/providerwrapper/provider_test.go
@@ -90,7 +90,18 @@ func TestPopulateKubernetesManifestFromObject(t *testing.T) {
 				"apiVersion": "example.com/v1",
 				"kind": "Widget",
 				"metadata": {
-					"name": "sample"
+					"name": "sample",
+					"namespace": "default",
+					"resourceVersion": "123",
+					"uid": "uid-123",
+					"managedFields": [
+						{
+							"manager": "controller"
+						}
+					]
+				},
+				"status": {
+					"phase": "Ready"
 				}
 			}
 		}`),
@@ -112,12 +123,31 @@ func TestPopulateKubernetesManifestFromObject(t *testing.T) {
 	if manifest["kind"] != "Widget" {
 		t.Fatalf("manifest.kind = %v, want %q", manifest["kind"], "Widget")
 	}
+	metadata := manifest["metadata"].(map[string]interface{})
+	if metadata["name"] != "sample" {
+		t.Fatalf("manifest.metadata.name = %v, want %q", metadata["name"], "sample")
+	}
+	for _, key := range []string{"resourceVersion", "uid", "managedFields"} {
+		if _, ok := metadata[key]; ok {
+			t.Fatalf("manifest.metadata.%s was not stripped", key)
+		}
+	}
+	if _, ok := manifest["status"]; ok {
+		t.Fatal("manifest.status was not stripped")
+	}
 	object, ok := attributes["object"].(map[string]interface{})
 	if !ok {
 		t.Fatalf("object type = %T, want map[string]interface{}", attributes["object"])
 	}
 	if object["kind"] != "Widget" {
 		t.Fatalf("object.kind = %v, want %q", object["kind"], "Widget")
+	}
+	objectMetadata := object["metadata"].(map[string]interface{})
+	if objectMetadata["uid"] != "uid-123" {
+		t.Fatalf("object.metadata.uid = %v, want %q", objectMetadata["uid"], "uid-123")
+	}
+	if _, ok := object["status"]; !ok {
+		t.Fatal("object.status was not preserved")
 	}
 	if !state.HasCurrentTypedAttributes() {
 		t.Fatal("typed attributes were not marked current after manifest population")

--- a/terraformutils/resource.go
+++ b/terraformutils/resource.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/chenrui333/terraformer/terraformutils/kubernetesmanifest"
 	"github.com/chenrui333/terraformer/terraformutils/providerwrapper"
 	"github.com/chenrui333/terraformer/terraformutils/tfcompat"
 	"github.com/chenrui333/terraformer/terraformutils/tfcompat/providerproto"
@@ -213,7 +214,7 @@ func resourceTypeConfigAttributes(resourceType string, attributes map[string]int
 	}
 	if !manifestAttributeHasValue(attributes["manifest"]) {
 		if object, ok := attributes["object"].(map[string]interface{}); ok && len(object) > 0 {
-			attributes["manifest"] = object
+			attributes["manifest"] = kubernetesmanifest.ConfigFromObject(object)
 		}
 	}
 	delete(attributes, "object")

--- a/terraformutils/resource.go
+++ b/terraformutils/resource.go
@@ -181,6 +181,7 @@ func (r *Resource) convertTFstate(schema *providerproto.GetProviderSchemaRespons
 		}
 		return err
 	}
+	attributes = resourceTypeConfigAttributes(r.InstanceInfo.Type, attributes)
 	if err == nil && needsTypedManifestAttributes(r.InstanceInfo.Type, attributes) {
 		return nil
 	}
@@ -204,6 +205,19 @@ func manifestAttributeHasValue(value interface{}) bool {
 	default:
 		return true
 	}
+}
+
+func resourceTypeConfigAttributes(resourceType string, attributes map[string]interface{}) map[string]interface{} {
+	if resourceType != "kubernetes_manifest" {
+		return attributes
+	}
+	if !manifestAttributeHasValue(attributes["manifest"]) {
+		if object, ok := attributes["object"].(map[string]interface{}); ok && len(object) > 0 {
+			attributes["manifest"] = object
+		}
+	}
+	delete(attributes, "object")
+	return attributes
 }
 
 func typedAttributesAsMap(raw json.RawMessage, ignoreKeys []*regexp.Regexp) (map[string]interface{}, error) {

--- a/terraformutils/resource.go
+++ b/terraformutils/resource.go
@@ -14,6 +14,7 @@ import (
 	"github.com/chenrui333/terraformer/terraformutils/providerwrapper"
 	"github.com/chenrui333/terraformer/terraformutils/tfcompat"
 	"github.com/chenrui333/terraformer/terraformutils/tfcompat/providerproto"
+	"github.com/chenrui333/terraformer/terraformutils/typedjson"
 	"github.com/zclconf/go-cty/cty"
 )
 
@@ -231,8 +232,8 @@ func typedAttributesAsMap(raw json.RawMessage, ignoreKeys []*regexp.Regexp) (map
 		return nil, fmt.Errorf("typed attributes are empty")
 	}
 
-	attributes := map[string]interface{}{}
-	if err := json.Unmarshal(raw, &attributes); err != nil {
+	attributes, err := typedjson.UnmarshalObject(raw)
+	if err != nil {
 		return nil, err
 	}
 	for key := range attributes {

--- a/terraformutils/resource.go
+++ b/terraformutils/resource.go
@@ -3,6 +3,7 @@
 package terraformutils
 
 import (
+	"encoding/json"
 	"fmt"
 	"log"
 	"regexp"
@@ -133,18 +134,21 @@ func (r *Resource) ParseTFstate(parser Flatmapper, impliedType cty.Type) error {
 	if err != nil {
 		return err
 	}
+	r.setItem(attributes)
+	return nil
+}
+
+func (r *Resource) setItem(attributes map[string]interface{}) {
+	if attributes == nil {
+		attributes = map[string]interface{}{} // ensure HCL can represent empty resource correctly
+	}
 
 	// add Additional Fields to resource
 	for key, value := range r.AdditionalFields {
 		attributes[key] = value
 	}
 
-	if attributes == nil {
-		attributes = map[string]interface{}{} // ensure HCL can represent empty resource correctly
-	}
-
 	r.Item = attributes
-	return nil
 }
 
 func (r *Resource) ConvertTFstate(provider *providerwrapper.ProviderWrapper) error {
@@ -161,7 +165,37 @@ func (r *Resource) ConvertTFstate(provider *providerwrapper.ProviderWrapper) err
 	parser := NewFlatmapParser(r.InstanceState.Attributes, ignoreKeys, allowEmptyValues)
 	schema := provider.GetSchema()
 	impliedType := schema.ResourceTypes[r.InstanceInfo.Type].Block.ImpliedType()
-	return r.ParseTFstate(parser, impliedType)
+	err := r.ParseTFstate(parser, impliedType)
+	if err == nil {
+		return nil
+	}
+
+	attributes, typedErr := typedAttributesAsMap(r.InstanceState.TypedAttributes, ignoreKeys)
+	if typedErr != nil {
+		return err
+	}
+	r.setItem(attributes)
+	return nil
+}
+
+func typedAttributesAsMap(raw json.RawMessage, ignoreKeys []*regexp.Regexp) (map[string]interface{}, error) {
+	if len(raw) == 0 {
+		return nil, fmt.Errorf("typed attributes are empty")
+	}
+
+	attributes := map[string]interface{}{}
+	if err := json.Unmarshal(raw, &attributes); err != nil {
+		return nil, err
+	}
+	for key := range attributes {
+		for _, pattern := range ignoreKeys {
+			if pattern.MatchString(key) {
+				delete(attributes, key)
+				break
+			}
+		}
+	}
+	return attributes, nil
 }
 
 func (r *Resource) ConvertTypedState(provider *providerwrapper.ProviderWrapper) error {

--- a/terraformutils/resource.go
+++ b/terraformutils/resource.go
@@ -217,6 +217,11 @@ func resourceTypeConfigAttributes(resourceType string, attributes map[string]int
 		}
 	}
 	delete(attributes, "object")
+	for key, value := range attributes {
+		if value == nil {
+			delete(attributes, key)
+		}
+	}
 	return attributes
 }
 

--- a/terraformutils/resource.go
+++ b/terraformutils/resource.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/chenrui333/terraformer/terraformutils/providerwrapper"
 	"github.com/chenrui333/terraformer/terraformutils/tfcompat"
+	"github.com/chenrui333/terraformer/terraformutils/tfcompat/providerproto"
 	"github.com/zclconf/go-cty/cty"
 )
 
@@ -152,6 +153,10 @@ func (r *Resource) setItem(attributes map[string]interface{}) {
 }
 
 func (r *Resource) ConvertTFstate(provider *providerwrapper.ProviderWrapper) error {
+	return r.convertTFstate(provider.GetSchema())
+}
+
+func (r *Resource) convertTFstate(schema *providerproto.GetProviderSchemaResponse) error {
 	ignoreKeys := []*regexp.Regexp{}
 	for _, pattern := range r.IgnoreKeys {
 		ignoreKeys = append(ignoreKeys, regexp.MustCompile(pattern))
@@ -163,19 +168,42 @@ func (r *Resource) ConvertTFstate(provider *providerwrapper.ProviderWrapper) err
 		}
 	}
 	parser := NewFlatmapParser(r.InstanceState.Attributes, ignoreKeys, allowEmptyValues)
-	schema := provider.GetSchema()
 	impliedType := schema.ResourceTypes[r.InstanceInfo.Type].Block.ImpliedType()
 	err := r.ParseTFstate(parser, impliedType)
-	if err == nil {
+	if err == nil && !needsTypedManifestAttributes(r.InstanceInfo.Type, r.Item) {
 		return nil
 	}
 
 	attributes, typedErr := typedAttributesAsMap(r.InstanceState.TypedAttributes, ignoreKeys)
 	if typedErr != nil {
+		if err == nil {
+			return nil
+		}
 		return err
+	}
+	if err == nil && needsTypedManifestAttributes(r.InstanceInfo.Type, attributes) {
+		return nil
 	}
 	r.setItem(attributes)
 	return nil
+}
+
+func needsTypedManifestAttributes(resourceType string, attributes map[string]interface{}) bool {
+	if resourceType != "kubernetes_manifest" {
+		return false
+	}
+	return !manifestAttributeHasValue(attributes["manifest"])
+}
+
+func manifestAttributeHasValue(value interface{}) bool {
+	switch value := value.(type) {
+	case nil:
+		return false
+	case map[string]interface{}:
+		return len(value) > 0
+	default:
+		return true
+	}
 }
 
 func typedAttributesAsMap(raw json.RawMessage, ignoreKeys []*regexp.Regexp) (map[string]interface{}, error) {

--- a/terraformutils/resource_test.go
+++ b/terraformutils/resource_test.go
@@ -202,7 +202,7 @@ func TestConvertTFstateUsesTypedManifestWhenFlatmapHasNoManifest(t *testing.T) {
 			Attributes: map[string]string{
 				"id": "apiVersion=example.com/v1,kind=Widget,name=sample",
 			},
-			TypedAttributes: json.RawMessage("{\"id\":\"apiVersion=example.com/v1,kind=Widget,name=sample\",\"manifest\":{},\"object\":{\"apiVersion\":\"example.com/v1\",\"kind\":\"Widget\",\"metadata\":{\"name\":\"sample\",\"uid\":\"uid-123\",\"resourceVersion\":\"123\",\"managedFields\":[{\"manager\":\"controller\"}]},\"status\":{\"phase\":\"Ready\"}},\"field_manager\":null,\"timeouts\":null,\"wait\":null}"),
+			TypedAttributes: json.RawMessage("{\"id\":\"apiVersion=example.com/v1,kind=Widget,name=sample\",\"manifest\":{},\"object\":{\"apiVersion\":\"example.com/v1\",\"kind\":\"Widget\",\"metadata\":{\"name\":\"sample\",\"uid\":\"uid-123\",\"resourceVersion\":\"123\",\"managedFields\":[{\"manager\":\"controller\"}]},\"spec\":{\"bigInteger\":9007199254740993},\"status\":{\"phase\":\"Ready\"}},\"field_manager\":null,\"timeouts\":null,\"wait\":null}"),
 		},
 		IgnoreKeys: []string{"^id$"},
 	}
@@ -230,6 +230,8 @@ func TestConvertTFstateUsesTypedManifestWhenFlatmapHasNoManifest(t *testing.T) {
 	if _, ok := manifest["status"]; ok {
 		t.Fatal("manifest.status was not stripped")
 	}
+	spec := manifest["spec"].(map[string]interface{})
+	assertJSONNumber(t, spec["bigInteger"], "9007199254740993")
 	if _, ok := resource.Item["id"]; ok {
 		t.Fatal("id attribute was not filtered from typed manifest fallback")
 	}
@@ -240,6 +242,17 @@ func TestConvertTFstateUsesTypedManifestWhenFlatmapHasNoManifest(t *testing.T) {
 		if _, ok := resource.Item[key]; ok {
 			t.Fatalf("%s null block attribute was not filtered from generated config item", key)
 		}
+	}
+}
+
+func assertJSONNumber(t *testing.T, value interface{}, want string) {
+	t.Helper()
+	number, ok := value.(json.Number)
+	if !ok {
+		t.Fatalf("number type = %T, want json.Number", value)
+	}
+	if number.String() != want {
+		t.Fatalf("number = %s, want %s", number.String(), want)
 	}
 }
 

--- a/terraformutils/resource_test.go
+++ b/terraformutils/resource_test.go
@@ -3,6 +3,8 @@
 package terraformutils
 
 import (
+	"encoding/json"
+	"regexp"
 	"testing"
 
 	"github.com/chenrui333/terraformer/terraformutils/tfcompat"
@@ -154,5 +156,38 @@ func TestResourceFilterByID(t *testing.T) {
 	}
 	if rf2.Filter(r) {
 		t.Error("Filter should reject resource with non-matching ID")
+	}
+}
+
+func TestTypedAttributesAsMapFiltersIgnoredTopLevelAttributes(t *testing.T) {
+	raw := json.RawMessage(`{
+		"id": "apiVersion=example.com/v1,kind=Widget,name=sample",
+		"manifest": {
+			"apiVersion": "example.com/v1",
+			"kind": "Widget"
+		},
+		"object": {
+			"computed": true
+		}
+	}`)
+	attributes, err := typedAttributesAsMap(raw, []*regexp.Regexp{
+		regexp.MustCompile("^id$"),
+		regexp.MustCompile("^object$"),
+	})
+	if err != nil {
+		t.Fatalf("typedAttributesAsMap() error = %v", err)
+	}
+	if _, ok := attributes["id"]; ok {
+		t.Fatal("id attribute was not filtered")
+	}
+	if _, ok := attributes["object"]; ok {
+		t.Fatal("object attribute was not filtered")
+	}
+	manifest, ok := attributes["manifest"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("manifest attribute type = %T, want map[string]interface{}", attributes["manifest"])
+	}
+	if manifest["apiVersion"] != "example.com/v1" {
+		t.Fatalf("manifest.apiVersion = %v, want %q", manifest["apiVersion"], "example.com/v1")
 	}
 }

--- a/terraformutils/resource_test.go
+++ b/terraformutils/resource_test.go
@@ -8,6 +8,9 @@ import (
 	"testing"
 
 	"github.com/chenrui333/terraformer/terraformutils/tfcompat"
+	"github.com/chenrui333/terraformer/terraformutils/tfcompat/configschema"
+	"github.com/chenrui333/terraformer/terraformutils/tfcompat/providerproto"
+	"github.com/zclconf/go-cty/cty"
 )
 
 func TestNewResource(t *testing.T) {
@@ -189,5 +192,77 @@ func TestTypedAttributesAsMapFiltersIgnoredTopLevelAttributes(t *testing.T) {
 	}
 	if manifest["apiVersion"] != "example.com/v1" {
 		t.Fatalf("manifest.apiVersion = %v, want %q", manifest["apiVersion"], "example.com/v1")
+	}
+}
+
+func TestConvertTFstateUsesTypedManifestWhenFlatmapHasNoManifest(t *testing.T) {
+	resource := Resource{
+		InstanceInfo: &tfcompat.InstanceInfo{Type: "kubernetes_manifest"},
+		InstanceState: &tfcompat.InstanceState{
+			Attributes: map[string]string{
+				"id": "apiVersion=example.com/v1,kind=Widget,name=sample",
+			},
+			TypedAttributes: json.RawMessage("{\"id\":\"apiVersion=example.com/v1,kind=Widget,name=sample\",\"manifest\":{\"apiVersion\":\"example.com/v1\",\"kind\":\"Widget\",\"metadata\":{\"name\":\"sample\"}}}"),
+		},
+		IgnoreKeys: []string{"^id$"},
+	}
+
+	if err := resource.convertTFstate(kubernetesManifestTestSchema()); err != nil {
+		t.Fatalf("ConvertTFstate() error = %v", err)
+	}
+
+	manifest, ok := resource.Item["manifest"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("manifest attribute type = %T, want map[string]interface{}", resource.Item["manifest"])
+	}
+	if manifest["apiVersion"] != "example.com/v1" {
+		t.Fatalf("manifest.apiVersion = %v, want %q", manifest["apiVersion"], "example.com/v1")
+	}
+	if _, ok := resource.Item["id"]; ok {
+		t.Fatal("id attribute was not filtered from typed manifest fallback")
+	}
+}
+
+func TestConvertTFstateKeepsParsedManifestWhenFlatmapHasManifest(t *testing.T) {
+	resource := Resource{
+		InstanceInfo: &tfcompat.InstanceInfo{Type: "kubernetes_manifest"},
+		InstanceState: &tfcompat.InstanceState{
+			Attributes: map[string]string{
+				"manifest.%":          "2",
+				"manifest.apiVersion": "example.com/v1",
+				"manifest.kind":       "Widget",
+			},
+			TypedAttributes: json.RawMessage("{\"manifest\":{\"apiVersion\":\"typed.example.com/v1\",\"kind\":\"Widget\"}}"),
+		},
+	}
+
+	if err := resource.convertTFstate(kubernetesManifestTestSchema()); err != nil {
+		t.Fatalf("ConvertTFstate() error = %v", err)
+	}
+
+	manifest := resource.Item["manifest"].(map[string]interface{})
+	if manifest["apiVersion"] != "example.com/v1" {
+		t.Fatalf("manifest.apiVersion = %v, want flatmap value %q", manifest["apiVersion"], "example.com/v1")
+	}
+}
+
+func kubernetesManifestTestSchema() *providerproto.GetProviderSchemaResponse {
+	return &providerproto.GetProviderSchemaResponse{
+		ResourceTypes: map[string]configschema.Schema{
+			"kubernetes_manifest": {
+				Block: &configschema.Block{
+					Attributes: map[string]*configschema.Attribute{
+						"id": {
+							Type:     cty.String,
+							Computed: true,
+						},
+						"manifest": {
+							Type:     cty.Map(cty.String),
+							Optional: true,
+						},
+					},
+				},
+			},
+		},
 	}
 }

--- a/terraformutils/resource_test.go
+++ b/terraformutils/resource_test.go
@@ -202,7 +202,7 @@ func TestConvertTFstateUsesTypedManifestWhenFlatmapHasNoManifest(t *testing.T) {
 			Attributes: map[string]string{
 				"id": "apiVersion=example.com/v1,kind=Widget,name=sample",
 			},
-			TypedAttributes: json.RawMessage("{\"id\":\"apiVersion=example.com/v1,kind=Widget,name=sample\",\"manifest\":{\"apiVersion\":\"example.com/v1\",\"kind\":\"Widget\",\"metadata\":{\"name\":\"sample\"}},\"object\":{\"apiVersion\":\"example.com/v1\",\"kind\":\"Widget\",\"status\":{\"phase\":\"Ready\"}}}"),
+			TypedAttributes: json.RawMessage("{\"id\":\"apiVersion=example.com/v1,kind=Widget,name=sample\",\"manifest\":{\"apiVersion\":\"example.com/v1\",\"kind\":\"Widget\",\"metadata\":{\"name\":\"sample\"}},\"object\":{\"apiVersion\":\"example.com/v1\",\"kind\":\"Widget\",\"status\":{\"phase\":\"Ready\"}},\"field_manager\":null,\"timeouts\":null,\"wait\":null}"),
 		},
 		IgnoreKeys: []string{"^id$"},
 	}
@@ -223,6 +223,11 @@ func TestConvertTFstateUsesTypedManifestWhenFlatmapHasNoManifest(t *testing.T) {
 	}
 	if _, ok := resource.Item["object"]; ok {
 		t.Fatal("object attribute was not filtered from generated config item")
+	}
+	for _, key := range []string{"field_manager", "timeouts", "wait"} {
+		if _, ok := resource.Item[key]; ok {
+			t.Fatalf("%s null block attribute was not filtered from generated config item", key)
+		}
 	}
 }
 

--- a/terraformutils/resource_test.go
+++ b/terraformutils/resource_test.go
@@ -202,7 +202,7 @@ func TestConvertTFstateUsesTypedManifestWhenFlatmapHasNoManifest(t *testing.T) {
 			Attributes: map[string]string{
 				"id": "apiVersion=example.com/v1,kind=Widget,name=sample",
 			},
-			TypedAttributes: json.RawMessage("{\"id\":\"apiVersion=example.com/v1,kind=Widget,name=sample\",\"manifest\":{\"apiVersion\":\"example.com/v1\",\"kind\":\"Widget\",\"metadata\":{\"name\":\"sample\"}}}"),
+			TypedAttributes: json.RawMessage("{\"id\":\"apiVersion=example.com/v1,kind=Widget,name=sample\",\"manifest\":{\"apiVersion\":\"example.com/v1\",\"kind\":\"Widget\",\"metadata\":{\"name\":\"sample\"}},\"object\":{\"apiVersion\":\"example.com/v1\",\"kind\":\"Widget\",\"status\":{\"phase\":\"Ready\"}}}"),
 		},
 		IgnoreKeys: []string{"^id$"},
 	}
@@ -220,6 +220,9 @@ func TestConvertTFstateUsesTypedManifestWhenFlatmapHasNoManifest(t *testing.T) {
 	}
 	if _, ok := resource.Item["id"]; ok {
 		t.Fatal("id attribute was not filtered from typed manifest fallback")
+	}
+	if _, ok := resource.Item["object"]; ok {
+		t.Fatal("object attribute was not filtered from generated config item")
 	}
 }
 

--- a/terraformutils/resource_test.go
+++ b/terraformutils/resource_test.go
@@ -202,7 +202,7 @@ func TestConvertTFstateUsesTypedManifestWhenFlatmapHasNoManifest(t *testing.T) {
 			Attributes: map[string]string{
 				"id": "apiVersion=example.com/v1,kind=Widget,name=sample",
 			},
-			TypedAttributes: json.RawMessage("{\"id\":\"apiVersion=example.com/v1,kind=Widget,name=sample\",\"manifest\":{\"apiVersion\":\"example.com/v1\",\"kind\":\"Widget\",\"metadata\":{\"name\":\"sample\"}},\"object\":{\"apiVersion\":\"example.com/v1\",\"kind\":\"Widget\",\"status\":{\"phase\":\"Ready\"}},\"field_manager\":null,\"timeouts\":null,\"wait\":null}"),
+			TypedAttributes: json.RawMessage("{\"id\":\"apiVersion=example.com/v1,kind=Widget,name=sample\",\"manifest\":{},\"object\":{\"apiVersion\":\"example.com/v1\",\"kind\":\"Widget\",\"metadata\":{\"name\":\"sample\",\"uid\":\"uid-123\",\"resourceVersion\":\"123\",\"managedFields\":[{\"manager\":\"controller\"}]},\"status\":{\"phase\":\"Ready\"}},\"field_manager\":null,\"timeouts\":null,\"wait\":null}"),
 		},
 		IgnoreKeys: []string{"^id$"},
 	}
@@ -217,6 +217,18 @@ func TestConvertTFstateUsesTypedManifestWhenFlatmapHasNoManifest(t *testing.T) {
 	}
 	if manifest["apiVersion"] != "example.com/v1" {
 		t.Fatalf("manifest.apiVersion = %v, want %q", manifest["apiVersion"], "example.com/v1")
+	}
+	metadata := manifest["metadata"].(map[string]interface{})
+	if metadata["name"] != "sample" {
+		t.Fatalf("manifest.metadata.name = %v, want %q", metadata["name"], "sample")
+	}
+	for _, key := range []string{"uid", "resourceVersion", "managedFields"} {
+		if _, ok := metadata[key]; ok {
+			t.Fatalf("manifest.metadata.%s was not stripped", key)
+		}
+	}
+	if _, ok := manifest["status"]; ok {
+		t.Fatal("manifest.status was not stripped")
 	}
 	if _, ok := resource.Item["id"]; ok {
 		t.Fatal("id attribute was not filtered from typed manifest fallback")

--- a/terraformutils/state_test.go
+++ b/terraformutils/state_test.go
@@ -117,6 +117,39 @@ func TestPrintTfStateFallsBackToAttributesFlat(t *testing.T) {
 	}
 }
 
+func TestPrintTfStatePreservesManifestObjectTypedAttribute(t *testing.T) {
+	resource := NewSimpleResource(
+		"apiVersion=example.com/v1,kind=Widget,name=sample",
+		"example.com/v1/Widget/sample",
+		"kubernetes_manifest",
+		"kubernetes",
+		nil,
+	)
+	resource.InstanceState.TypedAttributes = json.RawMessage("{\"manifest\":{\"apiVersion\":\"example.com/v1\",\"kind\":\"Widget\"},\"object\":{\"apiVersion\":\"example.com/v1\",\"kind\":\"Widget\",\"status\":{\"phase\":\"Ready\"}}}")
+
+	stateBytes, err := PrintTfState([]Resource{resource})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var state map[string]interface{}
+	if err := json.Unmarshal(stateBytes, &state); err != nil {
+		t.Fatal(err)
+	}
+	resources := state["resources"].([]interface{})
+	gotResource := resources[0].(map[string]interface{})
+	instances := gotResource["instances"].([]interface{})
+	instance := instances[0].(map[string]interface{})
+	attributes := instance["attributes"].(map[string]interface{})
+	object, ok := attributes["object"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("object attribute type = %T, want map[string]interface{}", attributes["object"])
+	}
+	if object["kind"] != "Widget" {
+		t.Fatalf("object.kind = %v, want %q", object["kind"], "Widget")
+	}
+}
+
 func TestConvertTypedStatePreservesCurrentTypedAttributes(t *testing.T) {
 	resource := NewResource(
 		"kind-lemur",

--- a/terraformutils/terraformoutput/hcl.go
+++ b/terraformutils/terraformoutput/hcl.go
@@ -48,12 +48,14 @@ func OutputHclFiles(resources []terraformutils.Resource, provider terraformutils
 
 	for i, r := range resources {
 		outputState := map[string]*tfcompat.OutputState{}
-		outputsByResource[r.InstanceInfo.Type+"_"+r.ResourceName+"_"+r.GetIDKey()] = map[string]interface{}{
-			"value": "${" + r.InstanceInfo.Type + "." + r.ResourceName + "." + r.GetIDKey() + "}",
-		}
-		outputState[r.InstanceInfo.Type+"_"+r.ResourceName+"_"+r.GetIDKey()] = &tfcompat.OutputState{
-			Type:  "string",
-			Value: r.InstanceState.Attributes[r.GetIDKey()],
+		if idKey, ok := resourceOutputIDKey(r); ok {
+			outputsByResource[r.InstanceInfo.Type+"_"+r.ResourceName+"_"+idKey] = map[string]interface{}{
+				"value": "${" + r.InstanceInfo.Type + "." + r.ResourceName + "." + idKey + "}",
+			}
+			outputState[r.InstanceInfo.Type+"_"+r.ResourceName+"_"+idKey] = &tfcompat.OutputState{
+				Type:  "string",
+				Value: r.InstanceState.Attributes[idKey],
+			}
 		}
 		for _, v := range provider.GetResourceConnections() {
 			for k, ids := range v {
@@ -136,6 +138,13 @@ func printFile(v []terraformutils.Resource, fileName, path, output string, sort 
 	}
 
 	return nil
+}
+
+func resourceOutputIDKey(resource terraformutils.Resource) (string, bool) {
+	if resource.InstanceInfo.Type == "kubernetes_manifest" {
+		return "", false
+	}
+	return resource.GetIDKey(), true
 }
 
 func PrintFile(path string, data []byte) error {

--- a/terraformutils/terraformoutput/output_test.go
+++ b/terraformutils/terraformoutput/output_test.go
@@ -5,7 +5,11 @@ package terraformoutput
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
+
+	"github.com/chenrui333/terraformer/terraformutils"
+	"github.com/zclconf/go-cty/cty"
 )
 
 func TestGetFileExtension(t *testing.T) {
@@ -115,4 +119,77 @@ func TestPrintFileReturnsWriteError(t *testing.T) {
 	if err := PrintFile(path, []byte("terraform {}")); err == nil {
 		t.Fatal("PrintFile() error = nil, want write error")
 	}
+}
+
+func TestOutputHclFilesSkipsManifestIDOutput(t *testing.T) {
+	path := t.TempDir()
+	resource := terraformutils.NewSimpleResource(
+		"apiVersion=example.com/v1,kind=Widget,name=sample",
+		"example.com/v1/Widget/sample",
+		"kubernetes_manifest",
+		"kubernetes",
+		nil,
+	)
+	resource.Item = map[string]interface{}{
+		"manifest": map[string]interface{}{
+			"apiVersion": "example.com/v1",
+			"kind":       "Widget",
+		},
+	}
+
+	if err := OutputHclFiles([]terraformutils.Resource{resource}, &testProvider{name: "kubernetes"}, path, "example.com/v1/widgets", false, "hcl", true); err != nil {
+		t.Fatalf("OutputHclFiles() error = %v", err)
+	}
+
+	outputsPath := filepath.Join(path, "outputs.tf")
+	if _, err := os.Stat(outputsPath); !os.IsNotExist(err) {
+		t.Fatalf("outputs.tf exists for manifest resource, stat err = %v", err)
+	}
+}
+
+func TestOutputHclFilesKeepsNativeIDOutput(t *testing.T) {
+	path := t.TempDir()
+	resource := terraformutils.NewResource(
+		"svc-123",
+		"sample",
+		"kubernetes_service_v1",
+		"kubernetes",
+		map[string]string{"id": "svc-123"},
+		nil,
+		nil,
+	)
+	resource.Item = map[string]interface{}{"metadata": map[string]interface{}{"name": "sample"}}
+
+	if err := OutputHclFiles([]terraformutils.Resource{resource}, &testProvider{name: "kubernetes"}, path, "services", false, "hcl", true); err != nil {
+		t.Fatalf("OutputHclFiles() error = %v", err)
+	}
+
+	data, err := os.ReadFile(filepath.Join(path, "outputs.tf"))
+	if err != nil {
+		t.Fatalf("ReadFile(outputs.tf) error = %v", err)
+	}
+	if !strings.Contains(string(data), "kubernetes_service_v1."+resource.ResourceName+".id") {
+		t.Fatalf("outputs.tf missing native id reference:\n%s", data)
+	}
+}
+
+type testProvider struct {
+	terraformutils.Provider
+	name string
+}
+
+func (p testProvider) GetName() string { return p.name }
+
+func (p testProvider) InitService(_ string, _ bool) error { return nil }
+
+func (p testProvider) GetConfig() cty.Value { return cty.EmptyObjectVal }
+
+func (p testProvider) GetBasicConfig() cty.Value { return cty.EmptyObjectVal }
+
+func (p testProvider) GetProviderData(_ ...string) map[string]interface{} {
+	return map[string]interface{}{}
+}
+
+func (p testProvider) GetResourceConnections() map[string]map[string][]string {
+	return map[string]map[string][]string{}
 }

--- a/terraformutils/typedjson/typedjson.go
+++ b/terraformutils/typedjson/typedjson.go
@@ -1,0 +1,18 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package typedjson
+
+import (
+	"bytes"
+	"encoding/json"
+)
+
+func UnmarshalObject(raw json.RawMessage) (map[string]interface{}, error) {
+	attributes := map[string]interface{}{}
+	decoder := json.NewDecoder(bytes.NewReader(raw))
+	decoder.UseNumber()
+	if err := decoder.Decode(&attributes); err != nil {
+		return nil, err
+	}
+	return attributes, nil
+}


### PR DESCRIPTION
Summary
- Add a `kubernetes_manifest` fallback for discovered untyped Kubernetes API extensions when no first-class Terraform provider resource exists.
- Generate Terraform provider import IDs for namespaced and cluster-scoped manifest resources.
- Document custom resource manifest imports and cover selection/import ID behavior in tests.

Notes
- First-class Kubernetes resources still prefer their explicit Terraform resource types.
- Native typed-client resources without explicit provider resources are skipped instead of being imported as manifests.
