### PR TITLE
aws(elasticache): add additional resources

### DIFF
--- a/docs/aws.md
+++ b/docs/aws.md
@@ -205,9 +205,13 @@ terraformer import aws --resources=sg --regions=us-east-1
     * `aws_eks_pod_identity_association`
 *   `elasticache`
     * `aws_elasticache_cluster`
+    * `aws_elasticache_global_replication_group`
     * `aws_elasticache_parameter_group`
-    * `aws_elasticache_subnet_group`
     * `aws_elasticache_replication_group`
+    * `aws_elasticache_serverless_cache`
+    * `aws_elasticache_subnet_group`
+    * `aws_elasticache_user`
+    * `aws_elasticache_user_group`
 *   `elastic_beanstalk`
     * `aws_elastic_beanstalk_application`
     * `aws_elastic_beanstalk_environment`

--- a/providers/aws/elasticache.go
+++ b/providers/aws/elasticache.go
@@ -4,17 +4,32 @@ package aws
 
 import (
 	"context"
+	"log"
 	"strings"
 
 	"github.com/chenrui333/terraformer/terraformutils"
 
 	"github.com/aws/aws-sdk-go-v2/service/elasticache"
+	elasticachetypes "github.com/aws/aws-sdk-go-v2/service/elasticache/types"
 )
 
 var elastiCacheAllowEmptyValues = []string{"tags."}
 
 type ElastiCacheGenerator struct {
 	AWSService
+}
+
+type elastiCacheOptionalResourceLoader struct {
+	name string
+	load func() error
+}
+
+func (g *ElastiCacheGenerator) loadOptionalResources(loaders []elastiCacheOptionalResourceLoader) {
+	for _, loader := range loaders {
+		if err := loader.load(); err != nil {
+			log.Printf("Skipping ElastiCache %s: %v", loader.name, err)
+		}
+	}
 }
 
 func (g *ElastiCacheGenerator) loadCacheClusters(svc *elasticache.Client) error {
@@ -130,6 +145,117 @@ func (g *ElastiCacheGenerator) loadReplicationGroups(svc *elasticache.Client) er
 	return nil
 }
 
+func (g *ElastiCacheGenerator) loadGlobalReplicationGroups(svc *elasticache.Client) error {
+	p := elasticache.NewDescribeGlobalReplicationGroupsPaginator(svc, &elasticache.DescribeGlobalReplicationGroupsInput{})
+	for p.HasMorePages() {
+		page, err := p.NextPage(context.TODO())
+		if err != nil {
+			return err
+		}
+		for _, globalReplicationGroup := range page.GlobalReplicationGroups {
+			resourceName := StringValue(globalReplicationGroup.GlobalReplicationGroupId)
+			if resourceName == "" || !elastiCacheStatusImportable(StringValue(globalReplicationGroup.Status)) {
+				continue
+			}
+			g.Resources = append(g.Resources, terraformutils.NewSimpleResource(
+				resourceName,
+				resourceName,
+				"aws_elasticache_global_replication_group",
+				"aws",
+				elastiCacheAllowEmptyValues,
+			))
+		}
+	}
+	return nil
+}
+
+func (g *ElastiCacheGenerator) loadServerlessCaches(svc *elasticache.Client) error {
+	p := elasticache.NewDescribeServerlessCachesPaginator(svc, &elasticache.DescribeServerlessCachesInput{})
+	for p.HasMorePages() {
+		page, err := p.NextPage(context.TODO())
+		if err != nil {
+			return err
+		}
+		for _, serverlessCache := range page.ServerlessCaches {
+			resourceName := StringValue(serverlessCache.ServerlessCacheName)
+			if resourceName == "" || !elastiCacheStatusImportable(StringValue(serverlessCache.Status)) {
+				continue
+			}
+			g.Resources = append(g.Resources, terraformutils.NewSimpleResource(
+				resourceName,
+				resourceName,
+				"aws_elasticache_serverless_cache",
+				"aws",
+				elastiCacheAllowEmptyValues,
+			))
+		}
+	}
+	return nil
+}
+
+func (g *ElastiCacheGenerator) loadUsers(svc *elasticache.Client) error {
+	p := elasticache.NewDescribeUsersPaginator(svc, &elasticache.DescribeUsersInput{})
+	for p.HasMorePages() {
+		page, err := p.NextPage(context.TODO())
+		if err != nil {
+			return err
+		}
+		for _, user := range page.Users {
+			resourceName := StringValue(user.UserId)
+			if resourceName == "" || !elastiCacheUserImportable(user) {
+				continue
+			}
+			g.Resources = append(g.Resources, terraformutils.NewSimpleResource(
+				resourceName,
+				resourceName,
+				"aws_elasticache_user",
+				"aws",
+				elastiCacheAllowEmptyValues,
+			))
+		}
+	}
+	return nil
+}
+
+func (g *ElastiCacheGenerator) loadUserGroups(svc *elasticache.Client) error {
+	p := elasticache.NewDescribeUserGroupsPaginator(svc, &elasticache.DescribeUserGroupsInput{})
+	for p.HasMorePages() {
+		page, err := p.NextPage(context.TODO())
+		if err != nil {
+			return err
+		}
+		for _, userGroup := range page.UserGroups {
+			resourceName := StringValue(userGroup.UserGroupId)
+			if resourceName == "" || !elastiCacheStatusImportable(StringValue(userGroup.Status)) {
+				continue
+			}
+			g.Resources = append(g.Resources, terraformutils.NewSimpleResource(
+				resourceName,
+				resourceName,
+				"aws_elasticache_user_group",
+				"aws",
+				elastiCacheAllowEmptyValues,
+			))
+		}
+	}
+	return nil
+}
+
+func elastiCacheStatusImportable(status string) bool {
+	status = strings.ToLower(status)
+	return status != "" && !strings.Contains(status, "delet") && !strings.Contains(status, "fail")
+}
+
+func elastiCacheUserImportable(user elasticachetypes.User) bool {
+	if !elastiCacheStatusImportable(StringValue(user.Status)) {
+		return false
+	}
+	if user.Authentication == nil {
+		return true
+	}
+	return user.Authentication.Type != elasticachetypes.AuthenticationTypePassword
+}
+
 // Generate TerraformResources from AWS API,
 // from each database create 1 TerraformResource.
 // Need only database name as ID for terraform resource
