### PR TITLE
feat(datadog): add team notification rule import

### DIFF
--- a/docs/datadog.md
+++ b/docs/datadog.md
@@ -156,6 +156,10 @@ Tag filters are order specific. For example, if your monitor has tags (in the or
 *   `team_membership`
     * `datadog_team_membership`
         * **_NOTE:_** Importing a single membership by ID requires quoting the `team_id:user_id` filter value, for example `--filter="team_membership='team-id:user-id'"`; memberships can also be filtered by `team_id`
+*   `team_notification_rule`
+    * `datadog_team_notification_rule`
+        * **_NOTE:_** Requires DataDog/datadog provider 3.85.0 or newer.
+        * **_NOTE:_** Importing a single notification rule by ID requires quoting the `team_id:rule_id` filter value, for example `--filter="team_notification_rule='team-id:rule-id'"`; notification rules can also be filtered by `team_id`
 *   `team_permission_setting`
     * `datadog_team_permission_setting`
         * **_NOTE:_** Requires DataDog/datadog provider 3.90.0 or newer.

--- a/providers/datadog/datadog_provider.go
+++ b/providers/datadog/datadog_provider.go
@@ -179,6 +179,7 @@ func (p *DatadogProvider) GetSupportedService() map[string]terraformutils.Servic
 		"team":                                 &TeamGenerator{},
 		"team_link":                            &TeamLinkGenerator{},
 		"team_membership":                      &TeamMembershipGenerator{},
+		"team_notification_rule":               &TeamNotificationRuleGenerator{},
 		"team_permission_setting":              &TeamPermissionSettingGenerator{},
 		"user":                                 &UserGenerator{},
 		"role":                                 &RoleGenerator{},

--- a/providers/datadog/team_notification_rule.go
+++ b/providers/datadog/team_notification_rule.go
@@ -45,17 +45,25 @@ func (g *TeamNotificationRuleGenerator) createResource(teamID string, teamNotifi
 		return terraformutils.Resource{}, fmt.Errorf("team notification rule %q missing team id", ruleID)
 	}
 
+	attributes := map[string]string{
+		"team_id": teamID,
+	}
+	seedTeamNotificationRuleEmail(attributes)
+
 	return terraformutils.NewResource(
 		ruleID,
 		fmt.Sprintf("team_notification_rule_%s_%s", teamID, ruleID),
 		"datadog_team_notification_rule",
 		"datadog",
-		map[string]string{
-			"team_id": teamID,
-		},
+		attributes,
 		TeamNotificationRuleAllowEmptyValues,
 		map[string]interface{}{},
 	), nil
+}
+
+func seedTeamNotificationRuleEmail(attributes map[string]string) {
+	// The Datadog provider treats minimal notification-rule responses as email disabled.
+	attributes["email.enabled"] = "false"
 }
 
 // InitResources Generate TerraformResources from Datadog API,
@@ -201,7 +209,10 @@ func teamNotificationRuleFromResponse(teamNotificationRuleResponse datadogV2.Tea
 	if !ok {
 		return datadogV2.TeamNotificationRule{}, false
 	}
+	return teamNotificationRuleFromRawData(dataRaw, ruleID)
+}
 
