### PR TITLE
feat(datadog): add monitor config policy import

### DIFF
--- a/docs/datadog.md
+++ b/docs/datadog.md
@@ -133,6 +133,8 @@ Tag filters are order specific. For example, if your monitor has tags (in the or
         * **_NOTE:_** Importing resource requires resource ID's to be passed via [Filter][1] option
 *   `monitor`
     * `datadog_monitor`
+*   `monitor_config_policy`
+    * `datadog_monitor_config_policy`
 *   `monitor_notification_rule`
     * `datadog_monitor_notification_rule`
         * **_NOTE:_** Requires DataDog/datadog provider 3.83.0 or newer.

--- a/providers/datadog/datadog_provider.go
+++ b/providers/datadog/datadog_provider.go
@@ -170,6 +170,7 @@ func (p *DatadogProvider) GetSupportedService() map[string]terraformutils.Servic
 		"integration_slack_channel":            &IntegrationSlackChannelGenerator{},
 		"metric_metadata":                      &MetricMetadataGenerator{},
 		"monitor":                              &MonitorGenerator{},
+		"monitor_config_policy":                &MonitorConfigPolicyGenerator{},
 		"monitor_notification_rule":            &MonitorNotificationRuleGenerator{},
 		"security_monitoring_default_rule":     &SecurityMonitoringDefaultRuleGenerator{},
 		"security_monitoring_rule":             &SecurityMonitoringRuleGenerator{},

--- a/providers/datadog/monitor_config_policy.go
+++ b/providers/datadog/monitor_config_policy.go
@@ -1,0 +1,171 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package datadog
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/DataDog/datadog-api-client-go/v2/api/datadog"
+	"github.com/DataDog/datadog-api-client-go/v2/api/datadogV2"
+
+	"github.com/chenrui333/terraformer/terraformutils"
+)
+
+var (
+	// MonitorConfigPolicyAllowEmptyValues ...
+	MonitorConfigPolicyAllowEmptyValues = []string{}
+)
+
+// MonitorConfigPolicyGenerator ...
+type MonitorConfigPolicyGenerator struct {
+	DatadogService
+}
+
+func (g *MonitorConfigPolicyGenerator) createResources(monitorConfigPolicies []datadogV2.MonitorConfigPolicyResponseData) ([]terraformutils.Resource, error) {
+	resources := []terraformutils.Resource{}
+	for _, monitorConfigPolicy := range monitorConfigPolicies {
+		resource, err := g.createResource(monitorConfigPolicy)
+		if err != nil {
+			return nil, err
+		}
+		resources = append(resources, resource)
+	}
+
+	return resources, nil
+}
+
+func (g *MonitorConfigPolicyGenerator) createResource(monitorConfigPolicy datadogV2.MonitorConfigPolicyResponseData) (terraformutils.Resource, error) {
+	policyID := monitorConfigPolicy.GetId()
+	if policyID == "" {
+		return terraformutils.Resource{}, fmt.Errorf("monitor config policy missing id")
+	}
+
+	return terraformutils.NewSimpleResource(
+		policyID,
+		fmt.Sprintf("monitor_config_policy_%s", policyID),
+		"datadog_monitor_config_policy",
+		"datadog",
+		MonitorConfigPolicyAllowEmptyValues,
+	), nil
+}
+
+// InitResources Generate TerraformResources from Datadog API,
+// from each monitor config policy create 1 TerraformResource.
+func (g *MonitorConfigPolicyGenerator) InitResources() error {
+	datadogClient := g.Args["datadogClient"].(*datadog.APIClient)
+	auth := g.Args["auth"].(context.Context)
+	api := datadogV2.NewMonitorsApi(datadogClient)
+
+	resources, filtered, err := g.filteredResources(auth, api)
+	if err != nil {
+		return err
+	}
+	if filtered {
+		g.Resources = resources
+		return nil
+	}
+
+	monitorConfigPolicies, err := listMonitorConfigPolicies(auth, api)
+	if err != nil {
+		return err
+	}
+	resources, err = g.createResources(monitorConfigPolicies)
+	if err != nil {
+		return err
+	}
+
+	g.Resources = resources
+	return nil
+}
+
+func (g *MonitorConfigPolicyGenerator) filteredResources(auth context.Context, api *datadogV2.MonitorsApi) ([]terraformutils.Resource, bool, error) {
+	resources := []terraformutils.Resource{}
+	filtered := false
+
+	for _, filter := range g.Filter {
+		if filter.FieldPath != "id" || !filter.IsApplicable("monitor_config_policy") {
+			continue
+		}
+
+		filtered = true
+		for _, value := range filter.AcceptableValues {
+			monitorConfigPolicy, err := getMonitorConfigPolicy(auth, api, value)
+			if err != nil {
+				return nil, true, err
+			}
+			resource, err := g.createResource(monitorConfigPolicy)
+			if err != nil {
+				return nil, true, err
+			}
+			resources = append(resources, resource)
+		}
+	}
+
+	return resources, filtered, nil
+}
+
+func getMonitorConfigPolicy(auth context.Context, api *datadogV2.MonitorsApi, policyID string) (datadogV2.MonitorConfigPolicyResponseData, error) {
+	response, httpResponse, err := api.GetMonitorConfigPolicy(auth, policyID)
+	defer closeDatadogResponseBody(httpResponse)
+	if err != nil {
+		return datadogV2.MonitorConfigPolicyResponseData{}, err
+	}
+
+	if policy, ok := response.GetDataOk(); ok {
+		return *policy, nil
+	}
+	if policy, ok := monitorConfigPolicyFromRawData(response.UnparsedObject["data"]); ok {
+		return policy, nil
+	}
+
+	return datadogV2.MonitorConfigPolicyResponseData{}, fmt.Errorf("monitor config policy %q not found", policyID)
+}
+
+func listMonitorConfigPolicies(auth context.Context, api *datadogV2.MonitorsApi) ([]datadogV2.MonitorConfigPolicyResponseData, error) {
+	response, httpResponse, err := api.ListMonitorConfigPolicies(auth)
+	defer closeDatadogResponseBody(httpResponse)
+	if err != nil {
+		return nil, err
+	}
+
+	policies := response.GetData()
+	if len(policies) == 0 {
+		policies = monitorConfigPoliciesFromRawData(response.UnparsedObject["data"])
+	}
+
+	return policies, nil
+}
+
+func monitorConfigPoliciesFromRawData(rawData interface{}) []datadogV2.MonitorConfigPolicyResponseData {
+	rawPolicies, ok := rawData.([]interface{})
+	if !ok {
+		return nil
+	}
+
+	monitorConfigPolicies := []datadogV2.MonitorConfigPolicyResponseData{}
+	for _, rawPolicy := range rawPolicies {
+		monitorConfigPolicy, ok := monitorConfigPolicyFromRawData(rawPolicy)
+		if !ok {
+			continue
+		}
+		monitorConfigPolicies = append(monitorConfigPolicies, monitorConfigPolicy)
+	}
+	return monitorConfigPolicies
+}
+
+func monitorConfigPolicyFromRawData(rawData interface{}) (datadogV2.MonitorConfigPolicyResponseData, bool) {
+	rawPolicy, ok := rawData.(map[string]interface{})
+	if !ok {
+		return datadogV2.MonitorConfigPolicyResponseData{}, false
+	}
+
+	rawPolicyID, ok := rawPolicy["id"].(string)
+	if !ok || rawPolicyID == "" {
+		return datadogV2.MonitorConfigPolicyResponseData{}, false
+	}
+
+	monitorConfigPolicy := datadogV2.NewMonitorConfigPolicyResponseDataWithDefaults()
+	monitorConfigPolicy.SetId(rawPolicyID)
+	return *monitorConfigPolicy, true
+}

