### PR TITLE
fix(providers): return client setup errors

### DIFF
--- a/providers/equinixmetal/device.go
+++ b/providers/equinixmetal/device.go
@@ -34,7 +34,10 @@ func (g DeviceGenerator) createResources(deviceList []packngo.Device) []terrafor
 }
 
 func (g *DeviceGenerator) InitResources() error {
-	client := g.generateClient()
+	client, err := g.generateClient()
+	if err != nil {
+		return err
+	}
 	output, err := g.listDevices(client)
 	if err != nil {
 		return err

--- a/providers/equinixmetal/equinixmetal_service.go
+++ b/providers/equinixmetal/equinixmetal_service.go
@@ -11,7 +11,6 @@ type EquinixMetalService struct { //nolint
 	terraformutils.Service
 }
 
-func (s *EquinixMetalService) generateClient() *packngo.Client {
-	client, _ := packngo.NewClient()
-	return client
+func (s *EquinixMetalService) generateClient() (*packngo.Client, error) {
+	return packngo.NewClient()
 }

--- a/providers/equinixmetal/spot_market_request.go
+++ b/providers/equinixmetal/spot_market_request.go
@@ -34,7 +34,10 @@ func (g SpotMarketRequestGenerator) createResources(spotMarketRequestsList []pac
 }
 
 func (g *SpotMarketRequestGenerator) InitResources() error {
-	client := g.generateClient()
+	client, err := g.generateClient()
+	if err != nil {
+		return err
+	}
 	output, err := g.listSpotMarketRequests(client)
 	if err != nil {
 		return err

--- a/providers/equinixmetal/ssh_key.go
+++ b/providers/equinixmetal/ssh_key.go
@@ -34,7 +34,10 @@ func (g SSHKeyGenerator) createResources(sshLeyList []packngo.SSHKey) []terrafor
 }
 
 func (g *SSHKeyGenerator) InitResources() error {
-	client := g.generateClient()
+	client, err := g.generateClient()
+	if err != nil {
+		return err
+	}
 	output, err := g.listSSHKeys(client)
 	if err != nil {
 		return err

--- a/providers/equinixmetal/volume.go
+++ b/providers/equinixmetal/volume.go
@@ -34,7 +34,10 @@ func (g VolumeGenerator) createResources(volumeList []packngo.Volume) []terrafor
 }
 
 func (g *VolumeGenerator) InitResources() error {
-	client := g.generateClient()
+	client, err := g.generateClient()
+	if err != nil {
+		return err
+	}
 	output, err := g.listVolumes(client)
 	if err != nil {
 		return err

--- a/providers/ibm/cis.go
+++ b/providers/ibm/cis.go
@@ -518,7 +518,10 @@ func (g *CISGenerator) InitResources() error {
 				Crn:    &crn,
 				ZoneID: &zoneID,
 			}
-			cisWAFPackageClient, _ := wafrulepackagesapiv1.NewWafRulePackagesApiV1(cisWAFPackagesOpt)
+			cisWAFPackageClient, err := wafrulepackagesapiv1.NewWafRulePackagesApiV1(cisWAFPackagesOpt)
+			if err != nil {
+				return err
+			}
 			wasPkgList, _, err := cisWAFPackageClient.ListWafPackages(&wafrulepackagesapiv1.ListWafPackagesOptions{})
 			if err != nil {
 				return err
@@ -545,7 +548,10 @@ func (g *CISGenerator) InitResources() error {
 						Crn:    &crn,
 						ZoneID: &zoneID,
 					}
-					cisWAFGroupClient, _ := wafrulegroupsapiv1.NewWafRuleGroupsApiV1(cisWAFGroupOpt)
+					cisWAFGroupClient, err := wafrulegroupsapiv1.NewWafRuleGroupsApiV1(cisWAFGroupOpt)
+					if err != nil {
+						return err
+					}
 					wasGrpList, _, err := cisWAFGroupClient.ListWafRuleGroups(&wafrulegroupsapiv1.ListWafRuleGroupsOptions{
 						PkgID: wafPkg.Result.ID,
 					})
@@ -567,7 +573,10 @@ func (g *CISGenerator) InitResources() error {
 				ZoneIdentifier: &zoneID,
 			}
 
-			rateLimitService, _ := zoneratelimitsv1.NewZoneRateLimitsV1(rateLimitPoolOpts)
+			rateLimitService, err := zoneratelimitsv1.NewZoneRateLimitsV1(rateLimitPoolOpts)
+			if err != nil {
+				return err
+			}
 			rateLimitList, _, err := rateLimitService.ListAllZoneRateLimits(&zoneratelimitsv1.ListAllZoneRateLimitsOptions{})
 			if err != nil {
 				fmt.Printf("Error in getting rate limit.")
@@ -667,7 +676,10 @@ func (g *CISGenerator) InitResources() error {
 				ZoneIdentifier: &zoneID,
 			}
 
-			cisEdgeFunctionClient, _ := edgefunctionsapiv1.NewEdgeFunctionsApiV1(cisEdgeFunctionOpt)
+			cisEdgeFunctionClient, err := edgefunctionsapiv1.NewEdgeFunctionsApiV1(cisEdgeFunctionOpt)
+			if err != nil {
+				return err
+			}
 			edgeActionResonse, _, err := cisEdgeFunctionClient.ListEdgeFunctionsActions(&edgefunctionsapiv1.ListEdgeFunctionsActionsOptions{})
 			if err != nil {
 				return err
@@ -696,7 +708,10 @@ func (g *CISGenerator) InitResources() error {
 				ZoneIdentifier: &zoneID,
 			}
 
-			rangeAppClient, _ := rangeapplicationsv1.NewRangeApplicationsV1(rangeAppOpt)
+			rangeAppClient, err := rangeapplicationsv1.NewRangeApplicationsV1(rangeAppOpt)
+			if err != nil {
+				return err
+			}
 			ranegAppList, _, err := rangeAppClient.ListRangeApps(&rangeapplicationsv1.ListRangeAppsOptions{})
 			if err != nil {
 				fmt.Printf("Error in getting range app list.")
@@ -718,7 +733,10 @@ func (g *CISGenerator) InitResources() error {
 				ZoneID: &zoneID,
 			}
 
-			pageRuleClient, _ := pageruleapiv1.NewPageRuleApiV1(pageRueleOpt)
+			pageRuleClient, err := pageruleapiv1.NewPageRuleApiV1(pageRueleOpt)
+			if err != nil {
+				return err
+			}
 			pageRuleList, _, err := pageRuleClient.ListPageRules(&pageruleapiv1.ListPageRulesOptions{})
 			if err != nil {
 				return err
@@ -738,7 +756,10 @@ func (g *CISGenerator) InitResources() error {
 				ZoneIdentifier: &zoneID,
 			}
 
-			customPageClient, _ := custompagesv1.NewCustomPagesV1(customPageOpt)
+			customPageClient, err := custompagesv1.NewCustomPagesV1(customPageOpt)
+			if err != nil {
+				return err
+			}
 			customPageList, _, err := customPageClient.ListInstanceCustomPages(&custompagesv1.ListInstanceCustomPagesOptions{})
 			if err != nil {
 				return err

--- a/providers/ibm/cloud_functions.go
+++ b/providers/ibm/cloud_functions.go
@@ -68,11 +68,17 @@ func (g CloudFunctionGenerator) loadTriggers(namespace, triggerName string) terr
  *
  */
 func setupOpenWhiskClientConfigIAM(response ns.NamespaceResponse, c *bluemix.Config, region string) (*whisk.Client, error) {
-	u, _ := url.Parse(fmt.Sprintf("https://%s.functions.cloud.ibm.com/api", region))
-	wskClient, _ := whisk.NewClient(http.DefaultClient, &whisk.Config{
+	u, err := url.Parse(fmt.Sprintf("https://%s.functions.cloud.ibm.com/api", region))
+	if err != nil {
+		return nil, err
+	}
+	wskClient, err := whisk.NewClient(http.DefaultClient, &whisk.Config{
 		Host:    u.Host,
 		Version: "v1",
 	})
+	if err != nil {
+		return nil, err
+	}
 
 	if os.Getenv("TF_LOG") != "" {
 		whisk.SetDebug(true)

--- a/providers/ibm/cos.go
+++ b/providers/ibm/cos.go
@@ -88,7 +88,10 @@ func (g *COSGenerator) InitResources() error {
 		singleSiteLocationRegex := regexp.MustCompile("^[a-z]{3}[0-9][0-9]-[a-z]{4,8}$")
 		regionLocationRegex := regexp.MustCompile("^[a-z]{2}-[a-z]{2,5}[0-9]?-[a-z]{4,8}$")
 		crossRegionLocationRegex := regexp.MustCompile("^[a-z]{2}-[a-z]{4,8}$")
-		d, _ := s3Client.ListBucketsExtended(&coss3.ListBucketsExtendedInput{})
+		d, err := s3Client.ListBucketsExtended(&coss3.ListBucketsExtendedInput{})
+		if err != nil {
+			return err
+		}
 		for _, b := range d.Buckets {
 			var apiType, location string
 

--- a/providers/okta/factor.go
+++ b/providers/okta/factor.go
@@ -14,7 +14,7 @@ type FactorGenerator struct {
 	OktaService
 }
 
-func (g FactorGenerator) createResources(ctx context.Context, factorList []*okta.UserFactor, client *sdk.APISupplement) []terraformutils.Resource {
+func (g FactorGenerator) createResources(ctx context.Context, factorList []*okta.UserFactor, client *sdk.APISupplement) ([]terraformutils.Resource, error) {
 	var resources []terraformutils.Resource
 	for _, factor := range factorList {
 		if factor.Status == "ACTIVE" {
@@ -31,7 +31,10 @@ func (g FactorGenerator) createResources(ctx context.Context, factorList []*okta
 			))
 
 			if factor.FactorType == "token:hotp" {
-				hotpFactorProfiles, _, _ := getHotpFactorProfiles(ctx, client)
+				hotpFactorProfiles, _, err := getHotpFactorProfiles(ctx, client)
+				if err != nil {
+					return nil, err
+				}
 
 				for _, factorProfile := range hotpFactorProfiles {
 					if factorProfile != nil {
@@ -56,7 +59,7 @@ func (g FactorGenerator) createResources(ctx context.Context, factorList []*okta
 			}
 		}
 	}
-	return resources
+	return resources, nil
 }
 
 func (g *FactorGenerator) InitResources() error {
@@ -74,7 +77,11 @@ func (g *FactorGenerator) InitResources() error {
 
 	factors = append(factors, output...)
 
-	g.Resources = g.createResources(ctx, factors, client)
+	resources, err := g.createResources(ctx, factors, client)
+	if err != nil {
+		return err
+	}
+	g.Resources = resources
 	return nil
 }
 

--- a/providers/xenorchestra/acls.go
+++ b/providers/xenorchestra/acls.go
@@ -25,7 +25,10 @@ func (g AclGenerator) createResources(acls []client.Acl) []terraformutils.Resour
 }
 
 func (g *AclGenerator) InitResources() error {
-	client := g.generateClient()
+	client, err := g.generateClient()
+	if err != nil {
+		return err
+	}
 	acls, err := client.GetAcls()
 
 	if err != nil {

--- a/providers/xenorchestra/resource_sets.go
+++ b/providers/xenorchestra/resource_sets.go
@@ -25,7 +25,10 @@ func (g ResourceSetGenerator) createResources(acls []client.ResourceSet) []terra
 }
 
 func (g *ResourceSetGenerator) InitResources() error {
-	client := g.generateClient()
+	client, err := g.generateClient()
+	if err != nil {
+		return err
+	}
 	acls, err := client.GetResourceSets()
 
 	if err != nil {

--- a/providers/xenorchestra/xenorchestra_service.go
+++ b/providers/xenorchestra/xenorchestra_service.go
@@ -10,12 +10,11 @@ type XenorchestraService struct { //nolint
 	terraformutils.Service
 }
 
-func (m *XenorchestraService) generateClient() *client.Client {
+func (m *XenorchestraService) generateClient() (*client.Client, error) {
 	config := client.Config{
 		Url:      m.Args["url"].(string),
 		Username: m.Args["username"].(string),
 		Password: m.Args["password"].(string),
 	}
-	client, _ := client.NewClient(config)
-	return client
+	return client.NewClient(config)
 }


### PR DESCRIPTION
## Summary

- Return provider client/setup errors instead of ignoring them in Equinix Metal and Xen Orchestra service helpers.
- Propagate IBM COS bucket listing, Cloud Functions OpenWhisk client, and CIS API client construction errors.
- Return Okta HOTP factor profile discovery errors instead of silently skipping those resources.