@@ -153,6 +279,12 @@ func (g *ElastiCacheGenerator) InitResources() error {
 	if err := g.loadSubnetGroups(svc); err != nil {
 		return err
 	}
+	g.loadOptionalResources([]elastiCacheOptionalResourceLoader{
+		{name: "global replication groups", load: func() error { return g.loadGlobalReplicationGroups(svc) }},
+		{name: "serverless caches", load: func() error { return g.loadServerlessCaches(svc) }},
+		{name: "users", load: func() error { return g.loadUsers(svc) }},
+		{name: "user groups", load: func() error { return g.loadUserGroups(svc) }},
+	})
 
 	return nil
 }

--- a/providers/aws/elasticache.go
+++ b/providers/aws/elasticache.go
@@ -157,12 +157,16 @@ func (g *ElastiCacheGenerator) loadGlobalReplicationGroups(svc *elasticache.Clie
 			if resourceName == "" || !elastiCacheStatusImportable(StringValue(globalReplicationGroup.Status)) {
 				continue
 			}
-			g.Resources = append(g.Resources, terraformutils.NewSimpleResource(
+			g.Resources = append(g.Resources, terraformutils.NewResource(
 				resourceName,
 				resourceName,
 				"aws_elasticache_global_replication_group",
 				"aws",
+				map[string]string{
+					"global_replication_group_id_suffix": elastiCacheGlobalReplicationGroupIDSuffix(resourceName),
+				},
 				elastiCacheAllowEmptyValues,
+				map[string]interface{}{},
 			))
 		}
 	}
@@ -244,6 +248,13 @@ func (g *ElastiCacheGenerator) loadUserGroups(svc *elasticache.Client) error {
 func elastiCacheStatusImportable(status string) bool {
 	status = strings.ToLower(status)
 	return status != "" && !strings.Contains(status, "delet") && !strings.Contains(status, "fail")
+}
+
+func elastiCacheGlobalReplicationGroupIDSuffix(id string) string {
+	if len(id) > 6 && id[5] == '-' {
+		return id[6:]
+	}
+	return id
 }
 
 func elastiCacheUserImportable(user elasticachetypes.User) bool {

--- a/providers/aws/elasticache.go
+++ b/providers/aws/elasticache.go
@@ -258,13 +258,7 @@ func elastiCacheGlobalReplicationGroupIDSuffix(id string) string {
 }
 
 func elastiCacheUserImportable(user elasticachetypes.User) bool {
-	if !elastiCacheStatusImportable(StringValue(user.Status)) {
-		return false
-	}
-	if user.Authentication == nil {
-		return true
-	}
-	return user.Authentication.Type != elasticachetypes.AuthenticationTypePassword
+	return elastiCacheStatusImportable(StringValue(user.Status))
 }
 
 // Generate TerraformResources from AWS API,

--- a/providers/aws/elasticache_test.go
+++ b/providers/aws/elasticache_test.go
@@ -1,0 +1,99 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package aws
+
+import (
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	elasticachetypes "github.com/aws/aws-sdk-go-v2/service/elasticache/types"
+)
+
+func TestElastiCacheStatusImportable(t *testing.T) {
+	tests := []struct {
+		name   string
+		status string
+		want   bool
+	}{
+		{name: "available", status: "available", want: true},
+		{name: "active", status: "active", want: true},
+		{name: "modifying", status: "modifying", want: true},
+		{name: "creating", status: "creating", want: true},
+		{name: "empty", status: "", want: false},
+		{name: "deleting", status: "deleting", want: false},
+		{name: "delete failed wording", status: "DELETE-FAILED", want: false},
+		{name: "create failed", status: "CREATE-FAILED", want: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := elastiCacheStatusImportable(tt.status)
+			if got != tt.want {
+				t.Fatalf("elastiCacheStatusImportable() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestElastiCacheUserImportable(t *testing.T) {
+	tests := []struct {
+		name string
+		user elasticachetypes.User
+		want bool
+	}{
+		{
+			name: "no password user",
+			user: elasticachetypes.User{
+				Status: aws.String("active"),
+				Authentication: &elasticachetypes.Authentication{
+					Type: elasticachetypes.AuthenticationTypeNoPassword,
+				},
+			},
+			want: true,
+		},
+		{
+			name: "iam user",
+			user: elasticachetypes.User{
+				Status: aws.String("active"),
+				Authentication: &elasticachetypes.Authentication{
+					Type: elasticachetypes.AuthenticationTypeIam,
+				},
+			},
+			want: true,
+		},
+		{
+			name: "password user",
+			user: elasticachetypes.User{
+				Status: aws.String("active"),
+				Authentication: &elasticachetypes.Authentication{
+					Type: elasticachetypes.AuthenticationTypePassword,
+				},
+			},
+			want: false,
+		},
+		{
+			name: "deleting user",
+			user: elasticachetypes.User{
+				Status: aws.String("deleting"),
+				Authentication: &elasticachetypes.Authentication{
+					Type: elasticachetypes.AuthenticationTypeNoPassword,
+				},
+			},
+			want: false,
+		},
+		{
+			name: "missing auth",
+			user: elasticachetypes.User{Status: aws.String("active")},
+			want: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := elastiCacheUserImportable(tt.user)
+			if got != tt.want {
+				t.Fatalf("elastiCacheUserImportable() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/providers/aws/elasticache_test.go
+++ b/providers/aws/elasticache_test.go
@@ -35,6 +35,29 @@ func TestElastiCacheStatusImportable(t *testing.T) {
 	}
 }
 
+func TestElastiCacheGlobalReplicationGroupIDSuffix(t *testing.T) {
+	tests := []struct {
+		name string
+		id   string
+		want string
+	}{
+		{name: "generated id", id: "abcde-orders", want: "orders"},
+		{name: "generated id with hyphen suffix", id: "abcde-prod-orders", want: "prod-orders"},
+		{name: "short id", id: "orders", want: "orders"},
+		{name: "six chars without separator", id: "abcdef", want: "abcdef"},
+		{name: "empty", id: "", want: ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := elastiCacheGlobalReplicationGroupIDSuffix(tt.id)
+			if got != tt.want {
+				t.Fatalf("elastiCacheGlobalReplicationGroupIDSuffix() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
 func TestElastiCacheUserImportable(t *testing.T) {
 	tests := []struct {
 		name string

--- a/providers/aws/elasticache_test.go
+++ b/providers/aws/elasticache_test.go
@@ -92,7 +92,7 @@ func TestElastiCacheUserImportable(t *testing.T) {
 					Type: elasticachetypes.AuthenticationTypePassword,
 				},
 			},
-			want: false,
+			want: true,
 		},
 		{
 			name: "deleting user",


### PR DESCRIPTION
## Summary

- add ElastiCache discovery for global replication groups, serverless caches, users, and user groups
- make the new ElastiCache API calls best-effort so narrower IAM does not block existing cluster/subnet/parameter imports
- skip password-auth ElastiCache users because AWS does not return password material needed for valid generated config
- document the new supported resources and add focused helper tests

## Notes

Password-auth ElastiCache users are intentionally not imported; IAM and no-password users are importable.
