### PR TITLE
fix(gitlab): return discovery list errors

### DIFF
--- a/providers/gitlab/gitlab_errors_test.go
+++ b/providers/gitlab/gitlab_errors_test.go
@@ -1,0 +1,67 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package gitlab
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	gitlabAPI "gitlab.com/gitlab-org/api/client-go"
+)
+
+func TestCreateGroupsReturnsGroupGetError(t *testing.T) {
+	ctx := context.Background()
+	client := newErrorGitLabClient(t)
+
+	_, err := createGroups(ctx, client, "test-group")
+	if err == nil {
+		t.Fatal("expected gitlab group get error")
+	}
+	if !strings.Contains(err.Error(), "get gitlab group test-group") {
+		t.Fatalf("expected wrapped gitlab group get error, got %q", err)
+	}
+}
+
+func TestCreateProjectsReturnsProjectListError(t *testing.T) {
+	ctx := context.Background()
+	client := newErrorGitLabClient(t)
+
+	_, err := createProjects(ctx, client, "test-group")
+	if err == nil {
+		t.Fatal("expected gitlab project list error")
+	}
+	if !strings.Contains(err.Error(), "list gitlab projects for test-group") {
+		t.Fatalf("expected wrapped gitlab project list error, got %q", err)
+	}
+}
+
+func TestCreateProjectVariablesReturnsListError(t *testing.T) {
+	ctx := context.Background()
+	client := newErrorGitLabClient(t)
+
+	_, err := createProjectVariables(ctx, client, &gitlabAPI.Project{ID: 123})
+	if err == nil {
+		t.Fatal("expected gitlab project variable list error")
+	}
+	if !strings.Contains(err.Error(), "list gitlab project variables for 123") {
+		t.Fatalf("expected wrapped gitlab project variable list error, got %q", err)
+	}
+}
+
+func newErrorGitLabClient(t *testing.T) *gitlabAPI.Client {
+	t.Helper()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		http.Error(w, "{\"message\":\"service unavailable\"}", http.StatusServiceUnavailable)
+	}))
+	t.Cleanup(server.Close)
+
+	client, err := gitlabAPI.NewClient("token", gitlabAPI.WithBaseURL(server.URL), gitlabAPI.WithHTTPClient(server.Client()))
+	if err != nil {
+		t.Fatal(err)
+	}
+	return client
+}

--- a/providers/gitlab/gitlab_errors_test.go
+++ b/providers/gitlab/gitlab_errors_test.go
@@ -59,7 +59,7 @@ func newErrorGitLabClient(t *testing.T) *gitlabAPI.Client {
 	}))
 	t.Cleanup(server.Close)
 
-	client, err := gitlabAPI.NewClient("token", gitlabAPI.WithBaseURL(server.URL), gitlabAPI.WithHTTPClient(server.Client()))
+	client, err := gitlabAPI.NewClient("token", gitlabAPI.WithBaseURL(server.URL), gitlabAPI.WithHTTPClient(server.Client()), gitlabAPI.WithoutRetries())
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/providers/gitlab/group.go
+++ b/providers/gitlab/group.go
@@ -5,7 +5,6 @@ package gitlab
 import (
 	"context"
 	"fmt"
-	"log"
 	"strings"
 
 	"github.com/chenrui333/terraformer/terraformutils"
@@ -25,17 +24,20 @@ func (g *GroupGenerator) InitResources() error {
 	}
 
 	group := g.Args["group"].(string)
-	g.Resources = append(g.Resources, createGroups(ctx, client, group)...)
+	resources, err := createGroups(ctx, client, group)
+	if err != nil {
+		return err
+	}
+	g.Resources = append(g.Resources, resources...)
 
 	return nil
 }
 
