### PR TITLE
feat(launchdarkly): add access token import

### DIFF
--- a/docs/launchdarkly.md
+++ b/docs/launchdarkly.md
@@ -4,7 +4,7 @@ Example:
 
 ```
 export LAUNCHDARKLY_ACCESS_TOKEN=[LAUNCHDARKLY_ACCESS_TOKEN]
-./terraformer import launchdarkly -r aiConfig,aiConfigVariation,aiTool,auditLogSubscription,customRole,destination,environment,featureFlag,flagTemplates,flagTrigger,metric,modelConfig,relayProxyConfiguration,segment,team,teamMember,view,webhook
+./terraformer import launchdarkly -r accessToken,aiConfig,aiConfigVariation,aiTool,auditLogSubscription,customRole,destination,environment,featureFlag,flagTemplates,flagTrigger,metric,modelConfig,relayProxyConfiguration,segment,team,teamMember,view,webhook
 ```
 
 Use `project` separately when you want LaunchDarkly environments managed as nested
@@ -19,6 +19,8 @@ same associations through `view_keys`.
 
 List of supported LaunchDarkly resources:
 
+*   `accessToken`
+    * `launchdarkly_access_token`
 *   `aiConfig`
     * `launchdarkly_ai_config`
 *   `aiConfigVariation`

--- a/providers/launchdarkly/access_token.go
+++ b/providers/launchdarkly/access_token.go
@@ -1,0 +1,80 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package launchdarkly
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/chenrui333/terraformer/terraformutils"
+	ldapi "github.com/launchdarkly/api-client-go/v22"
+)
+
+type AccessTokenGenerator struct {
+	LaunchDarklyService
+}
+
+func getAccessTokens(ctx context.Context, client *ldapi.APIClient) ([]ldapi.Token, error) {
+	tokens, err := getAccessTokensWithShowAll(ctx, client, true)
+	if err != nil {
+		return nil, err
+	}
+	return tokens, nil
+}
+
+func getAccessTokensWithShowAll(ctx context.Context, client *ldapi.APIClient, showAll bool) ([]ldapi.Token, error) {
+	var allTokens []ldapi.Token
+	for offset := int64(0); ; offset += pageSize {
+		request := client.AccessTokensApi.GetTokens(ctx).
+			Limit(pageSize).
+			Offset(offset)
+		if showAll {
+			request = request.ShowAll(true)
+		}
+		tokens, resp, err := request.Execute()
+		closeResponseBody(resp)
+		if err != nil {
+			if showAll && offset == 0 && resp != nil && resp.StatusCode == http.StatusForbidden {
+				return getAccessTokensWithShowAll(ctx, client, false)
+			}
+			return nil, err
+		}
+		if tokens == nil {
+			break
+		}
+		items := tokens.GetItems()
+		allTokens = append(allTokens, items...)
+		if tokens.TotalCount == nil || int64(len(allTokens)) >= int64(tokens.GetTotalCount()) {
+			break
+		}
+	}
+	return allTokens, nil
+}
+
+func accessTokenResourceName(name, id string) string {
+	return resourceNameWithID(name, id)
+}
+
+func (g *AccessTokenGenerator) loadAccessTokens(ctx context.Context, client *ldapi.APIClient) error {
+	tokens, err := getAccessTokens(ctx, client)
+	if err != nil {
+		return err
+	}
+	for _, token := range tokens {
+		tokenID := token.GetId()
+		resource := terraformutils.NewResource(
+			tokenID,
+			accessTokenResourceName(token.GetName(), tokenID),
+			"launchdarkly_access_token",
+			"launchdarkly",
+			map[string]string{},
+			[]string{},
+			map[string]interface{}{})
+		g.Resources = append(g.Resources, resource)
+	}
+	return nil
+}
+
+func (g *AccessTokenGenerator) InitResources() error {
+	return g.loadAccessTokens(g.GetArgs()["ctx"].(context.Context), g.GetArgs()["client"].(*ldapi.APIClient))
+}

--- a/providers/launchdarkly/access_token.go
+++ b/providers/launchdarkly/access_token.go
@@ -44,7 +44,7 @@ func getAccessTokensWithShowAll(ctx context.Context, client *ldapi.APIClient, sh
 		}
 		items := tokens.GetItems()
 		allTokens = append(allTokens, items...)
-		if tokens.TotalCount == nil || int64(len(allTokens)) >= int64(tokens.GetTotalCount()) {
+		if len(items) < pageSize {
 			break
 		}
 	}

