### PR TITLE
fix(gcp): return kms page errors

### DIFF
--- a/providers/gcp/kms.go
+++ b/providers/gcp/kms.go
@@ -4,7 +4,7 @@ package gcp
 
 import (
 	"context"
-	"log"
+	"fmt"
 	"strings"
 
 	"google.golang.org/api/cloudkms/v1"
@@ -20,7 +20,7 @@ type KmsGenerator struct {
 	GCPService
 }
 
-func (g KmsGenerator) createKmsRingResources(ctx context.Context, keyRingList *cloudkms.ProjectsLocationsKeyRingsListCall, kmsService *cloudkms.Service) []terraformutils.Resource {
+func (g KmsGenerator) createKmsRingResources(ctx context.Context, keyRingList *cloudkms.ProjectsLocationsKeyRingsListCall, kmsService *cloudkms.Service) ([]terraformutils.Resource, error) {
 	resources := []terraformutils.Resource{}
 	if err := keyRingList.Pages(ctx, func(page *cloudkms.ListKeyRingsResponse) error {
 		for _, obj := range page.KeyRings {
@@ -39,16 +39,20 @@ func (g KmsGenerator) createKmsRingResources(ctx context.Context, keyRingList *c
 				kmsAllowEmptyValues,
 				kmsAdditionalFields,
 			))
-			resources = append(resources, g.createKmsKeyResources(ctx, obj.Name, kmsService)...)
+			keyResources, err := g.createKmsKeyResources(ctx, obj.Name, kmsService)
+			if err != nil {
+				return err
+			}
+			resources = append(resources, keyResources...)
 		}
 		return nil
 	}); err != nil {
-		log.Println(err)
+		return nil, fmt.Errorf("list kms key rings: %w", err)
 	}
-	return resources
+	return resources, nil
 }
 
-func (g *KmsGenerator) createKmsKeyResources(ctx context.Context, keyRingName string, kmsService *cloudkms.Service) []terraformutils.Resource {
+func (g *KmsGenerator) createKmsKeyResources(ctx context.Context, keyRingName string, kmsService *cloudkms.Service) ([]terraformutils.Resource, error) {
 	resources := []terraformutils.Resource{}
 	keyList := kmsService.Projects.Locations.KeyRings.CryptoKeys.List(keyRingName)
 	if err := keyList.Pages(ctx, func(page *cloudkms.ListCryptoKeysResponse) error {
@@ -69,9 +73,9 @@ func (g *KmsGenerator) createKmsKeyResources(ctx context.Context, keyRingName st
 		}
 		return nil
 	}); err != nil {
-		log.Println(err)
+		return nil, fmt.Errorf("list kms crypto keys for %s: %w", keyRingName, err)
 	}
-	return resources
+	return resources, nil
 }
 
 // Generate TerraformResources from GCP API,
@@ -84,7 +88,11 @@ func (g *KmsGenerator) InitResources() error {
 
 	keyRingList := kmsService.Projects.Locations.KeyRings.List("projects/" + g.GetArgs()["project"].(string) + "/locations/global")
 
-	g.Resources = g.createKmsRingResources(ctx, keyRingList, kmsService)
+	resources, err := g.createKmsRingResources(ctx, keyRingList, kmsService)
+	if err != nil {
+		return err
+	}
+	g.Resources = resources
 	return nil
 }
 

--- a/providers/gcp/kms_test.go
+++ b/providers/gcp/kms_test.go
@@ -1,0 +1,67 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package gcp
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"google.golang.org/api/cloudkms/v1"
+	"google.golang.org/api/option"
+)
+
+func TestCreateKmsRingResourcesReturnsKeyRingListError(t *testing.T) {
+	ctx := context.Background()
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		http.Error(w, "{\"error\":{\"message\":\"service unavailable\"}}", http.StatusServiceUnavailable)
+	}))
+	t.Cleanup(server.Close)
+
+	kmsService := newTestKmsService(ctx, t, server.URL+"/")
+	_, err := (KmsGenerator{}).createKmsRingResources(ctx, kmsService.Projects.Locations.KeyRings.List("projects/test-project/locations/global"), kmsService)
+	if err == nil {
+		t.Fatal("expected kms key ring list error")
+	}
+	if !strings.Contains(err.Error(), "list kms key rings") {
+		t.Fatalf("expected wrapped kms key ring list error, got %q", err)
+	}
+}
+
+func TestCreateKmsRingResourcesReturnsCryptoKeyListError(t *testing.T) {
+	ctx := context.Background()
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if strings.Contains(r.URL.Path, "/cryptoKeys") {
+			http.Error(w, "{\"error\":{\"message\":\"service unavailable\"}}", http.StatusServiceUnavailable)
+			return
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte("{\"keyRings\":[{\"name\":\"projects/test-project/locations/global/keyRings/test-ring\"}]}"))
+	}))
+	t.Cleanup(server.Close)
+
+	kmsService := newTestKmsService(ctx, t, server.URL+"/")
+	g := KmsGenerator{}
+	g.SetArgs(map[string]interface{}{"project": "test-project"})
+
+	_, err := g.createKmsRingResources(ctx, kmsService.Projects.Locations.KeyRings.List("projects/test-project/locations/global"), kmsService)
+	if err == nil {
+		t.Fatal("expected kms crypto key list error")
+	}
+	if !strings.Contains(err.Error(), "list kms crypto keys") {
+		t.Fatalf("expected wrapped kms crypto key list error, got %q", err)
+	}
+}
+
+func newTestKmsService(ctx context.Context, t *testing.T, endpoint string) *cloudkms.Service {
+	t.Helper()
+
+	kmsService, err := cloudkms.NewService(ctx, option.WithEndpoint(endpoint), option.WithoutAuthentication())
+	if err != nil {
+		t.Fatal(err)
+	}
+	return kmsService
+}


### PR DESCRIPTION
## Summary

- Return GCP KMS key-ring pagination errors instead of logging and continuing with partial resources.
- Propagate nested crypto-key pagination errors while discovering key-ring resources.
- Add regression coverage for both KMS listing failure paths.