+func teamNotificationRuleFromRawData(dataRaw map[string]interface{}, ruleID string) (datadogV2.TeamNotificationRule, bool) {
 	// Minimal API responses without attributes are stored as UnparsedObject by the SDK.
 	if responseRuleID, ok := dataRaw["id"].(string); ok && responseRuleID != "" {
 		ruleID = responseRuleID
@@ -223,5 +234,30 @@ func listTeamNotificationRules(auth context.Context, api *datadogV2.TeamsApi, te
 	if err != nil {
 		return nil, err
 	}
-	return teamNotificationRulesResponse.GetData(), nil
+	return teamNotificationRulesFromResponse(teamNotificationRulesResponse), nil
+}
+
+func teamNotificationRulesFromResponse(teamNotificationRulesResponse datadogV2.TeamNotificationRulesResponse) []datadogV2.TeamNotificationRule {
+	if teamNotificationRules := teamNotificationRulesResponse.GetData(); len(teamNotificationRules) > 0 {
+		return teamNotificationRules
+	}
+
+	dataRaw, ok := teamNotificationRulesResponse.UnparsedObject["data"].([]interface{})
+	if !ok {
+		return nil
+	}
+
+	teamNotificationRules := []datadogV2.TeamNotificationRule{}
+	for _, rawTeamNotificationRule := range dataRaw {
+		teamNotificationRuleRaw, ok := rawTeamNotificationRule.(map[string]interface{})
+		if !ok {
+			continue
+		}
+		teamNotificationRule, ok := teamNotificationRuleFromRawData(teamNotificationRuleRaw, "")
+		if !ok {
+			continue
+		}
+		teamNotificationRules = append(teamNotificationRules, teamNotificationRule)
+	}
+	return teamNotificationRules
 }

--- a/providers/datadog/team_notification_rule.go
+++ b/providers/datadog/team_notification_rule.go
@@ -185,11 +185,34 @@ func getTeamNotificationRule(auth context.Context, api *datadogV2.TeamsApi, team
 		return datadogV2.TeamNotificationRule{}, err
 	}
 
-	teamNotificationRule, ok := teamNotificationRuleResponse.GetDataOk()
+	teamNotificationRule, ok := teamNotificationRuleFromResponse(teamNotificationRuleResponse, ruleID)
 	if !ok {
 		return datadogV2.TeamNotificationRule{}, fmt.Errorf("team notification rule %q not found", fmt.Sprintf("%s:%s", teamID, ruleID))
 	}
-	return *teamNotificationRule, nil
+	return teamNotificationRule, nil
+}
+
+func teamNotificationRuleFromResponse(teamNotificationRuleResponse datadogV2.TeamNotificationRuleResponse, ruleID string) (datadogV2.TeamNotificationRule, bool) {
+	if teamNotificationRule, ok := teamNotificationRuleResponse.GetDataOk(); ok {
+		return *teamNotificationRule, true
+	}
+
+	dataRaw, ok := teamNotificationRuleResponse.UnparsedObject["data"].(map[string]interface{})
+	if !ok {
+		return datadogV2.TeamNotificationRule{}, false
+	}
+
+	// Minimal API responses without attributes are stored as UnparsedObject by the SDK.
+	if responseRuleID, ok := dataRaw["id"].(string); ok && responseRuleID != "" {
+		ruleID = responseRuleID
+	}
+	if ruleID == "" {
+		return datadogV2.TeamNotificationRule{}, false
+	}
+
+	teamNotificationRule := datadogV2.TeamNotificationRule{}
+	teamNotificationRule.SetId(ruleID)
+	return teamNotificationRule, true
 }
 
 func listTeamNotificationRules(auth context.Context, api *datadogV2.TeamsApi, teamID string) ([]datadogV2.TeamNotificationRule, error) {

--- a/providers/datadog/team_notification_rule.go
+++ b/providers/datadog/team_notification_rule.go
@@ -1,0 +1,204 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package datadog
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/DataDog/datadog-api-client-go/v2/api/datadog"
+	"github.com/DataDog/datadog-api-client-go/v2/api/datadogV2"
+
+	"github.com/chenrui333/terraformer/terraformutils"
+)
+
+var (
+	// TeamNotificationRuleAllowEmptyValues ...
+	TeamNotificationRuleAllowEmptyValues = []string{}
+)
+
+// TeamNotificationRuleGenerator ...
+type TeamNotificationRuleGenerator struct {
+	DatadogService
+}
+
+func (g *TeamNotificationRuleGenerator) createResources(teamID string, teamNotificationRules []datadogV2.TeamNotificationRule) ([]terraformutils.Resource, error) {
+	resources := []terraformutils.Resource{}
+	for _, teamNotificationRule := range teamNotificationRules {
+		resource, err := g.createResource(teamID, teamNotificationRule)
+		if err != nil {
+			return nil, err
+		}
+		resources = append(resources, resource)
+	}
+
+	return resources, nil
+}
+
+func (g *TeamNotificationRuleGenerator) createResource(teamID string, teamNotificationRule datadogV2.TeamNotificationRule) (terraformutils.Resource, error) {
+	ruleID := teamNotificationRule.GetId()
+	if ruleID == "" {
+		return terraformutils.Resource{}, fmt.Errorf("team notification rule missing id")
+	}
+	if teamID == "" {
+		return terraformutils.Resource{}, fmt.Errorf("team notification rule %q missing team id", ruleID)
+	}
+
+	return terraformutils.NewResource(
+		ruleID,
+		fmt.Sprintf("team_notification_rule_%s_%s", teamID, ruleID),
+		"datadog_team_notification_rule",
+		"datadog",
+		map[string]string{
+			"team_id": teamID,
+		},
+		TeamNotificationRuleAllowEmptyValues,
+		map[string]interface{}{},
+	), nil
+}
+
+// InitResources Generate TerraformResources from Datadog API,
+// from each team notification rule create 1 TerraformResource.
+// Need Team Notification Rule ID formatted as '<team_id>:<rule_id>' for filter lookup.
+func (g *TeamNotificationRuleGenerator) InitResources() error {
+	datadogClient := g.Args["datadogClient"].(*datadog.APIClient)
+	auth := g.Args["auth"].(context.Context)
+	api := datadogV2.NewTeamsApi(datadogClient)
+
+	resources, filtered, err := g.filteredResources(auth, api)
+	if err != nil {
+		return err
+	}
+	if filtered {
+		g.Resources = resources
+		return nil
+	}
+
+	teams, err := listTeams(auth, api)
+	if err != nil {
+		return err
+	}
+	for _, team := range teams {
+		teamID := team.GetId()
+		teamNotificationRules, err := listTeamNotificationRules(auth, api, teamID)
+		if err != nil {
+			return err
+		}
+		teamResources, err := g.createResources(teamID, teamNotificationRules)
+		if err != nil {
+			return err
+		}
+		resources = append(resources, teamResources...)
+	}
+
+	g.Resources = resources
+	return nil
+}
+
+func (g *TeamNotificationRuleGenerator) filteredResources(auth context.Context, api *datadogV2.TeamsApi) ([]terraformutils.Resource, bool, error) {
+	resources := []terraformutils.Resource{}
+	filtered := false
+
+	for filterIndex, filter := range g.Filter {
+		if !filter.IsApplicable("team_notification_rule") {
+			continue
+		}
+
+		switch filter.FieldPath {
+		case "id":
+			filtered = true
+			filterIDs, err := parseTeamNotificationRuleImportIDs(filter.AcceptableValues)
+			if err != nil {
+				return nil, true, err
+			}
+			for _, filterID := range filterIDs {
+				teamNotificationRule, err := getTeamNotificationRule(auth, api, filterID.teamID, filterID.ruleID)
+				if err != nil {
+					return nil, true, err
+				}
+				resource, err := g.createResource(filterID.teamID, teamNotificationRule)
+				if err != nil {
+					return nil, true, err
+				}
+				resources = append(resources, resource)
+			}
+			g.Filter[filterIndex].AcceptableValues = teamNotificationRuleIDs(filterIDs)
+		case "team_id":
+			filtered = true
+			for _, teamID := range filter.AcceptableValues {
+				teamNotificationRules, err := listTeamNotificationRules(auth, api, teamID)
+				if err != nil {
+					return nil, true, err
+				}
+				teamResources, err := g.createResources(teamID, teamNotificationRules)
+				if err != nil {
+					return nil, true, err
+				}
+				resources = append(resources, teamResources...)
+			}
+		}
+	}
+
+	return resources, filtered, nil
+}
+
+type teamNotificationRuleFilterID struct {
+	teamID string
+	ruleID string
+}
+
+func parseTeamNotificationRuleImportIDs(importIDs []string) ([]teamNotificationRuleFilterID, error) {
+	filterIDs := []teamNotificationRuleFilterID{}
+	for _, importID := range importIDs {
+		teamID, ruleID, err := parseTeamNotificationRuleImportID(importID)
+		if err != nil {
+			return nil, err
+		}
+		filterIDs = append(filterIDs, teamNotificationRuleFilterID{teamID: teamID, ruleID: ruleID})
+	}
+	return filterIDs, nil
+}
+
+func teamNotificationRuleIDs(filterIDs []teamNotificationRuleFilterID) []string {
+	ruleIDs := []string{}
+	for _, filterID := range filterIDs {
+		ruleIDs = append(ruleIDs, filterID.ruleID)
+	}
+	return ruleIDs
+}
+
+func parseTeamNotificationRuleImportID(importID string) (string, string, error) {
+	parts := strings.SplitN(importID, ":", 2)
+	if len(parts) != 2 || parts[0] == "" || parts[1] == "" {
+		return "", "", fmt.Errorf("team notification rule import ID %q must be formatted as team_id:rule_id", importID)
+	}
+	return parts[0], parts[1], nil
+}
+
+func getTeamNotificationRule(auth context.Context, api *datadogV2.TeamsApi, teamID string, ruleID string) (datadogV2.TeamNotificationRule, error) {
+	teamNotificationRuleResponse, httpResponse, err := api.GetTeamNotificationRule(auth, teamID, ruleID)
+	if httpResponse != nil && httpResponse.Body != nil {
+		defer httpResponse.Body.Close()
+	}
+	if err != nil {
+		return datadogV2.TeamNotificationRule{}, err
+	}
+
+	teamNotificationRule, ok := teamNotificationRuleResponse.GetDataOk()
+	if !ok {
+		return datadogV2.TeamNotificationRule{}, fmt.Errorf("team notification rule %q not found", fmt.Sprintf("%s:%s", teamID, ruleID))
+	}
+	return *teamNotificationRule, nil
+}
+
+func listTeamNotificationRules(auth context.Context, api *datadogV2.TeamsApi, teamID string) ([]datadogV2.TeamNotificationRule, error) {
+	teamNotificationRulesResponse, httpResponse, err := api.GetTeamNotificationRules(auth, teamID)
+	if httpResponse != nil && httpResponse.Body != nil {
+		defer httpResponse.Body.Close()
+	}
+	if err != nil {
+		return nil, err
+	}
+	return teamNotificationRulesResponse.GetData(), nil
+}

--- a/providers/datadog/team_notification_rule_test.go
+++ b/providers/datadog/team_notification_rule_test.go
@@ -1,0 +1,159 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package datadog
+
+import (
+	"testing"
+
+	"github.com/DataDog/datadog-api-client-go/v2/api/datadogV2"
+	"github.com/chenrui333/terraformer/terraformutils"
+)
+
+func TestTeamNotificationRuleCreateResource(t *testing.T) {
+	ruleID := "rule-id"
+	teamNotificationRule := datadogV2.TeamNotificationRule{
+		Id: &ruleID,
+	}
+
+	resource, err := (&TeamNotificationRuleGenerator{}).createResource("team-id", teamNotificationRule)
+	if err != nil {
+		t.Fatalf("createResource() error = %v", err)
+	}
+	if resource.InstanceState.ID != "rule-id" {
+		t.Fatalf("resource ID = %q, want %q", resource.InstanceState.ID, "rule-id")
+	}
+	if resource.InstanceState.Attributes["team_id"] != "team-id" {
+		t.Fatalf("team_id attribute = %q, want %q", resource.InstanceState.Attributes["team_id"], "team-id")
+	}
+	if resource.ResourceName != "tfer--team_notification_rule_team-id_rule-id" {
+		t.Fatalf("resource name = %q, want %q", resource.ResourceName, "tfer--team_notification_rule_team-id_rule-id")
+	}
+	if resource.InstanceInfo.Type != "datadog_team_notification_rule" {
+		t.Fatalf("resource type = %q, want %q", resource.InstanceInfo.Type, "datadog_team_notification_rule")
+	}
+}
+
+func TestTeamNotificationRuleCreateResourceMissingID(t *testing.T) {
+	_, err := (&TeamNotificationRuleGenerator{}).createResource("team-id", datadogV2.TeamNotificationRule{})
+	if err == nil {
+		t.Fatal("createResource() error = nil, want error")
+	}
+}
+
+func TestTeamNotificationRuleCreateResourceMissingTeam(t *testing.T) {
+	ruleID := "rule-id"
+	_, err := (&TeamNotificationRuleGenerator{}).createResource("", datadogV2.TeamNotificationRule{
+		Id: &ruleID,
+	})
+	if err == nil {
+		t.Fatal("createResource() error = nil, want error")
+	}
+}
+
+func TestTeamNotificationRuleCreateResourcesAllowsSharedRuleIDs(t *testing.T) {
+	ruleID := "rule-id"
+	teamNotificationRule := datadogV2.TeamNotificationRule{
+		Id: &ruleID,
+	}
+
+	teamOneResources, err := (&TeamNotificationRuleGenerator{}).createResources("team-1", []datadogV2.TeamNotificationRule{teamNotificationRule})
+	if err != nil {
+		t.Fatalf("createResources() team-1 error = %v", err)
+	}
+	teamTwoResources, err := (&TeamNotificationRuleGenerator{}).createResources("team-2", []datadogV2.TeamNotificationRule{teamNotificationRule})
+	if err != nil {
+		t.Fatalf("createResources() team-2 error = %v", err)
+	}
+	if teamOneResources[0].ResourceName == teamTwoResources[0].ResourceName {
+		t.Fatalf("resource names should be unique, got %q", teamOneResources[0].ResourceName)
+	}
+}
+
+func TestParseTeamNotificationRuleImportID(t *testing.T) {
+	tests := []struct {
+		name       string
+		importID   string
+		wantTeamID string
+		wantRuleID string
+		wantErr    bool
+	}{
+		{
+			name:       "valid",
+			importID:   "team-id:rule-id",
+			wantTeamID: "team-id",
+			wantRuleID: "rule-id",
+		},
+		{
+			name:     "missing delimiter",
+			importID: "team-id",
+			wantErr:  true,
+		},
+		{
+			name:     "missing team id",
+			importID: ":rule-id",
+			wantErr:  true,
+		},
+		{
+			name:     "missing rule id",
+			importID: "team-id:",
+			wantErr:  true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			teamID, ruleID, err := parseTeamNotificationRuleImportID(tt.importID)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatal("parseTeamNotificationRuleImportID() error = nil, want error")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("parseTeamNotificationRuleImportID() error = %v", err)
+			}
+			if teamID != tt.wantTeamID {
+				t.Fatalf("teamID = %q, want %q", teamID, tt.wantTeamID)
+			}
+			if ruleID != tt.wantRuleID {
+				t.Fatalf("ruleID = %q, want %q", ruleID, tt.wantRuleID)
+			}
+		})
+	}
+}
+
+func TestTeamNotificationRuleNormalizeIDFilterValues(t *testing.T) {
+	filterIDs, err := parseTeamNotificationRuleImportIDs([]string{"team-1:rule-1", "team-2:rule-2"})
+	if err != nil {
+		t.Fatalf("parseTeamNotificationRuleImportIDs() error = %v", err)
+	}
+
+	ruleID := "rule-1"
+	resource, err := (&TeamNotificationRuleGenerator{}).createResource("team-1", datadogV2.TeamNotificationRule{Id: &ruleID})
+	if err != nil {
+		t.Fatalf("createResource() error = %v", err)
+	}
+
+	compositeFilter := terraformutils.ResourceFilter{
+		ServiceName:      "team_notification_rule",
+		FieldPath:        "id",
+		AcceptableValues: []string{"team-1:rule-1", "team-2:rule-2"},
+	}
+	if compositeFilter.Filter(resource) {
+		t.Fatal("composite id filter should not match resource whose state ID is the rule ID")
+	}
+
+	generator := TeamNotificationRuleGenerator{}
+	generator.Filter = []terraformutils.ResourceFilter{
+		{
+			ServiceName:      "team_notification_rule",
+			FieldPath:        "id",
+			AcceptableValues: []string{"team-1:rule-1", "team-2:rule-2"},
+		},
+	}
+	generator.Filter[0].AcceptableValues = teamNotificationRuleIDs(filterIDs)
+
+	if !generator.Filter[0].Filter(resource) {
+		t.Fatal("normalized id filter should keep resource whose state ID is the rule ID")
+	}
+}

