### PR TITLE
fix(providers): return nested discovery errors

### DIFF
--- a/providers/aws/alb.go
+++ b/providers/aws/alb.go
@@ -5,7 +5,6 @@ package aws
 import (
 	"context"
 	"fmt"
-	"log"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/elasticloadbalancingv2"
@@ -37,7 +36,7 @@ func (g *AlbGenerator) loadLB(svc *elasticloadbalancingv2.Client) error {
 			))
 			err := g.loadLBListener(svc, lb.LoadBalancerArn)
 			if err != nil {
-				log.Println(err)
+				return fmt.Errorf("load listeners for load balancer %s: %w", StringValue(lb.LoadBalancerArn), err)
 			}
 		}
 	}
@@ -62,11 +61,11 @@ func (g *AlbGenerator) loadLBListener(svc *elasticloadbalancingv2.Client, loadBa
 			))
 			err := g.loadLBListenerRule(svc, ls.ListenerArn)
 			if err != nil {
-				log.Println(err)
+				return fmt.Errorf("load listener rules for listener %s: %w", StringValue(ls.ListenerArn), err)
 			}
 			err = g.loadLBListenerCertificate(svc, &ls)
 			if err != nil {
-				log.Println(err)
+				return fmt.Errorf("load listener certificates for listener %s: %w", StringValue(ls.ListenerArn), err)
 			}
 		}
 	}
@@ -151,7 +150,7 @@ func (g *AlbGenerator) loadLBTargetGroup(svc *elasticloadbalancingv2.Client) err
 			))
 			err := g.loadTargetGroupTargets(svc, tg.TargetGroupArn)
 			if err != nil {
-				log.Println(err)
+				return fmt.Errorf("load target group targets for %s: %w", StringValue(tg.TargetGroupArn), err)
 			}
 		}
 	}

--- a/providers/aws/alb.go
+++ b/providers/aws/alb.go
@@ -104,6 +104,10 @@ func (g *AlbGenerator) loadLBListenerRule(svc *elasticloadbalancingv2.Client, li
 }
 
 func (g *AlbGenerator) loadLBListenerCertificate(svc *elasticloadbalancingv2.Client, loadBalancer *types.Listener) error {
+	if !listenerSupportsCertificates(loadBalancer.Protocol) {
+		return nil
+	}
+
 	lcs, err := svc.DescribeListenerCertificates(context.TODO(), &elasticloadbalancingv2.DescribeListenerCertificatesInput{
 		ListenerArn: loadBalancer.ListenerArn,
 	})
@@ -130,6 +134,10 @@ func (g *AlbGenerator) loadLBListenerCertificate(svc *elasticloadbalancingv2.Cli
 		))
 	}
 	return err
+}
+
+func listenerSupportsCertificates(protocol types.ProtocolEnum) bool {
+	return protocol == types.ProtocolEnumHttps || protocol == types.ProtocolEnumTls
 }
 
 func (g *AlbGenerator) loadLBTargetGroup(svc *elasticloadbalancingv2.Client) error {

--- a/providers/aws/alb_test.go
+++ b/providers/aws/alb_test.go
@@ -1,0 +1,33 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package aws
+
+import (
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/service/elasticloadbalancingv2/types"
+)
+
+func TestListenerSupportsCertificates(t *testing.T) {
+	tests := []struct {
+		name     string
+		protocol types.ProtocolEnum
+		want     bool
+	}{
+		{name: "https", protocol: types.ProtocolEnumHttps, want: true},
+		{name: "tls", protocol: types.ProtocolEnumTls, want: true},
+		{name: "http", protocol: types.ProtocolEnumHttp, want: false},
+		{name: "tcp", protocol: types.ProtocolEnumTcp, want: false},
+		{name: "udp", protocol: types.ProtocolEnumUdp, want: false},
+		{name: "tcp udp", protocol: types.ProtocolEnumTcpUdp, want: false},
+		{name: "geneve", protocol: types.ProtocolEnumGeneve, want: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := listenerSupportsCertificates(tt.protocol); got != tt.want {
+				t.Fatalf("listenerSupportsCertificates(%q) = %t, want %t", tt.protocol, got, tt.want)
+			}
+		})
+	}
+}

--- a/providers/aws/api_gateway.go
+++ b/providers/aws/api_gateway.go
@@ -4,7 +4,6 @@ package aws
 
 import (
 	"context"
-	"log"
 	"strings"
 
 	"github.com/aws/aws-sdk-go-v2/service/apigateway"
@@ -147,7 +146,7 @@ func (g *APIGatewayGenerator) loadResources(svc *apigateway.Client, restAPIID *s
 			))
 			err := g.loadResourceMethods(svc, restAPIID, resource)
 			if err != nil {
-				log.Println(err)
+				return err
 			}
 		}
 	}

