### PR TITLE
feat(datadog): add security monitoring filter import

### DIFF
--- a/docs/datadog.md
+++ b/docs/datadog.md
@@ -144,6 +144,8 @@ Tag filters are order specific. For example, if your monitor has tags (in the or
     * `datadog_role`
 *   `security_monitoring_default_rule`
     * `datadog_security_monitoring_default_rule`
+*   `security_monitoring_filter`
+    * `datadog_security_monitoring_filter`
 *   `security_monitoring_rule`
     * `datadog_security_monitoring_rule`
 *   `service_level_objective`

--- a/providers/datadog/datadog_provider.go
+++ b/providers/datadog/datadog_provider.go
@@ -174,6 +174,7 @@ func (p *DatadogProvider) GetSupportedService() map[string]terraformutils.Servic
 		"monitor_config_policy":                &MonitorConfigPolicyGenerator{},
 		"monitor_notification_rule":            &MonitorNotificationRuleGenerator{},
 		"security_monitoring_default_rule":     &SecurityMonitoringDefaultRuleGenerator{},
+		"security_monitoring_filter":           &SecurityMonitoringFilterGenerator{},
 		"security_monitoring_rule":             &SecurityMonitoringRuleGenerator{},
 		"service_level_objective":              &ServiceLevelObjectiveGenerator{},
 		"slo_correction":                       &SLOCorrectionGenerator{},

--- a/providers/datadog/security_monitoring_filter.go
+++ b/providers/datadog/security_monitoring_filter.go
@@ -1,0 +1,172 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package datadog
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/DataDog/datadog-api-client-go/v2/api/datadog"
+	"github.com/DataDog/datadog-api-client-go/v2/api/datadogV2"
+
+	"github.com/chenrui333/terraformer/terraformutils"
+)
+
+var (
+	// SecurityMonitoringFilterAllowEmptyValues ...
+	SecurityMonitoringFilterAllowEmptyValues = []string{}
+)
+
+// SecurityMonitoringFilterGenerator ...
+type SecurityMonitoringFilterGenerator struct {
+	DatadogService
+}
+
+func (g *SecurityMonitoringFilterGenerator) createResources(securityFilters []datadogV2.SecurityFilter) ([]terraformutils.Resource, error) {
+	resources := []terraformutils.Resource{}
+	for _, securityFilter := range securityFilters {
+		resource, err := g.createResource(securityFilter)
+		if err != nil {
+			return nil, err
+		}
+		resources = append(resources, resource)
+	}
+
+	return resources, nil
+}
+
+func (g *SecurityMonitoringFilterGenerator) createResource(securityFilter datadogV2.SecurityFilter) (terraformutils.Resource, error) {
+	securityFilterID := securityFilter.GetId()
+	if securityFilterID == "" {
+		return terraformutils.Resource{}, fmt.Errorf("security monitoring filter missing id")
+	}
+
+	return terraformutils.NewSimpleResource(
+		securityFilterID,
+		fmt.Sprintf("security_monitoring_filter_%s", securityFilterID),
+		"datadog_security_monitoring_filter",
+		"datadog",
+		SecurityMonitoringFilterAllowEmptyValues,
+	), nil
+}
+
+// InitResources Generate TerraformResources from Datadog API,
+// from each security_monitoring_filter create 1 TerraformResource.
+func (g *SecurityMonitoringFilterGenerator) InitResources() error {
+	datadogClient := g.Args["datadogClient"].(*datadog.APIClient)
+	auth := g.Args["auth"].(context.Context)
+	api := datadogV2.NewSecurityMonitoringApi(datadogClient)
+
+	resources, filtered, err := g.filteredResources(auth, api)
+	if err != nil {
+		return err
+	}
+	if filtered {
+		g.Resources = resources
+		return nil
+	}
+
+	securityFilters, err := listSecurityMonitoringFilters(auth, api)
+	if err != nil {
+		return err
+	}
+	resources, err = g.createResources(securityFilters)
+	if err != nil {
+		return err
+	}
+
+	g.Resources = resources
+	return nil
+}
+
+func (g *SecurityMonitoringFilterGenerator) filteredResources(auth context.Context, api *datadogV2.SecurityMonitoringApi) ([]terraformutils.Resource, bool, error) {
+	resources := []terraformutils.Resource{}
+	filtered := false
+
+	for _, filter := range g.Filter {
+		if filter.FieldPath != "id" || !filter.IsApplicable("security_monitoring_filter") {
+			continue
+		}
+
+		filtered = true
+		for _, value := range filter.AcceptableValues {
+			securityFilter, err := getSecurityMonitoringFilter(auth, api, value)
+			if err != nil {
+				return nil, true, err
+			}
+			resource, err := g.createResource(securityFilter)
+			if err != nil {
+				return nil, true, err
+			}
+			resources = append(resources, resource)
+		}
+	}
+
+	return resources, filtered, nil
+}
+
+func getSecurityMonitoringFilter(auth context.Context, api *datadogV2.SecurityMonitoringApi, securityFilterID string) (datadogV2.SecurityFilter, error) {
+	response, httpResponse, err := api.GetSecurityFilter(auth, securityFilterID)
+	defer closeDatadogResponseBody(httpResponse)
+	if err != nil {
+		return datadogV2.SecurityFilter{}, err
+	}
+
+	if securityFilter, ok := response.GetDataOk(); ok {
+		return *securityFilter, nil
+	}
+	if securityFilter, ok := securityMonitoringFilterFromRawData(response.UnparsedObject["data"]); ok {
+		return securityFilter, nil
+	}
+
+	return datadogV2.SecurityFilter{}, fmt.Errorf("security monitoring filter %q not found", securityFilterID)
+}
+
+func listSecurityMonitoringFilters(auth context.Context, api *datadogV2.SecurityMonitoringApi) ([]datadogV2.SecurityFilter, error) {
+	response, httpResponse, err := api.ListSecurityFilters(auth)
+	defer closeDatadogResponseBody(httpResponse)
+	if err != nil {
+		return nil, err
+	}
+
+	securityFilters := response.GetData()
+	if len(securityFilters) == 0 {
+		securityFilters = securityMonitoringFiltersFromRawData(response.UnparsedObject["data"])
+	}
+	return securityFilters, nil
+}
+
+func securityMonitoringFiltersFromRawData(rawData interface{}) []datadogV2.SecurityFilter {
+	rawFilters, ok := rawData.([]interface{})
+	if !ok {
+		return nil
+	}
+
+	securityFilters := []datadogV2.SecurityFilter{}
+	for _, rawFilter := range rawFilters {
+		securityFilter, ok := securityMonitoringFilterFromRawData(rawFilter)
+		if !ok {
+			continue
+		}
+		securityFilters = append(securityFilters, securityFilter)
+	}
+	return securityFilters
+}
+
+func securityMonitoringFilterFromRawData(rawData interface{}) (datadogV2.SecurityFilter, bool) {
+	rawFilter, ok := rawData.(map[string]interface{})
+	if !ok {
+		return datadogV2.SecurityFilter{}, false
+	}
+	if rawType, ok := rawFilter["type"].(string); ok && rawType != string(datadogV2.SECURITYFILTERTYPE_SECURITY_FILTERS) {
+		return datadogV2.SecurityFilter{}, false
+	}
+	rawID, ok := rawFilter["id"].(string)
+	if !ok || rawID == "" {
+		return datadogV2.SecurityFilter{}, false
+	}
+
+	securityFilter := datadogV2.NewSecurityFilterWithDefaults()
+	securityFilter.SetId(rawID)
+	return *securityFilter, true
+}

