### PR TITLE
fix(github): return discovery list errors

### DIFF
--- a/providers/github/github_errors_test.go
+++ b/providers/github/github_errors_test.go
@@ -1,0 +1,85 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package github
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+
+	githubAPI "github.com/google/go-github/v35/github"
+)
+
+func TestCreateMembershipsResourcesReturnsListError(t *testing.T) {
+	ctx := context.Background()
+	server := newErrorGitHubServer(t)
+	client := newTestGitHubClient(t, server)
+
+	_, err := createMembershipsResources(ctx, client, "test-org")
+	if err == nil {
+		t.Fatal("expected github members list error")
+	}
+	if !strings.Contains(err.Error(), "list github members for test-org") {
+		t.Fatalf("expected wrapped github members list error, got %q", err)
+	}
+}
+
+func TestCreateRepositoryWebhookResourcesReturnsListError(t *testing.T) {
+	ctx := context.Background()
+	server := newErrorGitHubServer(t)
+	client := newTestGitHubClient(t, server)
+
+	g := RepositoriesGenerator{}
+	g.SetArgs(map[string]interface{}{"owner": "test-org"})
+
+	_, err := g.createRepositoryWebhookResources(ctx, client, &githubAPI.Repository{Name: githubAPI.String("test-repo")})
+	if err == nil {
+		t.Fatal("expected github repository webhook list error")
+	}
+	if !strings.Contains(err.Error(), "list github repository webhooks for test-repo") {
+		t.Fatalf("expected wrapped github repository webhook list error, got %q", err)
+	}
+}
+
+func TestCreateTeamsResourcesReturnsNestedListError(t *testing.T) {
+	ctx := context.Background()
+	server := newErrorGitHubServer(t)
+	client := newTestGitHubClient(t, server)
+
+	g := TeamsGenerator{}
+	g.SetArgs(map[string]interface{}{"owner": "test-org"})
+
+	_, err := g.createTeamsResources(ctx, []*githubAPI.Team{{Slug: githubAPI.String("test-team")}}, client)
+	if err == nil {
+		t.Fatal("expected github team member list error")
+	}
+	if !strings.Contains(err.Error(), "list github team members for test-team") {
+		t.Fatalf("expected wrapped github team member list error, got %q", err)
+	}
+}
+
+func newErrorGitHubServer(t *testing.T) *httptest.Server {
+	t.Helper()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		http.Error(w, "{\"message\":\"service unavailable\"}", http.StatusServiceUnavailable)
+	}))
+	t.Cleanup(server.Close)
+	return server
+}
+
+func newTestGitHubClient(t *testing.T, server *httptest.Server) *githubAPI.Client {
+	t.Helper()
+
+	client := githubAPI.NewClient(server.Client())
+	baseURL, err := url.Parse(server.URL + "/")
+	if err != nil {
+		t.Fatal(err)
+	}
+	client.BaseURL = baseURL
+	client.UploadURL = baseURL
+	return client
+}

--- a/providers/github/github_organization.go
+++ b/providers/github/github_organization.go
@@ -19,9 +19,21 @@ func (g *OrganizationGenerator) InitResources() error {
 	}
 
 	owner := g.Args["owner"].(string)
-	g.Resources = append(g.Resources, createMembershipsResources(ctx, client, owner)...)
-	g.Resources = append(g.Resources, createOrganizationBlocksResources(ctx, client, owner)...)
-	g.Resources = append(g.Resources, createOrganizationProjects(ctx, client, owner)...)
+	membershipResources, err := createMembershipsResources(ctx, client, owner)
+	if err != nil {
+		return err
+	}
+	g.Resources = append(g.Resources, membershipResources...)
+	blockResources, err := createOrganizationBlocksResources(ctx, client, owner)
+	if err != nil {
+		return err
+	}
+	g.Resources = append(g.Resources, blockResources...)
+	projectResources, err := createOrganizationProjects(ctx, client, owner)
+	if err != nil {
+		return err
+	}
+	g.Resources = append(g.Resources, projectResources...)
 
 	return nil
 }

--- a/providers/github/members.go
+++ b/providers/github/members.go
@@ -4,7 +4,7 @@ package github
 
 import (
 	"context"
-	"log"
+	"fmt"
 
 	"github.com/chenrui333/terraformer/terraformutils"
 
@@ -25,12 +25,16 @@ func (g *MembersGenerator) InitResources() error {
 	}
 
 	owner := g.Args["owner"].(string)
-	g.Resources = append(g.Resources, createMembershipsResources(ctx, client, owner)...)
+	resources, err := createMembershipsResources(ctx, client, owner)
+	if err != nil {
+		return err
+	}
+	g.Resources = append(g.Resources, resources...)
 
 	return nil
 }
 
