### PR TITLE
fix(launchdarkly): include stable ids in resource names

### DIFF
--- a/providers/launchdarkly/environment.go
+++ b/providers/launchdarkly/environment.go
@@ -21,7 +21,7 @@ func (g *EnvironmentGenerator) loadEnvironments(ctx context.Context, client *lda
 	for _, env := range envs {
 		resource := terraformutils.NewResource(
 			projectKey+"/"+env.Key,
-			projectKey+"-"+env.Name,
+			environmentResourceName(projectKey, env.Name, env.Key),
 			"launchdarkly_environment",
 			"launchdarkly",
 			map[string]string{
@@ -33,6 +33,10 @@ func (g *EnvironmentGenerator) loadEnvironments(ctx context.Context, client *lda
 		g.Resources = append(g.Resources, resource)
 	}
 	return nil
+}
+
+func environmentResourceName(projectKey, name, key string) string {
+	return launchDarklyProjectResourceName(projectKey, name, key)
 }
 
 func (g *EnvironmentGenerator) InitResources() error {

--- a/providers/launchdarkly/feature_flags.go
+++ b/providers/launchdarkly/feature_flags.go
@@ -55,7 +55,7 @@ func (g *FeatureFlagsGenerator) loadFeatureFlags(ctx context.Context, client *ld
 	for _, featureFlag := range allFlags {
 		resource := terraformutils.NewResource(
 			featureFlag.Key,
-			project+"-"+featureFlag.Name,
+			featureFlagResourceName(project, featureFlag.Name, featureFlag.Key),
 			"launchdarkly_feature_flag",
 			"launchdarkly",
 			map[string]string{
@@ -72,6 +72,10 @@ func (g *FeatureFlagsGenerator) loadFeatureFlags(ctx context.Context, client *ld
 		g.Resources = append(g.Resources, resource)
 	}
 	return nil
+}
+
+func featureFlagResourceName(projectKey, name, key string) string {
+	return launchDarklyProjectResourceName(projectKey, name, key)
 }
 
 func (g *FeatureFlagsGenerator) InitResources() error {

--- a/providers/launchdarkly/metric.go
+++ b/providers/launchdarkly/metric.go
@@ -26,7 +26,7 @@ func (g *MetricGenerator) loadMetrics(ctx context.Context, apiKey, projectKey st
 		for _, metric := range metrics.GetItems() {
 			resource := terraformutils.NewResource(
 				projectKey+"/"+metric.Key,
-				projectKey+"-"+metric.Name,
+				metricResourceName(projectKey, metric.Name, metric.Key),
 				"launchdarkly_metric",
 				"launchdarkly",
 				map[string]string{
@@ -40,6 +40,10 @@ func (g *MetricGenerator) loadMetrics(ctx context.Context, apiKey, projectKey st
 		path = nextPagePath(metrics.GetLinks())
 	}
 	return nil
+}
+
+func metricResourceName(projectKey, name, key string) string {
+	return launchDarklyProjectResourceName(projectKey, name, key)
 }
 
 func (g *MetricGenerator) InitResources() error {

--- a/providers/launchdarkly/relay_proxy_configuration.go
+++ b/providers/launchdarkly/relay_proxy_configuration.go
@@ -27,7 +27,7 @@ func (g *RelayProxyConfigurationGenerator) loadRelayProxyConfigurations(ctx cont
 	for _, config := range configs.Items {
 		resource := terraformutils.NewResource(
 			config.Id,
-			resourceName(config.Name, config.Id),
+			relayProxyConfigurationResourceName(config.Name, config.Id),
 			"launchdarkly_relay_proxy_configuration",
 			"launchdarkly",
 			map[string]string{},
@@ -36,6 +36,10 @@ func (g *RelayProxyConfigurationGenerator) loadRelayProxyConfigurations(ctx cont
 		g.Resources = append(g.Resources, resource)
 	}
 	return nil
+}
+
+func relayProxyConfigurationResourceName(name, id string) string {
+	return resourceNameWithID(name, id)
 }
 
 func (g *RelayProxyConfigurationGenerator) InitResources() error {

--- a/providers/launchdarkly/resource_name_test.go
+++ b/providers/launchdarkly/resource_name_test.go
@@ -1,0 +1,62 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package launchdarkly
+
+import "testing"
+
+func TestGeneratedResourceNamesIncludeStableIdentifiers(t *testing.T) {
+	tests := []struct {
+		name string
+		got  string
+		want string
+	}{
+		{
+			name: "feature flag",
+			got:  featureFlagResourceName("proj", "Duplicate", "flag-key"),
+			want: "proj-Duplicate-flag-key",
+		},
+		{
+			name: "environment",
+			got:  environmentResourceName("proj", "Production", "prod"),
+			want: "proj-Production-prod",
+		},
+		{
+			name: "segment",
+			got:  segmentResourceName("proj", "prod", "Duplicate", "segment-key"),
+			want: "proj-prod-Duplicate-segment-key",
+		},
+		{
+			name: "metric",
+			got:  metricResourceName("proj", "Checkout", "checkout-count"),
+			want: "proj-Checkout-checkout-count",
+		},
+		{
+			name: "relay proxy configuration",
+			got:  relayProxyConfigurationResourceName("Production", "rpc-123"),
+			want: "Production-rpc-123",
+		},
+		{
+			name: "team",
+			got:  teamResourceName("Platform", "platform"),
+			want: "Platform-platform",
+		},
+		{
+			name: "team member",
+			got:  teamMemberResourceName("user@example.com", "member-123"),
+			want: "user@example.com-member-123",
+		},
+		{
+			name: "webhook",
+			got:  webhookResourceName("Deploy", "webhook-123"),
+			want: "Deploy-webhook-123",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.got != tt.want {
+				t.Fatalf("resource name = %q, want %q", tt.got, tt.want)
+			}
+		})
+	}
+}

--- a/providers/launchdarkly/segment.go
+++ b/providers/launchdarkly/segment.go
@@ -49,7 +49,7 @@ func (g *SegmentGenerator) loadSegment(ctx context.Context, client *ldapi.APICli
 	for _, segment := range allSegments {
 		resource := terraformutils.NewResource(
 			segment.Key,
-			project+"-"+envKey+"-"+segment.Name,
+			segmentResourceName(project, envKey, segment.Name, segment.Key),
 			"launchdarkly_segment",
 			"launchdarkly",
 			map[string]string{
@@ -63,6 +63,10 @@ func (g *SegmentGenerator) loadSegment(ctx context.Context, client *ldapi.APICli
 		g.Resources = append(g.Resources, resource)
 	}
 	return nil
+}
+
+func segmentResourceName(projectKey, envKey, name, key string) string {
+	return projectKey + "-" + envKey + "-" + resourceNameWithID(name, key)
 }
 
 func (g *SegmentGenerator) InitResources() error {

--- a/providers/launchdarkly/team.go
+++ b/providers/launchdarkly/team.go
@@ -38,7 +38,7 @@ func (g *TeamGenerator) loadTeams(ctx context.Context, client *ldapi.APIClient) 
 		teamKey := team.GetKey()
 		resource := terraformutils.NewResource(
 			teamKey,
-			resourceName(team.GetName(), teamKey),
+			teamResourceName(team.GetName(), teamKey),
 			"launchdarkly_team",
 			"launchdarkly",
 			map[string]string{
@@ -49,6 +49,10 @@ func (g *TeamGenerator) loadTeams(ctx context.Context, client *ldapi.APIClient) 
 		g.Resources = append(g.Resources, resource)
 	}
 	return nil
+}
+
+func teamResourceName(name, key string) string {
+	return resourceNameWithID(name, key)
 }
 
 func (g *TeamGenerator) InitResources() error {

--- a/providers/launchdarkly/team_member.go
+++ b/providers/launchdarkly/team_member.go
@@ -37,7 +37,7 @@ func (g *TeamMemberGenerator) loadTeamMembers(ctx context.Context, client *ldapi
 	for _, member := range allMembers {
 		resource := terraformutils.NewResource(
 			member.Id,
-			resourceName(member.Email, member.Id),
+			teamMemberResourceName(member.Email, member.Id),
 			"launchdarkly_team_member",
 			"launchdarkly",
 			map[string]string{},
@@ -46,6 +46,10 @@ func (g *TeamMemberGenerator) loadTeamMembers(ctx context.Context, client *ldapi
 		g.Resources = append(g.Resources, resource)
 	}
 	return nil
+}
+
+func teamMemberResourceName(email, id string) string {
+	return resourceNameWithID(email, id)
 }
 
 func (g *TeamMemberGenerator) InitResources() error {

--- a/providers/launchdarkly/webhook.go
+++ b/providers/launchdarkly/webhook.go
@@ -23,7 +23,7 @@ func (g *WebhookGenerator) loadWebhooks(ctx context.Context, apiKey string) erro
 		for _, webhook := range webhooks.GetItems() {
 			resource := terraformutils.NewResource(
 				webhook.Id,
-				resourceName(webhook.GetName(), webhook.Id),
+				webhookResourceName(webhook.GetName(), webhook.Id),
 				"launchdarkly_webhook",
 				"launchdarkly",
 				map[string]string{},
@@ -34,6 +34,10 @@ func (g *WebhookGenerator) loadWebhooks(ctx context.Context, apiKey string) erro
 		path = nextPagePath(webhooks.GetLinks())
 	}
 	return nil
+}
+
+func webhookResourceName(name, id string) string {
+	return resourceNameWithID(name, id)
 }
 
 func (g *WebhookGenerator) InitResources() error {


### PR DESCRIPTION
Summary
- Include stable LaunchDarkly keys or IDs in generated Terraform resource names for existing importers.
- Covers feature flags, environments, segments, metrics, relay proxy configurations, teams, team members, and webhooks.
- Add tests for duplicate-display-name-safe generated names.

Notes
- This keeps import IDs and seeded provider attributes unchanged; it only makes generated Terraform addresses less collision-prone.
