### PR TITLE
fix(gcp): return discovery list errors

### DIFF
--- a/providers/gcp/addresses_gen.go
+++ b/providers/gcp/addresses_gen.go
@@ -5,7 +5,7 @@ package gcp
 
 import (
 	"context"
-	"log"
+	"fmt"
 
 	"github.com/chenrui333/terraformer/terraformutils"
 
@@ -21,7 +21,7 @@ type AddressesGenerator struct {
 }
 
 // Run on addressesList and create for each TerraformResource
-func (g AddressesGenerator) createResources(ctx context.Context, addressesList *compute.AddressesListCall) []terraformutils.Resource {
+func (g AddressesGenerator) createResources(ctx context.Context, addressesList *compute.AddressesListCall) ([]terraformutils.Resource, error) {
 	resources := []terraformutils.Resource{}
 	if err := addressesList.Pages(ctx, func(page *compute.AddressList) error {
 		for _, obj := range page.Items {
@@ -41,9 +41,9 @@ func (g AddressesGenerator) createResources(ctx context.Context, addressesList *
 		}
 		return nil
 	}); err != nil {
-		log.Println(err)
+		return nil, fmt.Errorf("list addresses: %w", err)
 	}
-	return resources
+	return resources, nil
 }
 
 // Generate TerraformResources from GCP API,
@@ -57,7 +57,11 @@ func (g *AddressesGenerator) InitResources() error {
 	}
 
 	addressesList := computeService.Addresses.List(g.GetArgs()["project"].(string), g.GetArgs()["region"].(compute.Region).Name)
-	g.Resources = g.createResources(ctx, addressesList)
+	resources, err := g.createResources(ctx, addressesList)
+	if err != nil {
+		return err
+	}
+	g.Resources = resources
 
 	return nil
 

--- a/providers/gcp/autoscalers_gen.go
+++ b/providers/gcp/autoscalers_gen.go
@@ -5,7 +5,7 @@ package gcp
 
 import (
 	"context"
-	"log"
+	"fmt"
 	"strings"
 
 	"github.com/chenrui333/terraformer/terraformutils"
@@ -22,7 +22,7 @@ type AutoscalersGenerator struct {
 }
 
 // Run on autoscalersList and create for each TerraformResource
-func (g AutoscalersGenerator) createResources(ctx context.Context, autoscalersList *compute.AutoscalersListCall, zone string) []terraformutils.Resource {
+func (g AutoscalersGenerator) createResources(ctx context.Context, autoscalersList *compute.AutoscalersListCall, zone string) ([]terraformutils.Resource, error) {
 	resources := []terraformutils.Resource{}
 	if err := autoscalersList.Pages(ctx, func(page *compute.AutoscalerList) error {
 		for _, obj := range page.Items {
@@ -43,9 +43,9 @@ func (g AutoscalersGenerator) createResources(ctx context.Context, autoscalersLi
 		}
 		return nil
 	}); err != nil {
-		log.Println(err)
+		return nil, fmt.Errorf("list autoscalers: %w", err)
 	}
-	return resources
+	return resources, nil
 }
 
 // Generate TerraformResources from GCP API,
@@ -62,7 +62,11 @@ func (g *AutoscalersGenerator) InitResources() error {
 		t := strings.Split(zoneLink, "/")
 		zone := t[len(t)-1]
 		autoscalersList := computeService.Autoscalers.List(g.GetArgs()["project"].(string), zone)
-		g.Resources = append(g.Resources, g.createResources(ctx, autoscalersList, zone)...)
+		resources, err := g.createResources(ctx, autoscalersList, zone)
+		if err != nil {
+			return err
+		}
+		g.Resources = append(g.Resources, resources...)
 	}
 
 	return nil

--- a/providers/gcp/backendBuckets_gen.go
+++ b/providers/gcp/backendBuckets_gen.go
@@ -5,7 +5,7 @@ package gcp
 
 import (
 	"context"
-	"log"
+	"fmt"
 
 	"github.com/chenrui333/terraformer/terraformutils"
 
@@ -21,7 +21,7 @@ type BackendBucketsGenerator struct {
 }
 
 // Run on backendBucketsList and create for each TerraformResource
-func (g BackendBucketsGenerator) createResources(ctx context.Context, backendBucketsList *compute.BackendBucketsListCall) []terraformutils.Resource {
+func (g BackendBucketsGenerator) createResources(ctx context.Context, backendBucketsList *compute.BackendBucketsListCall) ([]terraformutils.Resource, error) {
 	resources := []terraformutils.Resource{}
 	if err := backendBucketsList.Pages(ctx, func(page *compute.BackendBucketList) error {
 		for _, obj := range page.Items {
@@ -41,9 +41,9 @@ func (g BackendBucketsGenerator) createResources(ctx context.Context, backendBuc
 		}
 		return nil
 	}); err != nil {
-		log.Println(err)
+		return nil, fmt.Errorf("list backendBuckets: %w", err)
 	}
-	return resources
+	return resources, nil
 }
 
 // Generate TerraformResources from GCP API,
@@ -57,7 +57,11 @@ func (g *BackendBucketsGenerator) InitResources() error {
 	}
 
 	backendBucketsList := computeService.BackendBuckets.List(g.GetArgs()["project"].(string))
-	g.Resources = g.createResources(ctx, backendBucketsList)
+	resources, err := g.createResources(ctx, backendBucketsList)
+	if err != nil {
+		return err
+	}
+	g.Resources = resources
 
 	return nil
 

--- a/providers/gcp/backendServices_gen.go
+++ b/providers/gcp/backendServices_gen.go
@@ -5,7 +5,7 @@ package gcp
 
 import (
 	"context"
-	"log"
+	"fmt"
 
 	"github.com/chenrui333/terraformer/terraformutils"
 
@@ -21,7 +21,7 @@ type BackendServicesGenerator struct {
 }
 
 // Run on backendServicesList and create for each TerraformResource
-func (g BackendServicesGenerator) createResources(ctx context.Context, backendServicesList *compute.BackendServicesListCall) []terraformutils.Resource {
+func (g BackendServicesGenerator) createResources(ctx context.Context, backendServicesList *compute.BackendServicesListCall) ([]terraformutils.Resource, error) {
 	resources := []terraformutils.Resource{}
 	if err := backendServicesList.Pages(ctx, func(page *compute.BackendServiceList) error {
 		for _, obj := range page.Items {
@@ -40,9 +40,9 @@ func (g BackendServicesGenerator) createResources(ctx context.Context, backendSe
 		}
 		return nil
 	}); err != nil {
-		log.Println(err)
+		return nil, fmt.Errorf("list backendServices: %w", err)
 	}
-	return resources
+	return resources, nil
 }
 
 // Generate TerraformResources from GCP API,
@@ -56,7 +56,11 @@ func (g *BackendServicesGenerator) InitResources() error {
 	}
 
 	backendServicesList := computeService.BackendServices.List(g.GetArgs()["project"].(string))
-	g.Resources = g.createResources(ctx, backendServicesList)
+	resources, err := g.createResources(ctx, backendServicesList)
+	if err != nil {
+		return err
+	}
+	g.Resources = resources
 
 	return nil
 

--- a/providers/gcp/cloudFunctions.go
+++ b/providers/gcp/cloudFunctions.go
@@ -4,7 +4,7 @@ package gcp
 
 import (
 	"context"
-	"log"
+	"fmt"
 	"strings"
 
 	"google.golang.org/api/cloudfunctions/v2"
@@ -22,7 +22,7 @@ type CloudFunctionsGenerator struct {
 }
 
 // Run on CloudFunctionsList and create for each TerraformResource
-func (g CloudFunctionsGenerator) createCloudFunctionsResources(ctx context.Context, functionsList *cloudfunctions.ProjectsLocationsFunctionsListCall) []terraformutils.Resource {
+func (g CloudFunctionsGenerator) createCloudFunctionsResources(ctx context.Context, functionsList *cloudfunctions.ProjectsLocationsFunctionsListCall) ([]terraformutils.Resource, error) {
 	resources := []terraformutils.Resource{}
 	if err := functionsList.Pages(ctx, func(page *cloudfunctions.ListFunctionsResponse) error {
 		for _, functions := range page.Functions {
@@ -46,12 +46,12 @@ func (g CloudFunctionsGenerator) createCloudFunctionsResources(ctx context.Conte
 		}
 		return nil
 	}); err != nil {
-		log.Println(err)
+		return nil, fmt.Errorf("list cloud functions gen1: %w", err)
 	}
-	return resources
+	return resources, nil
 }
 
-func (g CloudFunctionsGenerator) createCloudFunctions2ndGenResources(ctx context.Context, functionsList *cloudfunctions.ProjectsLocationsFunctionsListCall) []terraformutils.Resource {
+func (g CloudFunctionsGenerator) createCloudFunctions2ndGenResources(ctx context.Context, functionsList *cloudfunctions.ProjectsLocationsFunctionsListCall) ([]terraformutils.Resource, error) {
 	resources := []terraformutils.Resource{}
 	if err := functionsList.Pages(ctx, func(page *cloudfunctions.ListFunctionsResponse) error {
 		for _, functions := range page.Functions {
@@ -75,9 +75,9 @@ func (g CloudFunctionsGenerator) createCloudFunctions2ndGenResources(ctx context
 		}
 		return nil
 	}); err != nil {
-		log.Println(err)
+		return nil, fmt.Errorf("list cloud functions gen2: %w", err)
 	}
-	return resources
+	return resources, nil
 }
 
 // Generate TerraformResources from GCP API,
@@ -92,8 +92,18 @@ func (g *CloudFunctionsGenerator) InitResources() error {
 
 	functionsList := cloudfunctionsService.Projects.Locations.Functions.List("projects/" + g.GetArgs()["project"].(string) + "/locations/" + g.GetArgs()["region"].(compute.Region).Name)
 
-	g.Resources = append(g.Resources, g.createCloudFunctionsResources(ctx, functionsList)...)
-	g.Resources = append(g.Resources, g.createCloudFunctions2ndGenResources(ctx, functionsList)...)
+	functionResources, err := g.createCloudFunctionsResources(ctx, functionsList)
+	if err != nil {
+		return err
+	}
+	g.Resources = append(g.Resources, functionResources...)
+
+	functionsList = cloudfunctionsService.Projects.Locations.Functions.List("projects/" + g.GetArgs()["project"].(string) + "/locations/" + g.GetArgs()["region"].(compute.Region).Name)
+	function2Resources, err := g.createCloudFunctions2ndGenResources(ctx, functionsList)
+	if err != nil {
+		return err
+	}
+	g.Resources = append(g.Resources, function2Resources...)
 
 	return nil
 }

--- a/providers/gcp/cloudFunctions_test.go
+++ b/providers/gcp/cloudFunctions_test.go
@@ -1,0 +1,58 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package gcp
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"google.golang.org/api/cloudfunctions/v2"
+	"google.golang.org/api/option"
+)
+
+func TestCreateCloudFunctionsResourcesReturnsListError(t *testing.T) {
+	ctx := context.Background()
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		http.Error(w, "{\"error\":{\"message\":\"service unavailable\"}}", http.StatusServiceUnavailable)
+	}))
+	t.Cleanup(server.Close)
+
+	cloudFunctionsService := newTestCloudFunctionsService(ctx, t, server.URL+"/")
+	_, err := (CloudFunctionsGenerator{}).createCloudFunctionsResources(ctx, cloudFunctionsService.Projects.Locations.Functions.List("projects/test-project/locations/us-central1"))
+	if err == nil {
+		t.Fatal("expected cloud functions gen1 list error")
+	}
+	if !strings.Contains(err.Error(), "list cloud functions gen1") {
+		t.Fatalf("expected wrapped cloud functions gen1 list error, got %q", err)
+	}
+}
+
+func TestCreateCloudFunctions2ndGenResourcesReturnsListError(t *testing.T) {
+	ctx := context.Background()
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		http.Error(w, "{\"error\":{\"message\":\"service unavailable\"}}", http.StatusServiceUnavailable)
+	}))
+	t.Cleanup(server.Close)
+
+	cloudFunctionsService := newTestCloudFunctionsService(ctx, t, server.URL+"/")
+	_, err := (CloudFunctionsGenerator{}).createCloudFunctions2ndGenResources(ctx, cloudFunctionsService.Projects.Locations.Functions.List("projects/test-project/locations/us-central1"))
+	if err == nil {
+		t.Fatal("expected cloud functions gen2 list error")
+	}
+	if !strings.Contains(err.Error(), "list cloud functions gen2") {
+		t.Fatalf("expected wrapped cloud functions gen2 list error, got %q", err)
+	}
+}
+
+func newTestCloudFunctionsService(ctx context.Context, t *testing.T, endpoint string) *cloudfunctions.Service {
+	t.Helper()
+
+	cloudFunctionsService, err := cloudfunctions.NewService(ctx, option.WithEndpoint(endpoint), option.WithoutAuthentication())
+	if err != nil {
+		t.Fatal(err)
+	}
+	return cloudFunctionsService
+}

--- a/providers/gcp/compute_page_errors_test.go
+++ b/providers/gcp/compute_page_errors_test.go
@@ -1,0 +1,58 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package gcp
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"google.golang.org/api/compute/v1"
+	"google.golang.org/api/option"
+)
+
+func TestGeneratedComputeResourcesReturnRegionalListError(t *testing.T) {
+	ctx := context.Background()
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		http.Error(w, "{\"error\":{\"message\":\"service unavailable\"}}", http.StatusServiceUnavailable)
+	}))
+	t.Cleanup(server.Close)
+
+	computeService := newTestComputeService(ctx, t, server.URL+"/")
+	_, err := (AddressesGenerator{}).createResources(ctx, computeService.Addresses.List("test-project", "us-central1"))
+	if err == nil {
+		t.Fatal("expected address list error")
+	}
+	if !strings.Contains(err.Error(), "list addresses") {
+		t.Fatalf("expected wrapped address list error, got %q", err)
+	}
+}
+
+func TestGeneratedComputeResourcesReturnZonalListError(t *testing.T) {
+	ctx := context.Background()
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		http.Error(w, "{\"error\":{\"message\":\"service unavailable\"}}", http.StatusServiceUnavailable)
+	}))
+	t.Cleanup(server.Close)
+
+	computeService := newTestComputeService(ctx, t, server.URL+"/")
+	_, err := (DisksGenerator{}).createResources(ctx, computeService.Disks.List("test-project", "us-central1-a"), "us-central1-a")
+	if err == nil {
+		t.Fatal("expected disk list error")
+	}
+	if !strings.Contains(err.Error(), "list disks") {
+		t.Fatalf("expected wrapped disk list error, got %q", err)
+	}
+}
+
+func newTestComputeService(ctx context.Context, t *testing.T, endpoint string) *compute.Service {
+	t.Helper()
+
+	computeService, err := compute.NewService(ctx, option.WithEndpoint(endpoint), option.WithoutAuthentication())
+	if err != nil {
+		t.Fatal(err)
+	}
+	return computeService
+}

--- a/providers/gcp/disks_gen.go
+++ b/providers/gcp/disks_gen.go
@@ -5,7 +5,7 @@ package gcp
 
 import (
 	"context"
-	"log"
+	"fmt"
 	"strings"
 
 	"github.com/chenrui333/terraformer/terraformutils"
@@ -22,7 +22,7 @@ type DisksGenerator struct {
 }
 
 // Run on disksList and create for each TerraformResource
-func (g DisksGenerator) createResources(ctx context.Context, disksList *compute.DisksListCall, zone string) []terraformutils.Resource {
+func (g DisksGenerator) createResources(ctx context.Context, disksList *compute.DisksListCall, zone string) ([]terraformutils.Resource, error) {
 	resources := []terraformutils.Resource{}
 	if err := disksList.Pages(ctx, func(page *compute.DiskList) error {
 		for _, obj := range page.Items {
@@ -43,9 +43,9 @@ func (g DisksGenerator) createResources(ctx context.Context, disksList *compute.
 		}
 		return nil
 	}); err != nil {
-		log.Println(err)
+		return nil, fmt.Errorf("list disks: %w", err)
 	}
-	return resources
+	return resources, nil
 }
 
 // Generate TerraformResources from GCP API,
@@ -62,7 +62,11 @@ func (g *DisksGenerator) InitResources() error {
 		t := strings.Split(zoneLink, "/")
 		zone := t[len(t)-1]
 		disksList := computeService.Disks.List(g.GetArgs()["project"].(string), zone)
-		g.Resources = append(g.Resources, g.createResources(ctx, disksList, zone)...)
+		resources, err := g.createResources(ctx, disksList, zone)
+		if err != nil {
+			return err
+		}
+		g.Resources = append(g.Resources, resources...)
 	}
 
 	return nil

--- a/providers/gcp/externalVpnGateways_gen.go
+++ b/providers/gcp/externalVpnGateways_gen.go
@@ -5,7 +5,7 @@ package gcp
 
 import (
 	"context"
-	"log"
+	"fmt"
 
 	"github.com/chenrui333/terraformer/terraformutils"
 
@@ -21,7 +21,7 @@ type ExternalVpnGatewaysGenerator struct {
 }
 
 // Run on externalVpnGatewaysList and create for each TerraformResource
-func (g ExternalVpnGatewaysGenerator) createResources(ctx context.Context, externalVpnGatewaysList *compute.ExternalVpnGatewaysListCall) []terraformutils.Resource {
+func (g ExternalVpnGatewaysGenerator) createResources(ctx context.Context, externalVpnGatewaysList *compute.ExternalVpnGatewaysListCall) ([]terraformutils.Resource, error) {
 	resources := []terraformutils.Resource{}
 	if err := externalVpnGatewaysList.Pages(ctx, func(page *compute.ExternalVpnGatewayList) error {
 		for _, obj := range page.Items {
@@ -41,9 +41,9 @@ func (g ExternalVpnGatewaysGenerator) createResources(ctx context.Context, exter
 		}
 		return nil
 	}); err != nil {
-		log.Println(err)
+		return nil, fmt.Errorf("list externalVpnGateways: %w", err)
 	}
-	return resources
+	return resources, nil
 }
 
 // Generate TerraformResources from GCP API,
@@ -57,7 +57,11 @@ func (g *ExternalVpnGatewaysGenerator) InitResources() error {
 	}
 
 	externalVpnGatewaysList := computeService.ExternalVpnGateways.List(g.GetArgs()["project"].(string))
-	g.Resources = g.createResources(ctx, externalVpnGatewaysList)
+	resources, err := g.createResources(ctx, externalVpnGatewaysList)
+	if err != nil {
+		return err
+	}
+	g.Resources = resources
 
 	return nil
 

--- a/providers/gcp/firewall_gen.go
+++ b/providers/gcp/firewall_gen.go
@@ -5,7 +5,7 @@ package gcp
 
 import (
 	"context"
-	"log"
+	"fmt"
 
 	"github.com/chenrui333/terraformer/terraformutils"
 
@@ -21,7 +21,7 @@ type FirewallGenerator struct {
 }
 
 // Run on firewallList and create for each TerraformResource
-func (g FirewallGenerator) createResources(ctx context.Context, firewallList *compute.FirewallsListCall) []terraformutils.Resource {
+func (g FirewallGenerator) createResources(ctx context.Context, firewallList *compute.FirewallsListCall) ([]terraformutils.Resource, error) {
 	resources := []terraformutils.Resource{}
 	if err := firewallList.Pages(ctx, func(page *compute.FirewallList) error {
 		for _, obj := range page.Items {
@@ -41,9 +41,9 @@ func (g FirewallGenerator) createResources(ctx context.Context, firewallList *co
 		}
 		return nil
 	}); err != nil {
-		log.Println(err)
+		return nil, fmt.Errorf("list firewall: %w", err)
 	}
-	return resources
+	return resources, nil
 }
 
 // Generate TerraformResources from GCP API,
@@ -57,7 +57,11 @@ func (g *FirewallGenerator) InitResources() error {
 	}
 
 	firewallList := computeService.Firewalls.List(g.GetArgs()["project"].(string))
-	g.Resources = g.createResources(ctx, firewallList)
+	resources, err := g.createResources(ctx, firewallList)
+	if err != nil {
+		return err
+	}
+	g.Resources = resources
 
 	return nil
 

--- a/providers/gcp/forwardingRules_gen.go
+++ b/providers/gcp/forwardingRules_gen.go
@@ -5,7 +5,7 @@ package gcp
 
 import (
 	"context"
-	"log"
+	"fmt"
 
 	"github.com/chenrui333/terraformer/terraformutils"
 
@@ -21,7 +21,7 @@ type ForwardingRulesGenerator struct {
 }
 
 // Run on forwardingRulesList and create for each TerraformResource
-func (g ForwardingRulesGenerator) createResources(ctx context.Context, forwardingRulesList *compute.ForwardingRulesListCall) []terraformutils.Resource {
+func (g ForwardingRulesGenerator) createResources(ctx context.Context, forwardingRulesList *compute.ForwardingRulesListCall) ([]terraformutils.Resource, error) {
 	resources := []terraformutils.Resource{}
 	if err := forwardingRulesList.Pages(ctx, func(page *compute.ForwardingRuleList) error {
 		for _, obj := range page.Items {
@@ -41,9 +41,9 @@ func (g ForwardingRulesGenerator) createResources(ctx context.Context, forwardin
 		}
 		return nil
 	}); err != nil {
-		log.Println(err)
+		return nil, fmt.Errorf("list forwardingRules: %w", err)
 	}
-	return resources
+	return resources, nil
 }
 
 // Generate TerraformResources from GCP API,
@@ -57,7 +57,11 @@ func (g *ForwardingRulesGenerator) InitResources() error {
 	}
 
 	forwardingRulesList := computeService.ForwardingRules.List(g.GetArgs()["project"].(string), g.GetArgs()["region"].(compute.Region).Name)
-	g.Resources = g.createResources(ctx, forwardingRulesList)
+	resources, err := g.createResources(ctx, forwardingRulesList)
+	if err != nil {
+		return err
+	}
+	g.Resources = resources
 
 	return nil
 

--- a/providers/gcp/gcp_compute_code_generator/main.go
+++ b/providers/gcp/gcp_compute_code_generator/main.go
@@ -22,7 +22,7 @@ package gcp
 
 import (
 	"context"
-	"log"
+	"fmt"
 	{{ if .byZone  }}"strings"{{end}}
 
 	"github.com/chenrui333/terraformer/terraformutils"
@@ -42,7 +42,7 @@ type {{.titleResourceName}}Generator struct {
 }
 
 // Run on {{.resource}}List and create for each TerraformResource
-func (g {{.titleResourceName}}Generator) createResources(ctx context.Context, {{.resource}}List *compute.{{.titleResourceName}}ListCall{{ if .byZone  }}, zone string{{end}}) []terraformutils.Resource {
+func (g {{.titleResourceName}}Generator) createResources(ctx context.Context, {{.resource}}List *compute.{{.titleResourceName}}ListCall{{ if .byZone  }}, zone string{{end}}) ([]terraformutils.Resource, error) {
 	resources := []terraformutils.Resource{}
 	if err := {{.resource}}List.Pages(ctx, func(page *compute.{{.responseName}}) error {
 		for _, obj := range page.Items {
@@ -65,9 +65,9 @@ func (g {{.titleResourceName}}Generator) createResources(ctx context.Context, {{
 		}
 		return nil
 	}); err != nil {
-		log.Println(err)
+		return nil, fmt.Errorf("list {{.resource}}: %w", err)
 	}
-	return resources
+	return resources, nil
 }
 
 // Generate TerraformResources from GCP API,
@@ -84,11 +84,19 @@ func (g *{{.titleResourceName}}Generator) InitResources() error {
 		t := strings.Split(zoneLink, "/")
 		zone := t[len(t)-1]
 		{{.resource}}List := computeService.{{.titleResourceName}}.List(g.GetArgs()["project"].(string), zone)
-		g.Resources = append(g.Resources, g.createResources(ctx, {{.resource}}List, zone)...)
+		resources, err := g.createResources(ctx, {{.resource}}List, zone)
+		if err != nil {
+			return err
+		}
+		g.Resources = append(g.Resources, resources...)
 	}
 	{{else}}
 		{{.resource}}List := computeService.{{.titleResourceName}}.List({{.parameterOrder}})
-		g.Resources = g.createResources(ctx, {{.resource}}List)
+		resources, err := g.createResources(ctx, {{.resource}}List)
+		if err != nil {
+			return err
+		}
+		g.Resources = resources
 	{{end}}
 
 	return nil

--- a/providers/gcp/gcs.go
+++ b/providers/gcp/gcs.go
@@ -5,7 +5,6 @@ package gcp
 import (
 	"context"
 	"fmt"
-	"log"
 	"strconv"
 
 	"github.com/chenrui333/terraformer/terraformutils"
@@ -108,7 +107,11 @@ func (g *GcsGenerator) createBucketsResources(ctx context.Context, gcsService *s
 				}
 			}
 
-			resources = append(resources, g.createNotificationResources(gcsService, bucket)...)
+			notificationResources, err := g.createNotificationResources(gcsService, bucket)
+			if err != nil {
+				return err
+			}
+			resources = append(resources, notificationResources...)
 		}
 		return nil
 	}); err != nil {
@@ -117,12 +120,11 @@ func (g *GcsGenerator) createBucketsResources(ctx context.Context, gcsService *s
 	return resources, nil
 }
 
-func (g *GcsGenerator) createNotificationResources(gcsService *storage.Service, bucket *storage.Bucket) []terraformutils.Resource {
+func (g *GcsGenerator) createNotificationResources(gcsService *storage.Service, bucket *storage.Bucket) ([]terraformutils.Resource, error) {
 	resources := []terraformutils.Resource{}
 	notificationList, err := gcsService.Notifications.List(bucket.Name).Do()
 	if err != nil {
-		log.Println(err)
-		return resources
+		return nil, fmt.Errorf("list gcs notifications for %s: %w", bucket.Name, err)
 	}
 	for _, notification := range notificationList.Items {
 		resources = append(resources, terraformutils.NewResource(
@@ -135,7 +137,7 @@ func (g *GcsGenerator) createNotificationResources(gcsService *storage.Service, 
 			GcsAdditionalFields,
 		))
 	}
-	return resources
+	return resources, nil
 }
 
 // Generate TerraformResources from GCP API,
@@ -145,7 +147,6 @@ func (g *GcsGenerator) InitResources() error {
 	ctx := context.Background()
 	gcsService, err := storage.NewService(ctx)
 	if err != nil {
-		log.Print(err)
 		return err
 	}
 	resources, err := g.createBucketsResources(ctx, gcsService)

--- a/providers/gcp/gcs_test.go
+++ b/providers/gcp/gcs_test.go
@@ -36,3 +36,24 @@ func TestCreateBucketsResourcesReturnsBucketListError(t *testing.T) {
 		t.Fatalf("expected wrapped gcs bucket list error, got %q", err)
 	}
 }
+
+func TestCreateNotificationResourcesReturnsListError(t *testing.T) {
+	ctx := context.Background()
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		http.Error(w, "{\"error\":{\"message\":\"service unavailable\"}}", http.StatusServiceUnavailable)
+	}))
+	t.Cleanup(server.Close)
+
+	gcsService, err := storage.NewService(ctx, option.WithEndpoint(server.URL+"/"), option.WithoutAuthentication())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	_, err = (&GcsGenerator{}).createNotificationResources(gcsService, &storage.Bucket{Name: "test-bucket"})
+	if err == nil {
+		t.Fatal("expected gcs notification list error")
+	}
+	if !strings.Contains(err.Error(), "list gcs notifications for test-bucket") {
+		t.Fatalf("expected wrapped gcs notification list error, got %q", err)
+	}
+}

--- a/providers/gcp/globalAddresses_gen.go
+++ b/providers/gcp/globalAddresses_gen.go
@@ -5,7 +5,7 @@ package gcp
 
 import (
 	"context"
-	"log"
+	"fmt"
 
 	"github.com/chenrui333/terraformer/terraformutils"
 
@@ -21,7 +21,7 @@ type GlobalAddressesGenerator struct {
 }
 
 // Run on globalAddressesList and create for each TerraformResource
-func (g GlobalAddressesGenerator) createResources(ctx context.Context, globalAddressesList *compute.GlobalAddressesListCall) []terraformutils.Resource {
+func (g GlobalAddressesGenerator) createResources(ctx context.Context, globalAddressesList *compute.GlobalAddressesListCall) ([]terraformutils.Resource, error) {
 	resources := []terraformutils.Resource{}
 	if err := globalAddressesList.Pages(ctx, func(page *compute.AddressList) error {
 		for _, obj := range page.Items {
@@ -41,9 +41,9 @@ func (g GlobalAddressesGenerator) createResources(ctx context.Context, globalAdd
 		}
 		return nil
 	}); err != nil {
-		log.Println(err)
+		return nil, fmt.Errorf("list globalAddresses: %w", err)
 	}
-	return resources
+	return resources, nil
 }
 
 // Generate TerraformResources from GCP API,
@@ -57,7 +57,11 @@ func (g *GlobalAddressesGenerator) InitResources() error {
 	}
 
 	globalAddressesList := computeService.GlobalAddresses.List(g.GetArgs()["project"].(string))
-	g.Resources = g.createResources(ctx, globalAddressesList)
+	resources, err := g.createResources(ctx, globalAddressesList)
+	if err != nil {
+		return err
+	}
+	g.Resources = resources
 
 	return nil
 

--- a/providers/gcp/globalForwardingRules_gen.go
+++ b/providers/gcp/globalForwardingRules_gen.go
@@ -5,7 +5,7 @@ package gcp
 
 import (
 	"context"
-	"log"
+	"fmt"
 
 	"github.com/chenrui333/terraformer/terraformutils"
 
@@ -21,7 +21,7 @@ type GlobalForwardingRulesGenerator struct {
 }
 
 // Run on globalForwardingRulesList and create for each TerraformResource
-func (g GlobalForwardingRulesGenerator) createResources(ctx context.Context, globalForwardingRulesList *compute.GlobalForwardingRulesListCall) []terraformutils.Resource {
+func (g GlobalForwardingRulesGenerator) createResources(ctx context.Context, globalForwardingRulesList *compute.GlobalForwardingRulesListCall) ([]terraformutils.Resource, error) {
 	resources := []terraformutils.Resource{}
 	if err := globalForwardingRulesList.Pages(ctx, func(page *compute.ForwardingRuleList) error {
 		for _, obj := range page.Items {
@@ -40,9 +40,9 @@ func (g GlobalForwardingRulesGenerator) createResources(ctx context.Context, glo
 		}
 		return nil
 	}); err != nil {
-		log.Println(err)
+		return nil, fmt.Errorf("list globalForwardingRules: %w", err)
 	}
-	return resources
+	return resources, nil
 }
 
 // Generate TerraformResources from GCP API,
@@ -56,7 +56,11 @@ func (g *GlobalForwardingRulesGenerator) InitResources() error {
 	}
 
 	globalForwardingRulesList := computeService.GlobalForwardingRules.List(g.GetArgs()["project"].(string))
-	g.Resources = g.createResources(ctx, globalForwardingRulesList)
+	resources, err := g.createResources(ctx, globalForwardingRulesList)
+	if err != nil {
+		return err
+	}
+	g.Resources = resources
 
 	return nil
 

--- a/providers/gcp/healthChecks_gen.go
+++ b/providers/gcp/healthChecks_gen.go
@@ -5,7 +5,7 @@ package gcp
 
 import (
 	"context"
-	"log"
+	"fmt"
 
 	"github.com/chenrui333/terraformer/terraformutils"
 
@@ -21,7 +21,7 @@ type HealthChecksGenerator struct {
 }
 
 // Run on healthChecksList and create for each TerraformResource
-func (g HealthChecksGenerator) createResources(ctx context.Context, healthChecksList *compute.HealthChecksListCall) []terraformutils.Resource {
+func (g HealthChecksGenerator) createResources(ctx context.Context, healthChecksList *compute.HealthChecksListCall) ([]terraformutils.Resource, error) {
 	resources := []terraformutils.Resource{}
 	if err := healthChecksList.Pages(ctx, func(page *compute.HealthCheckList) error {
 		for _, obj := range page.Items {
@@ -41,9 +41,9 @@ func (g HealthChecksGenerator) createResources(ctx context.Context, healthChecks
 		}
 		return nil
 	}); err != nil {
-		log.Println(err)
+		return nil, fmt.Errorf("list healthChecks: %w", err)
 	}
-	return resources
+	return resources, nil
 }
 
 // Generate TerraformResources from GCP API,
@@ -57,7 +57,11 @@ func (g *HealthChecksGenerator) InitResources() error {
 	}
 
 	healthChecksList := computeService.HealthChecks.List(g.GetArgs()["project"].(string))
-	g.Resources = g.createResources(ctx, healthChecksList)
+	resources, err := g.createResources(ctx, healthChecksList)
+	if err != nil {
+		return err
+	}
+	g.Resources = resources
 
 	return nil
 

--- a/providers/gcp/httpHealthChecks_gen.go
+++ b/providers/gcp/httpHealthChecks_gen.go
@@ -5,7 +5,7 @@ package gcp
 
 import (
 	"context"
-	"log"
+	"fmt"
 
 	"github.com/chenrui333/terraformer/terraformutils"
 
@@ -21,7 +21,7 @@ type HttpHealthChecksGenerator struct {
 }
 
 // Run on httpHealthChecksList and create for each TerraformResource
-func (g HttpHealthChecksGenerator) createResources(ctx context.Context, httpHealthChecksList *compute.HttpHealthChecksListCall) []terraformutils.Resource {
+func (g HttpHealthChecksGenerator) createResources(ctx context.Context, httpHealthChecksList *compute.HttpHealthChecksListCall) ([]terraformutils.Resource, error) {
 	resources := []terraformutils.Resource{}
 	if err := httpHealthChecksList.Pages(ctx, func(page *compute.HttpHealthCheckList) error {
 		for _, obj := range page.Items {
@@ -41,9 +41,9 @@ func (g HttpHealthChecksGenerator) createResources(ctx context.Context, httpHeal
 		}
 		return nil
 	}); err != nil {
-		log.Println(err)
+		return nil, fmt.Errorf("list httpHealthChecks: %w", err)
 	}
-	return resources
+	return resources, nil
 }
 
 // Generate TerraformResources from GCP API,
@@ -57,7 +57,11 @@ func (g *HttpHealthChecksGenerator) InitResources() error {
 	}
 
 	httpHealthChecksList := computeService.HttpHealthChecks.List(g.GetArgs()["project"].(string))
-	g.Resources = g.createResources(ctx, httpHealthChecksList)
+	resources, err := g.createResources(ctx, httpHealthChecksList)
+	if err != nil {
+		return err
+	}
+	g.Resources = resources
 
 	return nil
 

--- a/providers/gcp/httpsHealthChecks_gen.go
+++ b/providers/gcp/httpsHealthChecks_gen.go
@@ -5,7 +5,7 @@ package gcp
 
 import (
 	"context"
-	"log"
+	"fmt"
 
 	"github.com/chenrui333/terraformer/terraformutils"
 
@@ -21,7 +21,7 @@ type HttpsHealthChecksGenerator struct {
 }
 
 // Run on httpsHealthChecksList and create for each TerraformResource
-func (g HttpsHealthChecksGenerator) createResources(ctx context.Context, httpsHealthChecksList *compute.HttpsHealthChecksListCall) []terraformutils.Resource {
+func (g HttpsHealthChecksGenerator) createResources(ctx context.Context, httpsHealthChecksList *compute.HttpsHealthChecksListCall) ([]terraformutils.Resource, error) {
 	resources := []terraformutils.Resource{}
 	if err := httpsHealthChecksList.Pages(ctx, func(page *compute.HttpsHealthCheckList) error {
 		for _, obj := range page.Items {
@@ -41,9 +41,9 @@ func (g HttpsHealthChecksGenerator) createResources(ctx context.Context, httpsHe
 		}
 		return nil
 	}); err != nil {
-		log.Println(err)
+		return nil, fmt.Errorf("list httpsHealthChecks: %w", err)
 	}
-	return resources
+	return resources, nil
 }
 
 // Generate TerraformResources from GCP API,
@@ -57,7 +57,11 @@ func (g *HttpsHealthChecksGenerator) InitResources() error {
 	}
 
 	httpsHealthChecksList := computeService.HttpsHealthChecks.List(g.GetArgs()["project"].(string))
-	g.Resources = g.createResources(ctx, httpsHealthChecksList)
+	resources, err := g.createResources(ctx, httpsHealthChecksList)
+	if err != nil {
+		return err
+	}
+	g.Resources = resources
 
 	return nil
 

--- a/providers/gcp/images_gen.go
+++ b/providers/gcp/images_gen.go
@@ -5,7 +5,7 @@ package gcp
 
 import (
 	"context"
-	"log"
+	"fmt"
 
 	"github.com/chenrui333/terraformer/terraformutils"
 
@@ -21,7 +21,7 @@ type ImagesGenerator struct {
 }
 
 // Run on imagesList and create for each TerraformResource
-func (g ImagesGenerator) createResources(ctx context.Context, imagesList *compute.ImagesListCall) []terraformutils.Resource {
+func (g ImagesGenerator) createResources(ctx context.Context, imagesList *compute.ImagesListCall) ([]terraformutils.Resource, error) {
 	resources := []terraformutils.Resource{}
 	if err := imagesList.Pages(ctx, func(page *compute.ImageList) error {
 		for _, obj := range page.Items {
@@ -41,9 +41,9 @@ func (g ImagesGenerator) createResources(ctx context.Context, imagesList *comput
 		}
 		return nil
 	}); err != nil {
-		log.Println(err)
+		return nil, fmt.Errorf("list images: %w", err)
 	}
-	return resources
+	return resources, nil
 }
 
 // Generate TerraformResources from GCP API,
@@ -57,7 +57,11 @@ func (g *ImagesGenerator) InitResources() error {
 	}
 
 	imagesList := computeService.Images.List(g.GetArgs()["project"].(string))
-	g.Resources = g.createResources(ctx, imagesList)
+	resources, err := g.createResources(ctx, imagesList)
+	if err != nil {
+		return err
+	}
+	g.Resources = resources
 
 	return nil
 

--- a/providers/gcp/instanceGroupManagers_gen.go
+++ b/providers/gcp/instanceGroupManagers_gen.go
@@ -5,7 +5,7 @@ package gcp
 
 import (
 	"context"
-	"log"
+	"fmt"
 	"strings"
 
 	"github.com/chenrui333/terraformer/terraformutils"
@@ -22,7 +22,7 @@ type InstanceGroupManagersGenerator struct {
 }
 
 // Run on instanceGroupManagersList and create for each TerraformResource
-func (g InstanceGroupManagersGenerator) createResources(ctx context.Context, instanceGroupManagersList *compute.InstanceGroupManagersListCall, zone string) []terraformutils.Resource {
+func (g InstanceGroupManagersGenerator) createResources(ctx context.Context, instanceGroupManagersList *compute.InstanceGroupManagersListCall, zone string) ([]terraformutils.Resource, error) {
 	resources := []terraformutils.Resource{}
 	if err := instanceGroupManagersList.Pages(ctx, func(page *compute.InstanceGroupManagerList) error {
 		for _, obj := range page.Items {
@@ -43,9 +43,9 @@ func (g InstanceGroupManagersGenerator) createResources(ctx context.Context, ins
 		}
 		return nil
 	}); err != nil {
-		log.Println(err)
+		return nil, fmt.Errorf("list instanceGroupManagers: %w", err)
 	}
-	return resources
+	return resources, nil
 }
 
 // Generate TerraformResources from GCP API,
@@ -62,7 +62,11 @@ func (g *InstanceGroupManagersGenerator) InitResources() error {
 		t := strings.Split(zoneLink, "/")
 		zone := t[len(t)-1]
 		instanceGroupManagersList := computeService.InstanceGroupManagers.List(g.GetArgs()["project"].(string), zone)
-		g.Resources = append(g.Resources, g.createResources(ctx, instanceGroupManagersList, zone)...)
+		resources, err := g.createResources(ctx, instanceGroupManagersList, zone)
+		if err != nil {
+			return err
+		}
+		g.Resources = append(g.Resources, resources...)
 	}
 
 	return nil

--- a/providers/gcp/instanceGroups_gen.go
+++ b/providers/gcp/instanceGroups_gen.go
@@ -5,7 +5,7 @@ package gcp
 
 import (
 	"context"
-	"log"
+	"fmt"
 	"strings"
 
 	"github.com/chenrui333/terraformer/terraformutils"
@@ -22,7 +22,7 @@ type InstanceGroupsGenerator struct {
 }
 
 // Run on instanceGroupsList and create for each TerraformResource
-func (g InstanceGroupsGenerator) createResources(ctx context.Context, instanceGroupsList *compute.InstanceGroupsListCall, zone string) []terraformutils.Resource {
+func (g InstanceGroupsGenerator) createResources(ctx context.Context, instanceGroupsList *compute.InstanceGroupsListCall, zone string) ([]terraformutils.Resource, error) {
 	resources := []terraformutils.Resource{}
 	if err := instanceGroupsList.Pages(ctx, func(page *compute.InstanceGroupList) error {
 		for _, obj := range page.Items {
@@ -43,9 +43,9 @@ func (g InstanceGroupsGenerator) createResources(ctx context.Context, instanceGr
 		}
 		return nil
 	}); err != nil {
-		log.Println(err)
+		return nil, fmt.Errorf("list instanceGroups: %w", err)
 	}
-	return resources
+	return resources, nil
 }
 
 // Generate TerraformResources from GCP API,
@@ -62,7 +62,11 @@ func (g *InstanceGroupsGenerator) InitResources() error {
 		t := strings.Split(zoneLink, "/")
 		zone := t[len(t)-1]
 		instanceGroupsList := computeService.InstanceGroups.List(g.GetArgs()["project"].(string), zone)
-		g.Resources = append(g.Resources, g.createResources(ctx, instanceGroupsList, zone)...)
+		resources, err := g.createResources(ctx, instanceGroupsList, zone)
+		if err != nil {
+			return err
+		}
+		g.Resources = append(g.Resources, resources...)
 	}
 
 	return nil

--- a/providers/gcp/instanceTemplates_gen.go
+++ b/providers/gcp/instanceTemplates_gen.go
@@ -5,7 +5,7 @@ package gcp
 
 import (
 	"context"
-	"log"
+	"fmt"
 
 	"github.com/chenrui333/terraformer/terraformutils"
 
@@ -21,7 +21,7 @@ type InstanceTemplatesGenerator struct {
 }
 
 // Run on instanceTemplatesList and create for each TerraformResource
-func (g InstanceTemplatesGenerator) createResources(ctx context.Context, instanceTemplatesList *compute.InstanceTemplatesListCall) []terraformutils.Resource {
+func (g InstanceTemplatesGenerator) createResources(ctx context.Context, instanceTemplatesList *compute.InstanceTemplatesListCall) ([]terraformutils.Resource, error) {
 	resources := []terraformutils.Resource{}
 	if err := instanceTemplatesList.Pages(ctx, func(page *compute.InstanceTemplateList) error {
 		for _, obj := range page.Items {
@@ -41,9 +41,9 @@ func (g InstanceTemplatesGenerator) createResources(ctx context.Context, instanc
 		}
 		return nil
 	}); err != nil {
-		log.Println(err)
+		return nil, fmt.Errorf("list instanceTemplates: %w", err)
 	}
-	return resources
+	return resources, nil
 }
 
 // Generate TerraformResources from GCP API,
@@ -57,7 +57,11 @@ func (g *InstanceTemplatesGenerator) InitResources() error {
 	}
 
 	instanceTemplatesList := computeService.InstanceTemplates.List(g.GetArgs()["project"].(string))
-	g.Resources = g.createResources(ctx, instanceTemplatesList)
+	resources, err := g.createResources(ctx, instanceTemplatesList)
+	if err != nil {
+		return err
+	}
+	g.Resources = resources
 
 	return nil
 

--- a/providers/gcp/instances.go
+++ b/providers/gcp/instances.go
@@ -4,7 +4,7 @@ package gcp
 
 import (
 	"context"
-	"log"
+	"fmt"
 	"strings"
 
 	"github.com/chenrui333/terraformer/terraformutils"
@@ -21,7 +21,7 @@ type InstancesGenerator struct {
 }
 
 // Run on instancesList and create for each TerraformResource
-func (g InstancesGenerator) createResources(ctx context.Context, instancesList *compute.InstancesListCall, zone string) []terraformutils.Resource {
+func (g InstancesGenerator) createResources(ctx context.Context, instancesList *compute.InstancesListCall, zone string) ([]terraformutils.Resource, error) {
 	resources := []terraformutils.Resource{}
 	if err := instancesList.Pages(ctx, func(page *compute.InstanceList) error {
 		for _, obj := range page.Items {
@@ -47,9 +47,9 @@ func (g InstancesGenerator) createResources(ctx context.Context, instancesList *
 		}
 		return nil
 	}); err != nil {
-		log.Println(err)
+		return nil, fmt.Errorf("list instances: %w", err)
 	}
-	return resources
+	return resources, nil
 }
 
 // Generate TerraformResources from GCP API,
@@ -66,7 +66,11 @@ func (g *InstancesGenerator) InitResources() error {
 		t := strings.Split(zoneLink, "/")
 		zone := t[len(t)-1]
 		instancesList := computeService.Instances.List(g.GetArgs()["project"].(string), zone)
-		g.Resources = append(g.Resources, g.createResources(ctx, instancesList, zone)...)
+		resources, err := g.createResources(ctx, instancesList, zone)
+		if err != nil {
+			return err
+		}
+		g.Resources = append(g.Resources, resources...)
 	}
 	return nil
 }

--- a/providers/gcp/interconnectAttachments_gen.go
+++ b/providers/gcp/interconnectAttachments_gen.go
@@ -5,7 +5,7 @@ package gcp
 
 import (
 	"context"
-	"log"
+	"fmt"
 
 	"github.com/chenrui333/terraformer/terraformutils"
 
@@ -21,7 +21,7 @@ type InterconnectAttachmentsGenerator struct {
 }
 
 // Run on interconnectAttachmentsList and create for each TerraformResource
-func (g InterconnectAttachmentsGenerator) createResources(ctx context.Context, interconnectAttachmentsList *compute.InterconnectAttachmentsListCall) []terraformutils.Resource {
+func (g InterconnectAttachmentsGenerator) createResources(ctx context.Context, interconnectAttachmentsList *compute.InterconnectAttachmentsListCall) ([]terraformutils.Resource, error) {
 	resources := []terraformutils.Resource{}
 	if err := interconnectAttachmentsList.Pages(ctx, func(page *compute.InterconnectAttachmentList) error {
 		for _, obj := range page.Items {
@@ -41,9 +41,9 @@ func (g InterconnectAttachmentsGenerator) createResources(ctx context.Context, i
 		}
 		return nil
 	}); err != nil {
-		log.Println(err)
+		return nil, fmt.Errorf("list interconnectAttachments: %w", err)
 	}
-	return resources
+	return resources, nil
 }
 
 // Generate TerraformResources from GCP API,
@@ -57,7 +57,11 @@ func (g *InterconnectAttachmentsGenerator) InitResources() error {
 	}
 
 	interconnectAttachmentsList := computeService.InterconnectAttachments.List(g.GetArgs()["project"].(string), g.GetArgs()["region"].(compute.Region).Name)
-	g.Resources = g.createResources(ctx, interconnectAttachmentsList)
+	resources, err := g.createResources(ctx, interconnectAttachmentsList)
+	if err != nil {
+		return err
+	}
+	g.Resources = resources
 
 	return nil
 

--- a/providers/gcp/networkEndpointGroups_gen.go
+++ b/providers/gcp/networkEndpointGroups_gen.go
@@ -5,7 +5,7 @@ package gcp
 
 import (
 	"context"
-	"log"
+	"fmt"
 	"strings"
 
 	"github.com/chenrui333/terraformer/terraformutils"
@@ -22,7 +22,7 @@ type NetworkEndpointGroupsGenerator struct {
 }
 
 // Run on networkEndpointGroupsList and create for each TerraformResource
-func (g NetworkEndpointGroupsGenerator) createResources(ctx context.Context, networkEndpointGroupsList *compute.NetworkEndpointGroupsListCall, zone string) []terraformutils.Resource {
+func (g NetworkEndpointGroupsGenerator) createResources(ctx context.Context, networkEndpointGroupsList *compute.NetworkEndpointGroupsListCall, zone string) ([]terraformutils.Resource, error) {
 	resources := []terraformutils.Resource{}
 	if err := networkEndpointGroupsList.Pages(ctx, func(page *compute.NetworkEndpointGroupList) error {
 		for _, obj := range page.Items {
@@ -43,9 +43,9 @@ func (g NetworkEndpointGroupsGenerator) createResources(ctx context.Context, net
 		}
 		return nil
 	}); err != nil {
-		log.Println(err)
+		return nil, fmt.Errorf("list networkEndpointGroups: %w", err)
 	}
-	return resources
+	return resources, nil
 }
 
 // Generate TerraformResources from GCP API,
@@ -62,7 +62,11 @@ func (g *NetworkEndpointGroupsGenerator) InitResources() error {
 		t := strings.Split(zoneLink, "/")
 		zone := t[len(t)-1]
 		networkEndpointGroupsList := computeService.NetworkEndpointGroups.List(g.GetArgs()["project"].(string), zone)
-		g.Resources = append(g.Resources, g.createResources(ctx, networkEndpointGroupsList, zone)...)
+		resources, err := g.createResources(ctx, networkEndpointGroupsList, zone)
+		if err != nil {
+			return err
+		}
+		g.Resources = append(g.Resources, resources...)
 	}
 
 	return nil

--- a/providers/gcp/networks_gen.go
+++ b/providers/gcp/networks_gen.go
@@ -5,7 +5,7 @@ package gcp
 
 import (
 	"context"
-	"log"
+	"fmt"
 
 	"github.com/chenrui333/terraformer/terraformutils"
 
@@ -21,7 +21,7 @@ type NetworksGenerator struct {
 }
 
 // Run on networksList and create for each TerraformResource
-func (g NetworksGenerator) createResources(ctx context.Context, networksList *compute.NetworksListCall) []terraformutils.Resource {
+func (g NetworksGenerator) createResources(ctx context.Context, networksList *compute.NetworksListCall) ([]terraformutils.Resource, error) {
 	resources := []terraformutils.Resource{}
 	if err := networksList.Pages(ctx, func(page *compute.NetworkList) error {
 		for _, obj := range page.Items {
@@ -41,9 +41,9 @@ func (g NetworksGenerator) createResources(ctx context.Context, networksList *co
 		}
 		return nil
 	}); err != nil {
-		log.Println(err)
+		return nil, fmt.Errorf("list networks: %w", err)
 	}
-	return resources
+	return resources, nil
 }
 
 // Generate TerraformResources from GCP API,
@@ -57,7 +57,11 @@ func (g *NetworksGenerator) InitResources() error {
 	}
 
 	networksList := computeService.Networks.List(g.GetArgs()["project"].(string))
-	g.Resources = g.createResources(ctx, networksList)
+	resources, err := g.createResources(ctx, networksList)
+	if err != nil {
+		return err
+	}
+	g.Resources = resources
 
 	return nil
 

--- a/providers/gcp/nodeGroups_gen.go
+++ b/providers/gcp/nodeGroups_gen.go
@@ -5,7 +5,7 @@ package gcp
 
 import (
 	"context"
-	"log"
+	"fmt"
 	"strings"
 
 	"github.com/chenrui333/terraformer/terraformutils"
@@ -22,7 +22,7 @@ type NodeGroupsGenerator struct {
 }
 
 // Run on nodeGroupsList and create for each TerraformResource
-func (g NodeGroupsGenerator) createResources(ctx context.Context, nodeGroupsList *compute.NodeGroupsListCall, zone string) []terraformutils.Resource {
+func (g NodeGroupsGenerator) createResources(ctx context.Context, nodeGroupsList *compute.NodeGroupsListCall, zone string) ([]terraformutils.Resource, error) {
 	resources := []terraformutils.Resource{}
 	if err := nodeGroupsList.Pages(ctx, func(page *compute.NodeGroupList) error {
 		for _, obj := range page.Items {
@@ -43,9 +43,9 @@ func (g NodeGroupsGenerator) createResources(ctx context.Context, nodeGroupsList
 		}
 		return nil
 	}); err != nil {
-		log.Println(err)
+		return nil, fmt.Errorf("list nodeGroups: %w", err)
 	}
-	return resources
+	return resources, nil
 }
 
 // Generate TerraformResources from GCP API,
@@ -62,7 +62,11 @@ func (g *NodeGroupsGenerator) InitResources() error {
 		t := strings.Split(zoneLink, "/")
 		zone := t[len(t)-1]
 		nodeGroupsList := computeService.NodeGroups.List(g.GetArgs()["project"].(string), zone)
-		g.Resources = append(g.Resources, g.createResources(ctx, nodeGroupsList, zone)...)
+		resources, err := g.createResources(ctx, nodeGroupsList, zone)
+		if err != nil {
+			return err
+		}
+		g.Resources = append(g.Resources, resources...)
 	}
 
 	return nil

--- a/providers/gcp/nodeTemplates_gen.go
+++ b/providers/gcp/nodeTemplates_gen.go
@@ -5,7 +5,7 @@ package gcp
 
 import (
 	"context"
-	"log"
+	"fmt"
 
 	"github.com/chenrui333/terraformer/terraformutils"
 
@@ -21,7 +21,7 @@ type NodeTemplatesGenerator struct {
 }
 
 // Run on nodeTemplatesList and create for each TerraformResource
-func (g NodeTemplatesGenerator) createResources(ctx context.Context, nodeTemplatesList *compute.NodeTemplatesListCall) []terraformutils.Resource {
+func (g NodeTemplatesGenerator) createResources(ctx context.Context, nodeTemplatesList *compute.NodeTemplatesListCall) ([]terraformutils.Resource, error) {
 	resources := []terraformutils.Resource{}
 	if err := nodeTemplatesList.Pages(ctx, func(page *compute.NodeTemplateList) error {
 		for _, obj := range page.Items {
@@ -41,9 +41,9 @@ func (g NodeTemplatesGenerator) createResources(ctx context.Context, nodeTemplat
 		}
 		return nil
 	}); err != nil {
-		log.Println(err)
+		return nil, fmt.Errorf("list nodeTemplates: %w", err)
 	}
-	return resources
+	return resources, nil
 }
 
 // Generate TerraformResources from GCP API,
@@ -57,7 +57,11 @@ func (g *NodeTemplatesGenerator) InitResources() error {
 	}
 
 	nodeTemplatesList := computeService.NodeTemplates.List(g.GetArgs()["project"].(string), g.GetArgs()["region"].(compute.Region).Name)
-	g.Resources = g.createResources(ctx, nodeTemplatesList)
+	resources, err := g.createResources(ctx, nodeTemplatesList)
+	if err != nil {
+		return err
+	}
+	g.Resources = resources
 
 	return nil
 

--- a/providers/gcp/packetMirrorings_gen.go
+++ b/providers/gcp/packetMirrorings_gen.go
@@ -5,7 +5,7 @@ package gcp
 
 import (
 	"context"
-	"log"
+	"fmt"
 
 	"github.com/chenrui333/terraformer/terraformutils"
 
@@ -21,7 +21,7 @@ type PacketMirroringsGenerator struct {
 }
 
 // Run on packetMirroringsList and create for each TerraformResource
-func (g PacketMirroringsGenerator) createResources(ctx context.Context, packetMirroringsList *compute.PacketMirroringsListCall) []terraformutils.Resource {
+func (g PacketMirroringsGenerator) createResources(ctx context.Context, packetMirroringsList *compute.PacketMirroringsListCall) ([]terraformutils.Resource, error) {
 	resources := []terraformutils.Resource{}
 	if err := packetMirroringsList.Pages(ctx, func(page *compute.PacketMirroringList) error {
 		for _, obj := range page.Items {
@@ -41,9 +41,9 @@ func (g PacketMirroringsGenerator) createResources(ctx context.Context, packetMi
 		}
 		return nil
 	}); err != nil {
-		log.Println(err)
+		return nil, fmt.Errorf("list packetMirrorings: %w", err)
 	}
-	return resources
+	return resources, nil
 }
 
 // Generate TerraformResources from GCP API,
@@ -57,7 +57,11 @@ func (g *PacketMirroringsGenerator) InitResources() error {
 	}
 
 	packetMirroringsList := computeService.PacketMirrorings.List(g.GetArgs()["project"].(string), g.GetArgs()["region"].(compute.Region).Name)
-	g.Resources = g.createResources(ctx, packetMirroringsList)
+	resources, err := g.createResources(ctx, packetMirroringsList)
+	if err != nil {
+		return err
+	}
+	g.Resources = resources
 
 	return nil
 

--- a/providers/gcp/regionAutoscalers_gen.go
+++ b/providers/gcp/regionAutoscalers_gen.go
@@ -5,7 +5,7 @@ package gcp
 
 import (
 	"context"
-	"log"
+	"fmt"
 
 	"github.com/chenrui333/terraformer/terraformutils"
 
@@ -21,7 +21,7 @@ type RegionAutoscalersGenerator struct {
 }
 
 // Run on regionAutoscalersList and create for each TerraformResource
-func (g RegionAutoscalersGenerator) createResources(ctx context.Context, regionAutoscalersList *compute.RegionAutoscalersListCall) []terraformutils.Resource {
+func (g RegionAutoscalersGenerator) createResources(ctx context.Context, regionAutoscalersList *compute.RegionAutoscalersListCall) ([]terraformutils.Resource, error) {
 	resources := []terraformutils.Resource{}
 	if err := regionAutoscalersList.Pages(ctx, func(page *compute.RegionAutoscalerList) error {
 		for _, obj := range page.Items {
@@ -41,9 +41,9 @@ func (g RegionAutoscalersGenerator) createResources(ctx context.Context, regionA
 		}
 		return nil
 	}); err != nil {
-		log.Println(err)
+		return nil, fmt.Errorf("list regionAutoscalers: %w", err)
 	}
-	return resources
+	return resources, nil
 }
 
 // Generate TerraformResources from GCP API,
@@ -57,7 +57,11 @@ func (g *RegionAutoscalersGenerator) InitResources() error {
 	}
 
 	regionAutoscalersList := computeService.RegionAutoscalers.List(g.GetArgs()["project"].(string), g.GetArgs()["region"].(compute.Region).Name)
-	g.Resources = g.createResources(ctx, regionAutoscalersList)
+	resources, err := g.createResources(ctx, regionAutoscalersList)
+	if err != nil {
+		return err
+	}
+	g.Resources = resources
 
 	return nil
 

--- a/providers/gcp/regionBackendServices_gen.go
+++ b/providers/gcp/regionBackendServices_gen.go
@@ -5,7 +5,7 @@ package gcp
 
 import (
 	"context"
-	"log"
+	"fmt"
 
 	"github.com/chenrui333/terraformer/terraformutils"
 
@@ -21,7 +21,7 @@ type RegionBackendServicesGenerator struct {
 }
 
 // Run on regionBackendServicesList and create for each TerraformResource
-func (g RegionBackendServicesGenerator) createResources(ctx context.Context, regionBackendServicesList *compute.RegionBackendServicesListCall) []terraformutils.Resource {
+func (g RegionBackendServicesGenerator) createResources(ctx context.Context, regionBackendServicesList *compute.RegionBackendServicesListCall) ([]terraformutils.Resource, error) {
 	resources := []terraformutils.Resource{}
 	if err := regionBackendServicesList.Pages(ctx, func(page *compute.BackendServiceList) error {
 		for _, obj := range page.Items {
@@ -41,9 +41,9 @@ func (g RegionBackendServicesGenerator) createResources(ctx context.Context, reg
 		}
 		return nil
 	}); err != nil {
-		log.Println(err)
+		return nil, fmt.Errorf("list regionBackendServices: %w", err)
 	}
-	return resources
+	return resources, nil
 }
 
 // Generate TerraformResources from GCP API,
@@ -57,7 +57,11 @@ func (g *RegionBackendServicesGenerator) InitResources() error {
 	}
 
 	regionBackendServicesList := computeService.RegionBackendServices.List(g.GetArgs()["project"].(string), g.GetArgs()["region"].(compute.Region).Name)
-	g.Resources = g.createResources(ctx, regionBackendServicesList)
+	resources, err := g.createResources(ctx, regionBackendServicesList)
+	if err != nil {
+		return err
+	}
+	g.Resources = resources
 
 	return nil
 

--- a/providers/gcp/regionDisks_gen.go
+++ b/providers/gcp/regionDisks_gen.go
@@ -5,7 +5,7 @@ package gcp
 
 import (
 	"context"
-	"log"
+	"fmt"
 
 	"github.com/chenrui333/terraformer/terraformutils"
 
@@ -21,7 +21,7 @@ type RegionDisksGenerator struct {
 }
 
 // Run on regionDisksList and create for each TerraformResource
-func (g RegionDisksGenerator) createResources(ctx context.Context, regionDisksList *compute.RegionDisksListCall) []terraformutils.Resource {
+func (g RegionDisksGenerator) createResources(ctx context.Context, regionDisksList *compute.RegionDisksListCall) ([]terraformutils.Resource, error) {
 	resources := []terraformutils.Resource{}
 	if err := regionDisksList.Pages(ctx, func(page *compute.DiskList) error {
 		for _, obj := range page.Items {
@@ -41,9 +41,9 @@ func (g RegionDisksGenerator) createResources(ctx context.Context, regionDisksLi
 		}
 		return nil
 	}); err != nil {
-		log.Println(err)
+		return nil, fmt.Errorf("list regionDisks: %w", err)
 	}
-	return resources
+	return resources, nil
 }
 
 // Generate TerraformResources from GCP API,
@@ -57,7 +57,11 @@ func (g *RegionDisksGenerator) InitResources() error {
 	}
 
 	regionDisksList := computeService.RegionDisks.List(g.GetArgs()["project"].(string), g.GetArgs()["region"].(compute.Region).Name)
-	g.Resources = g.createResources(ctx, regionDisksList)
+	resources, err := g.createResources(ctx, regionDisksList)
+	if err != nil {
+		return err
+	}
+	g.Resources = resources
 
 	return nil
 

--- a/providers/gcp/regionHealthChecks_gen.go
+++ b/providers/gcp/regionHealthChecks_gen.go
@@ -5,7 +5,7 @@ package gcp
 
 import (
 	"context"
-	"log"
+	"fmt"
 
 	"github.com/chenrui333/terraformer/terraformutils"
 
@@ -21,7 +21,7 @@ type RegionHealthChecksGenerator struct {
 }
 
 // Run on regionHealthChecksList and create for each TerraformResource
-func (g RegionHealthChecksGenerator) createResources(ctx context.Context, regionHealthChecksList *compute.RegionHealthChecksListCall) []terraformutils.Resource {
+func (g RegionHealthChecksGenerator) createResources(ctx context.Context, regionHealthChecksList *compute.RegionHealthChecksListCall) ([]terraformutils.Resource, error) {
 	resources := []terraformutils.Resource{}
 	if err := regionHealthChecksList.Pages(ctx, func(page *compute.HealthCheckList) error {
 		for _, obj := range page.Items {
@@ -41,9 +41,9 @@ func (g RegionHealthChecksGenerator) createResources(ctx context.Context, region
 		}
 		return nil
 	}); err != nil {
-		log.Println(err)
+		return nil, fmt.Errorf("list regionHealthChecks: %w", err)
 	}
-	return resources
+	return resources, nil
 }
 
 // Generate TerraformResources from GCP API,
@@ -57,7 +57,11 @@ func (g *RegionHealthChecksGenerator) InitResources() error {
 	}
 
 	regionHealthChecksList := computeService.RegionHealthChecks.List(g.GetArgs()["project"].(string), g.GetArgs()["region"].(compute.Region).Name)
-	g.Resources = g.createResources(ctx, regionHealthChecksList)
+	resources, err := g.createResources(ctx, regionHealthChecksList)
+	if err != nil {
+		return err
+	}
+	g.Resources = resources
 
 	return nil
 

--- a/providers/gcp/regionInstanceGroupManagers_gen.go
+++ b/providers/gcp/regionInstanceGroupManagers_gen.go
@@ -5,7 +5,7 @@ package gcp
 
 import (
 	"context"
-	"log"
+	"fmt"
 
 	"github.com/chenrui333/terraformer/terraformutils"
 
@@ -21,7 +21,7 @@ type RegionInstanceGroupManagersGenerator struct {
 }
 
 // Run on regionInstanceGroupManagersList and create for each TerraformResource
-func (g RegionInstanceGroupManagersGenerator) createResources(ctx context.Context, regionInstanceGroupManagersList *compute.RegionInstanceGroupManagersListCall) []terraformutils.Resource {
+func (g RegionInstanceGroupManagersGenerator) createResources(ctx context.Context, regionInstanceGroupManagersList *compute.RegionInstanceGroupManagersListCall) ([]terraformutils.Resource, error) {
 	resources := []terraformutils.Resource{}
 	if err := regionInstanceGroupManagersList.Pages(ctx, func(page *compute.RegionInstanceGroupManagerList) error {
 		for _, obj := range page.Items {
@@ -41,9 +41,9 @@ func (g RegionInstanceGroupManagersGenerator) createResources(ctx context.Contex
 		}
 		return nil
 	}); err != nil {
-		log.Println(err)
+		return nil, fmt.Errorf("list regionInstanceGroupManagers: %w", err)
 	}
-	return resources
+	return resources, nil
 }
 
 // Generate TerraformResources from GCP API,
@@ -57,7 +57,11 @@ func (g *RegionInstanceGroupManagersGenerator) InitResources() error {
 	}
 
 	regionInstanceGroupManagersList := computeService.RegionInstanceGroupManagers.List(g.GetArgs()["project"].(string), g.GetArgs()["region"].(compute.Region).Name)
-	g.Resources = g.createResources(ctx, regionInstanceGroupManagersList)
+	resources, err := g.createResources(ctx, regionInstanceGroupManagersList)
+	if err != nil {
+		return err
+	}
+	g.Resources = resources
 
 	return nil
 

--- a/providers/gcp/regionInstanceGroups_gen.go
+++ b/providers/gcp/regionInstanceGroups_gen.go
@@ -5,7 +5,7 @@ package gcp
 
 import (
 	"context"
-	"log"
+	"fmt"
 
 	"github.com/chenrui333/terraformer/terraformutils"
 
@@ -21,7 +21,7 @@ type RegionInstanceGroupsGenerator struct {
 }
 
 // Run on regionInstanceGroupsList and create for each TerraformResource
-func (g RegionInstanceGroupsGenerator) createResources(ctx context.Context, regionInstanceGroupsList *compute.RegionInstanceGroupsListCall) []terraformutils.Resource {
+func (g RegionInstanceGroupsGenerator) createResources(ctx context.Context, regionInstanceGroupsList *compute.RegionInstanceGroupsListCall) ([]terraformutils.Resource, error) {
 	resources := []terraformutils.Resource{}
 	if err := regionInstanceGroupsList.Pages(ctx, func(page *compute.RegionInstanceGroupList) error {
 		for _, obj := range page.Items {
@@ -41,9 +41,9 @@ func (g RegionInstanceGroupsGenerator) createResources(ctx context.Context, regi
 		}
 		return nil
 	}); err != nil {
-		log.Println(err)
+		return nil, fmt.Errorf("list regionInstanceGroups: %w", err)
 	}
-	return resources
+	return resources, nil
 }
 
 // Generate TerraformResources from GCP API,
@@ -57,7 +57,11 @@ func (g *RegionInstanceGroupsGenerator) InitResources() error {
 	}
 
 	regionInstanceGroupsList := computeService.RegionInstanceGroups.List(g.GetArgs()["project"].(string), g.GetArgs()["region"].(compute.Region).Name)
-	g.Resources = g.createResources(ctx, regionInstanceGroupsList)
+	resources, err := g.createResources(ctx, regionInstanceGroupsList)
+	if err != nil {
+		return err
+	}
+	g.Resources = resources
 
 	return nil
 

--- a/providers/gcp/regionSslCertificates_gen.go
+++ b/providers/gcp/regionSslCertificates_gen.go
@@ -5,7 +5,7 @@ package gcp
 
 import (
 	"context"
-	"log"
+	"fmt"
 
 	"github.com/chenrui333/terraformer/terraformutils"
 
@@ -21,7 +21,7 @@ type RegionSslCertificatesGenerator struct {
 }
 
 // Run on regionSslCertificatesList and create for each TerraformResource
-func (g RegionSslCertificatesGenerator) createResources(ctx context.Context, regionSslCertificatesList *compute.RegionSslCertificatesListCall) []terraformutils.Resource {
+func (g RegionSslCertificatesGenerator) createResources(ctx context.Context, regionSslCertificatesList *compute.RegionSslCertificatesListCall) ([]terraformutils.Resource, error) {
 	resources := []terraformutils.Resource{}
 	if err := regionSslCertificatesList.Pages(ctx, func(page *compute.SslCertificateList) error {
 		for _, obj := range page.Items {
@@ -41,9 +41,9 @@ func (g RegionSslCertificatesGenerator) createResources(ctx context.Context, reg
 		}
 		return nil
 	}); err != nil {
-		log.Println(err)
+		return nil, fmt.Errorf("list regionSslCertificates: %w", err)
 	}
-	return resources
+	return resources, nil
 }
 
 // Generate TerraformResources from GCP API,
@@ -57,7 +57,11 @@ func (g *RegionSslCertificatesGenerator) InitResources() error {
 	}
 
 	regionSslCertificatesList := computeService.RegionSslCertificates.List(g.GetArgs()["project"].(string), g.GetArgs()["region"].(compute.Region).Name)
-	g.Resources = g.createResources(ctx, regionSslCertificatesList)
+	resources, err := g.createResources(ctx, regionSslCertificatesList)
+	if err != nil {
+		return err
+	}
+	g.Resources = resources
 
 	return nil
 

--- a/providers/gcp/regionTargetHttpProxies_gen.go
+++ b/providers/gcp/regionTargetHttpProxies_gen.go
@@ -5,7 +5,7 @@ package gcp
 
 import (
 	"context"
-	"log"
+	"fmt"
 
 	"github.com/chenrui333/terraformer/terraformutils"
 
@@ -21,7 +21,7 @@ type RegionTargetHttpProxiesGenerator struct {
 }
 
 // Run on regionTargetHttpProxiesList and create for each TerraformResource
-func (g RegionTargetHttpProxiesGenerator) createResources(ctx context.Context, regionTargetHttpProxiesList *compute.RegionTargetHttpProxiesListCall) []terraformutils.Resource {
+func (g RegionTargetHttpProxiesGenerator) createResources(ctx context.Context, regionTargetHttpProxiesList *compute.RegionTargetHttpProxiesListCall) ([]terraformutils.Resource, error) {
 	resources := []terraformutils.Resource{}
 	if err := regionTargetHttpProxiesList.Pages(ctx, func(page *compute.TargetHttpProxyList) error {
 		for _, obj := range page.Items {
@@ -41,9 +41,9 @@ func (g RegionTargetHttpProxiesGenerator) createResources(ctx context.Context, r
 		}
 		return nil
 	}); err != nil {
-		log.Println(err)
+		return nil, fmt.Errorf("list regionTargetHttpProxies: %w", err)
 	}
-	return resources
+	return resources, nil
 }
 
 // Generate TerraformResources from GCP API,
@@ -57,7 +57,11 @@ func (g *RegionTargetHttpProxiesGenerator) InitResources() error {
 	}
 
 	regionTargetHttpProxiesList := computeService.RegionTargetHttpProxies.List(g.GetArgs()["project"].(string), g.GetArgs()["region"].(compute.Region).Name)
-	g.Resources = g.createResources(ctx, regionTargetHttpProxiesList)
+	resources, err := g.createResources(ctx, regionTargetHttpProxiesList)
+	if err != nil {
+		return err
+	}
+	g.Resources = resources
 
 	return nil
 

--- a/providers/gcp/regionTargetHttpsProxies_gen.go
+++ b/providers/gcp/regionTargetHttpsProxies_gen.go
@@ -5,7 +5,7 @@ package gcp
 
 import (
 	"context"
-	"log"
+	"fmt"
 
 	"github.com/chenrui333/terraformer/terraformutils"
 
@@ -21,7 +21,7 @@ type RegionTargetHttpsProxiesGenerator struct {
 }
 
 // Run on regionTargetHttpsProxiesList and create for each TerraformResource
-func (g RegionTargetHttpsProxiesGenerator) createResources(ctx context.Context, regionTargetHttpsProxiesList *compute.RegionTargetHttpsProxiesListCall) []terraformutils.Resource {
+func (g RegionTargetHttpsProxiesGenerator) createResources(ctx context.Context, regionTargetHttpsProxiesList *compute.RegionTargetHttpsProxiesListCall) ([]terraformutils.Resource, error) {
 	resources := []terraformutils.Resource{}
 	if err := regionTargetHttpsProxiesList.Pages(ctx, func(page *compute.TargetHttpsProxyList) error {
 		for _, obj := range page.Items {
@@ -41,9 +41,9 @@ func (g RegionTargetHttpsProxiesGenerator) createResources(ctx context.Context, 
 		}
 		return nil
 	}); err != nil {
-		log.Println(err)
+		return nil, fmt.Errorf("list regionTargetHttpsProxies: %w", err)
 	}
-	return resources
+	return resources, nil
 }
 
 // Generate TerraformResources from GCP API,
@@ -57,7 +57,11 @@ func (g *RegionTargetHttpsProxiesGenerator) InitResources() error {
 	}
 
 	regionTargetHttpsProxiesList := computeService.RegionTargetHttpsProxies.List(g.GetArgs()["project"].(string), g.GetArgs()["region"].(compute.Region).Name)
-	g.Resources = g.createResources(ctx, regionTargetHttpsProxiesList)
+	resources, err := g.createResources(ctx, regionTargetHttpsProxiesList)
+	if err != nil {
+		return err
+	}
+	g.Resources = resources
 
 	return nil
 

--- a/providers/gcp/regionUrlMaps_gen.go
+++ b/providers/gcp/regionUrlMaps_gen.go
@@ -5,7 +5,7 @@ package gcp
 
 import (
 	"context"
-	"log"
+	"fmt"
 
 	"github.com/chenrui333/terraformer/terraformutils"
 
@@ -21,7 +21,7 @@ type RegionUrlMapsGenerator struct {
 }
 
 // Run on regionUrlMapsList and create for each TerraformResource
-func (g RegionUrlMapsGenerator) createResources(ctx context.Context, regionUrlMapsList *compute.RegionUrlMapsListCall) []terraformutils.Resource {
+func (g RegionUrlMapsGenerator) createResources(ctx context.Context, regionUrlMapsList *compute.RegionUrlMapsListCall) ([]terraformutils.Resource, error) {
 	resources := []terraformutils.Resource{}
 	if err := regionUrlMapsList.Pages(ctx, func(page *compute.UrlMapList) error {
 		for _, obj := range page.Items {
@@ -41,9 +41,9 @@ func (g RegionUrlMapsGenerator) createResources(ctx context.Context, regionUrlMa
 		}
 		return nil
 	}); err != nil {
-		log.Println(err)
+		return nil, fmt.Errorf("list regionUrlMaps: %w", err)
 	}
-	return resources
+	return resources, nil
 }
 
 // Generate TerraformResources from GCP API,
@@ -57,7 +57,11 @@ func (g *RegionUrlMapsGenerator) InitResources() error {
 	}
 
 	regionUrlMapsList := computeService.RegionUrlMaps.List(g.GetArgs()["project"].(string), g.GetArgs()["region"].(compute.Region).Name)
-	g.Resources = g.createResources(ctx, regionUrlMapsList)
+	resources, err := g.createResources(ctx, regionUrlMapsList)
+	if err != nil {
+		return err
+	}
+	g.Resources = resources
 
 	return nil
 

--- a/providers/gcp/reservations_gen.go
+++ b/providers/gcp/reservations_gen.go
@@ -5,7 +5,7 @@ package gcp
 
 import (
 	"context"
-	"log"
+	"fmt"
 	"strings"
 
 	"github.com/chenrui333/terraformer/terraformutils"
@@ -22,7 +22,7 @@ type ReservationsGenerator struct {
 }
 
 // Run on reservationsList and create for each TerraformResource
-func (g ReservationsGenerator) createResources(ctx context.Context, reservationsList *compute.ReservationsListCall, zone string) []terraformutils.Resource {
+func (g ReservationsGenerator) createResources(ctx context.Context, reservationsList *compute.ReservationsListCall, zone string) ([]terraformutils.Resource, error) {
 	resources := []terraformutils.Resource{}
 	if err := reservationsList.Pages(ctx, func(page *compute.ReservationList) error {
 		for _, obj := range page.Items {
@@ -43,9 +43,9 @@ func (g ReservationsGenerator) createResources(ctx context.Context, reservations
 		}
 		return nil
 	}); err != nil {
-		log.Println(err)
+		return nil, fmt.Errorf("list reservations: %w", err)
 	}
-	return resources
+	return resources, nil
 }
 
 // Generate TerraformResources from GCP API,
@@ -62,7 +62,11 @@ func (g *ReservationsGenerator) InitResources() error {
 		t := strings.Split(zoneLink, "/")
 		zone := t[len(t)-1]
 		reservationsList := computeService.Reservations.List(g.GetArgs()["project"].(string), zone)
-		g.Resources = append(g.Resources, g.createResources(ctx, reservationsList, zone)...)
+		resources, err := g.createResources(ctx, reservationsList, zone)
+		if err != nil {
+			return err
+		}
+		g.Resources = append(g.Resources, resources...)
 	}
 
 	return nil

--- a/providers/gcp/resourcePolicies_gen.go
+++ b/providers/gcp/resourcePolicies_gen.go
@@ -5,7 +5,7 @@ package gcp
 
 import (
 	"context"
-	"log"
+	"fmt"
 
 	"github.com/chenrui333/terraformer/terraformutils"
 
@@ -21,7 +21,7 @@ type ResourcePoliciesGenerator struct {
 }
 
 // Run on resourcePoliciesList and create for each TerraformResource
-func (g ResourcePoliciesGenerator) createResources(ctx context.Context, resourcePoliciesList *compute.ResourcePoliciesListCall) []terraformutils.Resource {
+func (g ResourcePoliciesGenerator) createResources(ctx context.Context, resourcePoliciesList *compute.ResourcePoliciesListCall) ([]terraformutils.Resource, error) {
 	resources := []terraformutils.Resource{}
 	if err := resourcePoliciesList.Pages(ctx, func(page *compute.ResourcePolicyList) error {
 		for _, obj := range page.Items {
@@ -41,9 +41,9 @@ func (g ResourcePoliciesGenerator) createResources(ctx context.Context, resource
 		}
 		return nil
 	}); err != nil {
-		log.Println(err)
+		return nil, fmt.Errorf("list resourcePolicies: %w", err)
 	}
-	return resources
+	return resources, nil
 }
 
 // Generate TerraformResources from GCP API,
@@ -57,7 +57,11 @@ func (g *ResourcePoliciesGenerator) InitResources() error {
 	}
 
 	resourcePoliciesList := computeService.ResourcePolicies.List(g.GetArgs()["project"].(string), g.GetArgs()["region"].(compute.Region).Name)
-	g.Resources = g.createResources(ctx, resourcePoliciesList)
+	resources, err := g.createResources(ctx, resourcePoliciesList)
+	if err != nil {
+		return err
+	}
+	g.Resources = resources
 
 	return nil
 

--- a/providers/gcp/routers_gen.go
+++ b/providers/gcp/routers_gen.go
@@ -5,7 +5,7 @@ package gcp
 
 import (
 	"context"
-	"log"
+	"fmt"
 
 	"github.com/chenrui333/terraformer/terraformutils"
 
@@ -21,7 +21,7 @@ type RoutersGenerator struct {
 }
 
 // Run on routersList and create for each TerraformResource
-func (g RoutersGenerator) createResources(ctx context.Context, routersList *compute.RoutersListCall) []terraformutils.Resource {
+func (g RoutersGenerator) createResources(ctx context.Context, routersList *compute.RoutersListCall) ([]terraformutils.Resource, error) {
 	resources := []terraformutils.Resource{}
 	if err := routersList.Pages(ctx, func(page *compute.RouterList) error {
 		for _, obj := range page.Items {
@@ -41,9 +41,9 @@ func (g RoutersGenerator) createResources(ctx context.Context, routersList *comp
 		}
 		return nil
 	}); err != nil {
-		log.Println(err)
+		return nil, fmt.Errorf("list routers: %w", err)
 	}
-	return resources
+	return resources, nil
 }
 
 // Generate TerraformResources from GCP API,
@@ -57,7 +57,11 @@ func (g *RoutersGenerator) InitResources() error {
 	}
 
 	routersList := computeService.Routers.List(g.GetArgs()["project"].(string), g.GetArgs()["region"].(compute.Region).Name)
-	g.Resources = g.createResources(ctx, routersList)
+	resources, err := g.createResources(ctx, routersList)
+	if err != nil {
+		return err
+	}
+	g.Resources = resources
 
 	return nil
 

--- a/providers/gcp/routes_gen.go
+++ b/providers/gcp/routes_gen.go
@@ -5,7 +5,7 @@ package gcp
 
 import (
 	"context"
-	"log"
+	"fmt"
 
 	"github.com/chenrui333/terraformer/terraformutils"
 
@@ -21,7 +21,7 @@ type RoutesGenerator struct {
 }
 
 // Run on routesList and create for each TerraformResource
-func (g RoutesGenerator) createResources(ctx context.Context, routesList *compute.RoutesListCall) []terraformutils.Resource {
+func (g RoutesGenerator) createResources(ctx context.Context, routesList *compute.RoutesListCall) ([]terraformutils.Resource, error) {
 	resources := []terraformutils.Resource{}
 	if err := routesList.Pages(ctx, func(page *compute.RouteList) error {
 		for _, obj := range page.Items {
@@ -41,9 +41,9 @@ func (g RoutesGenerator) createResources(ctx context.Context, routesList *comput
 		}
 		return nil
 	}); err != nil {
-		log.Println(err)
+		return nil, fmt.Errorf("list routes: %w", err)
 	}
-	return resources
+	return resources, nil
 }
 
 // Generate TerraformResources from GCP API,
@@ -57,7 +57,11 @@ func (g *RoutesGenerator) InitResources() error {
 	}
 
 	routesList := computeService.Routes.List(g.GetArgs()["project"].(string))
-	g.Resources = g.createResources(ctx, routesList)
+	resources, err := g.createResources(ctx, routesList)
+	if err != nil {
+		return err
+	}
+	g.Resources = resources
 
 	return nil
 

--- a/providers/gcp/securityPolicies_gen.go
+++ b/providers/gcp/securityPolicies_gen.go
@@ -5,7 +5,7 @@ package gcp
 
 import (
 	"context"
-	"log"
+	"fmt"
 
 	"github.com/chenrui333/terraformer/terraformutils"
 
@@ -21,7 +21,7 @@ type SecurityPoliciesGenerator struct {
 }
 
 // Run on securityPoliciesList and create for each TerraformResource
-func (g SecurityPoliciesGenerator) createResources(ctx context.Context, securityPoliciesList *compute.SecurityPoliciesListCall) []terraformutils.Resource {
+func (g SecurityPoliciesGenerator) createResources(ctx context.Context, securityPoliciesList *compute.SecurityPoliciesListCall) ([]terraformutils.Resource, error) {
 	resources := []terraformutils.Resource{}
 	if err := securityPoliciesList.Pages(ctx, func(page *compute.SecurityPolicyList) error {
 		for _, obj := range page.Items {
@@ -41,9 +41,9 @@ func (g SecurityPoliciesGenerator) createResources(ctx context.Context, security
 		}
 		return nil
 	}); err != nil {
-		log.Println(err)
+		return nil, fmt.Errorf("list securityPolicies: %w", err)
 	}
-	return resources
+	return resources, nil
 }
 
 // Generate TerraformResources from GCP API,
@@ -57,7 +57,11 @@ func (g *SecurityPoliciesGenerator) InitResources() error {
 	}
 
 	securityPoliciesList := computeService.SecurityPolicies.List(g.GetArgs()["project"].(string))
-	g.Resources = g.createResources(ctx, securityPoliciesList)
+	resources, err := g.createResources(ctx, securityPoliciesList)
+	if err != nil {
+		return err
+	}
+	g.Resources = resources
 
 	return nil
 

--- a/providers/gcp/sslCertificates_gen.go
+++ b/providers/gcp/sslCertificates_gen.go
@@ -5,7 +5,7 @@ package gcp
 
 import (
 	"context"
-	"log"
+	"fmt"
 
 	"github.com/chenrui333/terraformer/terraformutils"
 
@@ -21,7 +21,7 @@ type SslCertificatesGenerator struct {
 }
 
 // Run on sslCertificatesList and create for each TerraformResource
-func (g SslCertificatesGenerator) createResources(ctx context.Context, sslCertificatesList *compute.SslCertificatesListCall) []terraformutils.Resource {
+func (g SslCertificatesGenerator) createResources(ctx context.Context, sslCertificatesList *compute.SslCertificatesListCall) ([]terraformutils.Resource, error) {
 	resources := []terraformutils.Resource{}
 	if err := sslCertificatesList.Pages(ctx, func(page *compute.SslCertificateList) error {
 		for _, obj := range page.Items {
@@ -41,9 +41,9 @@ func (g SslCertificatesGenerator) createResources(ctx context.Context, sslCertif
 		}
 		return nil
 	}); err != nil {
-		log.Println(err)
+		return nil, fmt.Errorf("list sslCertificates: %w", err)
 	}
-	return resources
+	return resources, nil
 }
 
 // Generate TerraformResources from GCP API,
@@ -57,7 +57,11 @@ func (g *SslCertificatesGenerator) InitResources() error {
 	}
 
 	sslCertificatesList := computeService.SslCertificates.List(g.GetArgs()["project"].(string))
-	g.Resources = g.createResources(ctx, sslCertificatesList)
+	resources, err := g.createResources(ctx, sslCertificatesList)
+	if err != nil {
+		return err
+	}
+	g.Resources = resources
 
 	return nil
 

--- a/providers/gcp/sslPolicies_gen.go
+++ b/providers/gcp/sslPolicies_gen.go
@@ -5,7 +5,7 @@ package gcp
 
 import (
 	"context"
-	"log"
+	"fmt"
 
 	"github.com/chenrui333/terraformer/terraformutils"
 
@@ -21,7 +21,7 @@ type SslPoliciesGenerator struct {
 }
 
 // Run on sslPoliciesList and create for each TerraformResource
-func (g SslPoliciesGenerator) createResources(ctx context.Context, sslPoliciesList *compute.SslPoliciesListCall) []terraformutils.Resource {
+func (g SslPoliciesGenerator) createResources(ctx context.Context, sslPoliciesList *compute.SslPoliciesListCall) ([]terraformutils.Resource, error) {
 	resources := []terraformutils.Resource{}
 	if err := sslPoliciesList.Pages(ctx, func(page *compute.SslPoliciesList) error {
 		for _, obj := range page.Items {
@@ -41,9 +41,9 @@ func (g SslPoliciesGenerator) createResources(ctx context.Context, sslPoliciesLi
 		}
 		return nil
 	}); err != nil {
-		log.Println(err)
+		return nil, fmt.Errorf("list sslPolicies: %w", err)
 	}
-	return resources
+	return resources, nil
 }
 
 // Generate TerraformResources from GCP API,
@@ -57,7 +57,11 @@ func (g *SslPoliciesGenerator) InitResources() error {
 	}
 
 	sslPoliciesList := computeService.SslPolicies.List(g.GetArgs()["project"].(string))
-	g.Resources = g.createResources(ctx, sslPoliciesList)
+	resources, err := g.createResources(ctx, sslPoliciesList)
+	if err != nil {
+		return err
+	}
+	g.Resources = resources
 
 	return nil
 

--- a/providers/gcp/subnetworks_gen.go
+++ b/providers/gcp/subnetworks_gen.go
@@ -5,7 +5,7 @@ package gcp
 
 import (
 	"context"
-	"log"
+	"fmt"
 
 	"github.com/chenrui333/terraformer/terraformutils"
 
@@ -21,7 +21,7 @@ type SubnetworksGenerator struct {
 }
 
 // Run on subnetworksList and create for each TerraformResource
-func (g SubnetworksGenerator) createResources(ctx context.Context, subnetworksList *compute.SubnetworksListCall) []terraformutils.Resource {
+func (g SubnetworksGenerator) createResources(ctx context.Context, subnetworksList *compute.SubnetworksListCall) ([]terraformutils.Resource, error) {
 	resources := []terraformutils.Resource{}
 	if err := subnetworksList.Pages(ctx, func(page *compute.SubnetworkList) error {
 		for _, obj := range page.Items {
@@ -41,9 +41,9 @@ func (g SubnetworksGenerator) createResources(ctx context.Context, subnetworksLi
 		}
 		return nil
 	}); err != nil {
-		log.Println(err)
+		return nil, fmt.Errorf("list subnetworks: %w", err)
 	}
-	return resources
+	return resources, nil
 }
 
 // Generate TerraformResources from GCP API,
@@ -57,7 +57,11 @@ func (g *SubnetworksGenerator) InitResources() error {
 	}
 
 	subnetworksList := computeService.Subnetworks.List(g.GetArgs()["project"].(string), g.GetArgs()["region"].(compute.Region).Name)
-	g.Resources = g.createResources(ctx, subnetworksList)
+	resources, err := g.createResources(ctx, subnetworksList)
+	if err != nil {
+		return err
+	}
+	g.Resources = resources
 
 	return nil
 

--- a/providers/gcp/targetHttpProxies_gen.go
+++ b/providers/gcp/targetHttpProxies_gen.go
@@ -5,7 +5,7 @@ package gcp
 
 import (
 	"context"
-	"log"
+	"fmt"
 
 	"github.com/chenrui333/terraformer/terraformutils"
 
@@ -21,7 +21,7 @@ type TargetHttpProxiesGenerator struct {
 }
 
 // Run on targetHttpProxiesList and create for each TerraformResource
-func (g TargetHttpProxiesGenerator) createResources(ctx context.Context, targetHttpProxiesList *compute.TargetHttpProxiesListCall) []terraformutils.Resource {
+func (g TargetHttpProxiesGenerator) createResources(ctx context.Context, targetHttpProxiesList *compute.TargetHttpProxiesListCall) ([]terraformutils.Resource, error) {
 	resources := []terraformutils.Resource{}
 	if err := targetHttpProxiesList.Pages(ctx, func(page *compute.TargetHttpProxyList) error {
 		for _, obj := range page.Items {
@@ -41,9 +41,9 @@ func (g TargetHttpProxiesGenerator) createResources(ctx context.Context, targetH
 		}
 		return nil
 	}); err != nil {
-		log.Println(err)
+		return nil, fmt.Errorf("list targetHttpProxies: %w", err)
 	}
-	return resources
+	return resources, nil
 }
 
 // Generate TerraformResources from GCP API,
@@ -57,7 +57,11 @@ func (g *TargetHttpProxiesGenerator) InitResources() error {
 	}
 
 	targetHttpProxiesList := computeService.TargetHttpProxies.List(g.GetArgs()["project"].(string))
-	g.Resources = g.createResources(ctx, targetHttpProxiesList)
+	resources, err := g.createResources(ctx, targetHttpProxiesList)
+	if err != nil {
+		return err
+	}
+	g.Resources = resources
 
 	return nil
 

--- a/providers/gcp/targetHttpsProxies_gen.go
+++ b/providers/gcp/targetHttpsProxies_gen.go
@@ -5,7 +5,7 @@ package gcp
 
 import (
 	"context"
-	"log"
+	"fmt"
 
 	"github.com/chenrui333/terraformer/terraformutils"
 
@@ -21,7 +21,7 @@ type TargetHttpsProxiesGenerator struct {
 }
 
 // Run on targetHttpsProxiesList and create for each TerraformResource
-func (g TargetHttpsProxiesGenerator) createResources(ctx context.Context, targetHttpsProxiesList *compute.TargetHttpsProxiesListCall) []terraformutils.Resource {
+func (g TargetHttpsProxiesGenerator) createResources(ctx context.Context, targetHttpsProxiesList *compute.TargetHttpsProxiesListCall) ([]terraformutils.Resource, error) {
 	resources := []terraformutils.Resource{}
 	if err := targetHttpsProxiesList.Pages(ctx, func(page *compute.TargetHttpsProxyList) error {
 		for _, obj := range page.Items {
@@ -41,9 +41,9 @@ func (g TargetHttpsProxiesGenerator) createResources(ctx context.Context, target
 		}
 		return nil
 	}); err != nil {
-		log.Println(err)
+		return nil, fmt.Errorf("list targetHttpsProxies: %w", err)
 	}
-	return resources
+	return resources, nil
 }
 
 // Generate TerraformResources from GCP API,
@@ -57,7 +57,11 @@ func (g *TargetHttpsProxiesGenerator) InitResources() error {
 	}
 
 	targetHttpsProxiesList := computeService.TargetHttpsProxies.List(g.GetArgs()["project"].(string))
-	g.Resources = g.createResources(ctx, targetHttpsProxiesList)
+	resources, err := g.createResources(ctx, targetHttpsProxiesList)
+	if err != nil {
+		return err
+	}
+	g.Resources = resources
 
 	return nil
 

--- a/providers/gcp/targetInstances_gen.go
+++ b/providers/gcp/targetInstances_gen.go
@@ -5,7 +5,7 @@ package gcp
 
 import (
 	"context"
-	"log"
+	"fmt"
 	"strings"
 
 	"github.com/chenrui333/terraformer/terraformutils"
@@ -22,7 +22,7 @@ type TargetInstancesGenerator struct {
 }
 
 // Run on targetInstancesList and create for each TerraformResource
-func (g TargetInstancesGenerator) createResources(ctx context.Context, targetInstancesList *compute.TargetInstancesListCall, zone string) []terraformutils.Resource {
+func (g TargetInstancesGenerator) createResources(ctx context.Context, targetInstancesList *compute.TargetInstancesListCall, zone string) ([]terraformutils.Resource, error) {
 	resources := []terraformutils.Resource{}
 	if err := targetInstancesList.Pages(ctx, func(page *compute.TargetInstanceList) error {
 		for _, obj := range page.Items {
@@ -43,9 +43,9 @@ func (g TargetInstancesGenerator) createResources(ctx context.Context, targetIns
 		}
 		return nil
 	}); err != nil {
-		log.Println(err)
+		return nil, fmt.Errorf("list targetInstances: %w", err)
 	}
-	return resources
+	return resources, nil
 }
 
 // Generate TerraformResources from GCP API,
@@ -62,7 +62,11 @@ func (g *TargetInstancesGenerator) InitResources() error {
 		t := strings.Split(zoneLink, "/")
 		zone := t[len(t)-1]
 		targetInstancesList := computeService.TargetInstances.List(g.GetArgs()["project"].(string), zone)
-		g.Resources = append(g.Resources, g.createResources(ctx, targetInstancesList, zone)...)
+		resources, err := g.createResources(ctx, targetInstancesList, zone)
+		if err != nil {
+			return err
+		}
+		g.Resources = append(g.Resources, resources...)
 	}
 
 	return nil

--- a/providers/gcp/targetPools_gen.go
+++ b/providers/gcp/targetPools_gen.go
@@ -5,7 +5,7 @@ package gcp
 
 import (
 	"context"
-	"log"
+	"fmt"
 
 	"github.com/chenrui333/terraformer/terraformutils"
 
@@ -21,7 +21,7 @@ type TargetPoolsGenerator struct {
 }
 
 // Run on targetPoolsList and create for each TerraformResource
-func (g TargetPoolsGenerator) createResources(ctx context.Context, targetPoolsList *compute.TargetPoolsListCall) []terraformutils.Resource {
+func (g TargetPoolsGenerator) createResources(ctx context.Context, targetPoolsList *compute.TargetPoolsListCall) ([]terraformutils.Resource, error) {
 	resources := []terraformutils.Resource{}
 	if err := targetPoolsList.Pages(ctx, func(page *compute.TargetPoolList) error {
 		for _, obj := range page.Items {
@@ -41,9 +41,9 @@ func (g TargetPoolsGenerator) createResources(ctx context.Context, targetPoolsLi
 		}
 		return nil
 	}); err != nil {
-		log.Println(err)
+		return nil, fmt.Errorf("list targetPools: %w", err)
 	}
-	return resources
+	return resources, nil
 }
 
 // Generate TerraformResources from GCP API,
@@ -57,7 +57,11 @@ func (g *TargetPoolsGenerator) InitResources() error {
 	}
 
 	targetPoolsList := computeService.TargetPools.List(g.GetArgs()["project"].(string), g.GetArgs()["region"].(compute.Region).Name)
-	g.Resources = g.createResources(ctx, targetPoolsList)
+	resources, err := g.createResources(ctx, targetPoolsList)
+	if err != nil {
+		return err
+	}
+	g.Resources = resources
 
 	return nil
 

--- a/providers/gcp/targetSslProxies_gen.go
+++ b/providers/gcp/targetSslProxies_gen.go
@@ -5,7 +5,7 @@ package gcp
 
 import (
 	"context"
-	"log"
+	"fmt"
 
 	"github.com/chenrui333/terraformer/terraformutils"
 
@@ -21,7 +21,7 @@ type TargetSslProxiesGenerator struct {
 }
 
 // Run on targetSslProxiesList and create for each TerraformResource
-func (g TargetSslProxiesGenerator) createResources(ctx context.Context, targetSslProxiesList *compute.TargetSslProxiesListCall) []terraformutils.Resource {
+func (g TargetSslProxiesGenerator) createResources(ctx context.Context, targetSslProxiesList *compute.TargetSslProxiesListCall) ([]terraformutils.Resource, error) {
 	resources := []terraformutils.Resource{}
 	if err := targetSslProxiesList.Pages(ctx, func(page *compute.TargetSslProxyList) error {
 		for _, obj := range page.Items {
@@ -41,9 +41,9 @@ func (g TargetSslProxiesGenerator) createResources(ctx context.Context, targetSs
 		}
 		return nil
 	}); err != nil {
-		log.Println(err)
+		return nil, fmt.Errorf("list targetSslProxies: %w", err)
 	}
-	return resources
+	return resources, nil
 }
 
 // Generate TerraformResources from GCP API,
@@ -57,7 +57,11 @@ func (g *TargetSslProxiesGenerator) InitResources() error {
 	}
 
 	targetSslProxiesList := computeService.TargetSslProxies.List(g.GetArgs()["project"].(string))
-	g.Resources = g.createResources(ctx, targetSslProxiesList)
+	resources, err := g.createResources(ctx, targetSslProxiesList)
+	if err != nil {
+		return err
+	}
+	g.Resources = resources
 
 	return nil
 

--- a/providers/gcp/targetTcpProxies_gen.go
+++ b/providers/gcp/targetTcpProxies_gen.go
@@ -5,7 +5,7 @@ package gcp
 
 import (
 	"context"
-	"log"
+	"fmt"
 
 	"github.com/chenrui333/terraformer/terraformutils"
 
@@ -21,7 +21,7 @@ type TargetTcpProxiesGenerator struct {
 }
 
 // Run on targetTcpProxiesList and create for each TerraformResource
-func (g TargetTcpProxiesGenerator) createResources(ctx context.Context, targetTcpProxiesList *compute.TargetTcpProxiesListCall) []terraformutils.Resource {
+func (g TargetTcpProxiesGenerator) createResources(ctx context.Context, targetTcpProxiesList *compute.TargetTcpProxiesListCall) ([]terraformutils.Resource, error) {
 	resources := []terraformutils.Resource{}
 	if err := targetTcpProxiesList.Pages(ctx, func(page *compute.TargetTcpProxyList) error {
 		for _, obj := range page.Items {
@@ -41,9 +41,9 @@ func (g TargetTcpProxiesGenerator) createResources(ctx context.Context, targetTc
 		}
 		return nil
 	}); err != nil {
-		log.Println(err)
+		return nil, fmt.Errorf("list targetTcpProxies: %w", err)
 	}
-	return resources
+	return resources, nil
 }
 
 // Generate TerraformResources from GCP API,
@@ -57,7 +57,11 @@ func (g *TargetTcpProxiesGenerator) InitResources() error {
 	}
 
 	targetTcpProxiesList := computeService.TargetTcpProxies.List(g.GetArgs()["project"].(string))
-	g.Resources = g.createResources(ctx, targetTcpProxiesList)
+	resources, err := g.createResources(ctx, targetTcpProxiesList)
+	if err != nil {
+		return err
+	}
+	g.Resources = resources
 
 	return nil
 

--- a/providers/gcp/targetVpnGateways_gen.go
+++ b/providers/gcp/targetVpnGateways_gen.go
@@ -5,7 +5,7 @@ package gcp
 
 import (
 	"context"
-	"log"
+	"fmt"
 
 	"github.com/chenrui333/terraformer/terraformutils"
 
@@ -21,7 +21,7 @@ type TargetVpnGatewaysGenerator struct {
 }
 
 // Run on targetVpnGatewaysList and create for each TerraformResource
-func (g TargetVpnGatewaysGenerator) createResources(ctx context.Context, targetVpnGatewaysList *compute.TargetVpnGatewaysListCall) []terraformutils.Resource {
+func (g TargetVpnGatewaysGenerator) createResources(ctx context.Context, targetVpnGatewaysList *compute.TargetVpnGatewaysListCall) ([]terraformutils.Resource, error) {
 	resources := []terraformutils.Resource{}
 	if err := targetVpnGatewaysList.Pages(ctx, func(page *compute.TargetVpnGatewayList) error {
 		for _, obj := range page.Items {
@@ -41,9 +41,9 @@ func (g TargetVpnGatewaysGenerator) createResources(ctx context.Context, targetV
 		}
 		return nil
 	}); err != nil {
-		log.Println(err)
+		return nil, fmt.Errorf("list targetVpnGateways: %w", err)
 	}
-	return resources
+	return resources, nil
 }
 
 // Generate TerraformResources from GCP API,
@@ -57,7 +57,11 @@ func (g *TargetVpnGatewaysGenerator) InitResources() error {
 	}
 
 	targetVpnGatewaysList := computeService.TargetVpnGateways.List(g.GetArgs()["project"].(string), g.GetArgs()["region"].(compute.Region).Name)
-	g.Resources = g.createResources(ctx, targetVpnGatewaysList)
+	resources, err := g.createResources(ctx, targetVpnGatewaysList)
+	if err != nil {
+		return err
+	}
+	g.Resources = resources
 
 	return nil
 

--- a/providers/gcp/urlMaps_gen.go
+++ b/providers/gcp/urlMaps_gen.go
@@ -5,7 +5,7 @@ package gcp
 
 import (
 	"context"
-	"log"
+	"fmt"
 
 	"github.com/chenrui333/terraformer/terraformutils"
 
@@ -21,7 +21,7 @@ type UrlMapsGenerator struct {
 }
 
 // Run on urlMapsList and create for each TerraformResource
-func (g UrlMapsGenerator) createResources(ctx context.Context, urlMapsList *compute.UrlMapsListCall) []terraformutils.Resource {
+func (g UrlMapsGenerator) createResources(ctx context.Context, urlMapsList *compute.UrlMapsListCall) ([]terraformutils.Resource, error) {
 	resources := []terraformutils.Resource{}
 	if err := urlMapsList.Pages(ctx, func(page *compute.UrlMapList) error {
 		for _, obj := range page.Items {
@@ -41,9 +41,9 @@ func (g UrlMapsGenerator) createResources(ctx context.Context, urlMapsList *comp
 		}
 		return nil
 	}); err != nil {
-		log.Println(err)
+		return nil, fmt.Errorf("list urlMaps: %w", err)
 	}
-	return resources
+	return resources, nil
 }
 
 // Generate TerraformResources from GCP API,
@@ -57,7 +57,11 @@ func (g *UrlMapsGenerator) InitResources() error {
 	}
 
 	urlMapsList := computeService.UrlMaps.List(g.GetArgs()["project"].(string))
-	g.Resources = g.createResources(ctx, urlMapsList)
+	resources, err := g.createResources(ctx, urlMapsList)
+	if err != nil {
+		return err
+	}
+	g.Resources = resources
 
 	return nil
 

--- a/providers/gcp/vpnTunnels_gen.go
+++ b/providers/gcp/vpnTunnels_gen.go
@@ -5,7 +5,7 @@ package gcp
 
 import (
 	"context"
-	"log"
+	"fmt"
 
 	"github.com/chenrui333/terraformer/terraformutils"
 
@@ -21,7 +21,7 @@ type VpnTunnelsGenerator struct {
 }
 
 // Run on vpnTunnelsList and create for each TerraformResource
-func (g VpnTunnelsGenerator) createResources(ctx context.Context, vpnTunnelsList *compute.VpnTunnelsListCall) []terraformutils.Resource {
+func (g VpnTunnelsGenerator) createResources(ctx context.Context, vpnTunnelsList *compute.VpnTunnelsListCall) ([]terraformutils.Resource, error) {
 	resources := []terraformutils.Resource{}
 	if err := vpnTunnelsList.Pages(ctx, func(page *compute.VpnTunnelList) error {
 		for _, obj := range page.Items {
@@ -41,9 +41,9 @@ func (g VpnTunnelsGenerator) createResources(ctx context.Context, vpnTunnelsList
 		}
 		return nil
 	}); err != nil {
-		log.Println(err)
+		return nil, fmt.Errorf("list vpnTunnels: %w", err)
 	}
-	return resources
+	return resources, nil
 }
 
 // Generate TerraformResources from GCP API,
@@ -57,7 +57,11 @@ func (g *VpnTunnelsGenerator) InitResources() error {
 	}
 
 	vpnTunnelsList := computeService.VpnTunnels.List(g.GetArgs()["project"].(string), g.GetArgs()["region"].(compute.Region).Name)
-	g.Resources = g.createResources(ctx, vpnTunnelsList)
+	resources, err := g.createResources(ctx, vpnTunnelsList)
+	if err != nil {
+		return err
+	}
+	g.Resources = resources
 
 	return nil
 


### PR DESCRIPTION
## Summary

- Return remaining GCP generated compute discovery pagination errors instead of logging and continuing with partial resources.
- Update the GCP compute generator template so regenerated compute services keep returning list errors.
- Return Cloud Functions and GCS notification list errors, with representative regression coverage for generated compute, Cloud Functions, and GCS notification failures.