--- a/providers/datadog/team_notification_rule_test.go
+++ b/providers/datadog/team_notification_rule_test.go
@@ -69,6 +69,79 @@ func TestTeamNotificationRuleCreateResourcesAllowsSharedRuleIDs(t *testing.T) {
 	}
 }
 
+func TestTeamNotificationRuleFromResponse(t *testing.T) {
+	ruleID := "rule-id"
+	teamNotificationRule := datadogV2.TeamNotificationRule{
+		Id: &ruleID,
+	}
+
+	tests := []struct {
+		name     string
+		response datadogV2.TeamNotificationRuleResponse
+		request  string
+		wantID   string
+		wantOK   bool
+	}{
+		{
+			name: "parsed data",
+			response: datadogV2.TeamNotificationRuleResponse{
+				Data: &teamNotificationRule,
+			},
+			request: "requested-rule-id",
+			wantID:  "rule-id",
+			wantOK:  true,
+		},
+		{
+			name: "minimal unparsed data",
+			response: datadogV2.TeamNotificationRuleResponse{
+				UnparsedObject: map[string]interface{}{
+					"data": map[string]interface{}{
+						"id":   "rule-id",
+						"type": "team_notification_rules",
+					},
+				},
+			},
+			request: "requested-rule-id",
+			wantID:  "rule-id",
+			wantOK:  true,
+		},
+		{
+			name: "minimal unparsed data without id",
+			response: datadogV2.TeamNotificationRuleResponse{
+				UnparsedObject: map[string]interface{}{
+					"data": map[string]interface{}{
+						"type": "team_notification_rules",
+					},
+				},
+			},
+			request: "requested-rule-id",
+			wantID:  "requested-rule-id",
+			wantOK:  true,
+		},
+		{
+			name:     "no data",
+			response: datadogV2.TeamNotificationRuleResponse{},
+			request:  "requested-rule-id",
+			wantOK:   false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, ok := teamNotificationRuleFromResponse(tt.response, tt.request)
+			if ok != tt.wantOK {
+				t.Fatalf("teamNotificationRuleFromResponse() ok = %t, want %t", ok, tt.wantOK)
+			}
+			if !tt.wantOK {
+				return
+			}
+			if got.GetId() != tt.wantID {
+				t.Fatalf("rule ID = %q, want %q", got.GetId(), tt.wantID)
+			}
+		})
+	}
+}
+
 func TestParseTeamNotificationRuleImportID(t *testing.T) {
 	tests := []struct {
 		name       string

--- a/providers/datadog/team_notification_rule_test.go
+++ b/providers/datadog/team_notification_rule_test.go
@@ -25,6 +25,9 @@ func TestTeamNotificationRuleCreateResource(t *testing.T) {
 	if resource.InstanceState.Attributes["team_id"] != "team-id" {
 		t.Fatalf("team_id attribute = %q, want %q", resource.InstanceState.Attributes["team_id"], "team-id")
 	}
+	if resource.InstanceState.Attributes["email.enabled"] != "false" {
+		t.Fatalf("email.enabled attribute = %q, want %q", resource.InstanceState.Attributes["email.enabled"], "false")
+	}
 	if resource.ResourceName != "tfer--team_notification_rule_team-id_rule-id" {
 		t.Fatalf("resource name = %q, want %q", resource.ResourceName, "tfer--team_notification_rule_team-id_rule-id")
 	}
@@ -137,6 +140,71 @@ func TestTeamNotificationRuleFromResponse(t *testing.T) {
 			}
 			if got.GetId() != tt.wantID {
 				t.Fatalf("rule ID = %q, want %q", got.GetId(), tt.wantID)
+			}
+		})
+	}
+}
+
+func TestTeamNotificationRulesFromResponse(t *testing.T) {
+	ruleID := "rule-id"
+	teamNotificationRule := datadogV2.TeamNotificationRule{
+		Id: &ruleID,
+	}
+
+	tests := []struct {
+		name     string
+		response datadogV2.TeamNotificationRulesResponse
+		wantIDs  []string
+	}{
+		{
+			name: "parsed data",
+			response: datadogV2.TeamNotificationRulesResponse{
+				Data: []datadogV2.TeamNotificationRule{teamNotificationRule},
+			},
+			wantIDs: []string{"rule-id"},
+		},
+		{
+			name: "minimal unparsed data",
+			response: datadogV2.TeamNotificationRulesResponse{
+				UnparsedObject: map[string]interface{}{
+					"data": []interface{}{
+						map[string]interface{}{
+							"id":   "rule-id",
+							"type": "team_notification_rules",
+						},
+					},
+				},
+			},
+			wantIDs: []string{"rule-id"},
+		},
+		{
+			name: "skips unparsed entries without id",
+			response: datadogV2.TeamNotificationRulesResponse{
+				UnparsedObject: map[string]interface{}{
+					"data": []interface{}{
+						map[string]interface{}{
+							"type": "team_notification_rules",
+						},
+					},
+				},
+			},
+		},
+		{
+			name:     "no data",
+			response: datadogV2.TeamNotificationRulesResponse{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := teamNotificationRulesFromResponse(tt.response)
+			if len(got) != len(tt.wantIDs) {
+				t.Fatalf("teamNotificationRulesFromResponse() len = %d, want %d", len(got), len(tt.wantIDs))
+			}
+			for i, wantID := range tt.wantIDs {
+				if got[i].GetId() != wantID {
+					t.Fatalf("rule ID[%d] = %q, want %q", i, got[i].GetId(), wantID)
+				}
 			}
 		})
 	}


### PR DESCRIPTION
Summary
- Add Terraformer import support for Datadog team notification rules.
- Support quoted team_id:rule_id filters and team_id-scoped imports.
- Document the provider version requirement and filter syntax.

Notes
- Seeds team_id before provider refresh so the Datadog provider can read each rule by team and rule ID.
- Normalizes composite filters to rule IDs before initial cleanup.
