### PR TITLE
fix(ibm): return toolchain target errors

### DIFF
--- a/cmd/import.go
+++ b/cmd/import.go
@@ -51,7 +51,7 @@ type importResourcesPostProcessor interface {
 }
 
 type importValidator interface {
-	ValidateImport() error
+	ValidateImport(resources []string) error
 }
 
 const DefaultPathPattern = "{output}/{provider}/{service}/"
@@ -116,10 +116,6 @@ func initOptionsAndWrapper(provider terraformutils.ProviderGenerator, options Im
 	if err != nil {
 		return nil, options, err
 	}
-	if err := validateImport(provider); err != nil {
-		return nil, options, err
-	}
-
 	if terraformerstring.ContainsString(options.Resources, "*") {
 		log.Println("Attempting an import of ALL resources in " + provider.GetName())
 		options.Resources = providerServices(provider)
@@ -141,6 +137,9 @@ func initOptionsAndWrapper(provider terraformutils.ProviderGenerator, options Im
 		}
 		options.Resources = localSlice
 	}
+	if err := validateImport(provider, options.Resources); err != nil {
+		return nil, options, err
+	}
 
 	providerWrapper, err := providerwrapper.NewProviderWrapper(provider.GetName(), provider.GetConfig(), options.Verbose, map[string]int{"retryCount": options.RetryCount, "retrySleepMs": options.RetrySleepMs})
 	if err != nil {
@@ -150,9 +149,9 @@ func initOptionsAndWrapper(provider terraformutils.ProviderGenerator, options Im
 	return providerWrapper, options, nil
 }
 
-func validateImport(provider terraformutils.ProviderGenerator) error {
+func validateImport(provider terraformutils.ProviderGenerator, resources []string) error {
 	if validator, ok := provider.(importValidator); ok {
-		return validator.ValidateImport()
+		return validator.ValidateImport(resources)
 	}
 	return nil
 }

--- a/cmd/import_test.go
+++ b/cmd/import_test.go
@@ -4,6 +4,7 @@ package cmd
 
 import (
 	"errors"
+	"reflect"
 	"testing"
 
 	"github.com/chenrui333/terraformer/terraformutils"
@@ -32,10 +33,12 @@ func (p *testProvider) GetResourceConnections() map[string]map[string][]string {
 
 type validatingTestProvider struct {
 	testProvider
-	err error
+	err       error
+	resources []string
 }
 
-func (p *validatingTestProvider) ValidateImport() error {
+func (p *validatingTestProvider) ValidateImport(resources []string) error {
+	p.resources = append([]string(nil), resources...)
 	return p.err
 }
 
@@ -97,14 +100,18 @@ func TestProviderServices(t *testing.T) {
 }
 
 func TestValidateImport(t *testing.T) {
-	if err := validateImport(&testProvider{}); err != nil {
+	resources := []string{"service"}
+	if err := validateImport(&testProvider{}, resources); err != nil {
 		t.Fatalf("expected provider without validator to pass, got %v", err)
 	}
 
 	wantErr := errors.New("validation failed")
 	provider := &validatingTestProvider{err: wantErr}
-	if err := validateImport(provider); !errors.Is(err, wantErr) {
+	if err := validateImport(provider, resources); !errors.Is(err, wantErr) {
 		t.Fatalf("expected validation error %v, got %v", wantErr, err)
+	}
+	if !reflect.DeepEqual(provider.resources, resources) {
+		t.Fatalf("expected validator resources %v, got %v", resources, provider.resources)
 	}
 }
 

--- a/providers/ibm/ibm_cd_toolchain.go
+++ b/providers/ibm/ibm_cd_toolchain.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"log"
 	"os"
-	"regexp"
 	"slices"
 	"strings"
 	"sync"
@@ -327,11 +326,9 @@ func getS2SPolicies(sess *session.Session, targetTcID string) (map[string][]iamp
 func (g *ToolchainGenerator) InitResources() error {
 	region := g.Args["region"].(string)
 
-	guidRegex := regexp.MustCompile("[0-9a-fA-F]{8}-([0-9a-fA-F]{4}-){3}[0-9a-fA-F]{12}$")
-
 	targetTcID := os.Getenv("IBM_CD_TOOLCHAIN_TARGET")
-	if targetTcID != "" && !guidRegex.MatchString(targetTcID) {
-		log.Fatal("Env variable IBM_CD_TOOLCHAIN_TARGET is not a GUID")
+	if err := validateCDToolchainTarget(); err != nil {
+		return err
 	}
 
 	apiKey := os.Getenv("IC_API_KEY")
@@ -402,7 +399,7 @@ func (g *ToolchainGenerator) InitResources() error {
 
 		tcID := crnSplit[7]
 
-		if !guidRegex.MatchString(tcID) {
+		if !cdToolchainTargetGUIDPattern.MatchString(tcID) {
 			fmt.Println("received invalid CRN format from Resource Controller, skipping...")
 			continue
 		}

--- a/providers/ibm/ibm_provider.go
+++ b/providers/ibm/ibm_provider.go
@@ -5,6 +5,7 @@ package ibm
 import (
 	"errors"
 	"os"
+	"regexp"
 	"sync"
 
 	"github.com/chenrui333/terraformer/terraformutils"
@@ -13,7 +14,11 @@ import (
 const DefaultRegion = "us-south"
 const NoRegion = ""
 
-var errMissingICAPIKey = errors.New("set IC_API_KEY env var")
+var (
+	errMissingICAPIKey           = errors.New("set IC_API_KEY env var")
+	errInvalidCDToolchainTarget  = errors.New("IBM_CD_TOOLCHAIN_TARGET must be a GUID")
+	cdToolchainTargetGUIDPattern = regexp.MustCompile("^[0-9a-fA-F]{8}-([0-9a-fA-F]{4}-){3}[0-9a-fA-F]{12}$")
+)
 
 var resourceMutex sync.RWMutex // Used for g.Resources
 
@@ -42,11 +47,31 @@ func (p *IBMProvider) Init(args []string) error {
 	return nil
 }
 
-func (p *IBMProvider) ValidateImport() error {
+func (p *IBMProvider) ValidateImport(resources []string) error {
 	if os.Getenv("IC_API_KEY") == "" {
 		return errMissingICAPIKey
 	}
+	if serviceRequested(resources, "ibm_cd_toolchain") {
+		return validateCDToolchainTarget()
+	}
 	return nil
+}
+
+func validateCDToolchainTarget() error {
+	targetTcID := os.Getenv("IBM_CD_TOOLCHAIN_TARGET")
+	if targetTcID != "" && !cdToolchainTargetGUIDPattern.MatchString(targetTcID) {
+		return errInvalidCDToolchainTarget
+	}
+	return nil
+}
+
+func serviceRequested(resources []string, service string) bool {
+	for _, resource := range resources {
+		if resource == service || resource == "*" {
+			return true
+		}
+	}
+	return false
 }
 
 func (p *IBMProvider) GetName() string {

--- a/providers/ibm/ibm_provider_test.go
+++ b/providers/ibm/ibm_provider_test.go
@@ -26,9 +26,36 @@ func TestProviderValidateImportRequiresAPIKey(t *testing.T) {
 	t.Setenv("IC_API_KEY", "")
 
 	provider := &IBMProvider{}
-	err := provider.ValidateImport()
+	err := provider.ValidateImport([]string{"ibm_is_image"})
 	if !errors.Is(err, errMissingICAPIKey) {
 		t.Fatalf("expected missing API key error, got %v", err)
+	}
+}
+
+func TestProviderValidateImportChecksToolchainTarget(t *testing.T) {
+	t.Setenv("IC_API_KEY", "api-key")
+	t.Setenv("IBM_CD_TOOLCHAIN_TARGET", "not-a-guid")
+
+	provider := &IBMProvider{}
+	if err := provider.ValidateImport([]string{"ibm_is_image"}); err != nil {
+		t.Fatalf("expected unrelated IBM import to ignore toolchain target, got %v", err)
+	}
+	if err := provider.ValidateImport([]string{"ibm_cd_toolchain"}); !errors.Is(err, errInvalidCDToolchainTarget) {
+		t.Fatalf("expected invalid toolchain target error, got %v", err)
+	}
+}
+
+func TestToolchainGeneratorReturnsInvalidTargetError(t *testing.T) {
+	t.Setenv("IBM_CD_TOOLCHAIN_TARGET", "not-a-guid")
+
+	generator := &ToolchainGenerator{}
+	generator.SetArgs(map[string]interface{}{
+		"region": DefaultRegion,
+	})
+
+	err := generator.InitResources()
+	if !errors.Is(err, errInvalidCDToolchainTarget) {
+		t.Fatalf("expected invalid toolchain target error, got %v", err)
 	}
 }
 


### PR DESCRIPTION
## Summary

- Return invalid `IBM_CD_TOOLCHAIN_TARGET` errors instead of exiting the process during IBM toolchain import.
- Pass the finalized resource list into live-import validation so IBM only checks the toolchain target when `ibm_cd_toolchain` is requested.
- Keep plan replay offline-safe by leaving provider and service initialization free of live credential or target checks.
