### PR TITLE
feat(launchdarkly): add view resources

### DIFF
--- a/docs/launchdarkly.md
+++ b/docs/launchdarkly.md
@@ -4,7 +4,7 @@ Example:
 
 ```
 export LAUNCHDARKLY_ACCESS_TOKEN=[LAUNCHDARKLY_ACCESS_TOKEN]
-./terraformer import launchdarkly -r aiConfig,aiConfigVariation,aiTool,auditLogSubscription,customRole,destination,environment,featureFlag,flagTemplates,flagTrigger,metric,modelConfig,relayProxyConfiguration,segment,team,teamMember,webhook
+./terraformer import launchdarkly -r aiConfig,aiConfigVariation,aiTool,auditLogSubscription,customRole,destination,environment,featureFlag,flagTemplates,flagTrigger,metric,modelConfig,relayProxyConfiguration,segment,team,teamMember,view,viewLinks,webhook
 ```
 
 Use `project` separately when you want LaunchDarkly environments managed as nested
@@ -49,5 +49,9 @@ List of supported LaunchDarkly resources:
     * `launchdarkly_team`
 *   `teamMember`
     * `launchdarkly_team_member`
+*   `view`
+    * `launchdarkly_view`
+*   `viewLinks`
+    * `launchdarkly_view_links`
 *   `webhook`
     * `launchdarkly_webhook`

--- a/docs/launchdarkly.md
+++ b/docs/launchdarkly.md
@@ -4,13 +4,18 @@ Example:
 
 ```
 export LAUNCHDARKLY_ACCESS_TOKEN=[LAUNCHDARKLY_ACCESS_TOKEN]
-./terraformer import launchdarkly -r aiConfig,aiConfigVariation,aiTool,auditLogSubscription,customRole,destination,environment,featureFlag,flagTemplates,flagTrigger,metric,modelConfig,relayProxyConfiguration,segment,team,teamMember,view,viewLinks,webhook
+./terraformer import launchdarkly -r aiConfig,aiConfigVariation,aiTool,auditLogSubscription,customRole,destination,environment,featureFlag,flagTemplates,flagTrigger,metric,modelConfig,relayProxyConfiguration,segment,team,teamMember,view,webhook
 ```
 
 Use `project` separately when you want LaunchDarkly environments managed as nested
 `launchdarkly_project` blocks. Avoid importing `project` and `environment` together,
 because that can generate both nested and standalone resources for the same
 environments.
+
+Use `viewLinks` separately when you want LaunchDarkly view associations managed
+as centralized `launchdarkly_view_links` blocks. Avoid importing `viewLinks`
+together with `featureFlag` or `segment`, because those resources can manage the
+same associations through `view_keys`.
 
 List of supported LaunchDarkly resources:
 

--- a/providers/launchdarkly/launchdarkly_provider.go
+++ b/providers/launchdarkly/launchdarkly_provider.go
@@ -74,6 +74,8 @@ func (p *LaunchDarklyProvider) GetSupportedService() map[string]terraformutils.S
 		"segment":                 &SegmentGenerator{},
 		"team":                    &TeamGenerator{},
 		"teamMember":              &TeamMemberGenerator{},
+		"view":                    &ViewGenerator{},
+		"viewLinks":               &ViewLinksGenerator{},
 		"webhook":                 &WebhookGenerator{},
 	}
 }

--- a/providers/launchdarkly/view.go
+++ b/providers/launchdarkly/view.go
@@ -20,6 +20,10 @@ type ViewLinksGenerator struct {
 	LaunchDarklyService
 }
 
