### PR TITLE
fix(aws): return discovery list errors

### DIFF
--- a/providers/aws/acm.go
+++ b/providers/aws/acm.go
@@ -4,7 +4,7 @@ package aws
 
 import (
 	"context"
-	"log"
+	"fmt"
 	"strings"
 
 	"github.com/chenrui333/terraformer/terraformutils"
@@ -20,14 +20,13 @@ type ACMGenerator struct {
 	AWSService
 }
 
-func (g *ACMGenerator) createCertificatesResources(svc *acm.Client) []terraformutils.Resource {
+func (g *ACMGenerator) createCertificatesResources(svc *acm.Client) ([]terraformutils.Resource, error) {
 	var resources []terraformutils.Resource
 	p := acm.NewListCertificatesPaginator(svc, &acm.ListCertificatesInput{})
 	for p.HasMorePages() {
 		page, err := p.NextPage(context.TODO())
 		if err != nil {
-			log.Println(err)
-			return resources
+			return nil, fmt.Errorf("list ACM certificates: %w", err)
 		}
 		for _, cert := range page.CertificateSummaryList {
 			certArn := *cert.CertificateArn
@@ -45,7 +44,7 @@ func (g *ACMGenerator) createCertificatesResources(svc *acm.Client) []terraformu
 			))
 		}
 	}
-	return resources
+	return resources, nil
 }
 
 // Generate TerraformResources from AWS API,
@@ -57,7 +56,11 @@ func (g *ACMGenerator) InitResources() error {
 	}
 	svc := acm.NewFromConfig(config)
 
-	g.Resources = g.createCertificatesResources(svc)
+	resources, err := g.createCertificatesResources(svc)
+	if err != nil {
+		return err
+	}
+	g.Resources = resources
 	return nil
 }
 

