### PR TITLE
fix(rabbitmq): return HTTP status errors

### DIFF
--- a/providers/rabbitmq/rabbitmq_service.go
+++ b/providers/rabbitmq/rabbitmq_service.go
@@ -3,8 +3,12 @@
 package rabbitmq
 
 import (
+	"context"
+	"fmt"
 	"io"
 	"net/http"
+	"strings"
+	"time"
 
 	"github.com/chenrui333/terraformer/terraformutils"
 )
@@ -16,7 +20,10 @@ type RBTService struct {
 func (s *RBTService) generateRequest(uri string) ([]byte, error) {
 	tr := &http.Transport{}
 	client := &http.Client{Transport: tr}
-	req, err := http.NewRequest("GET", s.Args["endpoint"].(string)+uri, nil)
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, s.Args["endpoint"].(string)+uri, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -26,6 +33,14 @@ func (s *RBTService) generateRequest(uri string) ([]byte, error) {
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if resp.StatusCode < http.StatusOK || resp.StatusCode >= http.StatusMultipleChoices {
+		body, err := io.ReadAll(resp.Body)
+		if err != nil {
+			return nil, fmt.Errorf("rabbitmq GET %s failed: %s; reading response body: %w", uri, resp.Status, err)
+		}
+		return nil, fmt.Errorf("rabbitmq GET %s failed: %s: %s", uri, resp.Status, strings.TrimSpace(string(body)))
+	}
+
 	body, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return nil, err

--- a/providers/rabbitmq/rabbitmq_service_test.go
+++ b/providers/rabbitmq/rabbitmq_service_test.go
@@ -1,0 +1,64 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package rabbitmq
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func TestGenerateRequestReturnsHTTPStatusErrors(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		http.Error(w, "not authorized", http.StatusUnauthorized)
+	}))
+	defer server.Close()
+
+	service := &RBTService{}
+	service.SetArgs(map[string]interface{}{
+		"endpoint": server.URL,
+		"username": "guest",
+		"password": "guest",
+	})
+
+	_, err := service.generateRequest("/api/queues")
+	if err == nil {
+		t.Fatal("expected HTTP error")
+	}
+	if !strings.Contains(err.Error(), "401 Unauthorized") {
+		t.Fatalf("expected status in error, got %q", err)
+	}
+	if !strings.Contains(err.Error(), "not authorized") {
+		t.Fatalf("expected response body in error, got %q", err)
+	}
+}
+
+func TestGenerateRequestReturnsBody(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		username, password, ok := r.BasicAuth()
+		if !ok || username != "guest" || password != "guest" {
+			t.Errorf("expected basic auth credentials")
+		}
+		if r.URL.Path != "/api/queues" {
+			t.Errorf("expected request path /api/queues, got %q", r.URL.Path)
+		}
+		_, _ = w.Write([]byte("{\"ok\":true}"))
+	}))
+	defer server.Close()
+
+	service := &RBTService{}
+	service.SetArgs(map[string]interface{}{
+		"endpoint": server.URL,
+		"username": "guest",
+		"password": "guest",
+	})
+
+	body, err := service.generateRequest("/api/queues")
+	if err != nil {
+		t.Fatalf("expected request to succeed: %v", err)
+	}
+	if string(body) != "{\"ok\":true}" {
+		t.Fatalf("expected response body, got %q", body)
+	}
+}


### PR DESCRIPTION
## Summary

- Return contextual RabbitMQ HTTP status errors from the shared request helper instead of passing error bodies to JSON decoders.
- Add a request timeout via context for RabbitMQ API reads.
- Cover success and non-2xx response handling for the shared helper.