--- a/providers/aws/route53.go
+++ b/providers/aws/route53.go
@@ -5,7 +5,6 @@ package aws
 import (
 	"context"
 	"fmt"
-	"log"
 	"strings"
 
 	"github.com/chenrui333/terraformer/terraformutils"
@@ -22,14 +21,13 @@ type Route53Generator struct {
 	AWSService
 }
 
-func (g *Route53Generator) createZonesResources(svc *route53.Client) []terraformutils.Resource {
+func (g *Route53Generator) createZonesResources(svc *route53.Client) ([]terraformutils.Resource, error) {
 	var resources []terraformutils.Resource
 	p := route53.NewListHostedZonesPaginator(svc, &route53.ListHostedZonesInput{})
 	for p.HasMorePages() {
 		page, err := p.NextPage(context.TODO())
 		if err != nil {
-			log.Println(err)
-			return resources
+			return nil, fmt.Errorf("list Route53 hosted zones: %w", err)
 		}
 		for _, zone := range page.HostedZones {
 			zoneID := cleanZoneID(StringValue(zone.Id))
@@ -45,14 +43,17 @@ func (g *Route53Generator) createZonesResources(svc *route53.Client) []terraform
 				route53AllowEmptyValues,
 				route53AdditionalFields,
 			))
-			records := g.createRecordsResources(svc, zoneID)
+			records, err := g.createRecordsResources(svc, zoneID)
+			if err != nil {
+				return nil, err
+			}
 			resources = append(resources, records...)
 		}
 	}
-	return resources
+	return resources, nil
 }
 