-func createMembershipsResources(ctx context.Context, client *githubAPI.Client, owner string) []terraformutils.Resource {
+func createMembershipsResources(ctx context.Context, client *githubAPI.Client, owner string) ([]terraformutils.Resource, error) {
 	resources := []terraformutils.Resource{}
 
 	opt := &githubAPI.ListMembersOptions{
@@ -41,8 +45,7 @@ func createMembershipsResources(ctx context.Context, client *githubAPI.Client, o
 	for {
 		members, resp, err := client.Organizations.ListMembers(ctx, owner, opt)
 		if err != nil {
-			log.Println(err)
-			return nil
+			return nil, fmt.Errorf("list github members for %s: %w", owner, err)
 		}
 
 		for _, member := range members {
@@ -64,5 +67,5 @@ func createMembershipsResources(ctx context.Context, client *githubAPI.Client, o
 		opt.Page = resp.NextPage
 	}
 
-	return resources
+	return resources, nil
 }

--- a/providers/github/organizationWebhooks.go
+++ b/providers/github/organizationWebhooks.go
@@ -4,7 +4,7 @@ package github
 
 import (
 	"context"
-	"log"
+	"fmt"
 	"strconv"
 
 	"github.com/chenrui333/terraformer/terraformutils"
@@ -30,8 +30,7 @@ func (g *OrganizationWebhooksGenerator) InitResources() error {
 	for {
 		hooks, resp, err := client.Organizations.ListHooks(ctx, g.Args["owner"].(string), opt)
 		if err != nil {
-			log.Println(err)
-			return nil
+			return fmt.Errorf("list github organization webhooks for %s: %w", g.Args["owner"].(string), err)
 		}
 
 		for _, hook := range hooks {

--- a/providers/github/organization_block.go
+++ b/providers/github/organization_block.go
@@ -4,7 +4,7 @@ package github
 
 import (
 	"context"
-	"log"
+	"fmt"
 
 	"github.com/chenrui333/terraformer/terraformutils"
 
@@ -24,12 +24,16 @@ func (g *OrganizationBlockGenerator) InitResources() error {
 	}
 
 	owner := g.Args["owner"].(string)
-	g.Resources = append(g.Resources, createOrganizationBlocksResources(ctx, client, owner)...)
+	resources, err := createOrganizationBlocksResources(ctx, client, owner)
+	if err != nil {
+		return err
+	}
+	g.Resources = append(g.Resources, resources...)
 
 	return nil
 }
 
-func createOrganizationBlocksResources(ctx context.Context, client *githubAPI.Client, owner string) []terraformutils.Resource {
+func createOrganizationBlocksResources(ctx context.Context, client *githubAPI.Client, owner string) ([]terraformutils.Resource, error) {
 	resources := []terraformutils.Resource{}
 
 	opt := &githubAPI.ListOptions{PerPage: 100}
@@ -38,8 +42,7 @@ func createOrganizationBlocksResources(ctx context.Context, client *githubAPI.Cl
 	for {
 		blocks, resp, err := client.Organizations.ListBlockedUsers(ctx, owner, opt)
 		if err != nil {
-			log.Println(err)
-			return nil
+			return nil, fmt.Errorf("list github organization blocks for %s: %w", owner, err)
 		}
 
 		for _, block := range blocks {
@@ -60,5 +63,5 @@ func createOrganizationBlocksResources(ctx context.Context, client *githubAPI.Cl
 		}
 		opt.Page = resp.NextPage
 	}
-	return resources
+	return resources, nil
 }

--- a/providers/github/organization_project.go
+++ b/providers/github/organization_project.go
@@ -4,7 +4,7 @@ package github
 
 import (
 	"context"
-	"log"
+	"fmt"
 	"strconv"
 
 	"github.com/chenrui333/terraformer/terraformutils"
@@ -25,12 +25,16 @@ func (g *OrganizationProjectGenerator) InitResources() error {
 	}
 
 	owner := g.Args["owner"].(string)
-	g.Resources = append(g.Resources, createOrganizationProjects(ctx, client, owner)...)
+	resources, err := createOrganizationProjects(ctx, client, owner)
+	if err != nil {
+		return err
+	}
+	g.Resources = append(g.Resources, resources...)
 
 	return nil
 }
 
-func createOrganizationProjects(ctx context.Context, client *githubAPI.Client, owner string) []terraformutils.Resource {
+func createOrganizationProjects(ctx context.Context, client *githubAPI.Client, owner string) ([]terraformutils.Resource, error) {
 	resources := []terraformutils.Resource{}
 
 	opt := &githubAPI.ProjectListOptions{
@@ -41,8 +45,7 @@ func createOrganizationProjects(ctx context.Context, client *githubAPI.Client, o
 	for {
 		projects, resp, err := client.Organizations.ListProjects(ctx, owner, opt)
 		if err != nil {
-			log.Println(err)
-			return nil
+			return nil, fmt.Errorf("list github organization projects for %s: %w", owner, err)
 		}
 
 		for _, project := range projects {
@@ -62,5 +65,5 @@ func createOrganizationProjects(ctx context.Context, client *githubAPI.Client, o
 		}
 		opt.Page = resp.NextPage
 	}
-	return resources
+	return resources, nil
 }

--- a/providers/github/repositories.go
+++ b/providers/github/repositories.go
@@ -4,7 +4,7 @@ package github
 
 import (
 	"context"
-	"log"
+	"fmt"
 	"strconv"
 
 	"github.com/chenrui333/terraformer/terraformutils"
@@ -30,8 +30,7 @@ func (g *RepositoriesGenerator) InitResources() error {
 	for {
 		repos, resp, err := client.Repositories.ListByOrg(ctx, g.GetArgs()["owner"].(string), opt)
 		if err != nil {
-			log.Println(err)
-			return nil
+			return fmt.Errorf("list github repositories for %s: %w", g.GetArgs()["owner"].(string), err)
 		}
 		for _, repo := range repos {
 			resource := terraformutils.NewSimpleResource(
@@ -43,10 +42,26 @@ func (g *RepositoriesGenerator) InitResources() error {
 			)
 			resource.SlowQueryRequired = true
 			g.Resources = append(g.Resources, resource)
-			g.Resources = append(g.Resources, g.createRepositoryWebhookResources(ctx, client, repo)...)
-			g.Resources = append(g.Resources, g.createRepositoryBranchProtectionResources(ctx, client, repo)...)
-			g.Resources = append(g.Resources, g.createRepositoryCollaboratorResources(ctx, client, repo)...)
-			g.Resources = append(g.Resources, g.createRepositoryDeployKeyResources(ctx, client, repo)...)
+			webhookResources, err := g.createRepositoryWebhookResources(ctx, client, repo)
+			if err != nil {
+				return err
+			}
+			g.Resources = append(g.Resources, webhookResources...)
+			branchProtectionResources, err := g.createRepositoryBranchProtectionResources(ctx, client, repo)
+			if err != nil {
+				return err
+			}
+			g.Resources = append(g.Resources, branchProtectionResources...)
+			collaboratorResources, err := g.createRepositoryCollaboratorResources(ctx, client, repo)
+			if err != nil {
+				return err
+			}
+			g.Resources = append(g.Resources, collaboratorResources...)
+			deployKeyResources, err := g.createRepositoryDeployKeyResources(ctx, client, repo)
+			if err != nil {
+				return err
+			}
+			g.Resources = append(g.Resources, deployKeyResources...)
 		}
 
 		if resp.NextPage == 0 {
@@ -58,11 +73,11 @@ func (g *RepositoriesGenerator) InitResources() error {
 	return nil
 }
 
-func (g *RepositoriesGenerator) createRepositoryWebhookResources(ctx context.Context, client *githubAPI.Client, repo *githubAPI.Repository) []terraformutils.Resource {
+func (g *RepositoriesGenerator) createRepositoryWebhookResources(ctx context.Context, client *githubAPI.Client, repo *githubAPI.Repository) ([]terraformutils.Resource, error) {
 	resources := []terraformutils.Resource{}
 	hooks, _, err := client.Repositories.ListHooks(ctx, g.GetArgs()["owner"].(string), repo.GetName(), nil)
 	if err != nil {
-		log.Println(err)
+		return nil, fmt.Errorf("list github repository webhooks for %s: %w", repo.GetName(), err)
 	}
 	for _, hook := range hooks {
 		resources = append(resources, terraformutils.NewResource(
@@ -77,14 +92,14 @@ func (g *RepositoriesGenerator) createRepositoryWebhookResources(ctx context.Con
 			map[string]interface{}{},
 		))
 	}
-	return resources
+	return resources, nil
 }
 
-func (g *RepositoriesGenerator) createRepositoryBranchProtectionResources(ctx context.Context, client *githubAPI.Client, repo *githubAPI.Repository) []terraformutils.Resource {
+func (g *RepositoriesGenerator) createRepositoryBranchProtectionResources(ctx context.Context, client *githubAPI.Client, repo *githubAPI.Repository) ([]terraformutils.Resource, error) {
 	resources := []terraformutils.Resource{}
 	branches, _, err := client.Repositories.ListBranches(ctx, g.GetArgs()["owner"].(string), repo.GetName(), nil)
 	if err != nil {
-		log.Println(err)
+		return nil, fmt.Errorf("list github repository branches for %s: %w", repo.GetName(), err)
 	}
 	for _, branch := range branches {
 		if branch.GetProtected() {
@@ -97,14 +112,14 @@ func (g *RepositoriesGenerator) createRepositoryBranchProtectionResources(ctx co
 			))
 		}
 	}
-	return resources
+	return resources, nil
 }
 
-func (g *RepositoriesGenerator) createRepositoryCollaboratorResources(ctx context.Context, client *githubAPI.Client, repo *githubAPI.Repository) []terraformutils.Resource {
+func (g *RepositoriesGenerator) createRepositoryCollaboratorResources(ctx context.Context, client *githubAPI.Client, repo *githubAPI.Repository) ([]terraformutils.Resource, error) {
 	resources := []terraformutils.Resource{}
 	collaborators, _, err := client.Repositories.ListCollaborators(ctx, g.GetArgs()["owner"].(string), repo.GetName(), nil)
 	if err != nil {
-		log.Println(err)
+		return nil, fmt.Errorf("list github repository collaborators for %s: %w", repo.GetName(), err)
 	}
 	for _, collaborator := range collaborators {
 		resources = append(resources, terraformutils.NewSimpleResource(
@@ -115,14 +130,14 @@ func (g *RepositoriesGenerator) createRepositoryCollaboratorResources(ctx contex
 			[]string{},
 		))
 	}
-	return resources
+	return resources, nil
 }
 
-func (g *RepositoriesGenerator) createRepositoryDeployKeyResources(ctx context.Context, client *githubAPI.Client, repo *githubAPI.Repository) []terraformutils.Resource {
+func (g *RepositoriesGenerator) createRepositoryDeployKeyResources(ctx context.Context, client *githubAPI.Client, repo *githubAPI.Repository) ([]terraformutils.Resource, error) {
 	resources := []terraformutils.Resource{}
 	deployKeys, _, err := client.Repositories.ListKeys(ctx, g.GetArgs()["owner"].(string), repo.GetName(), nil)
 	if err != nil {
-		log.Println(err)
+		return nil, fmt.Errorf("list github repository deploy keys for %s: %w", repo.GetName(), err)
 	}
 	for _, key := range deployKeys {
 		resources = append(resources, terraformutils.NewSimpleResource(
@@ -133,7 +148,7 @@ func (g *RepositoriesGenerator) createRepositoryDeployKeyResources(ctx context.C
 			[]string{},
 		))
 	}
-	return resources
+	return resources, nil
 }
 
 // PostGenerateHook for connect between resources

--- a/providers/github/teams.go
+++ b/providers/github/teams.go
@@ -4,7 +4,7 @@ package github
 
 import (
 	"context"
-	"log"
+	"fmt"
 	"strconv"
 
 	"github.com/chenrui333/terraformer/terraformutils"
@@ -16,7 +16,7 @@ type TeamsGenerator struct {
 	GithubService
 }
 
-func (g *TeamsGenerator) createTeamsResources(ctx context.Context, teams []*githubAPI.Team, client *githubAPI.Client) []terraformutils.Resource {
+func (g *TeamsGenerator) createTeamsResources(ctx context.Context, teams []*githubAPI.Team, client *githubAPI.Client) ([]terraformutils.Resource, error) {
 	resources := []terraformutils.Resource{}
 	for _, team := range teams {
 		resource := terraformutils.NewSimpleResource(
@@ -28,17 +28,25 @@ func (g *TeamsGenerator) createTeamsResources(ctx context.Context, teams []*gith
 		)
 		resource.SlowQueryRequired = true
 		resources = append(resources, resource)
-		resources = append(resources, g.createTeamMembersResources(ctx, team, client)...)
-		resources = append(resources, g.createTeamRepositoriesResources(ctx, team, client)...)
+		memberResources, err := g.createTeamMembersResources(ctx, team, client)
+		if err != nil {
+			return nil, err
+		}
+		resources = append(resources, memberResources...)
+		repositoryResources, err := g.createTeamRepositoriesResources(ctx, team, client)
+		if err != nil {
+			return nil, err
+		}
+		resources = append(resources, repositoryResources...)
 	}
-	return resources
+	return resources, nil
 }
 
-func (g *TeamsGenerator) createTeamMembersResources(ctx context.Context, team *githubAPI.Team, client *githubAPI.Client) []terraformutils.Resource {
+func (g *TeamsGenerator) createTeamMembersResources(ctx context.Context, team *githubAPI.Team, client *githubAPI.Client) ([]terraformutils.Resource, error) {
 	resources := []terraformutils.Resource{}
 	members, _, err := client.Teams.ListTeamMembersBySlug(ctx, g.Args["owner"].(string), team.GetSlug(), nil)
 	if err != nil {
-		log.Println(err)
+		return nil, fmt.Errorf("list github team members for %s: %w", team.GetSlug(), err)
 	}
 	for _, member := range members {
 		resources = append(resources, terraformutils.NewSimpleResource(
@@ -49,14 +57,14 @@ func (g *TeamsGenerator) createTeamMembersResources(ctx context.Context, team *g
 			[]string{},
 		))
 	}
-	return resources
+	return resources, nil
 }
 
-func (g *TeamsGenerator) createTeamRepositoriesResources(ctx context.Context, team *githubAPI.Team, client *githubAPI.Client) []terraformutils.Resource {
+func (g *TeamsGenerator) createTeamRepositoriesResources(ctx context.Context, team *githubAPI.Team, client *githubAPI.Client) ([]terraformutils.Resource, error) {
 	resources := []terraformutils.Resource{}
 	repos, _, err := client.Teams.ListTeamReposBySlug(ctx, g.Args["owner"].(string), team.GetSlug(), nil)
 	if err != nil {
-		log.Println(err)
+		return nil, fmt.Errorf("list github team repositories for %s: %w", team.GetSlug(), err)
 	}
 	for _, repo := range repos {
 		resources = append(resources, terraformutils.NewSimpleResource(
@@ -67,7 +75,7 @@ func (g *TeamsGenerator) createTeamRepositoriesResources(ctx context.Context, te
 			[]string{},
 		))
 	}
-	return resources
+	return resources, nil
 }
 
 // InitResources generates TerraformResources from Github API,
@@ -83,11 +91,14 @@ func (g *TeamsGenerator) InitResources() error {
 	for {
 		teams, resp, err := client.Teams.ListTeams(ctx, g.Args["owner"].(string), opt)
 		if err != nil {
-			log.Println(err)
-			return nil
+			return fmt.Errorf("list github teams for %s: %w", g.Args["owner"].(string), err)
 		}
 
-		g.Resources = append(g.Resources, g.createTeamsResources(ctx, teams, client)...)
+		resources, err := g.createTeamsResources(ctx, teams, client)
+		if err != nil {
+			return err
+		}
+		g.Resources = append(g.Resources, resources...)
 
 		if resp.NextPage == 0 {
 			break

--- a/providers/github/user_ssh_keys.go
+++ b/providers/github/user_ssh_keys.go
@@ -4,7 +4,7 @@ package github
 
 import (
 	"context"
-	"log"
+	"fmt"
 	"strconv"
 
 	"github.com/chenrui333/terraformer/terraformutils"
@@ -30,8 +30,7 @@ func (g *UserSSHKeyGenerator) InitResources() error {
 	for {
 		keys, resp, err := client.Users.ListKeys(ctx, "", opt)
 		if err != nil {
-			log.Println(err)
-			return nil
+			return fmt.Errorf("list github user ssh keys: %w", err)
 		}
 
 		for _, key := range keys {


### PR DESCRIPTION
## Summary

- Return GitHub provider discovery list errors instead of logging and continuing with empty or partial resources.
- Propagate nested repository and team discovery errors through provider initialization.
- Add regression coverage for organization member, repository webhook, and team member list failures.