--- a/providers/datadog/monitor_config_policy_test.go
+++ b/providers/datadog/monitor_config_policy_test.go
@@ -1,0 +1,87 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package datadog
+
+import (
+	"testing"
+
+	"github.com/DataDog/datadog-api-client-go/v2/api/datadogV2"
+)
+
+func TestMonitorConfigPolicyCreateResource(t *testing.T) {
+	monitorConfigPolicy := datadogV2.NewMonitorConfigPolicyResponseDataWithDefaults()
+	monitorConfigPolicy.SetId("policy-id")
+
+	generator := &MonitorConfigPolicyGenerator{}
+	resource, err := generator.createResource(*monitorConfigPolicy)
+	if err != nil {
+		t.Fatalf("createResource returned error: %v", err)
+	}
+
+	if resource.InstanceState.ID != "policy-id" {
+		t.Fatalf("resource ID = %q, want %q", resource.InstanceState.ID, "policy-id")
+	}
+	if resource.ResourceName != "tfer--monitor_config_policy_policy-id" {
+		t.Fatalf("resource name = %q, want %q", resource.ResourceName, "tfer--monitor_config_policy_policy-id")
+	}
+	if resource.InstanceInfo.Type != "datadog_monitor_config_policy" {
+		t.Fatalf("resource type = %q, want %q", resource.InstanceInfo.Type, "datadog_monitor_config_policy")
+	}
+}
+
+func TestMonitorConfigPolicyCreateResourceMissingID(t *testing.T) {
+	generator := &MonitorConfigPolicyGenerator{}
+	_, err := generator.createResource(datadogV2.MonitorConfigPolicyResponseData{})
+	if err == nil {
+		t.Fatal("createResource returned nil error, want missing id error")
+	}
+}
+
+func TestMonitorConfigPolicyCreateResources(t *testing.T) {
+	firstPolicy := datadogV2.NewMonitorConfigPolicyResponseDataWithDefaults()
+	firstPolicy.SetId("policy-1")
+	secondPolicy := datadogV2.NewMonitorConfigPolicyResponseDataWithDefaults()
+	secondPolicy.SetId("policy-2")
+
+	generator := &MonitorConfigPolicyGenerator{}
+	resources, err := generator.createResources([]datadogV2.MonitorConfigPolicyResponseData{
+		*firstPolicy,
+		*secondPolicy,
+	})
+	if err != nil {
+		t.Fatalf("createResources returned error: %v", err)
+	}
+
+	if len(resources) != 2 {
+		t.Fatalf("resource count = %d, want %d", len(resources), 2)
+	}
+	if resources[0].ResourceName == resources[1].ResourceName {
+		t.Fatalf("resource names should be unique, got %q", resources[0].ResourceName)
+	}
+}
+
+func TestMonitorConfigPoliciesFromRawData(t *testing.T) {
+	policies := monitorConfigPoliciesFromRawData([]interface{}{
+		map[string]interface{}{
+			"id":   "policy-1",
+			"type": "monitor_config_policy",
+		},
+		map[string]interface{}{
+			"id":   "policy-2",
+			"type": "monitor_config_policy",
+		},
+		map[string]interface{}{
+			"type": "monitor_config_policy",
+		},
+	})
+
+	if len(policies) != 2 {
+		t.Fatalf("policy count = %d, want %d", len(policies), 2)
+	}
+	if policies[0].GetId() != "policy-1" {
+		t.Fatalf("first policy ID = %q, want %q", policies[0].GetId(), "policy-1")
+	}
+	if policies[1].GetId() != "policy-2" {
+		t.Fatalf("second policy ID = %q, want %q", policies[1].GetId(), "policy-2")
+	}
+}


### PR DESCRIPTION
Summary
- Add Terraformer import support for Datadog monitor config policies.
- Support ID-filtered imports and unfiltered imports through the Datadog monitor config policy list API.
- Document the new Datadog resource in the provider docs.

Notes
- Seeds resources by policy ID so the Datadog provider can refresh full policy state.
- Closes Datadog SDK response bodies on both lookup and list paths.