-func (Route53Generator) createRecordsResources(svc *route53.Client, zoneID string) []terraformutils.Resource {
+func (Route53Generator) createRecordsResources(svc *route53.Client, zoneID string) ([]terraformutils.Resource, error) {
 	var resources []terraformutils.Resource
 	var sets *route53.ListResourceRecordSetsOutput
 	var err error
@@ -63,8 +64,7 @@ func (Route53Generator) createRecordsResources(svc *route53.Client, zoneID strin
 	for {
 		sets, err = svc.ListResourceRecordSets(context.TODO(), listParams)
 		if err != nil {
-			log.Println(err)
-			return resources
+			return nil, fmt.Errorf("list Route53 records for zone %s: %w", zoneID, err)
 		}
 		for _, record := range sets.ResourceRecordSets {
 			recordName := wildcardUnescape(StringValue(record.Name))
@@ -93,18 +93,17 @@ func (Route53Generator) createRecordsResources(svc *route53.Client, zoneID strin
 			break
 		}
 	}
-	return resources
+	return resources, nil
 }
 
-func (Route53Generator) createHealthChecksResources(svc *route53.Client) []terraformutils.Resource {
+func (Route53Generator) createHealthChecksResources(svc *route53.Client) ([]terraformutils.Resource, error) {
 	var resources []terraformutils.Resource
 
 	p := route53.NewListHealthChecksPaginator(svc, &route53.ListHealthChecksInput{})
 	for p.HasMorePages() {
 		page, err := p.NextPage(context.TODO())
 		if err != nil {
-			log.Println(err)
-			return resources
+			return nil, fmt.Errorf("list Route53 health checks: %w", err)
 		}
 		for _, healthCheck := range page.HealthChecks {
 			healthCheckStringType := string(healthCheck.HealthCheckConfig.Type)
@@ -118,7 +117,7 @@ func (Route53Generator) createHealthChecksResources(svc *route53.Client) []terra
 			))
 		}
 	}
-	return resources
+	return resources, nil
 }
 
 // Generate TerraformResources from AWS API,
@@ -130,8 +129,15 @@ func (g *Route53Generator) InitResources() error {
 	}
 	svc := route53.NewFromConfig(config)
 
-	g.Resources = g.createZonesResources(svc)
-	healthCheckResources := g.createHealthChecksResources(svc)
+	resources, err := g.createZonesResources(svc)
+	if err != nil {
+		return err
+	}
+	g.Resources = resources
+	healthCheckResources, err := g.createHealthChecksResources(svc)
+	if err != nil {
+		return err
+	}
 	g.Resources = append(g.Resources, healthCheckResources...)
 
 	return nil

--- a/providers/aws/sns.go
+++ b/providers/aws/sns.go
@@ -5,7 +5,6 @@ package aws
 import (
 	"context"
 	"fmt"
-	"log"
 
 	"github.com/aws/aws-sdk-go-v2/service/sns"
 	"github.com/chenrui333/terraformer/terraformutils"
@@ -51,8 +50,7 @@ func (g *SnsGenerator) InitResources() error {
 			for topicSubsPage.HasMorePages() {
 				topicSubsNextPage, err := topicSubsPage.NextPage(context.TODO())
 				if err != nil {
-					log.Println(err)
-					continue
+					return fmt.Errorf("list SNS subscriptions for topic %s: %w", StringValue(topic.TopicArn), err)
 				}
 				for _, subscription := range topicSubsNextPage.Subscriptions {
 					subscriptionID := arnLastSegment(StringValue(subscription.SubscriptionArn), ":")

--- a/providers/azure/eventhub.go
+++ b/providers/azure/eventhub.go
@@ -4,7 +4,6 @@ package azure
 
 import (
 	"context"
-	"log"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/eventhub/armeventhub"
 )
@@ -63,7 +62,6 @@ func (az *EventHubGenerator) appendEventHubs(namespace *armeventhub.EHNamespace,
 		for _, item := range page.Value {
 			az.AppendSimpleResource(*item.ID, *item.Name, "azurerm_eventhub")
 			if err := az.appendConsumerGroups(namespace, namespaceRg, *item.Name); err != nil {
-				log.Println(err)
 				return err
 			}
 		}

--- a/providers/heroku/team_collaborator.go
+++ b/providers/heroku/team_collaborator.go
@@ -4,7 +4,6 @@ package heroku
 
 import (
 	"context"
-	"log"
 
 	"github.com/chenrui333/terraformer/terraformutils"
 	heroku "github.com/heroku/heroku-go/v5"
@@ -14,17 +13,17 @@ type TeamCollaboratorGenerator struct {
 	HerokuService
 }
 
-func (g TeamCollaboratorGenerator) createResources(svc *heroku.Service, teamList []heroku.Team) []terraformutils.Resource {
+func (g TeamCollaboratorGenerator) createResources(svc *heroku.Service, teamList []heroku.Team) ([]terraformutils.Resource, error) {
 	var resources []terraformutils.Resource
 	for _, team := range teamList {
 		apps, err := svc.TeamAppListByTeam(context.TODO(), team.ID, &heroku.ListRange{Field: "id"})
 		if err != nil {
-			log.Println(err)
+			return nil, err
 		}
 		for _, app := range apps {
 			collaborators, err := svc.TeamAppCollaboratorList(context.TODO(), app.ID, &heroku.ListRange{Field: "id"})
 			if err != nil {
-				log.Println(err)
+				return nil, err
 			}
 			for _, collaborator := range collaborators {
 				resources = append(resources, terraformutils.NewResource(
@@ -38,7 +37,7 @@ func (g TeamCollaboratorGenerator) createResources(svc *heroku.Service, teamList
 			}
 		}
 	}
-	return resources
+	return resources, nil
 }
 
 func (g *TeamCollaboratorGenerator) InitResources() error {
@@ -47,6 +46,10 @@ func (g *TeamCollaboratorGenerator) InitResources() error {
 	if err != nil {
 		return err
 	}
-	g.Resources = g.createResources(svc, output)
+	resources, err := g.createResources(svc, output)
+	if err != nil {
+		return err
+	}
+	g.Resources = resources
 	return nil
 }

--- a/providers/heroku/team_member.go
+++ b/providers/heroku/team_member.go
@@ -5,7 +5,6 @@ package heroku
 import (
 	"context"
 	"fmt"
-	"log"
 
 	"github.com/chenrui333/terraformer/terraformutils"
 	heroku "github.com/heroku/heroku-go/v5"
@@ -15,12 +14,12 @@ type TeamMemberGenerator struct {
 	HerokuService
 }
 
-func (g TeamMemberGenerator) createResources(svc *heroku.Service, teamList []heroku.Team) []terraformutils.Resource {
+func (g TeamMemberGenerator) createResources(svc *heroku.Service, teamList []heroku.Team) ([]terraformutils.Resource, error) {
 	var resources []terraformutils.Resource
 	for _, team := range teamList {
 		output, err := svc.TeamMemberList(context.TODO(), team.ID, &heroku.ListRange{Field: "id"})
 		if err != nil {
-			log.Println(err)
+			return nil, err
 		}
 		for _, member := range output {
 			resources = append(resources, terraformutils.NewSimpleResource(
@@ -31,7 +30,7 @@ func (g TeamMemberGenerator) createResources(svc *heroku.Service, teamList []her
 				[]string{}))
 		}
 	}
-	return resources
+	return resources, nil
 }
 
 func (g *TeamMemberGenerator) InitResources() error {
@@ -40,6 +39,10 @@ func (g *TeamMemberGenerator) InitResources() error {
 	if err != nil {
 		return err
 	}
-	g.Resources = g.createResources(svc, output)
+	resources, err := g.createResources(svc, output)
+	if err != nil {
+		return err
+	}
+	g.Resources = resources
 	return nil
 }

--- a/providers/openstack/blockstorage.go
+++ b/providers/openstack/blockstorage.go
@@ -24,7 +24,7 @@ type BlockStorageGenerator struct {
 }
 
 // createResources iterate on all openstack_blockstorage_volume
-func (g *BlockStorageGenerator) createResources(list *pagination.Pager, clientType string) []terraformutils.Resource {
+func (g *BlockStorageGenerator) createResources(list *pagination.Pager, clientType string) ([]terraformutils.Resource, error) {
 	resources := []terraformutils.Resource{}
 
 	err := list.EachPage(func(page pagination.Page) (bool, error) {
@@ -54,10 +54,10 @@ func (g *BlockStorageGenerator) createResources(list *pagination.Pager, clientTy
 		return true, nil
 	})
 	if err != nil {
-		log.Println(err)
+		return nil, err
 	}
 
-	return resources
+	return resources, nil
 }
 
 // Creates a BlockStorage ServiceClient
@@ -106,7 +106,11 @@ func (g *BlockStorageGenerator) InitResources() error {
 
 	list := volumes.List(client, nil)
 
-	g.Resources = g.createResources(&list, client.Type)
+	resources, err := g.createResources(&list, client.Type)
+	if err != nil {
+		return err
+	}
+	g.Resources = resources
 
 	return nil
 }

--- a/providers/openstack/compute.go
+++ b/providers/openstack/compute.go
@@ -21,7 +21,7 @@ type ComputeGenerator struct {
 }
 
 // createResources iterate on all openstack_compute_instance_v2
-func (g *ComputeGenerator) createResources(list *pagination.Pager, volclient *gophercloud.ServiceClient) []terraformutils.Resource {
+func (g *ComputeGenerator) createResources(list *pagination.Pager, volclient *gophercloud.ServiceClient) ([]terraformutils.Resource, error) {
 	resources := []terraformutils.Resource{}
 
 	err := list.EachPage(func(page pagination.Page) (bool, error) {
@@ -107,9 +107,9 @@ func (g *ComputeGenerator) createResources(list *pagination.Pager, volclient *go
 		return true, nil
 	})
 	if err != nil {
-		log.Println(err)
+		return nil, err
 	}
-	return resources
+	return resources, nil
 }
 
 // Generate TerraformResources from OpenStack API,
@@ -138,7 +138,11 @@ func (g *ComputeGenerator) InitResources() error {
 		log.Println("VolumeImageMetadata requires blockStorage API v3")
 		volclient = nil
 	}
-	g.Resources = g.createResources(&list, volclient)
+	resources, err := g.createResources(&list, volclient)
+	if err != nil {
+		return err
+	}
+	g.Resources = resources
 
 	return nil
 }

--- a/providers/openstack/networking.go
+++ b/providers/openstack/networking.go
@@ -3,8 +3,6 @@
 package openstack
 
 import (
-	"log"
-
 	"github.com/chenrui333/terraformer/terraformutils"
 	"github.com/gophercloud/gophercloud"
 	"github.com/gophercloud/gophercloud/openstack"
@@ -18,7 +16,7 @@ type NetworkingGenerator struct {
 }
 
 // createResources iterate on all openstack_networking_secgroup_v2
-func (g *NetworkingGenerator) createSecgroupResources(list *pagination.Pager) []terraformutils.Resource {
+func (g *NetworkingGenerator) createSecgroupResources(list *pagination.Pager) ([]terraformutils.Resource, error) {
 	resources := []terraformutils.Resource{}
 
 	err := list.EachPage(func(page pagination.Page) (bool, error) {
@@ -42,9 +40,9 @@ func (g *NetworkingGenerator) createSecgroupResources(list *pagination.Pager) []
 		return true, nil
 	})
 	if err != nil {
-		log.Println(err)
+		return nil, err
 	}
-	return resources
+	return resources, nil
 }
 
 // createResources iterate on all openstack_networking_secgroup_v2
@@ -84,7 +82,11 @@ func (g *NetworkingGenerator) InitResources() error {
 
 	list := groups.List(client, groups.ListOpts{})
 
-	g.Resources = g.createSecgroupResources(&list)
+	resources, err := g.createSecgroupResources(&list)
+	if err != nil {
+		return err
+	}
+	g.Resources = resources
 
 	return nil
 }


### PR DESCRIPTION
## Summary

- Return AWS Route53, SNS, API Gateway, and ALB nested discovery errors instead of logging and continuing with partial resources.
- Propagate OpenStack compute, networking, and block storage paging/extraction failures.
- Return Heroku team member/collaborator list failures and remove one redundant Azure EventHub log-before-return.