--- a/providers/launchdarkly/access_token_test.go
+++ b/providers/launchdarkly/access_token_test.go
@@ -4,9 +4,11 @@ package launchdarkly
 
 import (
 	"context"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
+	"strings"
 	"testing"
 
 	ldapi "github.com/launchdarkly/api-client-go/v22"
@@ -19,9 +21,9 @@ func TestGetAccessTokensPagesAndRequestsShowAll(t *testing.T) {
 		w.Header().Set("Content-Type", "application/json")
 		switch r.URL.Query().Get("offset") {
 		case "0":
-			_, _ = w.Write([]byte("{\"items\":[{\"_id\":\"token-1\",\"ownerId\":\"owner\",\"memberId\":\"member\",\"creationDate\":1,\"lastModified\":1,\"name\":\"duplicate\",\"_links\":{}},{\"_id\":\"token-2\",\"ownerId\":\"owner\",\"memberId\":\"member\",\"creationDate\":1,\"lastModified\":1,\"name\":\"duplicate\",\"_links\":{}}],\"totalCount\":3}"))
+			writeTokenPage(t, w, 1, pageSize, pageSize)
 		case "20":
-			_, _ = w.Write([]byte("{\"items\":[{\"_id\":\"token-3\",\"ownerId\":\"owner\",\"memberId\":\"member\",\"creationDate\":1,\"lastModified\":1,\"_links\":{}}],\"totalCount\":3}"))
+			writeTokenPage(t, w, 21, 3, 3)
 		default:
 			t.Fatalf("unexpected query %q", r.URL.RawQuery)
 		}
@@ -36,8 +38,8 @@ func TestGetAccessTokensPagesAndRequestsShowAll(t *testing.T) {
 	if err != nil {
 		t.Fatalf("getAccessTokens() error = %v", err)
 	}
-	if len(tokens) != 3 {
-		t.Fatalf("getAccessTokens() returned %d tokens, want 3", len(tokens))
+	if len(tokens) != 23 {
+		t.Fatalf("getAccessTokens() returned %d tokens, want 23", len(tokens))
 	}
 	if len(requests) != 2 {
 		t.Fatalf("requests = %v, want 2 requests", requests)
@@ -50,6 +52,23 @@ func TestGetAccessTokensPagesAndRequestsShowAll(t *testing.T) {
 		if values.Get("showAll") != "true" {
 			t.Fatalf("query %q missing showAll=true", query)
 		}
+	}
+}
+
+func writeTokenPage(t *testing.T, w http.ResponseWriter, firstID, count, totalCount int) {
+	t.Helper()
+
+	items := make([]string, count)
+	for i := range items {
+		items[i] = fmt.Sprintf(
+			"{\"_id\":\"token-%d\",\"ownerId\":\"owner\",\"memberId\":\"member\",\"creationDate\":1,\"lastModified\":1,\"name\":\"duplicate\",\"_links\":{}}",
+			firstID+i,
+		)
+	}
+
+	_, err := fmt.Fprintf(w, "{\"items\":[%s],\"totalCount\":%d}", strings.Join(items, ","), totalCount)
+	if err != nil {
+		t.Fatalf("failed to write token page: %v", err)
 	}
 }
 

--- a/providers/launchdarkly/access_token_test.go
+++ b/providers/launchdarkly/access_token_test.go
@@ -1,0 +1,107 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package launchdarkly
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+
+	ldapi "github.com/launchdarkly/api-client-go/v22"
+)
+
+func TestGetAccessTokensPagesAndRequestsShowAll(t *testing.T) {
+	requests := make([]string, 0, 2)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requests = append(requests, r.URL.RawQuery)
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.Query().Get("offset") {
+		case "0":
+			_, _ = w.Write([]byte("{\"items\":[{\"_id\":\"token-1\",\"ownerId\":\"owner\",\"memberId\":\"member\",\"creationDate\":1,\"lastModified\":1,\"name\":\"duplicate\",\"_links\":{}},{\"_id\":\"token-2\",\"ownerId\":\"owner\",\"memberId\":\"member\",\"creationDate\":1,\"lastModified\":1,\"name\":\"duplicate\",\"_links\":{}}],\"totalCount\":3}"))
+		case "20":
+			_, _ = w.Write([]byte("{\"items\":[{\"_id\":\"token-3\",\"ownerId\":\"owner\",\"memberId\":\"member\",\"creationDate\":1,\"lastModified\":1,\"_links\":{}}],\"totalCount\":3}"))
+		default:
+			t.Fatalf("unexpected query %q", r.URL.RawQuery)
+		}
+	}))
+	defer server.Close()
+
+	config := ldapi.NewConfiguration()
+	config.Servers = ldapi.ServerConfigurations{{URL: server.URL}}
+	client := ldapi.NewAPIClient(config)
+
+	tokens, err := getAccessTokens(context.Background(), client)
+	if err != nil {
+		t.Fatalf("getAccessTokens() error = %v", err)
+	}
+	if len(tokens) != 3 {
+		t.Fatalf("getAccessTokens() returned %d tokens, want 3", len(tokens))
+	}
+	if len(requests) != 2 {
+		t.Fatalf("requests = %v, want 2 requests", requests)
+	}
+	for _, query := range requests {
+		values, err := url.ParseQuery(query)
+		if err != nil {
+			t.Fatalf("failed to parse query %q: %v", query, err)
+		}
+		if values.Get("showAll") != "true" {
+			t.Fatalf("query %q missing showAll=true", query)
+		}
+	}
+}
+
+func TestGetAccessTokensFallsBackWhenShowAllForbidden(t *testing.T) {
+	requests := make([]string, 0, 2)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requests = append(requests, r.URL.RawQuery)
+		w.Header().Set("Content-Type", "application/json")
+		if r.URL.Query().Get("showAll") == "true" {
+			w.WriteHeader(http.StatusForbidden)
+			_, _ = w.Write([]byte("{}"))
+			return
+		}
+		_, _ = w.Write([]byte("{\"items\":[{\"_id\":\"token-1\",\"ownerId\":\"owner\",\"memberId\":\"member\",\"creationDate\":1,\"lastModified\":1,\"_links\":{}}],\"totalCount\":1}"))
+	}))
+	defer server.Close()
+
+	config := ldapi.NewConfiguration()
+	config.Servers = ldapi.ServerConfigurations{{URL: server.URL}}
+	client := ldapi.NewAPIClient(config)
+
+	tokens, err := getAccessTokens(context.Background(), client)
+	if err != nil {
+		t.Fatalf("getAccessTokens() error = %v", err)
+	}
+	if len(tokens) != 1 {
+		t.Fatalf("getAccessTokens() returned %d tokens, want 1", len(tokens))
+	}
+	if len(requests) != 2 {
+		t.Fatalf("requests = %v, want showAll attempt and fallback", requests)
+	}
+
+	first, err := url.ParseQuery(requests[0])
+	if err != nil {
+		t.Fatalf("failed to parse query %q: %v", requests[0], err)
+	}
+	second, err := url.ParseQuery(requests[1])
+	if err != nil {
+		t.Fatalf("failed to parse query %q: %v", requests[1], err)
+	}
+	if first.Get("showAll") != "true" {
+		t.Fatalf("first query %q missing showAll=true", requests[0])
+	}
+	if second.Get("showAll") != "" {
+		t.Fatalf("fallback query %q should omit showAll", requests[1])
+	}
+}
+
+func TestAccessTokenResourceNameIncludesTokenID(t *testing.T) {
+	got := accessTokenResourceName("duplicate", "token-123")
+	want := "duplicate-token-123"
+	if got != want {
+		t.Fatalf("accessTokenResourceName() = %q, want %q", got, want)
+	}
+}

--- a/providers/launchdarkly/launchdarkly_provider.go
+++ b/providers/launchdarkly/launchdarkly_provider.go
@@ -57,6 +57,7 @@ func (LaunchDarklyProvider) GetResourceConnections() map[string]map[string][]str
 
 func (p *LaunchDarklyProvider) GetSupportedService() map[string]terraformutils.ServiceGenerator {
 	return map[string]terraformutils.ServiceGenerator{
+		"accessToken":             &AccessTokenGenerator{},
 		"aiConfig":                &AIConfigGenerator{},
 		"aiConfigVariation":       &AIConfigVariationGenerator{},
 		"aiTool":                  &AIToolGenerator{},


### PR DESCRIPTION
Summary
- Add LaunchDarkly access token import support.
- Register the `accessToken` service and document `launchdarkly_access_token`.
- Page through token discovery with `showAll=true`, falling back to caller-visible tokens if that is forbidden.

Notes
- `viewFilterLinks` remains intentionally unadvertised because LaunchDarkly does not expose the original filter expressions needed to recreate that resource.
