### PR TITLE
fix(gcp): return bigquery page errors

### DIFF
--- a/providers/gcp/bigquery.go
+++ b/providers/gcp/bigquery.go
@@ -4,7 +4,7 @@ package gcp
 
 import (
 	"context"
-	"log"
+	"fmt"
 	"strings"
 
 	"github.com/chenrui333/terraformer/terraformutils"
@@ -18,7 +18,7 @@ type BigQueryGenerator struct {
 }
 
 // Run on datasetsList and create for each TerraformResource
-func (g BigQueryGenerator) createDatasets(ctx context.Context, dataSetsList *bigquery.DatasetsListCall, bigQueryService *bigquery.Service) []terraformutils.Resource {
+func (g BigQueryGenerator) createDatasets(ctx context.Context, dataSetsList *bigquery.DatasetsListCall, bigQueryService *bigquery.Service) ([]terraformutils.Resource, error) {
 	resources := []terraformutils.Resource{}
 	if err := dataSetsList.Pages(ctx, func(page *bigquery.DatasetList) error {
 		for _, dataset := range page.Datasets {
@@ -39,16 +39,20 @@ func (g BigQueryGenerator) createDatasets(ctx context.Context, dataSetsList *big
 				bigQueryAllowEmptyValues,
 				map[string]interface{}{},
 			))
-			resources = append(resources, g.createResourcesTables(ctx, ID, bigQueryService)...)
+			tableResources, err := g.createResourcesTables(ctx, ID, bigQueryService)
+			if err != nil {
+				return err
+			}
+			resources = append(resources, tableResources...)
 		}
 		return nil
 	}); err != nil {
-		log.Println(err)
+		return nil, fmt.Errorf("list bigquery datasets: %w", err)
 	}
-	return resources
+	return resources, nil
 }
 
-func (g *BigQueryGenerator) createResourcesTables(ctx context.Context, datasetID string, bigQueryService *bigquery.Service) []terraformutils.Resource {
+func (g *BigQueryGenerator) createResourcesTables(ctx context.Context, datasetID string, bigQueryService *bigquery.Service) ([]terraformutils.Resource, error) {
 	resources := []terraformutils.Resource{}
 	tableList := bigQueryService.Tables.List(g.Args["project"].(string), datasetID)
 	if err := tableList.Pages(ctx, func(page *bigquery.TableList) error {
@@ -74,9 +78,9 @@ func (g *BigQueryGenerator) createResourcesTables(ctx context.Context, datasetID
 		}
 		return nil
 	}); err != nil {
-		log.Println(err)
+		return nil, fmt.Errorf("list bigquery tables for %s: %w", datasetID, err)
 	}
-	return resources
+	return resources, nil
 }
 
 // Generate TerraformResources from GCP API,
@@ -89,7 +93,11 @@ func (g *BigQueryGenerator) InitResources() error {
 
 	datasetsList := bigQueryService.Datasets.List(g.GetArgs()["project"].(string))
 
-	g.Resources = g.createDatasets(ctx, datasetsList, bigQueryService)
+	resources, err := g.createDatasets(ctx, datasetsList, bigQueryService)
+	if err != nil {
+		return err
+	}
+	g.Resources = resources
 	return nil
 }
 

--- a/providers/gcp/bigquery_test.go
+++ b/providers/gcp/bigquery_test.go
@@ -1,0 +1,67 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package gcp
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"google.golang.org/api/bigquery/v2"
+	"google.golang.org/api/option"
+)
+
+func TestCreateDatasetsReturnsDatasetListError(t *testing.T) {
+	ctx := context.Background()
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		http.Error(w, "{\"error\":{\"message\":\"service unavailable\"}}", http.StatusServiceUnavailable)
+	}))
+	t.Cleanup(server.Close)
+
+	bigQueryService := newTestBigQueryService(ctx, t, server.URL+"/")
+	_, err := (BigQueryGenerator{}).createDatasets(ctx, bigQueryService.Datasets.List("test-project"), bigQueryService)
+	if err == nil {
+		t.Fatal("expected bigquery dataset list error")
+	}
+	if !strings.Contains(err.Error(), "list bigquery datasets") {
+		t.Fatalf("expected wrapped bigquery dataset list error, got %q", err)
+	}
+}
+
+func TestCreateDatasetsReturnsTableListError(t *testing.T) {
+	ctx := context.Background()
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if strings.Contains(r.URL.Path, "/tables") {
+			http.Error(w, "{\"error\":{\"message\":\"service unavailable\"}}", http.StatusServiceUnavailable)
+			return
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte("{\"datasets\":[{\"id\":\"test-project:test_dataset\"}]}"))
+	}))
+	t.Cleanup(server.Close)
+
+	bigQueryService := newTestBigQueryService(ctx, t, server.URL+"/")
+	g := BigQueryGenerator{}
+	g.SetArgs(map[string]interface{}{"project": "test-project"})
+
+	_, err := g.createDatasets(ctx, bigQueryService.Datasets.List("test-project"), bigQueryService)
+	if err == nil {
+		t.Fatal("expected bigquery table list error")
+	}
+	if !strings.Contains(err.Error(), "list bigquery tables for test_dataset") {
+		t.Fatalf("expected wrapped bigquery table list error, got %q", err)
+	}
+}
+
+func newTestBigQueryService(ctx context.Context, t *testing.T, endpoint string) *bigquery.Service {
+	t.Helper()
+
+	bigQueryService, err := bigquery.NewService(ctx, option.WithEndpoint(endpoint), option.WithoutAuthentication())
+	if err != nil {
+		t.Fatal(err)
+	}
+	return bigQueryService
+}


### PR DESCRIPTION
## Summary

- Return BigQuery dataset pagination errors instead of logging and continuing with partial resources.
- Propagate nested table pagination errors while discovering datasets.
- Add regression coverage for both BigQuery listing failure paths.
