### PR TITLE
fix(gcp): return pubsub page errors

### DIFF
--- a/providers/gcp/pubsub.go
+++ b/providers/gcp/pubsub.go
@@ -4,7 +4,7 @@ package gcp
 
 import (
 	"context"
-	"log"
+	"fmt"
 	"strings"
 
 	"google.golang.org/api/pubsub/v1"
@@ -21,7 +21,7 @@ type PubsubGenerator struct {
 }
 
 // Run on subscriptionsList and create for each TerraformResource
-func (g PubsubGenerator) createSubscriptionsResources(ctx context.Context, subscriptionsList *pubsub.ProjectsSubscriptionsListCall) []terraformutils.Resource {
+func (g PubsubGenerator) createSubscriptionsResources(ctx context.Context, subscriptionsList *pubsub.ProjectsSubscriptionsListCall) ([]terraformutils.Resource, error) {
 	resources := []terraformutils.Resource{}
 	if err := subscriptionsList.Pages(ctx, func(page *pubsub.ListSubscriptionsResponse) error {
 		for _, obj := range page.Subscriptions {
@@ -42,13 +42,13 @@ func (g PubsubGenerator) createSubscriptionsResources(ctx context.Context, subsc
 		}
 		return nil
 	}); err != nil {
-		log.Println(err)
+		return nil, fmt.Errorf("list pubsub subscriptions: %w", err)
 	}
-	return resources
+	return resources, nil
 }
 
 // Run on topicsList and create for each TerraformResource
-func (g PubsubGenerator) createTopicsListResources(ctx context.Context, topicsList *pubsub.ProjectsTopicsListCall) []terraformutils.Resource {
+func (g PubsubGenerator) createTopicsListResources(ctx context.Context, topicsList *pubsub.ProjectsTopicsListCall) ([]terraformutils.Resource, error) {
 	resources := []terraformutils.Resource{}
 	if err := topicsList.Pages(ctx, func(page *pubsub.ListTopicsResponse) error {
 		for _, obj := range page.Topics {
@@ -69,9 +69,9 @@ func (g PubsubGenerator) createTopicsListResources(ctx context.Context, topicsLi
 		}
 		return nil
 	}); err != nil {
-		log.Println(err)
+		return nil, fmt.Errorf("list pubsub topics: %w", err)
 	}
-	return resources
+	return resources, nil
 }
 
 // Generate TerraformResources from GCP API,
@@ -83,10 +83,16 @@ func (g *PubsubGenerator) InitResources() error {
 	}
 
 	subscriptionsList := pubsubService.Projects.Subscriptions.List("projects/" + g.GetArgs()["project"].(string))
-	subscriptionsResources := g.createSubscriptionsResources(ctx, subscriptionsList)
+	subscriptionsResources, err := g.createSubscriptionsResources(ctx, subscriptionsList)
+	if err != nil {
+		return err
+	}
 
 	topicsList := pubsubService.Projects.Topics.List("projects/" + g.GetArgs()["project"].(string))
-	topicsResources := g.createTopicsListResources(ctx, topicsList)
+	topicsResources, err := g.createTopicsListResources(ctx, topicsList)
+	if err != nil {
+		return err
+	}
 
 	g.Resources = append(g.Resources, subscriptionsResources...)
 	g.Resources = append(g.Resources, topicsResources...)

--- a/providers/gcp/pubsub_test.go
+++ b/providers/gcp/pubsub_test.go
@@ -1,0 +1,58 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package gcp
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"google.golang.org/api/option"
+	"google.golang.org/api/pubsub/v1"
+)
+
+func TestCreateSubscriptionsResourcesReturnsListError(t *testing.T) {
+	ctx := context.Background()
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		http.Error(w, "{\"error\":{\"message\":\"service unavailable\"}}", http.StatusServiceUnavailable)
+	}))
+	t.Cleanup(server.Close)
+
+	pubsubService := newTestPubsubService(ctx, t, server.URL+"/")
+	_, err := (PubsubGenerator{}).createSubscriptionsResources(ctx, pubsubService.Projects.Subscriptions.List("projects/test-project"))
+	if err == nil {
+		t.Fatal("expected pubsub subscription list error")
+	}
+	if !strings.Contains(err.Error(), "list pubsub subscriptions") {
+		t.Fatalf("expected wrapped pubsub subscription list error, got %q", err)
+	}
+}
+
+func TestCreateTopicsListResourcesReturnsListError(t *testing.T) {
+	ctx := context.Background()
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		http.Error(w, "{\"error\":{\"message\":\"service unavailable\"}}", http.StatusServiceUnavailable)
+	}))
+	t.Cleanup(server.Close)
+
+	pubsubService := newTestPubsubService(ctx, t, server.URL+"/")
+	_, err := (PubsubGenerator{}).createTopicsListResources(ctx, pubsubService.Projects.Topics.List("projects/test-project"))
+	if err == nil {
+		t.Fatal("expected pubsub topic list error")
+	}
+	if !strings.Contains(err.Error(), "list pubsub topics") {
+		t.Fatalf("expected wrapped pubsub topic list error, got %q", err)
+	}
+}
+
+func newTestPubsubService(ctx context.Context, t *testing.T, endpoint string) *pubsub.Service {
+	t.Helper()
+
+	pubsubService, err := pubsub.NewService(ctx, option.WithEndpoint(endpoint), option.WithoutAuthentication())
+	if err != nil {
+		t.Fatal(err)
+	}
+	return pubsubService
+}


### PR DESCRIPTION
## Summary

- Return Pub/Sub subscription pagination errors instead of logging and continuing with partial resources.
- Return Pub/Sub topic pagination errors through provider initialization.
- Add regression coverage for both Pub/Sub listing failure paths.

