### PR TITLE
feat(datadog): add monitor notification rule import

### DIFF
--- a/docs/datadog.md
+++ b/docs/datadog.md
@@ -133,6 +133,9 @@ Tag filters are order specific. For example, if your monitor has tags (in the or
         * **_NOTE:_** Importing resource requires resource ID's to be passed via [Filter][1] option
 *   `monitor`
     * `datadog_monitor`
+*   `monitor_notification_rule`
+    * `datadog_monitor_notification_rule`
+        * **_NOTE:_** Requires DataDog/datadog provider 3.83.0 or newer.
 *   `role`
     * `datadog_role`
 *   `security_monitoring_default_rule`

--- a/providers/datadog/datadog_provider.go
+++ b/providers/datadog/datadog_provider.go
@@ -170,6 +170,7 @@ func (p *DatadogProvider) GetSupportedService() map[string]terraformutils.Servic
 		"integration_slack_channel":            &IntegrationSlackChannelGenerator{},
 		"metric_metadata":                      &MetricMetadataGenerator{},
 		"monitor":                              &MonitorGenerator{},
+		"monitor_notification_rule":            &MonitorNotificationRuleGenerator{},
 		"security_monitoring_default_rule":     &SecurityMonitoringDefaultRuleGenerator{},
 		"security_monitoring_rule":             &SecurityMonitoringRuleGenerator{},
 		"service_level_objective":              &ServiceLevelObjectiveGenerator{},

--- a/providers/datadog/monitor_notification_rule.go
+++ b/providers/datadog/monitor_notification_rule.go
@@ -1,0 +1,193 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package datadog
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/DataDog/datadog-api-client-go/v2/api/datadog"
+	"github.com/DataDog/datadog-api-client-go/v2/api/datadogV2"
+
+	"github.com/chenrui333/terraformer/terraformutils"
+)
+
+var (
+	// MonitorNotificationRuleAllowEmptyValues ...
+	MonitorNotificationRuleAllowEmptyValues = []string{}
+)
+
+// MonitorNotificationRuleGenerator ...
+type MonitorNotificationRuleGenerator struct {
+	DatadogService
+}
+
+func (g *MonitorNotificationRuleGenerator) createResources(monitorNotificationRules []datadogV2.MonitorNotificationRuleData) ([]terraformutils.Resource, error) {
+	resources := []terraformutils.Resource{}
+	for _, monitorNotificationRule := range monitorNotificationRules {
+		resource, err := g.createResource(monitorNotificationRule)
+		if err != nil {
+			return nil, err
+		}
+		resources = append(resources, resource)
+	}
+
+	return resources, nil
+}
+
+func (g *MonitorNotificationRuleGenerator) createResource(monitorNotificationRule datadogV2.MonitorNotificationRuleData) (terraformutils.Resource, error) {
+	ruleID := monitorNotificationRule.GetId()
+	if ruleID == "" {
+		return terraformutils.Resource{}, fmt.Errorf("monitor notification rule missing id")
+	}
+
+	return terraformutils.NewSimpleResource(
+		ruleID,
+		fmt.Sprintf("monitor_notification_rule_%s", ruleID),
+		"datadog_monitor_notification_rule",
+		"datadog",
+		MonitorNotificationRuleAllowEmptyValues,
+	), nil
+}
+
+// InitResources Generate TerraformResources from Datadog API,
+// from each monitor notification rule create 1 TerraformResource.
+func (g *MonitorNotificationRuleGenerator) InitResources() error {
+	datadogClient := g.Args["datadogClient"].(*datadog.APIClient)
+	auth := g.Args["auth"].(context.Context)
+	api := datadogV2.NewMonitorsApi(datadogClient)
+
+	resources, filtered, err := g.filteredResources(auth, api)
+	if err != nil {
+		return err
+	}
+	if filtered {
+		g.Resources = resources
+		return nil
+	}
+
+	monitorNotificationRules, err := listMonitorNotificationRules(auth, api)
+	if err != nil {
+		return err
+	}
+	resources, err = g.createResources(monitorNotificationRules)
+	if err != nil {
+		return err
+	}
+
+	g.Resources = resources
+	return nil
+}
+
+func (g *MonitorNotificationRuleGenerator) filteredResources(auth context.Context, api *datadogV2.MonitorsApi) ([]terraformutils.Resource, bool, error) {
+	resources := []terraformutils.Resource{}
+	filtered := false
+
+	for _, filter := range g.Filter {
+		if filter.FieldPath != "id" || !filter.IsApplicable("monitor_notification_rule") {
+			continue
+		}
+
+		filtered = true
+		for _, value := range filter.AcceptableValues {
+			monitorNotificationRule, err := getMonitorNotificationRule(auth, api, value)
+			if err != nil {
+				return nil, true, err
+			}
+			resource, err := g.createResource(monitorNotificationRule)
+			if err != nil {
+				return nil, true, err
+			}
+			resources = append(resources, resource)
+		}
+	}
+
+	return resources, filtered, nil
+}
+
+func getMonitorNotificationRule(auth context.Context, api *datadogV2.MonitorsApi, ruleID string) (datadogV2.MonitorNotificationRuleData, error) {
+	response, httpResponse, err := api.GetMonitorNotificationRule(auth, ruleID)
+	defer closeDatadogResponseBody(httpResponse)
+	if err != nil {
+		return datadogV2.MonitorNotificationRuleData{}, err
+	}
+
+	if rule, ok := response.GetDataOk(); ok {
+		return *rule, nil
+	}
+	if rule, ok := monitorNotificationRuleFromRawData(response.UnparsedObject["data"]); ok {
+		return rule, nil
+	}
+
+	return datadogV2.MonitorNotificationRuleData{}, fmt.Errorf("monitor notification rule %q not found", ruleID)
+}
+
+func listMonitorNotificationRules(auth context.Context, api *datadogV2.MonitorsApi) ([]datadogV2.MonitorNotificationRuleData, error) {
+	monitorNotificationRules := []datadogV2.MonitorNotificationRuleData{}
+	const pageSize = 1000
+	var page int32
+
+	for {
+		optionalParams := datadogV2.NewGetMonitorNotificationRulesOptionalParameters().
+			WithPage(page).
+			WithPerPage(pageSize)
+
+		response, httpResponse, err := api.GetMonitorNotificationRules(auth, *optionalParams)
+		closeDatadogResponseBody(httpResponse)
+		if err != nil {
+			return nil, err
+		}
+
+		rules := response.GetData()
+		if len(rules) == 0 {
+			rules = monitorNotificationRulesFromRawData(response.UnparsedObject["data"])
+		}
+		monitorNotificationRules = append(monitorNotificationRules, rules...)
+		if len(rules) < pageSize {
+			break
+		}
+		page++
+	}
+
+	return monitorNotificationRules, nil
+}
+
+func monitorNotificationRulesFromRawData(rawData interface{}) []datadogV2.MonitorNotificationRuleData {
+	rawRules, ok := rawData.([]interface{})
+	if !ok {
+		return nil
+	}
+
+	monitorNotificationRules := []datadogV2.MonitorNotificationRuleData{}
+	for _, rawRule := range rawRules {
+		monitorNotificationRule, ok := monitorNotificationRuleFromRawData(rawRule)
+		if !ok {
+			continue
+		}
+		monitorNotificationRules = append(monitorNotificationRules, monitorNotificationRule)
+	}
+	return monitorNotificationRules
+}
+
+func monitorNotificationRuleFromRawData(rawData interface{}) (datadogV2.MonitorNotificationRuleData, bool) {
+	rawRule, ok := rawData.(map[string]interface{})
+	if !ok {
+		return datadogV2.MonitorNotificationRuleData{}, false
+	}
+
+	rawRuleID, ok := rawRule["id"].(string)
+	if !ok || rawRuleID == "" {
+		return datadogV2.MonitorNotificationRuleData{}, false
+	}
+
+	monitorNotificationRule := datadogV2.NewMonitorNotificationRuleDataWithDefaults()
+	monitorNotificationRule.SetId(rawRuleID)
+	return *monitorNotificationRule, true
+}
+
+func closeDatadogResponseBody(response *http.Response) {
+	if response != nil && response.Body != nil {
+		response.Body.Close()
+	}
+}

