### PR TITLE
feat(datadog): add slo correction import

### DIFF
--- a/docs/datadog.md
+++ b/docs/datadog.md
@@ -148,6 +148,8 @@ Tag filters are order specific. For example, if your monitor has tags (in the or
     * `datadog_security_monitoring_rule`
 *   `service_level_objective`
     * `datadog_service_level_objective`
+*   `slo_correction`
+    * `datadog_slo_correction`
 *   `synthetics_global_variable`
     * `datadog_synthetics_global_variable`
         * **_NOTE:_** Importing resource requires resource ID's to be passed via [Filter][1] option

--- a/providers/datadog/datadog_provider.go
+++ b/providers/datadog/datadog_provider.go
@@ -176,6 +176,7 @@ func (p *DatadogProvider) GetSupportedService() map[string]terraformutils.Servic
 		"security_monitoring_default_rule":     &SecurityMonitoringDefaultRuleGenerator{},
 		"security_monitoring_rule":             &SecurityMonitoringRuleGenerator{},
 		"service_level_objective":              &ServiceLevelObjectiveGenerator{},
+		"slo_correction":                       &SLOCorrectionGenerator{},
 		"synthetics_test":                      &SyntheticsTestGenerator{},
 		"synthetics_global_variable":           &SyntheticsGlobalVariableGenerator{},
 		"synthetics_private_location":          &SyntheticsPrivateLocationGenerator{},

--- a/providers/datadog/slo_correction.go
+++ b/providers/datadog/slo_correction.go
@@ -1,0 +1,189 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package datadog
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/DataDog/datadog-api-client-go/v2/api/datadog"
+	"github.com/DataDog/datadog-api-client-go/v2/api/datadogV1"
+
+	"github.com/chenrui333/terraformer/terraformutils"
+)
+
+var (
+	// SLOCorrectionAllowEmptyValues ...
+	SLOCorrectionAllowEmptyValues = []string{}
+)
+
+// SLOCorrectionGenerator ...
+type SLOCorrectionGenerator struct {
+	DatadogService
+}
+
+func (g *SLOCorrectionGenerator) createResources(sloCorrections []datadogV1.SLOCorrection) ([]terraformutils.Resource, error) {
+	resources := []terraformutils.Resource{}
+	for _, sloCorrection := range sloCorrections {
+		resource, err := g.createResource(sloCorrection)
+		if err != nil {
+			return nil, err
+		}
+		resources = append(resources, resource)
+	}
+
+	return resources, nil
+}
+
+func (g *SLOCorrectionGenerator) createResource(sloCorrection datadogV1.SLOCorrection) (terraformutils.Resource, error) {
+	sloCorrectionID := sloCorrection.GetId()
+	if sloCorrectionID == "" {
+		return terraformutils.Resource{}, fmt.Errorf("slo correction missing id")
+	}
+
+	return terraformutils.NewSimpleResource(
+		sloCorrectionID,
+		fmt.Sprintf("slo_correction_%s", sloCorrectionID),
+		"datadog_slo_correction",
+		"datadog",
+		SLOCorrectionAllowEmptyValues,
+	), nil
+}
+
+// InitResources Generate TerraformResources from Datadog API,
+// from each slo_correction create 1 TerraformResource.
+func (g *SLOCorrectionGenerator) InitResources() error {
+	datadogClient := g.Args["datadogClient"].(*datadog.APIClient)
+	auth := g.Args["auth"].(context.Context)
+	api := datadogV1.NewServiceLevelObjectiveCorrectionsApi(datadogClient)
+
+	resources, filtered, err := g.filteredResources(auth, api)
+	if err != nil {
+		return err
+	}
+	if filtered {
+		g.Resources = resources
+		return nil
+	}
+
+	sloCorrections, err := listSLOCorrections(auth, api)
+	if err != nil {
+		return err
+	}
+	resources, err = g.createResources(sloCorrections)
+	if err != nil {
+		return err
+	}
+
+	g.Resources = resources
+	return nil
+}
+
+func (g *SLOCorrectionGenerator) filteredResources(auth context.Context, api *datadogV1.ServiceLevelObjectiveCorrectionsApi) ([]terraformutils.Resource, bool, error) {
+	resources := []terraformutils.Resource{}
+	filtered := false
+
+	for _, filter := range g.Filter {
+		if filter.FieldPath != "id" || !filter.IsApplicable("slo_correction") {
+			continue
+		}
+
+		filtered = true
+		for _, value := range filter.AcceptableValues {
+			sloCorrection, err := getSLOCorrection(auth, api, value)
+			if err != nil {
+				return nil, true, err
+			}
+			resource, err := g.createResource(sloCorrection)
+			if err != nil {
+				return nil, true, err
+			}
+			resources = append(resources, resource)
+		}
+	}
+
+	return resources, filtered, nil
+}
+
+func getSLOCorrection(auth context.Context, api *datadogV1.ServiceLevelObjectiveCorrectionsApi, sloCorrectionID string) (datadogV1.SLOCorrection, error) {
+	response, httpResponse, err := api.GetSLOCorrection(auth, sloCorrectionID)
+	defer closeDatadogResponseBody(httpResponse)
+	if err != nil {
+		return datadogV1.SLOCorrection{}, err
+	}
+
+	if sloCorrection, ok := response.GetDataOk(); ok {
+		return *sloCorrection, nil
+	}
+	if sloCorrection, ok := sloCorrectionFromRawData(response.UnparsedObject["data"]); ok {
+		return sloCorrection, nil
+	}
+
+	return datadogV1.SLOCorrection{}, fmt.Errorf("slo correction %q not found", sloCorrectionID)
+}
+
+func listSLOCorrections(auth context.Context, api *datadogV1.ServiceLevelObjectiveCorrectionsApi) ([]datadogV1.SLOCorrection, error) {
+	sloCorrections := []datadogV1.SLOCorrection{}
+	const pageSize int64 = 100
+	var offset int64
+
+	for {
+		optionalParams := datadogV1.NewListSLOCorrectionOptionalParameters().
+			WithLimit(pageSize).
+			WithOffset(offset)
+
+		response, httpResponse, err := api.ListSLOCorrection(auth, *optionalParams)
+		closeDatadogResponseBody(httpResponse)
+		if err != nil {
+			return nil, err
+		}
+
+		pageCorrections := response.GetData()
+		if len(pageCorrections) == 0 {
+			pageCorrections = sloCorrectionsFromRawData(response.UnparsedObject["data"])
+		}
+		sloCorrections = append(sloCorrections, pageCorrections...)
+
+		if len(pageCorrections) < int(pageSize) {
+			break
+		}
+		offset += pageSize
+	}
+
+	return sloCorrections, nil
+}
+
+func sloCorrectionsFromRawData(rawData interface{}) []datadogV1.SLOCorrection {
+	rawCorrections, ok := rawData.([]interface{})
+	if !ok {
+		return nil
+	}
+
+	sloCorrections := []datadogV1.SLOCorrection{}
+	for _, rawCorrection := range rawCorrections {
+		sloCorrection, ok := sloCorrectionFromRawData(rawCorrection)
+		if !ok {
+			continue
+		}
+		sloCorrections = append(sloCorrections, sloCorrection)
+	}
+	return sloCorrections
+}
+
+func sloCorrectionFromRawData(rawData interface{}) (datadogV1.SLOCorrection, bool) {
+	rawCorrection, ok := rawData.(map[string]interface{})
+	if !ok {
+		return datadogV1.SLOCorrection{}, false
+	}
+	if rawType, ok := rawCorrection["type"].(string); ok && rawType != string(datadogV1.SLOCORRECTIONTYPE_CORRECTION) {
+		return datadogV1.SLOCorrection{}, false
+	}
+	rawID, ok := rawCorrection["id"].(string)
+	if !ok || rawID == "" {
+		return datadogV1.SLOCorrection{}, false
+	}
+
+	sloCorrection := datadogV1.NewSLOCorrectionWithDefaults()
+	sloCorrection.SetId(rawID)
+	return *sloCorrection, true
+}

