### PR TITLE
aws(kinesis): add consumer and policy resources

### DIFF
--- a/docs/aws.md
+++ b/docs/aws.md
@@ -263,7 +263,9 @@ terraformer import aws --resources=sg --regions=us-east-1
     * `aws_iot_topic_rule`
     * `aws_iot_role_alias`
 *   `kinesis`
+    * `aws_kinesis_resource_policy`
     * `aws_kinesis_stream`
+    * `aws_kinesis_stream_consumer`
 *   `kms`
     * `aws_kms_key`
     * `aws_kms_alias`

--- a/providers/aws/kinesis.go
+++ b/providers/aws/kinesis.go
@@ -4,8 +4,14 @@ package aws
 
 import (
 	"context"
+	"errors"
+	"fmt"
+	"log"
+	"strings"
 
 	"github.com/aws/aws-sdk-go-v2/service/kinesis"
+	kinesistypes "github.com/aws/aws-sdk-go-v2/service/kinesis/types"
+	"github.com/aws/smithy-go"
 	"github.com/chenrui333/terraformer/terraformutils"
 )
 
@@ -13,6 +19,22 @@ var kinesisAllowEmptyValues = []string{"tags."}
 
 type KinesisGenerator struct {
 	AWSService
+}
+
+type kinesisOptionalResourceLoader struct {
+	name string
+	load func() error
+}
+
+func (g *KinesisGenerator) loadOptionalResources(loaders []kinesisOptionalResourceLoader) {
+	for _, loader := range loaders {
+		if err := loader.load(); err != nil {
+			if kinesisResourceMissing(err) {
+				continue
+			}
+			log.Printf("Skipping Kinesis %s: %v", loader.name, err)
+		}
+	}
 }
 
 func (g *KinesisGenerator) createResources(streamNames []string) []terraformutils.Resource {
@@ -28,6 +50,118 @@ func (g *KinesisGenerator) createResources(streamNames []string) []terraformutil
 			map[string]interface{}{}))
 	}
 	return resources
+}
+
+func (g *KinesisGenerator) loadStreamChildren(svc *kinesis.Client, streamName string) {
+	output, err := svc.DescribeStreamSummary(context.TODO(), &kinesis.DescribeStreamSummaryInput{
+		StreamName: &streamName,
+	})
+	if err != nil {
+		if !kinesisResourceMissing(err) {
+			log.Printf("Skipping Kinesis stream child resources for %s: %v", streamName, err)
+		}
+		return
+	}
+	if output.StreamDescriptionSummary == nil {
+		return
+	}
+	streamARN := StringValue(output.StreamDescriptionSummary.StreamARN)
+	if streamARN == "" {
+		return
+	}
+	g.loadOptionalResources([]kinesisOptionalResourceLoader{
+		{name: fmt.Sprintf("resource policy for stream %s", streamName), load: func() error {
+			return g.loadResourcePolicy(svc, streamARN, kinesisResourceName(streamName, "policy"))
+		}},
+		{name: fmt.Sprintf("stream consumers for %s", streamName), load: func() error {
+			return g.loadStreamConsumers(svc, streamName, streamARN)
+		}},
+	})
+}
+
+func (g *KinesisGenerator) loadStreamConsumers(svc *kinesis.Client, streamName string, streamARN string) error {
+	p := kinesis.NewListStreamConsumersPaginator(svc, &kinesis.ListStreamConsumersInput{StreamARN: &streamARN})
+	for p.HasMorePages() {
+		page, err := p.NextPage(context.TODO())
+		if err != nil {
+			return err
+		}
+		for _, consumer := range page.Consumers {
+			consumerARN := StringValue(consumer.ConsumerARN)
+			consumerName := StringValue(consumer.ConsumerName)
+			if consumerARN == "" || consumerName == "" || !kinesisConsumerImportable(consumer) {
+				continue
+			}
+			g.Resources = append(g.Resources, terraformutils.NewResource(
+				consumerARN,
+				kinesisResourceName(streamName, consumerName),
+				"aws_kinesis_stream_consumer",
+				"aws",
+				map[string]string{
+					"name":       consumerName,
+					"stream_arn": streamARN,
+				},
+				kinesisAllowEmptyValues,
+				map[string]interface{}{},
+			))
+			g.loadOptionalResources([]kinesisOptionalResourceLoader{
+				{name: fmt.Sprintf("resource policy for consumer %s", consumerName), load: func() error {
+					return g.loadResourcePolicy(svc, consumerARN, kinesisResourceName(streamName, consumerName, "policy"))
+				}},
+			})
+		}
+	}
+	return nil
+}
+
+func (g *KinesisGenerator) loadResourcePolicy(svc *kinesis.Client, resourceARN string, resourceName string) error {
+	output, err := svc.GetResourcePolicy(context.TODO(), &kinesis.GetResourcePolicyInput{ResourceARN: &resourceARN})
+	if err != nil {
+		return err
+	}
+	policy := StringValue(output.Policy)
+	if policy == "" {
+		return nil
+	}
+	g.Resources = append(g.Resources, terraformutils.NewResource(
+		resourceARN,
+		resourceName,
+		"aws_kinesis_resource_policy",
+		"aws",
+		map[string]string{
+			"policy":       policy,
+			"resource_arn": resourceARN,
+		},
+		kinesisAllowEmptyValues,
+		map[string]interface{}{},
+	))
+	return nil
+}
+
+func kinesisConsumerImportable(consumer kinesistypes.Consumer) bool {
+	return consumer.ConsumerStatus == kinesistypes.ConsumerStatusActive
+}
+
+func kinesisResourceName(parts ...string) string {
+	segments := make([]string, 0, len(parts))
+	for _, part := range parts {
+		if part != "" {
+			segments = append(segments, part)
+		}
+	}
+	if len(segments) == 0 {
+		return "kinesis_resource"
+	}
+	return strings.Join(segments, "/")
+}
+
+func kinesisResourceMissing(err error) bool {
+	var resourceNotFound *kinesistypes.ResourceNotFoundException
+	if errors.As(err, &resourceNotFound) {
+		return true
+	}
+	var apiErr smithy.APIError
+	return errors.As(err, &apiErr) && strings.Contains(strings.ToLower(apiErr.ErrorCode()), "resourcenotfound")
 }
 
 func (g *KinesisGenerator) InitResources() error {
@@ -48,12 +182,32 @@ func (g *KinesisGenerator) InitResources() error {
 		}
 
 		g.Resources = append(g.Resources, g.createResources(results.StreamNames)...)
+		for _, streamName := range results.StreamNames {
+			if streamName == "" {
+				continue
+			}
+			g.loadStreamChildren(svc, streamName)
+		}
 
 		if len(results.StreamNames) > 0 {
 			request = kinesis.ListStreamsInput{
 				ExclusiveStartStreamName: &results.StreamNames[len(results.StreamNames)-1],
 			}
 		}
+	}
+	return nil
+}
+
+func (g *KinesisGenerator) PostConvertHook() error {
+	for i, resource := range g.Resources {
+		if resource.InstanceInfo.Type != "aws_kinesis_resource_policy" {
+			continue
+		}
+		policy, ok := resource.Item["policy"].(string)
+		if !ok || policy == "" {
+			continue
+		}
+		g.Resources[i].Item["policy"] = fmt.Sprintf("<<POLICY\n%s\nPOLICY", g.escapeAwsInterpolation(policy))
 	}
 	return nil
 }