--- a/providers/datadog/monitor_notification_rule_test.go
+++ b/providers/datadog/monitor_notification_rule_test.go
@@ -1,0 +1,87 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package datadog
+
+import (
+	"testing"
+
+	"github.com/DataDog/datadog-api-client-go/v2/api/datadogV2"
+)
+
+func TestMonitorNotificationRuleCreateResource(t *testing.T) {
+	monitorNotificationRule := datadogV2.NewMonitorNotificationRuleDataWithDefaults()
+	monitorNotificationRule.SetId("rule-id")
+
+	generator := &MonitorNotificationRuleGenerator{}
+	resource, err := generator.createResource(*monitorNotificationRule)
+	if err != nil {
+		t.Fatalf("createResource returned error: %v", err)
+	}
+
+	if resource.InstanceState.ID != "rule-id" {
+		t.Fatalf("resource ID = %q, want %q", resource.InstanceState.ID, "rule-id")
+	}
+	if resource.ResourceName != "tfer--monitor_notification_rule_rule-id" {
+		t.Fatalf("resource name = %q, want %q", resource.ResourceName, "tfer--monitor_notification_rule_rule-id")
+	}
+	if resource.InstanceInfo.Type != "datadog_monitor_notification_rule" {
+		t.Fatalf("resource type = %q, want %q", resource.InstanceInfo.Type, "datadog_monitor_notification_rule")
+	}
+}
+
+func TestMonitorNotificationRuleCreateResourceMissingID(t *testing.T) {
+	generator := &MonitorNotificationRuleGenerator{}
+	_, err := generator.createResource(datadogV2.MonitorNotificationRuleData{})
+	if err == nil {
+		t.Fatal("createResource returned nil error, want missing id error")
+	}
+}
+
+func TestMonitorNotificationRuleCreateResources(t *testing.T) {
+	firstRule := datadogV2.NewMonitorNotificationRuleDataWithDefaults()
+	firstRule.SetId("rule-1")
+	secondRule := datadogV2.NewMonitorNotificationRuleDataWithDefaults()
+	secondRule.SetId("rule-2")
+
+	generator := &MonitorNotificationRuleGenerator{}
+	resources, err := generator.createResources([]datadogV2.MonitorNotificationRuleData{
+		*firstRule,
+		*secondRule,
+	})
+	if err != nil {
+		t.Fatalf("createResources returned error: %v", err)
+	}
+
+	if len(resources) != 2 {
+		t.Fatalf("resource count = %d, want %d", len(resources), 2)
+	}
+	if resources[0].ResourceName == resources[1].ResourceName {
+		t.Fatalf("resource names should be unique, got %q", resources[0].ResourceName)
+	}
+}
+
+func TestMonitorNotificationRulesFromRawData(t *testing.T) {
+	rules := monitorNotificationRulesFromRawData([]interface{}{
+		map[string]interface{}{
+			"id":   "rule-1",
+			"type": "monitor_notification_rule",
+		},
+		map[string]interface{}{
+			"id":   "rule-2",
+			"type": "monitor_notification_rule",
+		},
+		map[string]interface{}{
+			"type": "monitor_notification_rule",
+		},
+	})
+
+	if len(rules) != 2 {
+		t.Fatalf("rule count = %d, want %d", len(rules), 2)
+	}
+	if rules[0].GetId() != "rule-1" {
+		t.Fatalf("first rule ID = %q, want %q", rules[0].GetId(), "rule-1")
+	}
+	if rules[1].GetId() != "rule-2" {
+		t.Fatalf("second rule ID = %q, want %q", rules[1].GetId(), "rule-2")
+	}
+}


### PR DESCRIPTION
Summary
- Add Terraformer import support for Datadog monitor notification rules.
- Support ID-filtered imports and unfiltered imports through the Datadog monitor notification rule list API.
- Document the Datadog provider version requirement for the resource.

Notes
- Seeds resources by rule ID so the Datadog provider can refresh full rule state.
- Paginates list calls and closes API response bodies.
