### PR TITLE
fix(gcp): return cloud dns page errors

### DIFF
--- a/providers/gcp/clouddns.go
+++ b/providers/gcp/clouddns.go
@@ -5,7 +5,6 @@ package gcp
 import (
 	"context"
 	"fmt"
-	"log"
 	"strings"
 
 	"github.com/chenrui333/terraformer/terraformutils"
@@ -21,7 +20,7 @@ type CloudDNSGenerator struct {
 	GCPService
 }
 
-func (g CloudDNSGenerator) createZonesResources(ctx context.Context, svc *dns.Service, project string) []terraformutils.Resource {
+func (g CloudDNSGenerator) createZonesResources(ctx context.Context, svc *dns.Service, project string) ([]terraformutils.Resource, error) {
 	resources := []terraformutils.Resource{}
 	managedZonesListCall := svc.ManagedZones.List(project)
 	err := managedZonesListCall.Pages(ctx, func(listDNS *dns.ManagedZonesListResponse) error {
@@ -38,18 +37,21 @@ func (g CloudDNSGenerator) createZonesResources(ctx context.Context, svc *dns.Se
 				cloudDNSAllowEmptyValues,
 				cloudDNSAdditionalFields,
 			))
-			records := g.createRecordsResources(ctx, svc, project, zone.Name)
+			records, err := g.createRecordsResources(ctx, svc, project, zone.Name)
+			if err != nil {
+				return err
+			}
 			resources = append(resources, records...)
 		}
 		return nil
 	})
 	if err != nil {
-		log.Println(err)
-		return []terraformutils.Resource{}
+		return nil, fmt.Errorf("list dns managed zones: %w", err)
 	}
-	return resources
+	return resources, nil
 }
-func (g CloudDNSGenerator) createRecordsResources(ctx context.Context, svc *dns.Service, project, zoneName string) []terraformutils.Resource {
+
+func (g CloudDNSGenerator) createRecordsResources(ctx context.Context, svc *dns.Service, project, zoneName string) ([]terraformutils.Resource, error) {
 	resources := []terraformutils.Resource{}
 	managedRecordsListCall := svc.ResourceRecordSets.List(project, zoneName)
 	err := managedRecordsListCall.Pages(ctx, func(listDNS *dns.ResourceRecordSetsListResponse) error {
@@ -72,10 +74,9 @@ func (g CloudDNSGenerator) createRecordsResources(ctx context.Context, svc *dns.
 		return nil
 	})
 	if err != nil {
-		log.Println(err)
-		return []terraformutils.Resource{}
+		return nil, fmt.Errorf("list dns records for %s: %w", zoneName, err)
 	}
-	return resources
+	return resources, nil
 }
 
 // Generate TerraformResources from GCP API,
@@ -88,7 +89,11 @@ func (g *CloudDNSGenerator) InitResources() error {
 		return err
 	}
 
-	g.Resources = g.createZonesResources(ctx, svc, project)
+	resources, err := g.createZonesResources(ctx, svc, project)
+	if err != nil {
+		return err
+	}
+	g.Resources = resources
 	return nil
 }
 

--- a/providers/gcp/clouddns_test.go
+++ b/providers/gcp/clouddns_test.go
@@ -1,0 +1,64 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package gcp
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"google.golang.org/api/dns/v1"
+	"google.golang.org/api/option"
+)
+
+func TestCreateZonesResourcesReturnsManagedZoneListError(t *testing.T) {
+	ctx := context.Background()
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		http.Error(w, "{\"error\":{\"message\":\"service unavailable\"}}", http.StatusServiceUnavailable)
+	}))
+	t.Cleanup(server.Close)
+
+	dnsService := newTestDNSService(ctx, t, server.URL+"/")
+	_, err := (CloudDNSGenerator{}).createZonesResources(ctx, dnsService, "test-project")
+	if err == nil {
+		t.Fatal("expected dns managed zone list error")
+	}
+	if !strings.Contains(err.Error(), "list dns managed zones") {
+		t.Fatalf("expected wrapped dns managed zone list error, got %q", err)
+	}
+}
+
+func TestCreateZonesResourcesReturnsRecordListError(t *testing.T) {
+	ctx := context.Background()
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if strings.Contains(r.URL.Path, "/rrsets") {
+			http.Error(w, "{\"error\":{\"message\":\"service unavailable\"}}", http.StatusServiceUnavailable)
+			return
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte("{\"managedZones\":[{\"name\":\"test-zone\"}]}"))
+	}))
+	t.Cleanup(server.Close)
+
+	dnsService := newTestDNSService(ctx, t, server.URL+"/")
+	_, err := (CloudDNSGenerator{}).createZonesResources(ctx, dnsService, "test-project")
+	if err == nil {
+		t.Fatal("expected dns record list error")
+	}
+	if !strings.Contains(err.Error(), "list dns records for test-zone") {
+		t.Fatalf("expected wrapped dns record list error, got %q", err)
+	}
+}
+
+func newTestDNSService(ctx context.Context, t *testing.T, endpoint string) *dns.Service {
+	t.Helper()
+
+	dnsService, err := dns.NewService(ctx, option.WithEndpoint(endpoint), option.WithoutAuthentication())
+	if err != nil {
+		t.Fatal(err)
+	}
+	return dnsService
+}


### PR DESCRIPTION
## Summary

- Return Cloud DNS managed-zone pagination errors instead of logging and continuing with empty resources.
- Propagate nested record-set pagination errors while discovering managed zones.
- Add regression coverage for both Cloud DNS listing failure paths.