+func newLaunchDarklyViewAPIClient() *ldapi.APIClient {
+	return ldapi.NewAPIClient(ldapi.NewConfiguration())
+}
+
 func getViews(ctx context.Context, client *ldapi.APIClient, projectKey string) ([]ldapi.View, error) {
 	var allViews []ldapi.View
 	for offset := int32(0); ; offset += pageSize {
@@ -94,13 +98,14 @@ func (g *ViewGenerator) loadViews(ctx context.Context, client *ldapi.APIClient, 
 func (g *ViewGenerator) InitResources() error {
 	ctx := g.GetArgs()["ctx"].(context.Context)
 	client := g.GetArgs()["client"].(*ldapi.APIClient)
+	viewClient := newLaunchDarklyViewAPIClient()
 
 	projects, err := getProjects(ctx, client)
 	if err != nil {
 		return err
 	}
 	for _, project := range projects {
-		if err := g.loadViews(ctx, client, project.Key); err != nil {
+		if err := g.loadViews(ctx, viewClient, project.Key); err != nil {
 			return err
 		}
 	}
@@ -144,13 +149,14 @@ func (g *ViewLinksGenerator) loadViewLinks(ctx context.Context, client *ldapi.AP
 func (g *ViewLinksGenerator) InitResources() error {
 	ctx := g.GetArgs()["ctx"].(context.Context)
 	client := g.GetArgs()["client"].(*ldapi.APIClient)
+	viewClient := newLaunchDarklyViewAPIClient()
 
 	projects, err := getProjects(ctx, client)
 	if err != nil {
 		return err
 	}
 	for _, project := range projects {
-		if err := g.loadViewLinks(ctx, client, project.Key); err != nil {
+		if err := g.loadViewLinks(ctx, viewClient, project.Key); err != nil {
 			return err
 		}
 	}

--- a/providers/launchdarkly/view.go
+++ b/providers/launchdarkly/view.go
@@ -1,0 +1,158 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package launchdarkly
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/chenrui333/terraformer/terraformutils"
+	ldapi "github.com/launchdarkly/api-client-go/v22"
+)
+
+const launchDarklyViewAPIVersion = "beta"
+
+type ViewGenerator struct {
+	LaunchDarklyService
+}
+
+type ViewLinksGenerator struct {
+	LaunchDarklyService
+}
+
+func getViews(ctx context.Context, client *ldapi.APIClient, projectKey string) ([]ldapi.View, error) {
+	var allViews []ldapi.View
+	for offset := int32(0); ; offset += pageSize {
+		views, resp, err := client.ViewsBetaApi.GetViews(ctx, projectKey).
+			LDAPIVersion(launchDarklyViewAPIVersion).
+			Limit(pageSize).
+			Offset(offset).
+			Execute()
+		closeResponseBody(resp)
+		if err != nil {
+			return nil, err
+		}
+		if views == nil {
+			break
+		}
+		items := views.GetItems()
+		allViews = append(allViews, items...)
+		if len(items) == 0 || int64(len(allViews)) >= int64(views.GetTotalCount()) {
+			break
+		}
+	}
+	return allViews, nil
+}
+
+func getViewLinkedResources(ctx context.Context, client *ldapi.APIClient, projectKey, viewKey, resourceType string) ([]ldapi.ViewLinkedResource, error) {
+	var allResources []ldapi.ViewLinkedResource
+	for offset := int32(0); ; offset += pageSize {
+		resources, resp, err := client.ViewsBetaApi.GetLinkedResources(ctx, projectKey, viewKey, resourceType).
+			LDAPIVersion(launchDarklyViewAPIVersion).
+			Limit(pageSize).
+			Offset(offset).
+			Execute()
+		closeResponseBody(resp)
+		if err != nil {
+			return nil, err
+		}
+		if resources == nil {
+			break
+		}
+		items := resources.GetItems()
+		allResources = append(allResources, items...)
+		if len(items) == 0 || int64(len(allResources)) >= int64(resources.GetTotalCount()) {
+			break
+		}
+	}
+	return allResources, nil
+}
+
+func (g *ViewGenerator) loadViews(ctx context.Context, client *ldapi.APIClient, projectKey string) error {
+	views, err := getViews(ctx, client, projectKey)
+	if err != nil {
+		return err
+	}
+	for _, view := range views {
+		viewKey := view.GetKey()
+		resource := terraformutils.NewResource(
+			fmt.Sprintf("%s/%s", projectKey, viewKey),
+			launchDarklyProjectResourceName(projectKey, view.GetName(), viewKey),
+			"launchdarkly_view",
+			"launchdarkly",
+			map[string]string{
+				"project_key": projectKey,
+				"key":         viewKey,
+			},
+			[]string{},
+			map[string]interface{}{})
+		g.Resources = append(g.Resources, resource)
+	}
+	return nil
+}
+
+func (g *ViewGenerator) InitResources() error {
+	ctx := g.GetArgs()["ctx"].(context.Context)
+	client := g.GetArgs()["client"].(*ldapi.APIClient)
+
+	projects, err := getProjects(ctx, client)
+	if err != nil {
+		return err
+	}
+	for _, project := range projects {
+		if err := g.loadViews(ctx, client, project.Key); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (g *ViewLinksGenerator) loadViewLinks(ctx context.Context, client *ldapi.APIClient, projectKey string) error {
+	views, err := getViews(ctx, client, projectKey)
+	if err != nil {
+		return err
+	}
+	for _, view := range views {
+		viewKey := view.GetKey()
+		linkedFlags, err := getViewLinkedResources(ctx, client, projectKey, viewKey, "flags")
+		if err != nil {
+			return err
+		}
+		linkedSegments, err := getViewLinkedResources(ctx, client, projectKey, viewKey, "segments")
+		if err != nil {
+			return err
+		}
+		if len(linkedFlags) == 0 && len(linkedSegments) == 0 {
+			continue
+		}
+		resource := terraformutils.NewResource(
+			fmt.Sprintf("%s/%s", projectKey, viewKey),
+			fmt.Sprintf("%s-%s-links", projectKey, viewKey),
+			"launchdarkly_view_links",
+			"launchdarkly",
+			map[string]string{
+				"project_key": projectKey,
+				"view_key":    viewKey,
+			},
+			[]string{},
+			map[string]interface{}{})
+		g.Resources = append(g.Resources, resource)
+	}
+	return nil
+}
+
+func (g *ViewLinksGenerator) InitResources() error {
+	ctx := g.GetArgs()["ctx"].(context.Context)
+	client := g.GetArgs()["client"].(*ldapi.APIClient)
+
+	projects, err := getProjects(ctx, client)
+	if err != nil {
+		return err
+	}
+	for _, project := range projects {
+		if err := g.loadViewLinks(ctx, client, project.Key); err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/providers/launchdarkly/view_test.go
+++ b/providers/launchdarkly/view_test.go
@@ -1,0 +1,57 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package launchdarkly
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	ldapi "github.com/launchdarkly/api-client-go/v22"
+)
+
+func TestViewClientUsesOnlyBetaAPIVersion(t *testing.T) {
+	tests := []struct {
+		name string
+		run  func(context.Context, *ldapi.APIClient) error
+	}{
+		{
+			name: "views",
+			run: func(ctx context.Context, client *ldapi.APIClient) error {
+				_, err := getViews(ctx, client, "project")
+				return err
+			},
+		},
+		{
+			name: "linked resources",
+			run: func(ctx context.Context, client *ldapi.APIClient) error {
+				_, err := getViewLinkedResources(ctx, client, "project", "view", "flags")
+				return err
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var apiVersions []string
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				apiVersions = r.Header.Values("LD-API-Version")
+				w.Header().Set("Content-Type", "application/json")
+				_, _ = w.Write([]byte(`{"items":[],"totalCount":0}`))
+			}))
+			defer server.Close()
+
+			client := newLaunchDarklyViewAPIClient()
+			client.GetConfig().Servers = ldapi.ServerConfigurations{{URL: server.URL}}
+
+			if err := tt.run(context.Background(), client); err != nil {
+				t.Fatalf("view beta request returned error: %v", err)
+			}
+
+			if len(apiVersions) != 1 || apiVersions[0] != launchDarklyViewAPIVersion {
+				t.Fatalf("expected only LD-API-Version %q, got %q", launchDarklyViewAPIVersion, apiVersions)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Summary
- add LaunchDarkly view import support
- add LaunchDarkly view link import support for views with linked flags or segments
- document the new view resource groups

Notes
- view filter links are not included because the API exposes resolved links, not the original filter expressions needed to recreate that resource