--- a/providers/datadog/security_monitoring_filter.go
+++ b/providers/datadog/security_monitoring_filter.go
@@ -14,7 +14,7 @@ import (
 
 var (
 	// SecurityMonitoringFilterAllowEmptyValues ...
-	SecurityMonitoringFilterAllowEmptyValues = []string{}
+	SecurityMonitoringFilterAllowEmptyValues = []string{"query", "exclusion_filter.*.query"}
 )
 
 // SecurityMonitoringFilterGenerator ...

--- a/providers/datadog/security_monitoring_filter_test.go
+++ b/providers/datadog/security_monitoring_filter_test.go
@@ -3,10 +3,57 @@
 package datadog
 
 import (
+	"regexp"
 	"testing"
 
 	"github.com/DataDog/datadog-api-client-go/v2/api/datadogV2"
+	"github.com/zclconf/go-cty/cty"
+
+	"github.com/chenrui333/terraformer/terraformutils"
 )
+
+func TestSecurityMonitoringFilterAllowEmptyValuesPreservesQueries(t *testing.T) {
+	allowEmptyValues := []*regexp.Regexp{}
+	for _, pattern := range SecurityMonitoringFilterAllowEmptyValues {
+		allowEmptyValues = append(allowEmptyValues, regexp.MustCompile(pattern))
+	}
+
+	parser := terraformutils.NewFlatmapParser(map[string]string{
+		"query":                    "",
+		"exclusion_filter.#":       "1",
+		"exclusion_filter.0.name":  "catch-all",
+		"exclusion_filter.0.query": "",
+	}, nil, allowEmptyValues)
+	filterType := cty.Object(map[string]cty.Type{
+		"query": cty.String,
+		"exclusion_filter": cty.List(cty.Object(map[string]cty.Type{
+			"name":  cty.String,
+			"query": cty.String,
+		})),
+	})
+
+	result, err := parser.Parse(filterType)
+	if err != nil {
+		t.Fatalf("Parse returned error: %v", err)
+	}
+	if result["query"] != "" {
+		t.Fatalf("query = %v, want empty string", result["query"])
+	}
+	exclusionFilters, ok := result["exclusion_filter"].([]interface{})
+	if !ok {
+		t.Fatalf("exclusion_filter = %T, want []interface{}", result["exclusion_filter"])
+	}
+	if len(exclusionFilters) != 1 {
+		t.Fatalf("exclusion_filter length = %d, want %d", len(exclusionFilters), 1)
+	}
+	exclusionFilter, ok := exclusionFilters[0].(map[string]interface{})
+	if !ok {
+		t.Fatalf("exclusion_filter[0] = %T, want map[string]interface{}", exclusionFilters[0])
+	}
+	if exclusionFilter["query"] != "" {
+		t.Fatalf("exclusion_filter[0].query = %v, want empty string", exclusionFilter["query"])
+	}
+}
 
 func TestSecurityMonitoringFilterCreateResource(t *testing.T) {
 	securityFilter := datadogV2.NewSecurityFilterWithDefaults()

--- a/providers/datadog/security_monitoring_filter_test.go
+++ b/providers/datadog/security_monitoring_filter_test.go
@@ -1,0 +1,96 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package datadog
+
+import (
+	"testing"
+
+	"github.com/DataDog/datadog-api-client-go/v2/api/datadogV2"
+)
+
+func TestSecurityMonitoringFilterCreateResource(t *testing.T) {
+	securityFilter := datadogV2.NewSecurityFilterWithDefaults()
+	securityFilter.SetId("filter-id")
+
+	generator := &SecurityMonitoringFilterGenerator{}
+	resource, err := generator.createResource(*securityFilter)
+	if err != nil {
+		t.Fatalf("createResource returned error: %v", err)
+	}
+
+	if resource.InstanceState.ID != "filter-id" {
+		t.Fatalf("resource ID = %q, want %q", resource.InstanceState.ID, "filter-id")
+	}
+	if resource.ResourceName != "tfer--security_monitoring_filter_filter-id" {
+		t.Fatalf("resource name = %q, want %q", resource.ResourceName, "tfer--security_monitoring_filter_filter-id")
+	}
+	if resource.InstanceInfo.Type != "datadog_security_monitoring_filter" {
+		t.Fatalf("resource type = %q, want %q", resource.InstanceInfo.Type, "datadog_security_monitoring_filter")
+	}
+}
+
+func TestSecurityMonitoringFilterCreateResourceMissingID(t *testing.T) {
+	generator := &SecurityMonitoringFilterGenerator{}
+	_, err := generator.createResource(datadogV2.SecurityFilter{})
+	if err == nil {
+		t.Fatal("createResource returned nil error, want missing id error")
+	}
+}
+
+func TestSecurityMonitoringFilterCreateResources(t *testing.T) {
+	firstFilter := datadogV2.NewSecurityFilterWithDefaults()
+	firstFilter.SetId("filter-1")
+	secondFilter := datadogV2.NewSecurityFilterWithDefaults()
+	secondFilter.SetId("filter-2")
+
+	generator := &SecurityMonitoringFilterGenerator{}
+	resources, err := generator.createResources([]datadogV2.SecurityFilter{
+		*firstFilter,
+		*secondFilter,
+	})
+	if err != nil {
+		t.Fatalf("createResources returned error: %v", err)
+	}
+
+	if len(resources) != 2 {
+		t.Fatalf("resource count = %d, want %d", len(resources), 2)
+	}
+	if resources[0].ResourceName == resources[1].ResourceName {
+		t.Fatalf("resource names should be unique, got %q", resources[0].ResourceName)
+	}
+}
+
+func TestSecurityMonitoringFiltersFromRawData(t *testing.T) {
+	securityFilters := securityMonitoringFiltersFromRawData([]interface{}{
+		map[string]interface{}{
+			"id":   "filter-1",
+			"type": "security_filters",
+		},
+		map[string]interface{}{
+			"id": "filter-2",
+		},
+		map[string]interface{}{
+			"id":   "ignored-type",
+			"type": "unknown",
+		},
+		map[string]interface{}{
+			"type": "security_filters",
+		},
+	})
+
+	if len(securityFilters) != 2 {
+		t.Fatalf("filter count = %d, want %d", len(securityFilters), 2)
+	}
+	if securityFilters[0].GetId() != "filter-1" {
+		t.Fatalf("first filter ID = %q, want %q", securityFilters[0].GetId(), "filter-1")
+	}
+	if securityFilters[1].GetId() != "filter-2" {
+		t.Fatalf("second filter ID = %q, want %q", securityFilters[1].GetId(), "filter-2")
+	}
+}
+
+func TestSecurityMonitoringFilterFromRawDataRejectsNonObjects(t *testing.T) {
+	if _, ok := securityMonitoringFilterFromRawData("filter-id"); ok {
+		t.Fatal("securityMonitoringFilterFromRawData accepted non-object raw data")
+	}
+}


### PR DESCRIPTION
Summary
- Add Terraformer import support for Datadog security monitoring filters.
- Support ID-filtered imports through `GetSecurityFilter` and full imports through `ListSecurityFilters`.
- Document the new Datadog resource in the provider docs.

Notes
- Resources are keyed by filter ID to keep generated resources unique.
- SDK response bodies are closed on both lookup and list paths.