--- a/providers/datadog/slo_correction_test.go
+++ b/providers/datadog/slo_correction_test.go
@@ -1,0 +1,96 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package datadog
+
+import (
+	"testing"
+
+	"github.com/DataDog/datadog-api-client-go/v2/api/datadogV1"
+)
+
+func TestSLOCorrectionCreateResource(t *testing.T) {
+	sloCorrection := datadogV1.NewSLOCorrectionWithDefaults()
+	sloCorrection.SetId("correction-id")
+
+	generator := &SLOCorrectionGenerator{}
+	resource, err := generator.createResource(*sloCorrection)
+	if err != nil {
+		t.Fatalf("createResource returned error: %v", err)
+	}
+
+	if resource.InstanceState.ID != "correction-id" {
+		t.Fatalf("resource ID = %q, want %q", resource.InstanceState.ID, "correction-id")
+	}
+	if resource.ResourceName != "tfer--slo_correction_correction-id" {
+		t.Fatalf("resource name = %q, want %q", resource.ResourceName, "tfer--slo_correction_correction-id")
+	}
+	if resource.InstanceInfo.Type != "datadog_slo_correction" {
+		t.Fatalf("resource type = %q, want %q", resource.InstanceInfo.Type, "datadog_slo_correction")
+	}
+}
+
+func TestSLOCorrectionCreateResourceMissingID(t *testing.T) {
+	generator := &SLOCorrectionGenerator{}
+	_, err := generator.createResource(datadogV1.SLOCorrection{})
+	if err == nil {
+		t.Fatal("createResource returned nil error, want missing id error")
+	}
+}
+
+func TestSLOCorrectionCreateResources(t *testing.T) {
+	firstCorrection := datadogV1.NewSLOCorrectionWithDefaults()
+	firstCorrection.SetId("correction-1")
+	secondCorrection := datadogV1.NewSLOCorrectionWithDefaults()
+	secondCorrection.SetId("correction-2")
+
+	generator := &SLOCorrectionGenerator{}
+	resources, err := generator.createResources([]datadogV1.SLOCorrection{
+		*firstCorrection,
+		*secondCorrection,
+	})
+	if err != nil {
+		t.Fatalf("createResources returned error: %v", err)
+	}
+
+	if len(resources) != 2 {
+		t.Fatalf("resource count = %d, want %d", len(resources), 2)
+	}
+	if resources[0].ResourceName == resources[1].ResourceName {
+		t.Fatalf("resource names should be unique, got %q", resources[0].ResourceName)
+	}
+}
+
+func TestSLOCorrectionsFromRawData(t *testing.T) {
+	sloCorrections := sloCorrectionsFromRawData([]interface{}{
+		map[string]interface{}{
+			"id":   "correction-1",
+			"type": "correction",
+		},
+		map[string]interface{}{
+			"id": "correction-2",
+		},
+		map[string]interface{}{
+			"id":   "ignored-type",
+			"type": "unknown",
+		},
+		map[string]interface{}{
+			"type": "correction",
+		},
+	})
+
+	if len(sloCorrections) != 2 {
+		t.Fatalf("correction count = %d, want %d", len(sloCorrections), 2)
+	}
+	if sloCorrections[0].GetId() != "correction-1" {
+		t.Fatalf("first correction ID = %q, want %q", sloCorrections[0].GetId(), "correction-1")
+	}
+	if sloCorrections[1].GetId() != "correction-2" {
+		t.Fatalf("second correction ID = %q, want %q", sloCorrections[1].GetId(), "correction-2")
+	}
+}
+
+func TestSLOCorrectionFromRawDataRejectsNonObjects(t *testing.T) {
+	if _, ok := sloCorrectionFromRawData("correction-id"); ok {
+		t.Fatal("sloCorrectionFromRawData accepted non-object raw data")
+	}
+}


### PR DESCRIPTION
Summary
- Add Terraformer import support for Datadog SLO corrections.
- Support ID-filtered imports and unfiltered imports through the Datadog SLO correction list API.
- Document the new Datadog resource in the provider docs.

Notes
- Resources are keyed by correction ID so multiple corrections for the same SLO stay unique.
- SDK response bodies are closed on both lookup and paginated list paths.
