### PR TITLE
fix(gcp): return scheduler page errors

### DIFF
--- a/providers/gcp/schedulerJobs.go
+++ b/providers/gcp/schedulerJobs.go
@@ -4,7 +4,7 @@ package gcp
 
 import (
 	"context"
-	"log"
+	"fmt"
 	"strings"
 
 	cloudscheduler "google.golang.org/api/cloudscheduler/v1beta1"
@@ -22,7 +22,7 @@ type SchedulerJobsGenerator struct {
 }
 
 // Run on SchedulerJobsList and create for each TerraformResource
-func (g SchedulerJobsGenerator) createResources(ctx context.Context, jobsList *cloudscheduler.ProjectsLocationsJobsListCall) []terraformutils.Resource {
+func (g SchedulerJobsGenerator) createResources(ctx context.Context, jobsList *cloudscheduler.ProjectsLocationsJobsListCall) ([]terraformutils.Resource, error) {
 	resources := []terraformutils.Resource{}
 	if err := jobsList.Pages(ctx, func(page *cloudscheduler.ListJobsResponse) error {
 		for _, obj := range page.Jobs {
@@ -44,9 +44,9 @@ func (g SchedulerJobsGenerator) createResources(ctx context.Context, jobsList *c
 		}
 		return nil
 	}); err != nil {
-		log.Println(err)
+		return nil, fmt.Errorf("list scheduler jobs: %w", err)
 	}
-	return resources
+	return resources, nil
 }
 
 // Generate TerraformResources from GCP API,
@@ -59,6 +59,10 @@ func (g *SchedulerJobsGenerator) InitResources() error {
 
 	jobsList := cloudSchedulerService.Projects.Locations.Jobs.List("projects/" + g.GetArgs()["project"].(string) + "/locations/" + g.GetArgs()["region"].(compute.Region).Name)
 
-	g.Resources = g.createResources(ctx, jobsList)
+	resources, err := g.createResources(ctx, jobsList)
+	if err != nil {
+		return err
+	}
+	g.Resources = resources
 	return nil
 }

--- a/providers/gcp/schedulerJobs_test.go
+++ b/providers/gcp/schedulerJobs_test.go
@@ -1,0 +1,35 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package gcp
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	cloudscheduler "google.golang.org/api/cloudscheduler/v1beta1"
+	"google.golang.org/api/option"
+)
+
+func TestCreateSchedulerJobResourcesReturnsListError(t *testing.T) {
+	ctx := context.Background()
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		http.Error(w, "{\"error\":{\"message\":\"service unavailable\"}}", http.StatusServiceUnavailable)
+	}))
+	t.Cleanup(server.Close)
+
+	schedulerService, err := cloudscheduler.NewService(ctx, option.WithEndpoint(server.URL+"/"), option.WithoutAuthentication())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	_, err = (SchedulerJobsGenerator{}).createResources(ctx, schedulerService.Projects.Locations.Jobs.List("projects/test-project/locations/us-central1"))
+	if err == nil {
+		t.Fatal("expected scheduler job list error")
+	}
+	if !strings.Contains(err.Error(), "list scheduler jobs") {
+		t.Fatalf("expected wrapped scheduler job list error, got %q", err)
+	}
+}


### PR DESCRIPTION
## Summary

- Return Cloud Scheduler job pagination errors instead of logging and continuing with partial resources.
- Add regression coverage for the scheduler job listing failure path.
