### PR TITLE
fix(azure): return metadata status errors

### DIFF
--- a/providers/azure/azure_provider.go
+++ b/providers/azure/azure_provider.go
@@ -457,6 +457,14 @@ func discoverCloudConfig(metadataHost, environment string) (cloud.Configuration,
 		return cloud.Configuration{}, err
 	}
 	defer resp.Body.Close()
+	if resp.StatusCode < http.StatusOK || resp.StatusCode >= http.StatusMultipleChoices {
+		body, err := io.ReadAll(resp.Body)
+		if err != nil {
+			return cloud.Configuration{}, fmt.Errorf("metadata endpoint returned %s; reading response body: %w", resp.Status, err)
+		}
+		return cloud.Configuration{}, fmt.Errorf("metadata endpoint returned %s: %s", resp.Status, strings.TrimSpace(string(body)))
+	}
+
 	type cloudEndpoint struct {
 		Authentication struct {
 			LoginEndpoint string   `json:"loginEndpoint"`

--- a/providers/azure/helper_test.go
+++ b/providers/azure/helper_test.go
@@ -244,6 +244,30 @@ func TestDiscoverCloudConfigFallsBackToMetadataHostResourceManager(t *testing.T)
 	}
 }
 
+func TestDiscoverCloudConfigReturnsMetadataHTTPStatusErrors(t *testing.T) {
+	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		http.Error(w, "metadata unavailable", http.StatusServiceUnavailable)
+	}))
+	defer server.Close()
+
+	oldClient := http.DefaultClient
+	http.DefaultClient = server.Client()
+	t.Cleanup(func() {
+		http.DefaultClient = oldClient
+	})
+
+	_, err := discoverCloudConfig(strings.TrimPrefix(server.URL, "https://"), "")
+	if err == nil {
+		t.Fatal("expected metadata HTTP status error")
+	}
+	if !strings.Contains(err.Error(), "503 Service Unavailable") {
+		t.Fatalf("expected status in error, got %q", err)
+	}
+	if !strings.Contains(err.Error(), "metadata unavailable") {
+		t.Fatalf("expected response body in error, got %q", err)
+	}
+}
+
 func TestAzureCLIUnavailableFallbackCredentialAllowsChainedFallback(t *testing.T) {
 	for _, errMessage := range []string{
 		"AzureCLICredential: Azure CLI not found on path",


### PR DESCRIPTION
## Summary

- Return Azure metadata endpoint HTTP status errors before decoding cloud metadata JSON.
- Include the metadata response body in the error to make custom cloud discovery failures easier to diagnose.
- Add regression coverage for non-2xx metadata responses.
