### PR TITLE
feat(datadog): add security monitoring suppression import

### DIFF
--- a/docs/datadog.md
+++ b/docs/datadog.md
@@ -148,6 +148,9 @@ Tag filters are order specific. For example, if your monitor has tags (in the or
     * `datadog_security_monitoring_filter`
 *   `security_monitoring_rule`
     * `datadog_security_monitoring_rule`
+*   `security_monitoring_suppression`
+    * `datadog_security_monitoring_suppression`
+        * **_NOTE:_** Requires DataDog/datadog provider 3.36.0 or newer.
 *   `service_level_objective`
     * `datadog_service_level_objective`
 *   `slo_correction`

--- a/providers/datadog/datadog_provider.go
+++ b/providers/datadog/datadog_provider.go
@@ -176,6 +176,7 @@ func (p *DatadogProvider) GetSupportedService() map[string]terraformutils.Servic
 		"security_monitoring_default_rule":     &SecurityMonitoringDefaultRuleGenerator{},
 		"security_monitoring_filter":           &SecurityMonitoringFilterGenerator{},
 		"security_monitoring_rule":             &SecurityMonitoringRuleGenerator{},
+		"security_monitoring_suppression":      &SecurityMonitoringSuppressionGenerator{},
 		"service_level_objective":              &ServiceLevelObjectiveGenerator{},
 		"slo_correction":                       &SLOCorrectionGenerator{},
 		"synthetics_test":                      &SyntheticsTestGenerator{},

--- a/providers/datadog/security_monitoring_suppression.go
+++ b/providers/datadog/security_monitoring_suppression.go
@@ -14,7 +14,7 @@ import (
 
 var (
 	// SecurityMonitoringSuppressionAllowEmptyValues ...
-	SecurityMonitoringSuppressionAllowEmptyValues = []string{"rule_query"}
+	SecurityMonitoringSuppressionAllowEmptyValues = []string{"rule_query", "suppression_query"}
 )
 
 // SecurityMonitoringSuppressionGenerator ...

--- a/providers/datadog/security_monitoring_suppression.go
+++ b/providers/datadog/security_monitoring_suppression.go
@@ -1,0 +1,199 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package datadog
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/DataDog/datadog-api-client-go/v2/api/datadog"
+	"github.com/DataDog/datadog-api-client-go/v2/api/datadogV2"
+
+	"github.com/chenrui333/terraformer/terraformutils"
+)
+
+var (
+	// SecurityMonitoringSuppressionAllowEmptyValues ...
+	SecurityMonitoringSuppressionAllowEmptyValues = []string{"rule_query"}
+)
+
+// SecurityMonitoringSuppressionGenerator ...
+type SecurityMonitoringSuppressionGenerator struct {
+	DatadogService
+}
+
+func (g *SecurityMonitoringSuppressionGenerator) createResources(suppressions []datadogV2.SecurityMonitoringSuppression) ([]terraformutils.Resource, error) {
+	resources := []terraformutils.Resource{}
+	for _, suppression := range suppressions {
+		resource, err := g.createResource(suppression)
+		if err != nil {
+			return nil, err
+		}
+		resources = append(resources, resource)
+	}
+
+	return resources, nil
+}
+
+func (g *SecurityMonitoringSuppressionGenerator) createResource(suppression datadogV2.SecurityMonitoringSuppression) (terraformutils.Resource, error) {
+	suppressionID := suppression.GetId()
+	if suppressionID == "" {
+		return terraformutils.Resource{}, fmt.Errorf("security monitoring suppression missing id")
+	}
+
+	return terraformutils.NewSimpleResource(
+		suppressionID,
+		fmt.Sprintf("security_monitoring_suppression_%s", suppressionID),
+		"datadog_security_monitoring_suppression",
+		"datadog",
+		SecurityMonitoringSuppressionAllowEmptyValues,
+	), nil
+}
+
+// InitResources Generate TerraformResources from Datadog API,
+// from each security_monitoring_suppression create 1 TerraformResource.
+func (g *SecurityMonitoringSuppressionGenerator) InitResources() error {
+	datadogClient := g.Args["datadogClient"].(*datadog.APIClient)
+	auth := g.Args["auth"].(context.Context)
+	api := datadogV2.NewSecurityMonitoringApi(datadogClient)
+
+	resources, filtered, err := g.filteredResources(auth, api)
+	if err != nil {
+		return err
+	}
+	if filtered {
+		g.Resources = resources
+		return nil
+	}
+
+	suppressions, err := listSecurityMonitoringSuppressions(auth, api)
+	if err != nil {
+		return err
+	}
+	resources, err = g.createResources(suppressions)
+	if err != nil {
+		return err
+	}
+
+	g.Resources = resources
+	return nil
+}
+
+func (g *SecurityMonitoringSuppressionGenerator) filteredResources(auth context.Context, api *datadogV2.SecurityMonitoringApi) ([]terraformutils.Resource, bool, error) {
+	resources := []terraformutils.Resource{}
+	filtered := false
+
+	for _, filter := range g.Filter {
+		if filter.FieldPath != "id" || !filter.IsApplicable("security_monitoring_suppression") {
+			continue
+		}
+
+		filtered = true
+		for _, value := range filter.AcceptableValues {
+			suppression, err := getSecurityMonitoringSuppression(auth, api, value)
+			if err != nil {
+				return nil, true, err
+			}
+			resource, err := g.createResource(suppression)
+			if err != nil {
+				return nil, true, err
+			}
+			resources = append(resources, resource)
+		}
+	}
+
+	return resources, filtered, nil
+}
+
+func getSecurityMonitoringSuppression(auth context.Context, api *datadogV2.SecurityMonitoringApi, suppressionID string) (datadogV2.SecurityMonitoringSuppression, error) {
+	response, httpResponse, err := api.GetSecurityMonitoringSuppression(auth, suppressionID)
+	defer closeDatadogResponseBody(httpResponse)
+	if err != nil {
+		return datadogV2.SecurityMonitoringSuppression{}, err
+	}
+
+	if suppression, ok := response.GetDataOk(); ok {
+		return *suppression, nil
+	}
+	if suppression, ok := securityMonitoringSuppressionFromRawData(response.UnparsedObject["data"]); ok {
+		return suppression, nil
+	}
+
+	return datadogV2.SecurityMonitoringSuppression{}, fmt.Errorf("security monitoring suppression %q not found", suppressionID)
+}
+
+func listSecurityMonitoringSuppressions(auth context.Context, api *datadogV2.SecurityMonitoringApi) ([]datadogV2.SecurityMonitoringSuppression, error) {
+	suppressions := []datadogV2.SecurityMonitoringSuppression{}
+	const pageSize int64 = 100
+	var pageNumber int64
+
+	for {
+		optionalParams := datadogV2.NewListSecurityMonitoringSuppressionsOptionalParameters().
+			WithPageSize(pageSize).
+			WithPageNumber(pageNumber)
+
+		response, httpResponse, err := api.ListSecurityMonitoringSuppressions(auth, *optionalParams)
+		closeDatadogResponseBody(httpResponse)
+		if err != nil {
+			return nil, err
+		}
+
+		pageSuppressions := response.GetData()
+		if len(pageSuppressions) == 0 {
+			pageSuppressions = securityMonitoringSuppressionsFromRawData(response.UnparsedObject["data"])
+		}
+		suppressions = append(suppressions, pageSuppressions...)
+
+		if !securityMonitoringSuppressionsHasNextPage(response, pageNumber, pageSize, len(pageSuppressions)) {
+			break
+		}
+		pageNumber++
+	}
+
+	return suppressions, nil
+}
+
+func securityMonitoringSuppressionsHasNextPage(response datadogV2.SecurityMonitoringPaginatedSuppressionsResponse, pageNumber int64, pageSize int64, pageItems int) bool {
+	if meta, ok := response.GetMetaOk(); ok {
+		page := meta.GetPage()
+		if totalCount, ok := page.GetTotalCountOk(); ok {
+			return *totalCount > pageSize*(pageNumber+1)
+		}
+	}
+	return pageItems == int(pageSize)
+}
+
+func securityMonitoringSuppressionsFromRawData(rawData interface{}) []datadogV2.SecurityMonitoringSuppression {
+	rawSuppressions, ok := rawData.([]interface{})
+	if !ok {
+		return nil
+	}
+
+	suppressions := []datadogV2.SecurityMonitoringSuppression{}
+	for _, rawSuppression := range rawSuppressions {
+		suppression, ok := securityMonitoringSuppressionFromRawData(rawSuppression)
+		if !ok {
+			continue
+		}
+		suppressions = append(suppressions, suppression)
+	}
+	return suppressions
+}
+
+func securityMonitoringSuppressionFromRawData(rawData interface{}) (datadogV2.SecurityMonitoringSuppression, bool) {
+	rawSuppression, ok := rawData.(map[string]interface{})
+	if !ok {
+		return datadogV2.SecurityMonitoringSuppression{}, false
+	}
+	if rawType, ok := rawSuppression["type"].(string); ok && rawType != string(datadogV2.SECURITYMONITORINGSUPPRESSIONTYPE_SUPPRESSIONS) {
+		return datadogV2.SecurityMonitoringSuppression{}, false
+	}
+	rawID, ok := rawSuppression["id"].(string)
+	if !ok || rawID == "" {
+		return datadogV2.SecurityMonitoringSuppression{}, false
+	}
+
+	suppression := datadogV2.NewSecurityMonitoringSuppressionWithDefaults()
+	suppression.SetId(rawID)
+	return *suppression, true
+}

--- a/providers/datadog/security_monitoring_suppression_test.go
+++ b/providers/datadog/security_monitoring_suppression_test.go
@@ -12,17 +12,19 @@ import (
 	"github.com/chenrui333/terraformer/terraformutils"
 )
 
-func TestSecurityMonitoringSuppressionAllowEmptyValuesPreservesRuleQuery(t *testing.T) {
+func TestSecurityMonitoringSuppressionAllowEmptyValuesPreservesQueries(t *testing.T) {
 	allowEmptyValues := []*regexp.Regexp{}
 	for _, pattern := range SecurityMonitoringSuppressionAllowEmptyValues {
 		allowEmptyValues = append(allowEmptyValues, regexp.MustCompile(pattern))
 	}
 
 	parser := terraformutils.NewFlatmapParser(map[string]string{
-		"rule_query": "",
+		"rule_query":        "",
+		"suppression_query": "",
 	}, nil, allowEmptyValues)
 	suppressionType := cty.Object(map[string]cty.Type{
-		"rule_query": cty.String,
+		"rule_query":        cty.String,
+		"suppression_query": cty.String,
 	})
 
 	result, err := parser.Parse(suppressionType)
@@ -31,6 +33,9 @@ func TestSecurityMonitoringSuppressionAllowEmptyValuesPreservesRuleQuery(t *test
 	}
 	if result["rule_query"] != "" {
 		t.Fatalf("rule_query = %v, want empty string", result["rule_query"])
+	}
+	if result["suppression_query"] != "" {
+		t.Fatalf("suppression_query = %v, want empty string", result["suppression_query"])
 	}
 }
 

--- a/providers/datadog/security_monitoring_suppression_test.go
+++ b/providers/datadog/security_monitoring_suppression_test.go
@@ -1,0 +1,138 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package datadog
+
+import (
+	"regexp"
+	"testing"
+
+	"github.com/DataDog/datadog-api-client-go/v2/api/datadogV2"
+	"github.com/zclconf/go-cty/cty"
+
+	"github.com/chenrui333/terraformer/terraformutils"
+)
+
+func TestSecurityMonitoringSuppressionAllowEmptyValuesPreservesRuleQuery(t *testing.T) {
+	allowEmptyValues := []*regexp.Regexp{}
+	for _, pattern := range SecurityMonitoringSuppressionAllowEmptyValues {
+		allowEmptyValues = append(allowEmptyValues, regexp.MustCompile(pattern))
+	}
+
+	parser := terraformutils.NewFlatmapParser(map[string]string{
+		"rule_query": "",
+	}, nil, allowEmptyValues)
+	suppressionType := cty.Object(map[string]cty.Type{
+		"rule_query": cty.String,
+	})
+
+	result, err := parser.Parse(suppressionType)
+	if err != nil {
+		t.Fatalf("Parse returned error: %v", err)
+	}
+	if result["rule_query"] != "" {
+		t.Fatalf("rule_query = %v, want empty string", result["rule_query"])
+	}
+}
+
+func TestSecurityMonitoringSuppressionCreateResource(t *testing.T) {
+	suppression := datadogV2.NewSecurityMonitoringSuppressionWithDefaults()
+	suppression.SetId("suppression-id")
+
+	generator := &SecurityMonitoringSuppressionGenerator{}
+	resource, err := generator.createResource(*suppression)
+	if err != nil {
+		t.Fatalf("createResource returned error: %v", err)
+	}
+
+	if resource.InstanceState.ID != "suppression-id" {
+		t.Fatalf("resource ID = %q, want %q", resource.InstanceState.ID, "suppression-id")
+	}
+	if resource.ResourceName != "tfer--security_monitoring_suppression_suppression-id" {
+		t.Fatalf("resource name = %q, want %q", resource.ResourceName, "tfer--security_monitoring_suppression_suppression-id")
+	}
+	if resource.InstanceInfo.Type != "datadog_security_monitoring_suppression" {
+		t.Fatalf("resource type = %q, want %q", resource.InstanceInfo.Type, "datadog_security_monitoring_suppression")
+	}
+}
+
+func TestSecurityMonitoringSuppressionCreateResourceMissingID(t *testing.T) {
+	generator := &SecurityMonitoringSuppressionGenerator{}
+	_, err := generator.createResource(datadogV2.SecurityMonitoringSuppression{})
+	if err == nil {
+		t.Fatal("createResource returned nil error, want missing id error")
+	}
+}
+
+func TestSecurityMonitoringSuppressionCreateResources(t *testing.T) {
+	firstSuppression := datadogV2.NewSecurityMonitoringSuppressionWithDefaults()
+	firstSuppression.SetId("suppression-1")
+	secondSuppression := datadogV2.NewSecurityMonitoringSuppressionWithDefaults()
+	secondSuppression.SetId("suppression-2")
+
+	generator := &SecurityMonitoringSuppressionGenerator{}
+	resources, err := generator.createResources([]datadogV2.SecurityMonitoringSuppression{
+		*firstSuppression,
+		*secondSuppression,
+	})
+	if err != nil {
+		t.Fatalf("createResources returned error: %v", err)
+	}
+
+	if len(resources) != 2 {
+		t.Fatalf("resource count = %d, want %d", len(resources), 2)
+	}
+	if resources[0].ResourceName == resources[1].ResourceName {
+		t.Fatalf("resource names should be unique, got %q", resources[0].ResourceName)
+	}
+}
+
+func TestSecurityMonitoringSuppressionsFromRawData(t *testing.T) {
+	suppressions := securityMonitoringSuppressionsFromRawData([]interface{}{
+		map[string]interface{}{
+			"id":   "suppression-1",
+			"type": "suppressions",
+		},
+		map[string]interface{}{
+			"id": "suppression-2",
+		},
+		map[string]interface{}{
+			"id":   "ignored-type",
+			"type": "unknown",
+		},
+		map[string]interface{}{
+			"type": "suppressions",
+		},
+	})
+
+	if len(suppressions) != 2 {
+		t.Fatalf("suppression count = %d, want %d", len(suppressions), 2)
+	}
+	if suppressions[0].GetId() != "suppression-1" {
+		t.Fatalf("first suppression ID = %q, want %q", suppressions[0].GetId(), "suppression-1")
+	}
+	if suppressions[1].GetId() != "suppression-2" {
+		t.Fatalf("second suppression ID = %q, want %q", suppressions[1].GetId(), "suppression-2")
+	}
+}
+
+func TestSecurityMonitoringSuppressionFromRawDataRejectsNonObjects(t *testing.T) {
+	if _, ok := securityMonitoringSuppressionFromRawData("suppression-id"); ok {
+		t.Fatal("securityMonitoringSuppressionFromRawData accepted non-object raw data")
+	}
+}
+
+func TestSecurityMonitoringSuppressionsHasNextPage(t *testing.T) {
+	response := datadogV2.NewSecurityMonitoringPaginatedSuppressionsResponseWithDefaults()
+	meta := datadogV2.NewSecurityMonitoringSuppressionsMetaWithDefaults()
+	page := datadogV2.NewSecurityMonitoringSuppressionsPageMetaWithDefaults()
+	page.SetTotalCount(101)
+	meta.SetPage(*page)
+	response.SetMeta(*meta)
+
+	if !securityMonitoringSuppressionsHasNextPage(*response, 0, 100, 100) {
+		t.Fatal("hasNextPage = false, want true")
+	}
+	if securityMonitoringSuppressionsHasNextPage(*response, 1, 100, 1) {
+		t.Fatal("hasNextPage = true, want false")
+	}
+}


### PR DESCRIPTION
Summary
- Add Terraformer import support for Datadog security monitoring suppressions.
- Support ID-filtered imports through `GetSecurityMonitoringSuppression` and full imports through the paginated suppression list API.
- Document the new Datadog resource and its minimum provider version.

Notes
- Resources are keyed by suppression ID to keep generated resources unique.
- Empty required `rule_query` values are preserved during flatmap conversion.
- SDK response bodies are closed on both lookup and list paths.
