### PR TITLE
fix(gcp): return memorystore page errors

### DIFF
--- a/providers/gcp/memoryStore.go
+++ b/providers/gcp/memoryStore.go
@@ -4,7 +4,7 @@ package gcp
 
 import (
 	"context"
-	"log"
+	"fmt"
 	"strings"
 
 	"google.golang.org/api/compute/v1"
@@ -22,7 +22,7 @@ type MemoryStoreGenerator struct {
 }
 
 // Run on redisInstancesList and create for each TerraformResource
-func (g MemoryStoreGenerator) createResources(ctx context.Context, redisInstancesList *redis.ProjectsLocationsInstancesListCall) []terraformutils.Resource {
+func (g MemoryStoreGenerator) createResources(ctx context.Context, redisInstancesList *redis.ProjectsLocationsInstancesListCall) ([]terraformutils.Resource, error) {
 	resources := []terraformutils.Resource{}
 	if err := redisInstancesList.Pages(ctx, func(page *redis.ListInstancesResponse) error {
 		for _, obj := range page.Instances {
@@ -44,9 +44,9 @@ func (g MemoryStoreGenerator) createResources(ctx context.Context, redisInstance
 		}
 		return nil
 	}); err != nil {
-		log.Println(err)
+		return nil, fmt.Errorf("list redis instances: %w", err)
 	}
-	return resources
+	return resources, nil
 }
 
 // Generate TerraformResources from GCP API,
@@ -61,6 +61,10 @@ func (g *MemoryStoreGenerator) InitResources() error {
 
 	redisInstancesList := redisService.Projects.Locations.Instances.List("projects/" + g.GetArgs()["project"].(string) + "/locations/" + g.GetArgs()["region"].(compute.Region).Name)
 
-	g.Resources = g.createResources(ctx, redisInstancesList)
+	resources, err := g.createResources(ctx, redisInstancesList)
+	if err != nil {
+		return err
+	}
+	g.Resources = resources
 	return nil
 }

--- a/providers/gcp/memoryStore_test.go
+++ b/providers/gcp/memoryStore_test.go
@@ -1,0 +1,35 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package gcp
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"google.golang.org/api/option"
+	"google.golang.org/api/redis/v1"
+)
+
+func TestCreateMemoryStoreResourcesReturnsListError(t *testing.T) {
+	ctx := context.Background()
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		http.Error(w, "{\"error\":{\"message\":\"service unavailable\"}}", http.StatusServiceUnavailable)
+	}))
+	t.Cleanup(server.Close)
+
+	redisService, err := redis.NewService(ctx, option.WithEndpoint(server.URL+"/"), option.WithoutAuthentication())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	_, err = (MemoryStoreGenerator{}).createResources(ctx, redisService.Projects.Locations.Instances.List("projects/test-project/locations/us-central1"))
+	if err == nil {
+		t.Fatal("expected redis instance list error")
+	}
+	if !strings.Contains(err.Error(), "list redis instances") {
+		t.Fatalf("expected wrapped redis instance list error, got %q", err)
+	}
+}


### PR DESCRIPTION
## Summary

- Return MemoryStore Redis instance pagination errors instead of logging and continuing with partial resources.
- Add regression coverage for the Redis instance listing failure path.
