### PR TITLE
feat(datadog): add metric tag configuration import

### DIFF
--- a/docs/datadog.md
+++ b/docs/datadog.md
@@ -131,6 +131,8 @@ Tag filters are order specific. For example, if your monitor has tags (in the or
 *   `metric_metadata`
     * `datadog_metric_metadata`
         * **_NOTE:_** Importing resource requires resource ID's to be passed via [Filter][1] option
+*   `metric_tag_configuration`
+    * `datadog_metric_tag_configuration`
 *   `monitor`
     * `datadog_monitor`
 *   `monitor_config_policy`

--- a/providers/datadog/datadog_provider.go
+++ b/providers/datadog/datadog_provider.go
@@ -169,6 +169,7 @@ func (p *DatadogProvider) GetSupportedService() map[string]terraformutils.Servic
 		"integration_pagerduty_service_object": &IntegrationPagerdutyServiceObjectGenerator{},
 		"integration_slack_channel":            &IntegrationSlackChannelGenerator{},
 		"metric_metadata":                      &MetricMetadataGenerator{},
+		"metric_tag_configuration":             &MetricTagConfigurationGenerator{},
 		"monitor":                              &MonitorGenerator{},
 		"monitor_config_policy":                &MonitorConfigPolicyGenerator{},
 		"monitor_notification_rule":            &MonitorNotificationRuleGenerator{},

--- a/providers/datadog/metric_tag_configuration.go
+++ b/providers/datadog/metric_tag_configuration.go
@@ -1,0 +1,243 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package datadog
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/DataDog/datadog-api-client-go/v2/api/datadog"
+	"github.com/DataDog/datadog-api-client-go/v2/api/datadogV2"
+
+	"github.com/chenrui333/terraformer/terraformutils"
+)
+
+var (
+	// MetricTagConfigurationAllowEmptyValues ...
+	MetricTagConfigurationAllowEmptyValues = []string{}
+)
+
+// MetricTagConfigurationGenerator ...
+type MetricTagConfigurationGenerator struct {
+	DatadogService
+}
+
+func (g *MetricTagConfigurationGenerator) createResources(metricTagConfigurations []datadogV2.MetricTagConfiguration) ([]terraformutils.Resource, error) {
+	resources := []terraformutils.Resource{}
+	for _, metricTagConfiguration := range metricTagConfigurations {
+		resource, err := g.createResource(metricTagConfiguration)
+		if err != nil {
+			return nil, err
+		}
+		resources = append(resources, resource)
+	}
+
+	return resources, nil
+}
+
+func (g *MetricTagConfigurationGenerator) createResource(metricTagConfiguration datadogV2.MetricTagConfiguration) (terraformutils.Resource, error) {
+	metricName := metricTagConfiguration.GetId()
+	if metricName == "" {
+		return terraformutils.Resource{}, fmt.Errorf("metric tag configuration missing metric name")
+	}
+
+	return terraformutils.NewSimpleResource(
+		metricName,
+		fmt.Sprintf("metric_tag_configuration_%s", metricName),
+		"datadog_metric_tag_configuration",
+		"datadog",
+		MetricTagConfigurationAllowEmptyValues,
+	), nil
+}
+
+// InitResources Generate TerraformResources from Datadog API,
+// from each metric tag configuration create 1 TerraformResource.
+func (g *MetricTagConfigurationGenerator) InitResources() error {
+	datadogClient := g.Args["datadogClient"].(*datadog.APIClient)
+	auth := g.Args["auth"].(context.Context)
+	api := datadogV2.NewMetricsApi(datadogClient)
+
+	resources, filtered, err := g.filteredResources(auth, api)
+	if err != nil {
+		return err
+	}
+	if filtered {
+		g.Resources = resources
+		return nil
+	}
+
+	metricTagConfigurations, err := listMetricTagConfigurations(auth, api)
+	if err != nil {
+		return err
+	}
+	resources, err = g.createResources(metricTagConfigurations)
+	if err != nil {
+		return err
+	}
+
+	g.Resources = resources
+	return nil
+}
+
+func (g *MetricTagConfigurationGenerator) filteredResources(auth context.Context, api *datadogV2.MetricsApi) ([]terraformutils.Resource, bool, error) {
+	resources := []terraformutils.Resource{}
+	filtered := false
+
+	for _, filter := range g.Filter {
+		if filter.FieldPath != "id" || !filter.IsApplicable("metric_tag_configuration") {
+			continue
+		}
+
+		filtered = true
+		for _, value := range filter.AcceptableValues {
+			metricTagConfiguration, err := getMetricTagConfiguration(auth, api, value)
+			if err != nil {
+				return nil, true, err
+			}
+			resource, err := g.createResource(metricTagConfiguration)
+			if err != nil {
+				return nil, true, err
+			}
+			resources = append(resources, resource)
+		}
+	}
+
+	return resources, filtered, nil
+}
+
+func getMetricTagConfiguration(auth context.Context, api *datadogV2.MetricsApi, metricName string) (datadogV2.MetricTagConfiguration, error) {
+	response, httpResponse, err := api.ListTagConfigurationByName(auth, metricName)
+	defer closeDatadogResponseBody(httpResponse)
+	if err != nil {
+		return datadogV2.MetricTagConfiguration{}, err
+	}
+
+	if configuration, ok := response.GetDataOk(); ok {
+		return *configuration, nil
+	}
+	if configuration, ok := metricTagConfigurationFromRawData(response.UnparsedObject["data"]); ok {
+		return configuration, nil
+	}
+
+	return datadogV2.MetricTagConfiguration{}, fmt.Errorf("metric tag configuration %q not found", metricName)
+}
+
+func listMetricTagConfigurations(auth context.Context, api *datadogV2.MetricsApi) ([]datadogV2.MetricTagConfiguration, error) {
+	metricTagConfigurations := []datadogV2.MetricTagConfiguration{}
+	const pageSize int32 = 1000
+	var cursor string
+
+	for {
+		optionalParams := datadogV2.NewListTagConfigurationsOptionalParameters().
+			WithFilterConfigured(true).
+			WithPageSize(pageSize)
+		if cursor != "" {
+			optionalParams.WithPageCursor(cursor)
+		}
+
+		response, httpResponse, err := api.ListTagConfigurations(auth, *optionalParams)
+		closeDatadogResponseBody(httpResponse)
+		if err != nil {
+			return nil, err
+		}
+
+		metricTagConfigurations = append(metricTagConfigurations, metricTagConfigurationsFromItems(response.GetData())...)
+		if len(response.GetData()) == 0 {
+			metricTagConfigurations = append(metricTagConfigurations, metricTagConfigurationsFromRawData(response.UnparsedObject["data"])...)
+		}
+
+		nextCursor := nextMetricTagConfigurationCursor(response)
+		if nextCursor == "" {
+			break
+		}
+		cursor = nextCursor
+	}
+
+	return metricTagConfigurations, nil
+}
+
+func metricTagConfigurationsFromItems(items []datadogV2.MetricsAndMetricTagConfigurations) []datadogV2.MetricTagConfiguration {
+	metricTagConfigurations := []datadogV2.MetricTagConfiguration{}
+	for _, item := range items {
+		if item.MetricTagConfiguration != nil {
+			metricTagConfigurations = append(metricTagConfigurations, *item.MetricTagConfiguration)
+			continue
+		}
+		if item.Metric != nil {
+			metricTagConfiguration, ok := metricTagConfigurationFromMetricName(item.Metric.GetId())
+			if !ok {
+				continue
+			}
+			metricTagConfigurations = append(metricTagConfigurations, metricTagConfiguration)
+			continue
+		}
+		metricTagConfiguration, ok := metricTagConfigurationFromRawData(item.UnparsedObject)
+		if !ok {
+			continue
+		}
+		metricTagConfigurations = append(metricTagConfigurations, metricTagConfiguration)
+	}
+	return metricTagConfigurations
+}
+
+func metricTagConfigurationsFromRawData(rawData interface{}) []datadogV2.MetricTagConfiguration {
+	rawConfigurations, ok := rawData.([]interface{})
+	if !ok {
+		return nil
+	}
+
+	metricTagConfigurations := []datadogV2.MetricTagConfiguration{}
+	for _, rawConfiguration := range rawConfigurations {
+		metricTagConfiguration, ok := metricTagConfigurationFromRawData(rawConfiguration)
+		if !ok {
+			continue
+		}
+		metricTagConfigurations = append(metricTagConfigurations, metricTagConfiguration)
+	}
+	return metricTagConfigurations
+}
+
+func metricTagConfigurationFromRawData(rawData interface{}) (datadogV2.MetricTagConfiguration, bool) {
+	rawConfiguration, ok := rawData.(map[string]interface{})
+	if !ok {
+		return datadogV2.MetricTagConfiguration{}, false
+	}
+	if rawType, ok := rawConfiguration["type"].(string); ok {
+		switch rawType {
+		case string(datadogV2.METRICTAGCONFIGURATIONTYPE_MANAGE_TAGS), string(datadogV2.METRICTYPE_METRICS):
+		default:
+			return datadogV2.MetricTagConfiguration{}, false
+		}
+	}
+
+	rawMetricName, ok := rawConfiguration["id"].(string)
+	if !ok {
+		return datadogV2.MetricTagConfiguration{}, false
+	}
+	return metricTagConfigurationFromMetricName(rawMetricName)
+}
+
+func metricTagConfigurationFromMetricName(metricName string) (datadogV2.MetricTagConfiguration, bool) {
+	if metricName == "" {
+		return datadogV2.MetricTagConfiguration{}, false
+	}
+	metricTagConfiguration := datadogV2.NewMetricTagConfigurationWithDefaults()
+	metricTagConfiguration.SetId(metricName)
+	return *metricTagConfiguration, true
+}
+
+func nextMetricTagConfigurationCursor(response datadogV2.MetricsAndMetricTagConfigurationsResponse) string {
+	meta, ok := response.GetMetaOk()
+	if !ok {
+		return ""
+	}
+	pagination, ok := meta.GetPaginationOk()
+	if !ok {
+		return ""
+	}
+	nextCursor, ok := pagination.GetNextCursorOk()
+	if !ok || nextCursor == nil {
+		return ""
+	}
+	return *nextCursor
+}

