### PR TITLE
fix(providers): remove redundant error logs

### DIFF
--- a/providers/azure/container.go
+++ b/providers/azure/container.go
@@ -4,7 +4,6 @@ package azure
 
 import (
 	"context"
-	"log"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/containerinstance/armcontainerinstance/v2"
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/containerregistry/armcontainerregistry/v2"
@@ -132,7 +131,6 @@ func (g *ContainerGenerator) listAndAddForContainerRegistry() ([]terraformutils.
 
 		webhooks, err := g.listRegistryWebhooks(id.ResourceGroup, *containerRegistry.Name)
 		if err != nil {
-			log.Println(err)
 			return resources, err
 		}
 		resources = append(resources, webhooks...)

--- a/providers/azure/synapse.go
+++ b/providers/azure/synapse.go
@@ -6,7 +6,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"log"
 	"net/http"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/cloud"
@@ -235,12 +234,10 @@ func (az *SynapseGenerator) InitResources() error {
 		}
 		err = az.appendFirewallRule(workspace, workspaceRg)
 		if err != nil {
-			log.Println(err)
 			return err
 		}
 		err = az.appendManagedPrivateEndpoint(workspace)
 		if err != nil {
-			log.Println(err)
 			return err
 		}
 	}

--- a/providers/azuread/azuread_provider.go
+++ b/providers/azuread/azuread_provider.go
@@ -4,7 +4,6 @@ package azuread
 
 import (
 	"errors"
-	"log"
 	"os"
 
 	"github.com/chenrui333/terraformer/terraformutils"
@@ -39,7 +38,6 @@ func (p *AzureADProvider) setEnvConfig() error {
 func (p *AzureADProvider) Init(_ []string) error {
 	err := p.setEnvConfig()
 	if err != nil {
-		log.Println(err.Error())
 		return err
 	}
 

--- a/providers/azuread/azuread_service.go
+++ b/providers/azuread/azuread_service.go
@@ -4,8 +4,6 @@ package azuread
 
 import (
 	"context"
-	"fmt"
-	"log"
 
 	"github.com/chenrui333/terraformer/terraformutils"
 	"github.com/hashicorp/go-azure-sdk/sdk/auth"
@@ -38,8 +36,6 @@ func (az *AzureADService) getAuthorizer() (auth.Authorizer, error) {
 	}
 	authorizer, err := auth.NewAuthorizerFromCredentials(ctx, credentials, environment.MicrosoftGraph)
 	if err != nil {
-		fmt.Println(err.Error())
-		log.Println(err.Error())
 		return nil, err
 	}
 	return authorizer, nil
@@ -48,8 +44,6 @@ func (az *AzureADService) getAuthorizer() (auth.Authorizer, error) {
 func (az *AzureADService) getUserClient() (*msgraph.UsersClient, error) {
 	authorizer, err := az.getAuthorizer()
 	if err != nil {
-		fmt.Println(err.Error())
-		log.Println(err.Error())
 		return nil, err
 	}
 
@@ -62,8 +56,6 @@ func (az *AzureADService) getUserClient() (*msgraph.UsersClient, error) {
 func (az *AzureADService) getApplicationsClient() (*msgraph.ApplicationsClient, error) {
 	authorizer, err := az.getAuthorizer()
 	if err != nil {
-		fmt.Println(err.Error())
-		log.Println(err.Error())
 		return nil, err
 	}
 
@@ -76,8 +68,6 @@ func (az *AzureADService) getApplicationsClient() (*msgraph.ApplicationsClient, 
 func (az *AzureADService) getGroupsClient() (*msgraph.GroupsClient, error) {
 	authorizer, err := az.getAuthorizer()
 	if err != nil {
-		fmt.Println(err.Error())
-		log.Println(err.Error())
 		return nil, err
 	}
 
@@ -90,8 +80,6 @@ func (az *AzureADService) getGroupsClient() (*msgraph.GroupsClient, error) {
 func (az *AzureADService) getServicePrincipalsClient() (*msgraph.ServicePrincipalsClient, error) {
 	authorizer, err := az.getAuthorizer()
 	if err != nil {
-		fmt.Println(err.Error())
-		log.Println(err.Error())
 		return nil, err
 	}
 
@@ -104,8 +92,6 @@ func (az *AzureADService) getServicePrincipalsClient() (*msgraph.ServicePrincipa
 func (az *AzureADService) getAppRoleAssignmentsClient() (*msgraph.AppRoleAssignedToClient, error) {
 	authorizer, err := az.getAuthorizer()
 	if err != nil {
-		fmt.Println(err.Error())
-		log.Println(err.Error())
 		return nil, err
 	}
 

--- a/providers/azuredevops/azuredevops_service.go
+++ b/providers/azuredevops/azuredevops_service.go
@@ -5,7 +5,6 @@ package azuredevops
 
 import (
 	"context"
-	"log"
 
 	"github.com/microsoft/azure-devops-go-api/azuredevops"
 	"github.com/microsoft/azure-devops-go-api/azuredevops/core"
@@ -38,7 +37,6 @@ func (az *AzureDevOpsService) getCoreClient() (core.Client, error) {
 	ctx := context.Background()
 	client, err := core.NewClient(ctx, az.getConnection())
 	if err != nil {
-		log.Println(err)
 		return nil, err
 	}
 	return client, nil
@@ -48,7 +46,6 @@ func (az *AzureDevOpsService) getGraphClient() (graph.Client, error) {
 	ctx := context.Background()
 	client, err := graph.NewClient(ctx, az.getConnection())
 	if err != nil {
-		log.Println(err)
 		return nil, err
 	}
 	return client, nil
@@ -58,7 +55,6 @@ func (az *AzureDevOpsService) getGitClient() (git.Client, error) {
 	ctx := context.Background()
 	client, err := git.NewClient(ctx, az.getConnection())
 	if err != nil {
-		log.Println(err)
 		return nil, err
 	}
 	return client, nil

--- a/providers/cloudflare/dns.go
+++ b/providers/cloudflare/dns.go
@@ -5,7 +5,6 @@ package cloudflare
 import (
 	"context"
 	"fmt"
-	"log"
 
 	"github.com/chenrui333/terraformer/terraformutils"
 	cf "github.com/cloudflare/cloudflare-go"
@@ -18,7 +17,6 @@ type DNSGenerator struct {
 func (*DNSGenerator) createZonesResource(api *cf.API, zoneID, _ string) ([]terraformutils.Resource, error) {
 	zoneDetails, err := api.ZoneDetails(context.Background(), zoneID)
 	if err != nil {
-		log.Println(err)
 		return []terraformutils.Resource{}, err
 	}
 
@@ -42,7 +40,6 @@ func (*DNSGenerator) createRecordsResources(api *cf.API, zoneID, zoneName string
 	resources := []terraformutils.Resource{}
 	records, _, err := api.ListDNSRecords(context.Background(), cf.ZoneIdentifier(zoneID), cf.ListDNSRecordsParams{})
 	if err != nil {
-		log.Println(err)
 		return resources, err
 	}
 
@@ -71,13 +68,11 @@ func (*DNSGenerator) createRecordsResources(api *cf.API, zoneID, zoneName string
 func (g *DNSGenerator) InitResources() error {
 	api, err := g.initializeAPI()
 	if err != nil {
-		log.Println(err)
 		return err
 	}
 
 	zones, err := api.ListZones(context.Background())
 	if err != nil {
-		log.Println(err)
 		return err
 	}
 
@@ -90,7 +85,6 @@ func (g *DNSGenerator) InitResources() error {
 		for _, f := range funcs {
 			tmpRes, err := f(api, zone.ID, zone.Name)
 			if err != nil {
-				log.Println(err)
 				return err
 			}
 			g.Resources = append(g.Resources, tmpRes...)

--- a/providers/ibm/satellite_data_plane.go
+++ b/providers/ibm/satellite_data_plane.go
@@ -4,7 +4,6 @@ package ibm
 
 import (
 	"fmt"
-	"log"
 	"os"
 	"reflect"
 	"strings"
@@ -195,7 +194,6 @@ func (g *SatelliteDataPlaneGenerator) InitResources() error {
 	// VPC
 	vpcObj, err := vpcClient(region, sess)
 	if err != nil {
-		log.Println("Error building VPC object: ", err)
 		return err
 	}
 

--- a/providers/okta/app.go
+++ b/providers/okta/app.go
@@ -4,7 +4,6 @@ package okta
 
 import (
 	"context"
-	"log"
 
 	"github.com/okta/okta-sdk-golang/v2/okta"
 )
@@ -38,7 +37,6 @@ func getAllApplications(ctx context.Context, client *okta.Client) ([]*okta.Appli
 		var nextAppSet []*okta.Application
 		resp, err = resp.Next(ctx, &nextAppSet)
 		if err != nil {
-			log.Println("fff")
 			return nil, err
 		}
 		apps = append(apps, nextAppSet...)


### PR DESCRIPTION
## Summary

- Remove redundant provider logs that immediately returned the same error to callers.
- Clean up now-unused imports across Azure, AzureAD, Azure DevOps, Cloudflare, IBM, and Okta providers.
- Drop the stray Okta pagination debug log while preserving the returned error path.