--- a/providers/aws/docdb.go
+++ b/providers/aws/docdb.go
@@ -4,7 +4,6 @@ package aws
 
 import (
 	"context"
-	"log"
 
 	"github.com/aws/aws-sdk-go-v2/service/docdb"
 	"github.com/chenrui333/terraformer/terraformutils"
@@ -24,15 +23,15 @@ func (g *DocDBGenerator) InitResources() error {
 	svc := docdb.NewFromConfig(config)
 
 	if err := g.getClusters(svc); err != nil {
-		log.Println(err)
+		return err
 	}
 
 	if err := g.getSubnetGroups(svc); err != nil {
-		log.Println(err)
+		return err
 	}
 
 	if err := g.getParameterGroups(svc); err != nil {
-		log.Println(err)
+		return err
 	}
 
 	return nil

--- a/providers/aws/dx.go
+++ b/providers/aws/dx.go
@@ -106,18 +106,17 @@ func (g *DirectConnectGenerator) InitResources() error {
 	}
 	svc := directconnect.NewFromConfig(config)
 	if err := g.getDirectConnectGateways(svc); err != nil {
-		log.Println(err)
 		return err
 	}
 
 	err = g.getDirectConnectVritualInterfaces(svc)
 	if err != nil {
-		log.Println(err)
+		return err
 	}
 
 	err = g.getDirectConnectConnections(svc)
 	if err != nil {
-		log.Println(err)
+		return err
 	}
 
 	return nil

--- a/providers/aws/eip.go
+++ b/providers/aws/eip.go
@@ -4,7 +4,7 @@ package aws
 
 import (
 	"context"
-	"log"
+	"fmt"
 
 	"github.com/chenrui333/terraformer/terraformutils"
 
@@ -17,13 +17,12 @@ type ElasticIPGenerator struct {
 	AWSService
 }
 
-func (g *ElasticIPGenerator) createElasticIpsResources(svc *ec2.Client) []terraformutils.Resource {
+func (g *ElasticIPGenerator) createElasticIpsResources(svc *ec2.Client) ([]terraformutils.Resource, error) {
 	resources := []terraformutils.Resource{}
 	addresses, err := svc.DescribeAddresses(context.TODO(), &ec2.DescribeAddressesInput{})
 
 	if err != nil {
-		log.Println(err)
-		return resources
+		return nil, fmt.Errorf("describe elastic IP addresses: %w", err)
 	}
 
 	for _, eip := range addresses.Addresses {
@@ -36,7 +35,7 @@ func (g *ElasticIPGenerator) createElasticIpsResources(svc *ec2.Client) []terraf
 		))
 	}
 
-	return resources
+	return resources, nil
 }
 
 // Generate TerraformResources from AWS API,
@@ -48,6 +47,10 @@ func (g *ElasticIPGenerator) InitResources() error {
 	}
 	svc := ec2.NewFromConfig(config)
 
-	g.Resources = g.createElasticIpsResources(svc)
+	resources, err := g.createElasticIpsResources(svc)
+	if err != nil {
+		return err
+	}
+	g.Resources = resources
 	return nil
 }

--- a/providers/aws/medialive.go
+++ b/providers/aws/medialive.go
@@ -4,7 +4,6 @@ package aws
 
 import (
 	"context"
-	"log"
 
 	"github.com/aws/aws-sdk-go-v2/service/medialive"
 	"github.com/chenrui333/terraformer/terraformutils"
@@ -25,15 +24,15 @@ func (g *MediaLiveGenerator) InitResources() error {
 	g.Resources = []terraformutils.Resource{}
 
 	if err := g.GetChannels(svc); err != nil {
-		log.Println(err)
+		return err
 	}
 
 	if err := g.GetInputs(svc); err != nil {
-		log.Println(err)
+		return err
 	}
 
 	if err := g.GetInputSecurityGroups(svc); err != nil {
-		log.Println(err)
+		return err
 	}
 
 	return nil

--- a/providers/aws/opsworks.go
+++ b/providers/aws/opsworks.go
@@ -5,7 +5,6 @@ package aws
 
 import (
 	"context"
-	"log"
 
 	"github.com/aws/aws-sdk-go-v2/service/opsworks"
 	"github.com/aws/aws-sdk-go-v2/service/opsworks/types"
@@ -160,22 +159,22 @@ func (g *OpsworksGenerator) fetchStacks(svc *opsworks.Client) error {
 
 		e := g.fetchApps(stack.StackId, svc)
 		if e != nil {
-			log.Println(err)
+			return e
 		}
 
 		e = g.fetchInstances(stack.StackId, svc)
 		if e != nil {
-			log.Println(err)
+			return e
 		}
 
 		e = g.fetchRdsInstances(stack.StackId, svc)
 		if e != nil {
-			log.Println(err)
+			return e
 		}
 
 		e = g.fetchLayers(stack.StackId, svc)
 		if e != nil {
-			log.Println(err)
+			return e
 		}
 	}
 	return nil

--- a/providers/aws/route_table.go
+++ b/providers/aws/route_table.go
@@ -4,7 +4,7 @@ package aws
 
 import (
 	"context"
-	"log"
+	"fmt"
 
 	"github.com/chenrui333/terraformer/terraformutils"
 
@@ -17,14 +17,13 @@ type RouteTableGenerator struct {
 	AWSService
 }
 
-func (g *RouteTableGenerator) createRouteTablesResources(svc *ec2.Client) []terraformutils.Resource {
+func (g *RouteTableGenerator) createRouteTablesResources(svc *ec2.Client) ([]terraformutils.Resource, error) {
 	var resources []terraformutils.Resource
 	p := ec2.NewDescribeRouteTablesPaginator(svc, &ec2.DescribeRouteTablesInput{})
 	for p.HasMorePages() {
 		page, err := p.NextPage(context.TODO())
 		if err != nil {
-			log.Println(err)
-			return resources
+			return nil, fmt.Errorf("describe route tables: %w", err)
 		}
 		for _, table := range page.RouteTables {
 			// route table
@@ -82,7 +81,7 @@ func (g *RouteTableGenerator) createRouteTablesResources(svc *ec2.Client) []terr
 			}
 		}
 	}
-	return resources
+	return resources, nil
 }
 
 // Generate TerraformResources from AWS API,
@@ -94,6 +93,10 @@ func (g *RouteTableGenerator) InitResources() error {
 	}
 	svc := ec2.NewFromConfig(config)
 
-	g.Resources = g.createRouteTablesResources(svc)
+	resources, err := g.createRouteTablesResources(svc)
+	if err != nil {
+		return err
+	}
+	g.Resources = resources
 	return nil
 }

--- a/providers/aws/transit_gateway.go
+++ b/providers/aws/transit_gateway.go
@@ -4,7 +4,6 @@ package aws
 
 import (
 	"context"
-	"log"
 
 	"github.com/chenrui333/terraformer/terraformutils"
 
@@ -93,17 +92,17 @@ func (g *TransitGatewayGenerator) InitResources() error {
 	g.Resources = []terraformutils.Resource{}
 	err := g.getTransitGateways(svc)
 	if err != nil {
-		log.Println(err)
+		return err
 	}
 
 	err = g.getTransitGatewayRouteTables(svc)
 	if err != nil {
-		log.Println(err)
+		return err
 	}
 
 	err = g.getTransitGatewayVpcAttachments(svc)
 	if err != nil {
-		log.Println(err)
+		return err
 	}
 
 	return nil


### PR DESCRIPTION
## Summary

- Return hard AWS discovery errors instead of logging and continuing with partial resources.
- Propagate discovery failures for EC2 address/route table, ACM, Direct Connect, DocumentDB, MediaLive, OpsWorks, and Transit Gateway resource loading.
- Leave explicit optional enrichment skip paths unchanged.