--- a/providers/datadog/metric_tag_configuration.go
+++ b/providers/datadog/metric_tag_configuration.go
@@ -14,8 +14,11 @@ import (
 
 var (
 	// MetricTagConfigurationAllowEmptyValues ...
-	MetricTagConfigurationAllowEmptyValues = []string{}
+	MetricTagConfigurationAllowEmptyValues = []string{"tags."}
 )
+
+// Avoid Datadog's one-hour default window when importing all configured metric tags.
+const metricTagConfigurationListWindowSeconds int64 = 60 * 60 * 24 * 30
 
 // MetricTagConfigurationGenerator ...
 type MetricTagConfigurationGenerator struct {
@@ -48,6 +51,30 @@ func (g *MetricTagConfigurationGenerator) createResource(metricTagConfiguration 
 		"datadog",
 		MetricTagConfigurationAllowEmptyValues,
 	), nil
+}
+
+func (g *MetricTagConfigurationGenerator) PostConvertHook() error {
+	for i := range g.Resources {
+		resource := &g.Resources[i]
+		if resource.Item == nil {
+			resource.Item = map[string]interface{}{}
+		}
+		if _, ok := resource.Item["tags"]; ok {
+			continue
+		}
+		if !metricTagConfigurationStateHasEmptyTags(resource) {
+			continue
+		}
+		resource.Item["tags"] = []interface{}{}
+	}
+	return nil
+}
+
+func metricTagConfigurationStateHasEmptyTags(resource *terraformutils.Resource) bool {
+	if resource == nil || resource.InstanceState == nil || resource.InstanceState.Attributes == nil {
+		return false
+	}
+	return resource.InstanceState.Attributes["tags.#"] == "0"
 }
 
 // InitResources Generate TerraformResources from Datadog API,
@@ -130,6 +157,7 @@ func listMetricTagConfigurations(auth context.Context, api *datadogV2.MetricsApi
 	for {
 		optionalParams := datadogV2.NewListTagConfigurationsOptionalParameters().
 			WithFilterConfigured(true).
+			WithWindowSeconds(metricTagConfigurationListWindowSeconds).
 			WithPageSize(pageSize)
 		if cursor != "" {
 			optionalParams.WithPageCursor(cursor)

--- a/providers/datadog/metric_tag_configuration_test.go
+++ b/providers/datadog/metric_tag_configuration_test.go
@@ -1,0 +1,138 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package datadog
+
+import (
+	"testing"
+
+	"github.com/DataDog/datadog-api-client-go/v2/api/datadogV2"
+)
+
+func TestMetricTagConfigurationCreateResource(t *testing.T) {
+	metricTagConfiguration := datadogV2.NewMetricTagConfigurationWithDefaults()
+	metricTagConfiguration.SetId("example.terraform.metric")
+
+	generator := &MetricTagConfigurationGenerator{}
+	resource, err := generator.createResource(*metricTagConfiguration)
+	if err != nil {
+		t.Fatalf("createResource returned error: %v", err)
+	}
+
+	if resource.InstanceState.ID != "example.terraform.metric" {
+		t.Fatalf("resource ID = %q, want %q", resource.InstanceState.ID, "example.terraform.metric")
+	}
+	if resource.ResourceName != "tfer--metric_tag_configuration_example-002E-terraform-002E-metric" {
+		t.Fatalf("resource name = %q, want %q", resource.ResourceName, "tfer--metric_tag_configuration_example-002E-terraform-002E-metric")
+	}
+	if resource.InstanceInfo.Type != "datadog_metric_tag_configuration" {
+		t.Fatalf("resource type = %q, want %q", resource.InstanceInfo.Type, "datadog_metric_tag_configuration")
+	}
+}
+
+func TestMetricTagConfigurationCreateResourceMissingMetricName(t *testing.T) {
+	generator := &MetricTagConfigurationGenerator{}
+	_, err := generator.createResource(datadogV2.MetricTagConfiguration{})
+	if err == nil {
+		t.Fatal("createResource returned nil error, want missing metric name error")
+	}
+}
+
+func TestMetricTagConfigurationCreateResources(t *testing.T) {
+	firstConfiguration := datadogV2.NewMetricTagConfigurationWithDefaults()
+	firstConfiguration.SetId("example.first.metric")
+	secondConfiguration := datadogV2.NewMetricTagConfigurationWithDefaults()
+	secondConfiguration.SetId("example.second.metric")
+
+	generator := &MetricTagConfigurationGenerator{}
+	resources, err := generator.createResources([]datadogV2.MetricTagConfiguration{
+		*firstConfiguration,
+		*secondConfiguration,
+	})
+	if err != nil {
+		t.Fatalf("createResources returned error: %v", err)
+	}
+
+	if len(resources) != 2 {
+		t.Fatalf("resource count = %d, want %d", len(resources), 2)
+	}
+	if resources[0].ResourceName == resources[1].ResourceName {
+		t.Fatalf("resource names should be unique, got %q", resources[0].ResourceName)
+	}
+}
+
+func TestMetricTagConfigurationsFromItems(t *testing.T) {
+	metricTagConfiguration := datadogV2.NewMetricTagConfigurationWithDefaults()
+	metricTagConfiguration.SetId("example.configured.metric")
+	metric := datadogV2.NewMetricWithDefaults()
+	metric.SetId("example.configured.metric.from.list")
+
+	configurations := metricTagConfigurationsFromItems([]datadogV2.MetricsAndMetricTagConfigurations{
+		datadogV2.MetricTagConfigurationAsMetricsAndMetricTagConfigurations(metricTagConfiguration),
+		datadogV2.MetricAsMetricsAndMetricTagConfigurations(metric),
+		{
+			UnparsedObject: map[string]interface{}{
+				"id":   "example.raw.configured.metric",
+				"type": "manage_tags",
+			},
+		},
+		{
+			UnparsedObject: map[string]interface{}{
+				"id":   "example.plain.metric",
+				"type": "metrics",
+			},
+		},
+	})
+
+	if len(configurations) != 4 {
+		t.Fatalf("configuration count = %d, want %d", len(configurations), 4)
+	}
+	if configurations[0].GetId() != "example.configured.metric" {
+		t.Fatalf("first configuration ID = %q, want %q", configurations[0].GetId(), "example.configured.metric")
+	}
+	if configurations[1].GetId() != "example.configured.metric.from.list" {
+		t.Fatalf("second configuration ID = %q, want %q", configurations[1].GetId(), "example.configured.metric.from.list")
+	}
+	if configurations[2].GetId() != "example.raw.configured.metric" {
+		t.Fatalf("third configuration ID = %q, want %q", configurations[2].GetId(), "example.raw.configured.metric")
+	}
+	if configurations[3].GetId() != "example.plain.metric" {
+		t.Fatalf("fourth configuration ID = %q, want %q", configurations[3].GetId(), "example.plain.metric")
+	}
+}
+
+func TestMetricTagConfigurationsFromRawData(t *testing.T) {
+	configurations := metricTagConfigurationsFromRawData([]interface{}{
+		map[string]interface{}{
+			"id":   "example.first.metric",
+			"type": "manage_tags",
+		},
+		map[string]interface{}{
+			"id":   "example.second.metric",
+			"type": "manage_tags",
+		},
+		map[string]interface{}{
+			"id":   "example.plain.metric",
+			"type": "metrics",
+		},
+		map[string]interface{}{
+			"id":   "example.ignored.metric",
+			"type": "unknown",
+		},
+		map[string]interface{}{
+			"type": "manage_tags",
+		},
+	})
+
+	if len(configurations) != 3 {
+		t.Fatalf("configuration count = %d, want %d", len(configurations), 3)
+	}
+	if configurations[0].GetId() != "example.first.metric" {
+		t.Fatalf("first configuration ID = %q, want %q", configurations[0].GetId(), "example.first.metric")
+	}
+	if configurations[1].GetId() != "example.second.metric" {
+		t.Fatalf("second configuration ID = %q, want %q", configurations[1].GetId(), "example.second.metric")
+	}
+	if configurations[2].GetId() != "example.plain.metric" {
+		t.Fatalf("third configuration ID = %q, want %q", configurations[2].GetId(), "example.plain.metric")
+	}
+}

--- a/providers/datadog/metric_tag_configuration_test.go
+++ b/providers/datadog/metric_tag_configuration_test.go
@@ -6,6 +6,8 @@ import (
 	"testing"
 
 	"github.com/DataDog/datadog-api-client-go/v2/api/datadogV2"
+
+	"github.com/chenrui333/terraformer/terraformutils"
 )
 
 func TestMetricTagConfigurationCreateResource(t *testing.T) {
@@ -34,6 +36,64 @@ func TestMetricTagConfigurationCreateResourceMissingMetricName(t *testing.T) {
 	_, err := generator.createResource(datadogV2.MetricTagConfiguration{})
 	if err == nil {
 		t.Fatal("createResource returned nil error, want missing metric name error")
+	}
+}
+
+func TestMetricTagConfigurationPostConvertHookPreservesEmptyTags(t *testing.T) {
+	resource := terraformutils.NewSimpleResource(
+		"example.empty.tags.metric",
+		"metric_tag_configuration_example.empty.tags.metric",
+		"datadog_metric_tag_configuration",
+		"datadog",
+		MetricTagConfigurationAllowEmptyValues,
+	)
+	resource.InstanceState.Attributes = map[string]string{
+		"metric_name": "example.empty.tags.metric",
+		"tags.#":      "0",
+	}
+	resource.Item = map[string]interface{}{
+		"metric_name": "example.empty.tags.metric",
+	}
+
+	generator := &MetricTagConfigurationGenerator{}
+	generator.Resources = []terraformutils.Resource{resource}
+
+	if err := generator.PostConvertHook(); err != nil {
+		t.Fatalf("PostConvertHook returned error: %v", err)
+	}
+
+	tags, ok := generator.Resources[0].Item["tags"].([]interface{})
+	if !ok {
+		t.Fatalf("tags = %T, want []interface{}", generator.Resources[0].Item["tags"])
+	}
+	if len(tags) != 0 {
+		t.Fatalf("tags length = %d, want %d", len(tags), 0)
+	}
+}
+
+func TestMetricTagConfigurationPostConvertHookDoesNotInventUnknownTags(t *testing.T) {
+	resource := terraformutils.NewSimpleResource(
+		"example.unknown.tags.metric",
+		"metric_tag_configuration_example.unknown.tags.metric",
+		"datadog_metric_tag_configuration",
+		"datadog",
+		MetricTagConfigurationAllowEmptyValues,
+	)
+	resource.InstanceState.Attributes = map[string]string{
+		"metric_name": "example.unknown.tags.metric",
+	}
+	resource.Item = map[string]interface{}{
+		"metric_name": "example.unknown.tags.metric",
+	}
+
+	generator := &MetricTagConfigurationGenerator{}
+	generator.Resources = []terraformutils.Resource{resource}
+
+	if err := generator.PostConvertHook(); err != nil {
+		t.Fatalf("PostConvertHook returned error: %v", err)
+	}
+	if _, ok := generator.Resources[0].Item["tags"]; ok {
+		t.Fatal("PostConvertHook added tags without empty tags state")
 	}
 }
 


### PR DESCRIPTION
Summary
- Add Terraformer import support for Datadog metric tag configurations.
- Support ID-filtered imports by metric name and unfiltered imports through the configured metrics list API.
- Document the new Datadog resource in the provider docs.

Notes
- Seeds resources by metric name so the Datadog provider can refresh full tag configuration state.
- Uses configured-metric filtering, cursor pagination, and closes Datadog SDK response bodies.
