### PR TITLE
fix(launchdarkly): close SDK response bodies

### DIFF
--- a/providers/launchdarkly/feature_flags.go
+++ b/providers/launchdarkly/feature_flags.go
@@ -16,7 +16,8 @@ type FeatureFlagsGenerator struct {
 }
 
 func (g *FeatureFlagsGenerator) loadFeatureFlagEnv(ctx context.Context, client *ldapi.APIClient, projectKey, flagKey string) error {
-	ff, _, err := client.FeatureFlagsApi.GetFeatureFlag(ctx, projectKey, flagKey).Execute()
+	ff, resp, err := client.FeatureFlagsApi.GetFeatureFlag(ctx, projectKey, flagKey).Execute()
+	closeResponseBody(resp)
 	if err != nil {
 		return err
 	}
@@ -40,10 +41,11 @@ func (g *FeatureFlagsGenerator) loadFeatureFlagEnv(ctx context.Context, client *
 func (g *FeatureFlagsGenerator) loadFeatureFlags(ctx context.Context, client *ldapi.APIClient, project string) error {
 	var allFlags []ldapi.FeatureFlag
 	for offset := int64(0); ; offset += pageSize {
-		featureFlags, _, err := client.FeatureFlagsApi.GetFeatureFlags(ctx, project).
+		featureFlags, resp, err := client.FeatureFlagsApi.GetFeatureFlags(ctx, project).
 			Limit(pageSize).
 			Offset(offset).
 			Execute()
+		closeResponseBody(resp)
 		if err != nil {
 			return err
 		}

--- a/providers/launchdarkly/project.go
+++ b/providers/launchdarkly/project.go
@@ -18,10 +18,11 @@ type ProjectGenerator struct {
 func getProjects(ctx context.Context, client *ldapi.APIClient) ([]ldapi.Project, error) {
 	var allProjects []ldapi.Project
 	for offset := int64(0); ; offset += pageSize {
-		projects, _, err := client.ProjectsApi.GetProjects(ctx).
+		projects, resp, err := client.ProjectsApi.GetProjects(ctx).
 			Limit(pageSize).
 			Offset(offset).
 			Execute()
+		closeResponseBody(resp)
 		if err != nil {
 			return nil, err
 		}

--- a/providers/launchdarkly/segment.go
+++ b/providers/launchdarkly/segment.go
@@ -16,10 +16,11 @@ type SegmentGenerator struct {
 func getEnvironments(ctx context.Context, client *ldapi.APIClient, projectKey string) ([]ldapi.Environment, error) {
 	var allEnvs []ldapi.Environment
 	for offset := int64(0); ; offset += pageSize {
-		envs, _, err := client.EnvironmentsApi.GetEnvironmentsByProject(ctx, projectKey).
+		envs, resp, err := client.EnvironmentsApi.GetEnvironmentsByProject(ctx, projectKey).
 			Limit(pageSize).
 			Offset(offset).
 			Execute()
+		closeResponseBody(resp)
 		if err != nil {
 			return nil, err
 		}
@@ -34,10 +35,11 @@ func getEnvironments(ctx context.Context, client *ldapi.APIClient, projectKey st
 func (g *SegmentGenerator) loadSegment(ctx context.Context, client *ldapi.APIClient, project, envKey string) error {
 	var allSegments []ldapi.UserSegment
 	for offset := int64(0); ; offset += pageSize {
-		segments, _, err := client.SegmentsApi.GetSegments(ctx, project, envKey).
+		segments, resp, err := client.SegmentsApi.GetSegments(ctx, project, envKey).
 			Limit(pageSize).
 			Offset(offset).
 			Execute()
+		closeResponseBody(resp)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
Summary
- Close LaunchDarkly SDK response bodies in project, feature flag, environment, and segment discovery.
- Clears the package-wide `bodyclose` findings for `providers/launchdarkly`.

Notes
- No import IDs or generated Terraform attributes changed.