--- a/providers/aws/kinesis.go
+++ b/providers/aws/kinesis.go
@@ -63,7 +63,7 @@ func (g *KinesisGenerator) shouldLoadStreamChildren(streamName string) bool {
 	if g.hasUntypedIDFilters() && !g.hasUntypedChildIDFilters() {
 		return false
 	}
-	return g.streamMatchesExplicitIDFilters(streamName) ||
+	return g.streamAllowsChildDiscovery(streamName) ||
 		g.hasTypedFilterFor("kinesis_stream_consumer") ||
 		g.hasTypedFilterFor("kinesis_resource_policy") ||
 		g.hasUntypedChildIDFilters()
@@ -83,7 +83,7 @@ func (g *KinesisGenerator) shouldAppendStreamConsumers(streamName string) bool {
 	if g.hasTypedFilterFor("kinesis_resource_policy") {
 		return false
 	}
-	return g.streamMatchesExplicitIDFilters(streamName)
+	return g.streamAllowsChildDiscovery(streamName)
 }
 
 func (g *KinesisGenerator) shouldLoadResourcePolicies(streamName string) bool {
@@ -96,7 +96,7 @@ func (g *KinesisGenerator) shouldLoadResourcePolicies(streamName string) bool {
 	if g.hasTypedFilterFor("kinesis_stream_consumer") {
 		return false
 	}
-	return g.streamMatchesExplicitIDFilters(streamName)
+	return g.streamAllowsChildDiscovery(streamName)
 }
 
 func (g *KinesisGenerator) shouldAppendStreamResource(streamName string) bool {
@@ -119,6 +119,13 @@ func (g *KinesisGenerator) shouldAppendStreamResource(streamName string) bool {
 	return !g.hasTypedFilterFor("kinesis_stream_consumer") && !g.hasTypedFilterFor("kinesis_resource_policy")
 }
 
+func (g *KinesisGenerator) streamAllowsChildDiscovery(streamName string) bool {
+	if g.hasTypedNonIDStreamFilters() {
+		return false
+	}
+	return g.streamMatchesExplicitIDFilters(streamName)
+}
+
 func (g *KinesisGenerator) streamMatchesExplicitIDFilters(streamName string) bool {
 	streamResource := newKinesisStreamResource(streamName)
 	for _, filter := range g.Filter {
@@ -132,6 +139,15 @@ func (g *KinesisGenerator) streamMatchesExplicitIDFilters(streamName string) boo
 func (g *KinesisGenerator) hasTypedFilterFor(resourceType string) bool {
 	for _, filter := range g.Filter {
 		if filter.ServiceName != "" && filter.IsApplicable(resourceType) {
+			return true
+		}
+	}
+	return false
+}
+
+func (g *KinesisGenerator) hasTypedNonIDStreamFilters() bool {
+	for _, filter := range g.Filter {
+		if filter.ServiceName != "" && filter.FieldPath != "id" && filter.IsApplicable("kinesis_stream") {
 			return true
 		}
 	}

--- a/providers/aws/kinesis.go
+++ b/providers/aws/kinesis.go
@@ -67,13 +67,20 @@ func (g *KinesisGenerator) shouldLoadStreamChildren(streamName string) bool {
 }
 
 func (g *KinesisGenerator) shouldLoadStreamConsumers(streamName string) bool {
+	return g.shouldAppendStreamConsumers(streamName) || g.shouldLoadResourcePolicies(streamName)
+}
+
+func (g *KinesisGenerator) shouldAppendStreamConsumers(streamName string) bool {
 	if g.hasUntypedIDFilters() && !g.hasUntypedChildIDFilters() {
 		return false
 	}
-	return g.streamMatchesExplicitIDFilters(streamName) ||
-		g.hasTypedFilterFor("kinesis_stream_consumer") ||
-		g.hasTypedFilterFor("kinesis_resource_policy") ||
-		g.hasUntypedChildIDFilters()
+	if g.hasUntypedChildIDFilters() || g.hasTypedFilterFor("kinesis_stream_consumer") {
+		return true
+	}
+	if g.hasTypedFilterFor("kinesis_resource_policy") {
+		return false
+	}
+	return g.streamMatchesExplicitIDFilters(streamName)
 }
 
 func (g *KinesisGenerator) shouldLoadResourcePolicies(streamName string) bool {
@@ -83,7 +90,7 @@ func (g *KinesisGenerator) shouldLoadResourcePolicies(streamName string) bool {
 	if g.hasTypedFilterFor("kinesis_resource_policy") {
 		return true
 	}
-	if g.hasTypedFilterFor("kinesis_stream_consumer") && !g.hasTypedFilterFor("kinesis_stream") {
+	if g.hasTypedFilterFor("kinesis_stream_consumer") {
 		return false
 	}
 	return g.streamMatchesExplicitIDFilters(streamName)
@@ -150,6 +157,7 @@ func (g *KinesisGenerator) loadStreamChildren(svc *kinesis.Client, streamName st
 	}
 
 	loadPolicies := g.shouldLoadResourcePolicies(streamName)
+	appendConsumers := g.shouldAppendStreamConsumers(streamName)
 	loaders := []kinesisOptionalResourceLoader{}
 	if loadPolicies {
 		loaders = append(loaders, kinesisOptionalResourceLoader{
@@ -163,14 +171,14 @@ func (g *KinesisGenerator) loadStreamChildren(svc *kinesis.Client, streamName st
 		loaders = append(loaders, kinesisOptionalResourceLoader{
 			name: fmt.Sprintf("stream consumers for %s", streamName),
 			load: func() error {
-				return g.loadStreamConsumers(svc, streamName, streamARN, loadPolicies)
+				return g.loadStreamConsumers(svc, streamName, streamARN, loadPolicies, appendConsumers)
 			},
 		})
 	}
 	g.loadOptionalResources(loaders)
 }
 
-func (g *KinesisGenerator) loadStreamConsumers(svc *kinesis.Client, streamName string, streamARN string, loadPolicies bool) error {
+func (g *KinesisGenerator) loadStreamConsumers(svc *kinesis.Client, streamName string, streamARN string, loadPolicies bool, appendConsumers bool) error {
 	p := kinesis.NewListStreamConsumersPaginator(svc, &kinesis.ListStreamConsumersInput{StreamARN: &streamARN})
 	for p.HasMorePages() {
 		page, err := p.NextPage(context.TODO())
@@ -183,18 +191,20 @@ func (g *KinesisGenerator) loadStreamConsumers(svc *kinesis.Client, streamName s
 			if consumerARN == "" || consumerName == "" || !kinesisConsumerImportable(consumer) {
 				continue
 			}
-			g.Resources = append(g.Resources, terraformutils.NewResource(
-				consumerARN,
-				kinesisResourceName(streamName, consumerName),
-				"aws_kinesis_stream_consumer",
-				"aws",
-				map[string]string{
-					"name":       consumerName,
-					"stream_arn": streamARN,
-				},
-				kinesisAllowEmptyValues,
-				map[string]interface{}{},
-			))
+			if appendConsumers {
+				g.Resources = append(g.Resources, terraformutils.NewResource(
+					consumerARN,
+					kinesisResourceName(streamName, consumerName),
+					"aws_kinesis_stream_consumer",
+					"aws",
+					map[string]string{
+						"name":       consumerName,
+						"stream_arn": streamARN,
+					},
+					kinesisAllowEmptyValues,
+					map[string]interface{}{},
+				))
+			}
 			if !loadPolicies {
 				continue
 			}

--- a/providers/aws/kinesis.go
+++ b/providers/aws/kinesis.go
@@ -59,7 +59,7 @@ func newKinesisStreamResource(resourceName string) terraformutils.Resource {
 func (g *KinesisGenerator) shouldLoadStreamChildren(streamName string) bool {
 	streamResource := newKinesisStreamResource(streamName)
 	for _, filter := range g.Filter {
-		if filter.FieldPath == "id" && !filter.Filter(streamResource) {
+		if filter.ServiceName != "" && filter.FieldPath == "id" && filter.IsApplicable("kinesis_stream") && !filter.Filter(streamResource) {
 			return false
 		}
 	}

--- a/providers/aws/kinesis.go
+++ b/providers/aws/kinesis.go
@@ -57,9 +57,23 @@ func newKinesisStreamResource(resourceName string) terraformutils.Resource {
 }
 
 func (g *KinesisGenerator) shouldLoadStreamChildren(streamName string) bool {
-	if g.hasChildResourceFilters() {
-		return true
-	}
+	return g.streamMatchesExplicitIDFilters(streamName) ||
+		g.hasFilterFor("kinesis_stream_consumer") ||
+		g.hasFilterFor("kinesis_resource_policy")
+}
+
+func (g *KinesisGenerator) shouldLoadStreamConsumers(streamName string) bool {
+	return g.streamMatchesExplicitIDFilters(streamName) ||
+		g.hasFilterFor("kinesis_stream_consumer") ||
+		g.hasFilterFor("kinesis_resource_policy")
+}
+
+func (g *KinesisGenerator) shouldLoadResourcePolicies(streamName string) bool {
+	return g.streamMatchesExplicitIDFilters(streamName) ||
+		g.hasFilterFor("kinesis_resource_policy")
+}
+
+func (g *KinesisGenerator) streamMatchesExplicitIDFilters(streamName string) bool {
 	streamResource := newKinesisStreamResource(streamName)
 	for _, filter := range g.Filter {
 		if filter.ServiceName != "" && filter.FieldPath == "id" && filter.IsApplicable("kinesis_stream") && !filter.Filter(streamResource) {
@@ -69,12 +83,12 @@ func (g *KinesisGenerator) shouldLoadStreamChildren(streamName string) bool {
 	return true
 }
 
-func (g *KinesisGenerator) hasChildResourceFilters() bool {
+func (g *KinesisGenerator) hasFilterFor(resourceType string) bool {
 	for _, filter := range g.Filter {
 		if filter.ServiceName == "" {
 			return true
 		}
-		if filter.IsApplicable("kinesis_stream_consumer") || filter.IsApplicable("kinesis_resource_policy") {
+		if filter.IsApplicable(resourceType) {
 			return true
 		}
 	}
@@ -98,17 +112,29 @@ func (g *KinesisGenerator) loadStreamChildren(svc *kinesis.Client, streamName st
 	if streamARN == "" {
 		return
 	}
-	g.loadOptionalResources([]kinesisOptionalResourceLoader{
-		{name: fmt.Sprintf("resource policy for stream %s", streamName), load: func() error {
-			return g.loadResourcePolicy(svc, streamARN, kinesisResourceName(streamName, "policy"))
-		}},
-		{name: fmt.Sprintf("stream consumers for %s", streamName), load: func() error {
-			return g.loadStreamConsumers(svc, streamName, streamARN)
-		}},
-	})
+
+	loadPolicies := g.shouldLoadResourcePolicies(streamName)
+	loaders := []kinesisOptionalResourceLoader{}
+	if loadPolicies {
+		loaders = append(loaders, kinesisOptionalResourceLoader{
+			name: fmt.Sprintf("resource policy for stream %s", streamName),
+			load: func() error {
+				return g.loadResourcePolicy(svc, streamARN, kinesisResourceName(streamName, "policy"))
+			},
+		})
+	}
+	if g.shouldLoadStreamConsumers(streamName) {
+		loaders = append(loaders, kinesisOptionalResourceLoader{
+			name: fmt.Sprintf("stream consumers for %s", streamName),
+			load: func() error {
+				return g.loadStreamConsumers(svc, streamName, streamARN, loadPolicies)
+			},
+		})
+	}
+	g.loadOptionalResources(loaders)
 }
 
-func (g *KinesisGenerator) loadStreamConsumers(svc *kinesis.Client, streamName string, streamARN string) error {
+func (g *KinesisGenerator) loadStreamConsumers(svc *kinesis.Client, streamName string, streamARN string, loadPolicies bool) error {
 	p := kinesis.NewListStreamConsumersPaginator(svc, &kinesis.ListStreamConsumersInput{StreamARN: &streamARN})
 	for p.HasMorePages() {
 		page, err := p.NextPage(context.TODO())
@@ -133,6 +159,9 @@ func (g *KinesisGenerator) loadStreamConsumers(svc *kinesis.Client, streamName s
 				kinesisAllowEmptyValues,
 				map[string]interface{}{},
 			))
+			if !loadPolicies {
+				continue
+			}
 			g.loadOptionalResources([]kinesisOptionalResourceLoader{
 				{name: fmt.Sprintf("resource policy for consumer %s", consumerName), load: func() error {
 					return g.loadResourcePolicy(svc, consumerARN, kinesisResourceName(streamName, consumerName, "policy"))

--- a/providers/aws/kinesis.go
+++ b/providers/aws/kinesis.go
@@ -57,20 +57,36 @@ func newKinesisStreamResource(resourceName string) terraformutils.Resource {
 }
 
 func (g *KinesisGenerator) shouldLoadStreamChildren(streamName string) bool {
+	if g.hasUntypedIDFilters() && !g.hasUntypedChildIDFilters() {
+		return false
+	}
 	return g.streamMatchesExplicitIDFilters(streamName) ||
-		g.hasFilterFor("kinesis_stream_consumer") ||
-		g.hasFilterFor("kinesis_resource_policy")
+		g.hasTypedFilterFor("kinesis_stream_consumer") ||
+		g.hasTypedFilterFor("kinesis_resource_policy") ||
+		g.hasUntypedChildIDFilters()
 }
 
 func (g *KinesisGenerator) shouldLoadStreamConsumers(streamName string) bool {
+	if g.hasUntypedIDFilters() && !g.hasUntypedChildIDFilters() {
+		return false
+	}
 	return g.streamMatchesExplicitIDFilters(streamName) ||
-		g.hasFilterFor("kinesis_stream_consumer") ||
-		g.hasFilterFor("kinesis_resource_policy")
+		g.hasTypedFilterFor("kinesis_stream_consumer") ||
+		g.hasTypedFilterFor("kinesis_resource_policy") ||
+		g.hasUntypedChildIDFilters()
 }
 
 func (g *KinesisGenerator) shouldLoadResourcePolicies(streamName string) bool {
-	return g.streamMatchesExplicitIDFilters(streamName) ||
-		g.hasFilterFor("kinesis_resource_policy")
+	if g.hasUntypedIDFilters() {
+		return g.hasUntypedChildIDFilters()
+	}
+	if g.hasTypedFilterFor("kinesis_resource_policy") {
+		return true
+	}
+	if g.hasTypedFilterFor("kinesis_stream_consumer") && !g.hasTypedFilterFor("kinesis_stream") {
+		return false
+	}
+	return g.streamMatchesExplicitIDFilters(streamName)
 }
 
 func (g *KinesisGenerator) streamMatchesExplicitIDFilters(streamName string) bool {
@@ -83,13 +99,33 @@ func (g *KinesisGenerator) streamMatchesExplicitIDFilters(streamName string) boo
 	return true
 }
 
-func (g *KinesisGenerator) hasFilterFor(resourceType string) bool {
+func (g *KinesisGenerator) hasTypedFilterFor(resourceType string) bool {
 	for _, filter := range g.Filter {
-		if filter.ServiceName == "" {
+		if filter.ServiceName != "" && filter.IsApplicable(resourceType) {
 			return true
 		}
-		if filter.IsApplicable(resourceType) {
+	}
+	return false
+}
+
+func (g *KinesisGenerator) hasUntypedIDFilters() bool {
+	for _, filter := range g.Filter {
+		if filter.ServiceName == "" && filter.FieldPath == "id" {
 			return true
+		}
+	}
+	return false
+}
+
+func (g *KinesisGenerator) hasUntypedChildIDFilters() bool {
+	for _, filter := range g.Filter {
+		if filter.ServiceName != "" || filter.FieldPath != "id" {
+			continue
+		}
+		for _, value := range filter.AcceptableValues {
+			if strings.HasPrefix(value, "arn:") && strings.Contains(value, ":stream/") {
+				return true
+			}
 		}
 	}
 	return false

--- a/providers/aws/kinesis.go
+++ b/providers/aws/kinesis.go
@@ -57,6 +57,9 @@ func newKinesisStreamResource(resourceName string) terraformutils.Resource {
 }
 
 func (g *KinesisGenerator) shouldLoadStreamChildren(streamName string) bool {
+	if g.hasChildResourceFilters() {
+		return true
+	}
 	streamResource := newKinesisStreamResource(streamName)
 	for _, filter := range g.Filter {
 		if filter.ServiceName != "" && filter.FieldPath == "id" && filter.IsApplicable("kinesis_stream") && !filter.Filter(streamResource) {
@@ -64,6 +67,18 @@ func (g *KinesisGenerator) shouldLoadStreamChildren(streamName string) bool {
 		}
 	}
 	return true
+}
+
+func (g *KinesisGenerator) hasChildResourceFilters() bool {
+	for _, filter := range g.Filter {
+		if filter.ServiceName == "" {
+			return true
+		}
+		if filter.IsApplicable("kinesis_stream_consumer") || filter.IsApplicable("kinesis_resource_policy") {
+			return true
+		}
+	}
+	return false
 }
 
 func (g *KinesisGenerator) loadStreamChildren(svc *kinesis.Client, streamName string) {

--- a/providers/aws/kinesis.go
+++ b/providers/aws/kinesis.go
@@ -40,6 +40,9 @@ func (g *KinesisGenerator) loadOptionalResources(loaders []kinesisOptionalResour
 func (g *KinesisGenerator) createResources(streamNames []string) []terraformutils.Resource {
 	var resources []terraformutils.Resource
 	for _, resourceName := range streamNames {
+		if !g.shouldAppendStreamResource(resourceName) {
+			continue
+		}
 		resources = append(resources, newKinesisStreamResource(resourceName))
 	}
 	return resources
@@ -94,6 +97,26 @@ func (g *KinesisGenerator) shouldLoadResourcePolicies(streamName string) bool {
 		return false
 	}
 	return g.streamMatchesExplicitIDFilters(streamName)
+}
+
+func (g *KinesisGenerator) shouldAppendStreamResource(streamName string) bool {
+	streamResource := newKinesisStreamResource(streamName)
+	hasUntypedIDFilter := false
+	for _, filter := range g.Filter {
+		if filter.FieldPath != "id" {
+			continue
+		}
+		if filter.ServiceName == "" {
+			hasUntypedIDFilter = true
+		}
+		if filter.IsApplicable("kinesis_stream") && !filter.Filter(streamResource) {
+			return false
+		}
+	}
+	if g.hasTypedFilterFor("kinesis_stream") || hasUntypedIDFilter {
+		return true
+	}
+	return !g.hasTypedFilterFor("kinesis_stream_consumer") && !g.hasTypedFilterFor("kinesis_resource_policy")
 }
 
 func (g *KinesisGenerator) streamMatchesExplicitIDFilters(streamName string) bool {

--- a/providers/aws/kinesis.go
+++ b/providers/aws/kinesis.go
@@ -40,16 +40,30 @@ func (g *KinesisGenerator) loadOptionalResources(loaders []kinesisOptionalResour
 func (g *KinesisGenerator) createResources(streamNames []string) []terraformutils.Resource {
 	var resources []terraformutils.Resource
 	for _, resourceName := range streamNames {
-		resources = append(resources, terraformutils.NewResource(
-			resourceName,
-			resourceName,
-			"aws_kinesis_stream",
-			"aws",
-			map[string]string{"name": resourceName},
-			kinesisAllowEmptyValues,
-			map[string]interface{}{}))
+		resources = append(resources, newKinesisStreamResource(resourceName))
 	}
 	return resources
+}
+
+func newKinesisStreamResource(resourceName string) terraformutils.Resource {
+	return terraformutils.NewResource(
+		resourceName,
+		resourceName,
+		"aws_kinesis_stream",
+		"aws",
+		map[string]string{"name": resourceName},
+		kinesisAllowEmptyValues,
+		map[string]interface{}{})
+}
+
+func (g *KinesisGenerator) shouldLoadStreamChildren(streamName string) bool {
+	streamResource := newKinesisStreamResource(streamName)
+	for _, filter := range g.Filter {
+		if filter.FieldPath == "id" && !filter.Filter(streamResource) {
+			return false
+		}
+	}
+	return true
 }
 
 func (g *KinesisGenerator) loadStreamChildren(svc *kinesis.Client, streamName string) {
@@ -183,7 +197,7 @@ func (g *KinesisGenerator) InitResources() error {
 
 		g.Resources = append(g.Resources, g.createResources(results.StreamNames)...)
 		for _, streamName := range results.StreamNames {
-			if streamName == "" {
+			if streamName == "" || !g.shouldLoadStreamChildren(streamName) {
 				continue
 			}
 			g.loadStreamChildren(svc, streamName)

--- a/providers/aws/kinesis_test.go
+++ b/providers/aws/kinesis_test.go
@@ -137,6 +137,15 @@ func TestKinesisShouldLoadStreamChildrenHonorsStreamIDFilters(t *testing.T) {
 			want:   true,
 		},
 		{
+			name: "untyped stream id filter skips child discovery",
+			filters: []terraformutils.ResourceFilter{{
+				FieldPath:        "id",
+				AcceptableValues: []string{"orders"},
+			}},
+			stream: "payments",
+			want:   false,
+		},
+		{
 			name: "non-id stream filter is handled by post-refresh cleanup",
 			filters: []terraformutils.ResourceFilter{{
 				ServiceName:      "kinesis_stream",
@@ -206,6 +215,16 @@ func TestKinesisShouldLoadResourcePoliciesHonorsFilters(t *testing.T) {
 			want:   false,
 		},
 		{
+			name: "typed consumer filter alone does not load every policy",
+			filters: []terraformutils.ResourceFilter{{
+				ServiceName:      "kinesis_stream_consumer",
+				FieldPath:        "id",
+				AcceptableValues: []string{"arn:aws:kinesis:us-east-1:123456789012:stream/payments/consumer/app:1"},
+			}},
+			stream: "orders",
+			want:   false,
+		},
+		{
 			name: "typed policy filter loads policies despite stream filter",
 			filters: []terraformutils.ResourceFilter{
 				{
@@ -230,6 +249,15 @@ func TestKinesisShouldLoadResourcePoliciesHonorsFilters(t *testing.T) {
 			}},
 			stream: "payments",
 			want:   true,
+		},
+		{
+			name: "untyped stream id filter does not load policies",
+			filters: []terraformutils.ResourceFilter{{
+				FieldPath:        "id",
+				AcceptableValues: []string{"orders"},
+			}},
+			stream: "orders",
+			want:   false,
 		},
 	}
 
@@ -280,6 +308,16 @@ func TestKinesisShouldLoadStreamConsumersHonorsFilters(t *testing.T) {
 			want:   true,
 		},
 		{
+			name: "typed consumer filter alone loads consumers",
+			filters: []terraformutils.ResourceFilter{{
+				ServiceName:      "kinesis_stream_consumer",
+				FieldPath:        "id",
+				AcceptableValues: []string{"arn:aws:kinesis:us-east-1:123456789012:stream/payments/consumer/app:1"},
+			}},
+			stream: "orders",
+			want:   true,
+		},
+		{
 			name: "typed policy filter loads consumers for consumer policies",
 			filters: []terraformutils.ResourceFilter{
 				{
@@ -295,6 +333,15 @@ func TestKinesisShouldLoadStreamConsumersHonorsFilters(t *testing.T) {
 			},
 			stream: "payments",
 			want:   true,
+		},
+		{
+			name: "untyped stream id filter does not load consumers",
+			filters: []terraformutils.ResourceFilter{{
+				FieldPath:        "id",
+				AcceptableValues: []string{"orders"},
+			}},
+			stream: "orders",
+			want:   false,
 		},
 	}
 

--- a/providers/aws/kinesis_test.go
+++ b/providers/aws/kinesis_test.go
@@ -55,6 +55,68 @@ func TestKinesisResourceName(t *testing.T) {
 	}
 }
 
+func TestKinesisShouldLoadStreamChildrenHonorsStreamIDFilters(t *testing.T) {
+	tests := []struct {
+		name    string
+		filters []terraformutils.ResourceFilter
+		stream  string
+		want    bool
+	}{
+		{name: "no filters", stream: "orders", want: true},
+		{
+			name: "matching stream id filter",
+			filters: []terraformutils.ResourceFilter{{
+				ServiceName:      "kinesis_stream",
+				FieldPath:        "id",
+				AcceptableValues: []string{"orders"},
+			}},
+			stream: "orders",
+			want:   true,
+		},
+		{
+			name: "nonmatching stream id filter",
+			filters: []terraformutils.ResourceFilter{{
+				ServiceName:      "kinesis_stream",
+				FieldPath:        "id",
+				AcceptableValues: []string{"orders"},
+			}},
+			stream: "payments",
+			want:   false,
+		},
+		{
+			name: "child filter does not suppress stream discovery",
+			filters: []terraformutils.ResourceFilter{{
+				ServiceName:      "kinesis_stream_consumer",
+				FieldPath:        "id",
+				AcceptableValues: []string{"arn:aws:kinesis:us-east-1:123456789012:stream/orders/consumer/app:1"},
+			}},
+			stream: "orders",
+			want:   true,
+		},
+		{
+			name: "non-id stream filter is handled by post-refresh cleanup",
+			filters: []terraformutils.ResourceFilter{{
+				ServiceName:      "kinesis_stream",
+				FieldPath:        "tags.env",
+				AcceptableValues: []string{"prod"},
+			}},
+			stream: "orders",
+			want:   true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := &KinesisGenerator{}
+			g.Filter = tt.filters
+			got := g.shouldLoadStreamChildren(tt.stream)
+			if got != tt.want {
+				t.Fatalf("shouldLoadStreamChildren() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
 func TestKinesisResourceMissing(t *testing.T) {
 	tests := []struct {
 		name string

--- a/providers/aws/kinesis_test.go
+++ b/providers/aws/kinesis_test.go
@@ -94,6 +94,15 @@ func TestKinesisShouldLoadStreamChildrenHonorsStreamIDFilters(t *testing.T) {
 			want:   true,
 		},
 		{
+			name: "untyped child id filter reaches cleanup",
+			filters: []terraformutils.ResourceFilter{{
+				FieldPath:        "id",
+				AcceptableValues: []string{"arn:aws:kinesis:us-east-1:123456789012:stream/orders/consumer/app:1"},
+			}},
+			stream: "orders",
+			want:   true,
+		},
+		{
 			name: "non-id stream filter is handled by post-refresh cleanup",
 			filters: []terraformutils.ResourceFilter{{
 				ServiceName:      "kinesis_stream",

--- a/providers/aws/kinesis_test.go
+++ b/providers/aws/kinesis_test.go
@@ -314,13 +314,30 @@ func TestKinesisShouldLoadStreamChildrenHonorsStreamIDFilters(t *testing.T) {
 			want:   false,
 		},
 		{
-			name: "non-id stream filter is handled by post-refresh cleanup",
+			name: "non-id stream filter skips child discovery",
 			filters: []terraformutils.ResourceFilter{{
 				ServiceName:      "kinesis_stream",
 				FieldPath:        "tags.env",
 				AcceptableValues: []string{"prod"},
 			}},
 			stream: "orders",
+			want:   false,
+		},
+		{
+			name: "child filter keeps discovery despite non-id stream filter",
+			filters: []terraformutils.ResourceFilter{
+				{
+					ServiceName:      "kinesis_stream",
+					FieldPath:        "tags.env",
+					AcceptableValues: []string{"prod"},
+				},
+				{
+					ServiceName:      "kinesis_stream_consumer",
+					FieldPath:        "id",
+					AcceptableValues: []string{"arn:aws:kinesis:us-east-1:123456789012:stream/payments/consumer/app:1"},
+				},
+			},
+			stream: "payments",
 			want:   true,
 		},
 	}
@@ -427,6 +444,33 @@ func TestKinesisShouldLoadResourcePoliciesHonorsFilters(t *testing.T) {
 			stream: "orders",
 			want:   false,
 		},
+		{
+			name: "non-id stream filter does not load policies",
+			filters: []terraformutils.ResourceFilter{{
+				ServiceName:      "kinesis_stream",
+				FieldPath:        "tags.env",
+				AcceptableValues: []string{"prod"},
+			}},
+			stream: "orders",
+			want:   false,
+		},
+		{
+			name: "policy filter loads policies despite non-id stream filter",
+			filters: []terraformutils.ResourceFilter{
+				{
+					ServiceName:      "kinesis_stream",
+					FieldPath:        "tags.env",
+					AcceptableValues: []string{"prod"},
+				},
+				{
+					ServiceName:      "kinesis_resource_policy",
+					FieldPath:        "id",
+					AcceptableValues: []string{"arn:aws:kinesis:us-east-1:123456789012:stream/payments"},
+				},
+			},
+			stream: "payments",
+			want:   true,
+		},
 	}
 
 	for _, tt := range tests {
@@ -511,6 +555,33 @@ func TestKinesisShouldLoadStreamConsumersHonorsFilters(t *testing.T) {
 			stream: "orders",
 			want:   false,
 		},
+		{
+			name: "non-id stream filter does not load consumers",
+			filters: []terraformutils.ResourceFilter{{
+				ServiceName:      "kinesis_stream",
+				FieldPath:        "tags.env",
+				AcceptableValues: []string{"prod"},
+			}},
+			stream: "orders",
+			want:   false,
+		},
+		{
+			name: "consumer filter loads consumers despite non-id stream filter",
+			filters: []terraformutils.ResourceFilter{
+				{
+					ServiceName:      "kinesis_stream",
+					FieldPath:        "tags.env",
+					AcceptableValues: []string{"prod"},
+				},
+				{
+					ServiceName:      "kinesis_stream_consumer",
+					FieldPath:        "id",
+					AcceptableValues: []string{"arn:aws:kinesis:us-east-1:123456789012:stream/payments/consumer/app:1"},
+				},
+			},
+			stream: "payments",
+			want:   true,
+		},
 	}
 
 	for _, tt := range tests {
@@ -594,6 +665,16 @@ func TestKinesisShouldAppendStreamConsumersHonorsFilters(t *testing.T) {
 			filters: []terraformutils.ResourceFilter{{
 				FieldPath:        "id",
 				AcceptableValues: []string{"orders"},
+			}},
+			stream: "orders",
+			want:   false,
+		},
+		{
+			name: "non-id stream filter does not append consumers",
+			filters: []terraformutils.ResourceFilter{{
+				ServiceName:      "kinesis_stream",
+				FieldPath:        "tags.env",
+				AcceptableValues: []string{"prod"},
 			}},
 			stream: "orders",
 			want:   false,

--- a/providers/aws/kinesis_test.go
+++ b/providers/aws/kinesis_test.go
@@ -55,6 +55,174 @@ func TestKinesisResourceName(t *testing.T) {
 	}
 }
 
+func TestKinesisShouldAppendStreamResourceHonorsFilters(t *testing.T) {
+	tests := []struct {
+		name    string
+		filters []terraformutils.ResourceFilter
+		stream  string
+		want    bool
+	}{
+		{name: "no filters", stream: "orders", want: true},
+		{
+			name: "typed child consumer filter does not append parents",
+			filters: []terraformutils.ResourceFilter{{
+				ServiceName:      "kinesis_stream_consumer",
+				FieldPath:        "id",
+				AcceptableValues: []string{"arn:aws:kinesis:us-east-1:123456789012:stream/orders/consumer/app:1"},
+			}},
+			stream: "orders",
+			want:   false,
+		},
+		{
+			name: "typed policy filter does not append parents",
+			filters: []terraformutils.ResourceFilter{{
+				ServiceName:      "kinesis_resource_policy",
+				FieldPath:        "id",
+				AcceptableValues: []string{"arn:aws:kinesis:us-east-1:123456789012:stream/orders"},
+			}},
+			stream: "orders",
+			want:   false,
+		},
+		{
+			name: "typed stream id filter matches parent",
+			filters: []terraformutils.ResourceFilter{{
+				ServiceName:      "kinesis_stream",
+				FieldPath:        "id",
+				AcceptableValues: []string{"orders"},
+			}},
+			stream: "orders",
+			want:   true,
+		},
+		{
+			name: "typed stream id filter skips nonmatching parent",
+			filters: []terraformutils.ResourceFilter{{
+				ServiceName:      "kinesis_stream",
+				FieldPath:        "id",
+				AcceptableValues: []string{"orders"},
+			}},
+			stream: "payments",
+			want:   false,
+		},
+		{
+			name: "typed stream tag filter waits for post-refresh cleanup",
+			filters: []terraformutils.ResourceFilter{{
+				ServiceName:      "kinesis_stream",
+				FieldPath:        "tags.env",
+				AcceptableValues: []string{"prod"},
+			}},
+			stream: "orders",
+			want:   true,
+		},
+		{
+			name: "untyped stream id filter matches parent",
+			filters: []terraformutils.ResourceFilter{{
+				FieldPath:        "id",
+				AcceptableValues: []string{"orders"},
+			}},
+			stream: "orders",
+			want:   true,
+		},
+		{
+			name: "untyped stream id filter skips nonmatching parent",
+			filters: []terraformutils.ResourceFilter{{
+				FieldPath:        "id",
+				AcceptableValues: []string{"orders"},
+			}},
+			stream: "payments",
+			want:   false,
+		},
+		{
+			name: "untyped child arn filter does not append parents",
+			filters: []terraformutils.ResourceFilter{{
+				FieldPath:        "id",
+				AcceptableValues: []string{"arn:aws:kinesis:us-east-1:123456789012:stream/orders/consumer/app:1"},
+			}},
+			stream: "orders",
+			want:   false,
+		},
+		{
+			name: "typed stream and child filters append matching parent only",
+			filters: []terraformutils.ResourceFilter{
+				{
+					ServiceName:      "kinesis_stream",
+					FieldPath:        "id",
+					AcceptableValues: []string{"orders"},
+				},
+				{
+					ServiceName:      "kinesis_stream_consumer",
+					FieldPath:        "id",
+					AcceptableValues: []string{"arn:aws:kinesis:us-east-1:123456789012:stream/payments/consumer/app:1"},
+				},
+			},
+			stream: "orders",
+			want:   true,
+		},
+		{
+			name: "untyped stream and child id values append matching parent",
+			filters: []terraformutils.ResourceFilter{{
+				FieldPath:        "id",
+				AcceptableValues: []string{"orders", "arn:aws:kinesis:us-east-1:123456789012:stream/payments/consumer/app:1"},
+			}},
+			stream: "orders",
+			want:   true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := &KinesisGenerator{}
+			g.Filter = tt.filters
+			got := g.shouldAppendStreamResource(tt.stream)
+			if got != tt.want {
+				t.Fatalf("shouldAppendStreamResource() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestKinesisCreateResourcesAppliesInitialFilters(t *testing.T) {
+	tests := []struct {
+		name    string
+		filters []terraformutils.ResourceFilter
+		want    []string
+	}{
+		{name: "no filters", want: []string{"orders", "payments"}},
+		{
+			name: "typed child filter excludes parents",
+			filters: []terraformutils.ResourceFilter{{
+				ServiceName:      "kinesis_stream_consumer",
+				FieldPath:        "id",
+				AcceptableValues: []string{"arn:aws:kinesis:us-east-1:123456789012:stream/orders/consumer/app:1"},
+			}},
+			want: nil,
+		},
+		{
+			name: "untyped stream id filter keeps matching parent",
+			filters: []terraformutils.ResourceFilter{{
+				FieldPath:        "id",
+				AcceptableValues: []string{"orders"},
+			}},
+			want: []string{"orders"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := &KinesisGenerator{}
+			g.Filter = tt.filters
+			resources := g.createResources([]string{"orders", "payments"})
+			if len(resources) != len(tt.want) {
+				t.Fatalf("createResources() len = %d, want %d", len(resources), len(tt.want))
+			}
+			for i, want := range tt.want {
+				if got := resources[i].InstanceState.ID; got != want {
+					t.Fatalf("createResources()[%d].ID = %q, want %q", i, got, want)
+				}
+			}
+		})
+	}
+}
+
 func TestKinesisShouldLoadStreamChildrenHonorsStreamIDFilters(t *testing.T) {
 	tests := []struct {
 		name    string

--- a/providers/aws/kinesis_test.go
+++ b/providers/aws/kinesis_test.go
@@ -1,0 +1,101 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package aws
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+
+	kinesistypes "github.com/aws/aws-sdk-go-v2/service/kinesis/types"
+	"github.com/aws/smithy-go"
+	"github.com/chenrui333/terraformer/terraformutils"
+)
+
+func TestKinesisConsumerImportable(t *testing.T) {
+	tests := []struct {
+		name     string
+		consumer kinesistypes.Consumer
+		want     bool
+	}{
+		{name: "active", consumer: kinesistypes.Consumer{ConsumerStatus: kinesistypes.ConsumerStatusActive}, want: true},
+		{name: "creating", consumer: kinesistypes.Consumer{ConsumerStatus: kinesistypes.ConsumerStatusCreating}, want: false},
+		{name: "deleting", consumer: kinesistypes.Consumer{ConsumerStatus: kinesistypes.ConsumerStatusDeleting}, want: false},
+		{name: "empty", consumer: kinesistypes.Consumer{}, want: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := kinesisConsumerImportable(tt.consumer)
+			if got != tt.want {
+				t.Fatalf("kinesisConsumerImportable() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestKinesisResourceName(t *testing.T) {
+	tests := []struct {
+		name  string
+		parts []string
+		want  string
+	}{
+		{name: "filters empty parts", parts: []string{"", "orders", "", "policy"}, want: "orders/policy"},
+		{name: "preserves segment boundaries", parts: []string{"orders", "stream", "policy"}, want: "orders/stream/policy"},
+		{name: "fallback", parts: nil, want: "kinesis_resource"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := kinesisResourceName(tt.parts...)
+			if got != tt.want {
+				t.Fatalf("kinesisResourceName() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestKinesisResourceMissing(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{name: "typed resource not found", err: &kinesistypes.ResourceNotFoundException{}, want: true},
+		{name: "wrapped resource not found", err: fmt.Errorf("wrapped: %w", &kinesistypes.ResourceNotFoundException{}), want: true},
+		{name: "api resource not found code", err: &smithy.GenericAPIError{Code: "ResourceNotFoundException"}, want: true},
+		{name: "other", err: errors.New("boom"), want: false},
+		{name: "nil", err: nil, want: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := kinesisResourceMissing(tt.err)
+			if got != tt.want {
+				t.Fatalf("kinesisResourceMissing() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestKinesisPostConvertHookWrapsResourcePolicy(t *testing.T) {
+	resource := terraformutils.NewSimpleResource(
+		"arn:aws:kinesis:us-east-1:123456789012:stream/orders",
+		"orders/policy",
+		"aws_kinesis_resource_policy",
+		"aws",
+		kinesisAllowEmptyValues,
+	)
+	resource.Item = map[string]interface{}{"policy": "{\"Resource\":\"$" + "{aws:kinesis}\"}"}
+	g := &KinesisGenerator{}
+	g.Resources = []terraformutils.Resource{resource}
+
+	if err := g.PostConvertHook(); err != nil {
+		t.Fatalf("PostConvertHook() error = %v", err)
+	}
+
+	want := "<<POLICY\n{\"Resource\":\"$" + "$" + "{aws:kinesis}\"}\nPOLICY"
+	if got := g.Resources[0].Item["policy"]; got != want {
+		t.Fatalf("policy = %q, want %q", got, want)
+	}
+}

--- a/providers/aws/kinesis_test.go
+++ b/providers/aws/kinesis_test.go
@@ -84,6 +84,40 @@ func TestKinesisShouldLoadStreamChildrenHonorsStreamIDFilters(t *testing.T) {
 			want:   false,
 		},
 		{
+			name: "child id filter keeps discovery despite nonmatching stream filter",
+			filters: []terraformutils.ResourceFilter{
+				{
+					ServiceName:      "kinesis_stream",
+					FieldPath:        "id",
+					AcceptableValues: []string{"orders"},
+				},
+				{
+					ServiceName:      "kinesis_stream_consumer",
+					FieldPath:        "id",
+					AcceptableValues: []string{"arn:aws:kinesis:us-east-1:123456789012:stream/payments/consumer/app:1"},
+				},
+			},
+			stream: "payments",
+			want:   true,
+		},
+		{
+			name: "resource policy filter keeps discovery despite nonmatching stream filter",
+			filters: []terraformutils.ResourceFilter{
+				{
+					ServiceName:      "kinesis_stream",
+					FieldPath:        "id",
+					AcceptableValues: []string{"orders"},
+				},
+				{
+					ServiceName:      "kinesis_resource_policy",
+					FieldPath:        "id",
+					AcceptableValues: []string{"arn:aws:kinesis:us-east-1:123456789012:stream/payments"},
+				},
+			},
+			stream: "payments",
+			want:   true,
+		},
+		{
 			name: "child filter does not suppress stream discovery",
 			filters: []terraformutils.ResourceFilter{{
 				ServiceName:      "kinesis_stream_consumer",

--- a/providers/aws/kinesis_test.go
+++ b/providers/aws/kinesis_test.go
@@ -160,6 +160,156 @@ func TestKinesisShouldLoadStreamChildrenHonorsStreamIDFilters(t *testing.T) {
 	}
 }
 
+func TestKinesisShouldLoadResourcePoliciesHonorsFilters(t *testing.T) {
+	tests := []struct {
+		name    string
+		filters []terraformutils.ResourceFilter
+		stream  string
+		want    bool
+	}{
+		{name: "no filters", stream: "orders", want: true},
+		{
+			name: "matching stream id filter",
+			filters: []terraformutils.ResourceFilter{{
+				ServiceName:      "kinesis_stream",
+				FieldPath:        "id",
+				AcceptableValues: []string{"orders"},
+			}},
+			stream: "orders",
+			want:   true,
+		},
+		{
+			name: "nonmatching stream id filter",
+			filters: []terraformutils.ResourceFilter{{
+				ServiceName:      "kinesis_stream",
+				FieldPath:        "id",
+				AcceptableValues: []string{"orders"},
+			}},
+			stream: "payments",
+			want:   false,
+		},
+		{
+			name: "typed consumer filter does not load unrelated policies",
+			filters: []terraformutils.ResourceFilter{
+				{
+					ServiceName:      "kinesis_stream",
+					FieldPath:        "id",
+					AcceptableValues: []string{"orders"},
+				},
+				{
+					ServiceName:      "kinesis_stream_consumer",
+					FieldPath:        "id",
+					AcceptableValues: []string{"arn:aws:kinesis:us-east-1:123456789012:stream/payments/consumer/app:1"},
+				},
+			},
+			stream: "payments",
+			want:   false,
+		},
+		{
+			name: "typed policy filter loads policies despite stream filter",
+			filters: []terraformutils.ResourceFilter{
+				{
+					ServiceName:      "kinesis_stream",
+					FieldPath:        "id",
+					AcceptableValues: []string{"orders"},
+				},
+				{
+					ServiceName:      "kinesis_resource_policy",
+					FieldPath:        "id",
+					AcceptableValues: []string{"arn:aws:kinesis:us-east-1:123456789012:stream/payments"},
+				},
+			},
+			stream: "payments",
+			want:   true,
+		},
+		{
+			name: "untyped id filter reaches cleanup",
+			filters: []terraformutils.ResourceFilter{{
+				FieldPath:        "id",
+				AcceptableValues: []string{"arn:aws:kinesis:us-east-1:123456789012:stream/payments/consumer/app:1"},
+			}},
+			stream: "payments",
+			want:   true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := &KinesisGenerator{}
+			g.Filter = tt.filters
+			got := g.shouldLoadResourcePolicies(tt.stream)
+			if got != tt.want {
+				t.Fatalf("shouldLoadResourcePolicies() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestKinesisShouldLoadStreamConsumersHonorsFilters(t *testing.T) {
+	tests := []struct {
+		name    string
+		filters []terraformutils.ResourceFilter
+		stream  string
+		want    bool
+	}{
+		{
+			name: "nonmatching stream id filter",
+			filters: []terraformutils.ResourceFilter{{
+				ServiceName:      "kinesis_stream",
+				FieldPath:        "id",
+				AcceptableValues: []string{"orders"},
+			}},
+			stream: "payments",
+			want:   false,
+		},
+		{
+			name: "typed consumer filter loads consumers despite stream filter",
+			filters: []terraformutils.ResourceFilter{
+				{
+					ServiceName:      "kinesis_stream",
+					FieldPath:        "id",
+					AcceptableValues: []string{"orders"},
+				},
+				{
+					ServiceName:      "kinesis_stream_consumer",
+					FieldPath:        "id",
+					AcceptableValues: []string{"arn:aws:kinesis:us-east-1:123456789012:stream/payments/consumer/app:1"},
+				},
+			},
+			stream: "payments",
+			want:   true,
+		},
+		{
+			name: "typed policy filter loads consumers for consumer policies",
+			filters: []terraformutils.ResourceFilter{
+				{
+					ServiceName:      "kinesis_stream",
+					FieldPath:        "id",
+					AcceptableValues: []string{"orders"},
+				},
+				{
+					ServiceName:      "kinesis_resource_policy",
+					FieldPath:        "id",
+					AcceptableValues: []string{"arn:aws:kinesis:us-east-1:123456789012:stream/payments/consumer/app:1"},
+				},
+			},
+			stream: "payments",
+			want:   true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := &KinesisGenerator{}
+			g.Filter = tt.filters
+			got := g.shouldLoadStreamConsumers(tt.stream)
+			if got != tt.want {
+				t.Fatalf("shouldLoadStreamConsumers() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
 func TestKinesisResourceMissing(t *testing.T) {
 	tests := []struct {
 		name string

--- a/providers/aws/kinesis_test.go
+++ b/providers/aws/kinesis_test.go
@@ -357,6 +357,93 @@ func TestKinesisShouldLoadStreamConsumersHonorsFilters(t *testing.T) {
 	}
 }
 
+func TestKinesisShouldAppendStreamConsumersHonorsFilters(t *testing.T) {
+	tests := []struct {
+		name    string
+		filters []terraformutils.ResourceFilter
+		stream  string
+		want    bool
+	}{
+		{name: "no filters", stream: "orders", want: true},
+		{
+			name: "matching stream id filter",
+			filters: []terraformutils.ResourceFilter{{
+				ServiceName:      "kinesis_stream",
+				FieldPath:        "id",
+				AcceptableValues: []string{"orders"},
+			}},
+			stream: "orders",
+			want:   true,
+		},
+		{
+			name: "typed consumer filter appends consumers",
+			filters: []terraformutils.ResourceFilter{{
+				ServiceName:      "kinesis_stream_consumer",
+				FieldPath:        "id",
+				AcceptableValues: []string{"arn:aws:kinesis:us-east-1:123456789012:stream/payments/consumer/app:1"},
+			}},
+			stream: "orders",
+			want:   true,
+		},
+		{
+			name: "typed policy filter enumerates without appending consumers",
+			filters: []terraformutils.ResourceFilter{{
+				ServiceName:      "kinesis_resource_policy",
+				FieldPath:        "id",
+				AcceptableValues: []string{"arn:aws:kinesis:us-east-1:123456789012:stream/orders/consumer/app:1"},
+			}},
+			stream: "orders",
+			want:   false,
+		},
+		{
+			name: "typed stream and policy filters do not append consumers",
+			filters: []terraformutils.ResourceFilter{
+				{
+					ServiceName:      "kinesis_stream",
+					FieldPath:        "id",
+					AcceptableValues: []string{"orders"},
+				},
+				{
+					ServiceName:      "kinesis_resource_policy",
+					FieldPath:        "id",
+					AcceptableValues: []string{"arn:aws:kinesis:us-east-1:123456789012:stream/orders"},
+				},
+			},
+			stream: "orders",
+			want:   false,
+		},
+		{
+			name: "untyped child id filter can append matching consumers",
+			filters: []terraformutils.ResourceFilter{{
+				FieldPath:        "id",
+				AcceptableValues: []string{"arn:aws:kinesis:us-east-1:123456789012:stream/orders/consumer/app:1"},
+			}},
+			stream: "orders",
+			want:   true,
+		},
+		{
+			name: "untyped stream id filter does not append consumers",
+			filters: []terraformutils.ResourceFilter{{
+				FieldPath:        "id",
+				AcceptableValues: []string{"orders"},
+			}},
+			stream: "orders",
+			want:   false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := &KinesisGenerator{}
+			g.Filter = tt.filters
+			got := g.shouldAppendStreamConsumers(tt.stream)
+			if got != tt.want {
+				t.Fatalf("shouldAppendStreamConsumers() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
 func TestKinesisResourceMissing(t *testing.T) {
 	tests := []struct {
 		name string


### PR DESCRIPTION
## Summary

- add best-effort Kinesis discovery for stream consumers and resource policies on streams/consumers
- keep existing stream imports intact while skipping missing or unauthorized child-resource lookups
- document the expanded Kinesis coverage and add helper tests for status filters, resource names, missing-resource handling, and policy heredoc formatting