-func createGroups(ctx context.Context, client *gitlab.Client, groupID string) []terraformutils.Resource {
+func createGroups(ctx context.Context, client *gitlab.Client, groupID string) ([]terraformutils.Resource, error) {
 	resources := []terraformutils.Resource{}
 	group, _, err := client.Groups.GetGroup(groupID, nil, gitlab.WithContext(ctx))
 	if err != nil {
-		log.Println(err)
-		return nil
+		return nil, fmt.Errorf("get gitlab group %s: %w", groupID, err)
 	}
 
 	resource := terraformutils.NewSimpleResource(
@@ -51,20 +53,28 @@ func createGroups(ctx context.Context, client *gitlab.Client, groupID string) []
 
 	resource.SlowQueryRequired = true
 	resources = append(resources, resource)
-	resources = append(resources, createGroupVariables(ctx, client, group)...)
-	resources = append(resources, createGroupMembership(ctx, client, group)...)
+	variableResources, err := createGroupVariables(ctx, client, group)
+	if err != nil {
+		return nil, err
+	}
+	resources = append(resources, variableResources...)
+	membershipResources, err := createGroupMembership(ctx, client, group)
+	if err != nil {
+		return nil, err
+	}
+	resources = append(resources, membershipResources...)
 
-	return resources
+	return resources, nil
 }
-func createGroupVariables(ctx context.Context, client *gitlab.Client, group *gitlab.Group) []terraformutils.Resource {
+
+func createGroupVariables(ctx context.Context, client *gitlab.Client, group *gitlab.Group) ([]terraformutils.Resource, error) {
 	resources := []terraformutils.Resource{}
 	opt := &gitlab.ListGroupVariablesOptions{}
 
 	for {
 		groupVariables, resp, err := client.GroupVariables.ListVariables(group.ID, opt, gitlab.WithContext(ctx))
 		if err != nil {
-			log.Println(err)
-			return nil
+			return nil, fmt.Errorf("list gitlab group variables for %d: %w", group.ID, err)
 		}
 
 		for _, groupVariable := range groupVariables {
@@ -84,18 +94,17 @@ func createGroupVariables(ctx context.Context, client *gitlab.Client, group *git
 		}
 		opt.Page = resp.NextPage
 	}
-	return resources
+	return resources, nil
 }
 
-func createGroupMembership(ctx context.Context, client *gitlab.Client, group *gitlab.Group) []terraformutils.Resource {
+func createGroupMembership(ctx context.Context, client *gitlab.Client, group *gitlab.Group) ([]terraformutils.Resource, error) {
 	resources := []terraformutils.Resource{}
 	opt := &gitlab.ListGroupMembersOptions{}
 
 	for {
 		groupMembers, resp, err := client.Groups.ListGroupMembers(group.ID, opt, gitlab.WithContext(ctx))
 		if err != nil {
-			log.Println(err)
-			return nil
+			return nil, fmt.Errorf("list gitlab group memberships for %d: %w", group.ID, err)
 		}
 
 		for _, groupMember := range groupMembers {
@@ -115,7 +124,7 @@ func createGroupMembership(ctx context.Context, client *gitlab.Client, group *gi
 		}
 		opt.Page = resp.NextPage
 	}
-	return resources
+	return resources, nil
 }
 
 func getGroupResourceName(group *gitlab.Group) string {

--- a/providers/gitlab/project.go
+++ b/providers/gitlab/project.go
@@ -5,7 +5,6 @@ package gitlab
 import (
 	"context"
 	"fmt"
-	"log"
 	"strings"
 
 	"github.com/chenrui333/terraformer/terraformutils"
@@ -25,12 +24,16 @@ func (g *ProjectGenerator) InitResources() error {
 	}
 
 	group := g.Args["group"].(string)
-	g.Resources = append(g.Resources, createProjects(ctx, client, group)...)
+	resources, err := createProjects(ctx, client, group)
+	if err != nil {
+		return err
+	}
+	g.Resources = append(g.Resources, resources...)
 
 	return nil
 }
 
-func createProjects(ctx context.Context, client *gitlab.Client, group string) []terraformutils.Resource {
+func createProjects(ctx context.Context, client *gitlab.Client, group string) ([]terraformutils.Resource, error) {
 	resources := []terraformutils.Resource{}
 	opt := &gitlab.ListGroupProjectsOptions{
 		ListOptions: gitlab.ListOptions{
@@ -41,8 +44,7 @@ func createProjects(ctx context.Context, client *gitlab.Client, group string) []
 	for {
 		projects, resp, err := client.Groups.ListGroupProjects(group, opt, gitlab.WithContext(ctx))
 		if err != nil {
-			log.Println(err)
-			return nil
+			return nil, fmt.Errorf("list gitlab projects for %s: %w", group, err)
 		}
 
 		for _, project := range projects {
@@ -59,10 +61,26 @@ func createProjects(ctx context.Context, client *gitlab.Client, group string) []
 
 			resource.SlowQueryRequired = true
 			resources = append(resources, resource)
-			resources = append(resources, createProjectVariables(ctx, client, project)...)
-			resources = append(resources, createBranchProtections(ctx, client, project)...)
-			resources = append(resources, createTagProtections(ctx, client, project)...)
-			resources = append(resources, createProjectMembership(ctx, client, project)...)
+			variableResources, err := createProjectVariables(ctx, client, project)
+			if err != nil {
+				return nil, err
+			}
+			resources = append(resources, variableResources...)
+			branchProtectionResources, err := createBranchProtections(ctx, client, project)
+			if err != nil {
+				return nil, err
+			}
+			resources = append(resources, branchProtectionResources...)
+			tagProtectionResources, err := createTagProtections(ctx, client, project)
+			if err != nil {
+				return nil, err
+			}
+			resources = append(resources, tagProtectionResources...)
+			membershipResources, err := createProjectMembership(ctx, client, project)
+			if err != nil {
+				return nil, err
+			}
+			resources = append(resources, membershipResources...)
 		}
 
 		if resp.NextPage == 0 {
@@ -70,17 +88,17 @@ func createProjects(ctx context.Context, client *gitlab.Client, group string) []
 		}
 		opt.Page = resp.NextPage
 	}
-	return resources
+	return resources, nil
 }
-func createProjectVariables(ctx context.Context, client *gitlab.Client, project *gitlab.Project) []terraformutils.Resource {
+
+func createProjectVariables(ctx context.Context, client *gitlab.Client, project *gitlab.Project) ([]terraformutils.Resource, error) {
 	resources := []terraformutils.Resource{}
 	opt := &gitlab.ListProjectVariablesOptions{}
 
 	for {
 		projectVariables, resp, err := client.ProjectVariables.ListVariables(project.ID, opt, gitlab.WithContext(ctx))
 		if err != nil {
-			log.Println(err)
-			return nil
+			return nil, fmt.Errorf("list gitlab project variables for %d: %w", project.ID, err)
 		}
 
 		for _, projectVariable := range projectVariables {
@@ -100,18 +118,17 @@ func createProjectVariables(ctx context.Context, client *gitlab.Client, project 
 		}
 		opt.Page = resp.NextPage
 	}
-	return resources
+	return resources, nil
 }
 
-func createBranchProtections(ctx context.Context, client *gitlab.Client, project *gitlab.Project) []terraformutils.Resource {
+func createBranchProtections(ctx context.Context, client *gitlab.Client, project *gitlab.Project) ([]terraformutils.Resource, error) {
 	resources := []terraformutils.Resource{}
 	opt := &gitlab.ListProtectedBranchesOptions{}
 
 	for {
 		protectedBranches, resp, err := client.ProtectedBranches.ListProtectedBranches(project.ID, opt, gitlab.WithContext(ctx))
 		if err != nil {
-			log.Println(err)
-			return nil
+			return nil, fmt.Errorf("list gitlab branch protections for %d: %w", project.ID, err)
 		}
 
 		for _, protectedBranch := range protectedBranches {
@@ -131,18 +148,17 @@ func createBranchProtections(ctx context.Context, client *gitlab.Client, project
 		}
 		opt.Page = resp.NextPage
 	}
-	return resources
+	return resources, nil
 }
 
-func createTagProtections(ctx context.Context, client *gitlab.Client, project *gitlab.Project) []terraformutils.Resource {
+func createTagProtections(ctx context.Context, client *gitlab.Client, project *gitlab.Project) ([]terraformutils.Resource, error) {
 	resources := []terraformutils.Resource{}
 	opt := &gitlab.ListProtectedTagsOptions{}
 
 	for {
 		protectedTags, resp, err := client.ProtectedTags.ListProtectedTags(project.ID, opt, gitlab.WithContext(ctx))
 		if err != nil {
-			log.Println(err)
-			return nil
+			return nil, fmt.Errorf("list gitlab tag protections for %d: %w", project.ID, err)
 		}
 
 		for _, protectedTag := range protectedTags {
@@ -162,18 +178,17 @@ func createTagProtections(ctx context.Context, client *gitlab.Client, project *g
 		}
 		opt.Page = resp.NextPage
 	}
-	return resources
+	return resources, nil
 }
 
-func createProjectMembership(ctx context.Context, client *gitlab.Client, project *gitlab.Project) []terraformutils.Resource {
+func createProjectMembership(ctx context.Context, client *gitlab.Client, project *gitlab.Project) ([]terraformutils.Resource, error) {
 	resources := []terraformutils.Resource{}
 	opt := &gitlab.ListProjectMembersOptions{}
 
 	for {
 		projectMembers, resp, err := client.ProjectMembers.ListProjectMembers(project.ID, opt, gitlab.WithContext(ctx))
 		if err != nil {
-			log.Println(err)
-			return nil
+			return nil, fmt.Errorf("list gitlab project memberships for %d: %w", project.ID, err)
 		}
 
 		for _, projectMember := range projectMembers {
@@ -193,7 +208,7 @@ func createProjectMembership(ctx context.Context, client *gitlab.Client, project
 		}
 		opt.Page = resp.NextPage
 	}
-	return resources
+	return resources, nil
 }
 
 func getProjectResourceName(project *gitlab.Project) string {


### PR DESCRIPTION
## Summary

- Return GitLab project and group discovery errors instead of logging and continuing with empty or partial resources.
- Propagate nested project variable, branch protection, tag protection, membership, group variable, and group membership list errors.
- Add regression coverage for group lookup, project listing, and project variable listing failures.
