### PR TITLE
feat(cloudflare): expand resource imports

### DIFF
--- a/README.md
+++ b/README.md
@@ -275,7 +275,7 @@ Links to download Terraform provider plugins:
     * RabbitMQ provider >=1.1.0 - [here](https://releases.hashicorp.com/terraform-provider-rabbitmq/)
 * Network
     * Myrasec provider >1.44 - [here](https://github.com/Myra-Security-GmbH/terraform-provider-myrasec)
-    * Cloudflare provider >=5.19.1 - [here](https://github.com/cloudflare/terraform-provider-cloudflare/releases)
+    * Cloudflare provider >=5.19.1 - [Cloudflare provider releases](https://github.com/cloudflare/terraform-provider-cloudflare/releases)
     * Fastly provider >0.16.1 - [here](https://releases.hashicorp.com/terraform-provider-fastly/)
     * NS1 provider >1.8.3 - [here](https://releases.hashicorp.com/terraform-provider-ns1/)
     * PAN-OS provider >= 1.8.3 - [here](https://github.com/PaloAltoNetworks/terraform-provider-panos)

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ A CLI tool that generates `tf`/`json` and `tfstate` files based on existing infr
         * [OctopusDeploy](/docs/octopus.md)
         * [RabbitMQ](/docs/rabbitmq.md)
     * Network
-        * [Cloudflare](/docs/cloudflare.md) (broken, see #1761)
+        * [Cloudflare](/docs/cloudflare.md)
         * [Myrasec](/docs/myrasec.md)
         * [PAN-OS](/docs/panos.md)
     * VCS
@@ -275,7 +275,7 @@ Links to download Terraform provider plugins:
     * RabbitMQ provider >=1.1.0 - [here](https://releases.hashicorp.com/terraform-provider-rabbitmq/)
 * Network
     * Myrasec provider >1.44 - [here](https://github.com/Myra-Security-GmbH/terraform-provider-myrasec)
-    * Cloudflare provider >1.16 - [here](https://releases.hashicorp.com/terraform-provider-cloudflare/)
+    * Cloudflare provider >=5.19.1 - [here](https://github.com/cloudflare/terraform-provider-cloudflare/releases)
     * Fastly provider >0.16.1 - [here](https://releases.hashicorp.com/terraform-provider-fastly/)
     * NS1 provider >1.8.3 - [here](https://releases.hashicorp.com/terraform-provider-ns1/)
     * PAN-OS provider >= 1.8.3 - [here](https://github.com/PaloAltoNetworks/terraform-provider-panos)

--- a/docs/cloudflare.md
+++ b/docs/cloudflare.md
@@ -30,10 +30,8 @@ List of supported Cloudflare services:
 * `account_member`
   * `cloudflare_account_member`
 * `certificates`
-  * `cloudflare_certificate_pack`
   * `cloudflare_custom_hostname`
   * `cloudflare_mtls_certificate`
-  * `cloudflare_origin_ca_certificate`
 * `dns`
   * `cloudflare_dns_record`
   * `cloudflare_zone`

--- a/docs/cloudflare.md
+++ b/docs/cloudflare.md
@@ -1,7 +1,7 @@
 ### Use with Cloudflare
 
 Example using a Cloudflare API Key and corresponding email:
-```
+```bash
 export CLOUDFLARE_API_KEY=[CLOUDFLARE_API_KEY]
 export CLOUDFLARE_EMAIL=[CLOUDFLARE_EMAIL]
 export CLOUDFLARE_ACCOUNT_ID=[CLOUDFLARE_ACCOUNT_ID]
@@ -10,7 +10,7 @@ export CLOUDFLARE_ACCOUNT_ID=[CLOUDFLARE_ACCOUNT_ID]
 
 or using a Cloudflare API Token:
 
-```
+```bash
 export CLOUDFLARE_API_TOKEN=[CLOUDFLARE_API_TOKEN]
 export CLOUDFLARE_ACCOUNT_ID=[CLOUDFLARE_ACCOUNT_ID]
 ./terraformer import cloudflare --resources=dns,firewall,ruleset,access,storage

--- a/docs/cloudflare.md
+++ b/docs/cloudflare.md
@@ -5,7 +5,7 @@ Example using a Cloudflare API Key and corresponding email:
 export CLOUDFLARE_API_KEY=[CLOUDFLARE_API_KEY]
 export CLOUDFLARE_EMAIL=[CLOUDFLARE_EMAIL]
 export CLOUDFLARE_ACCOUNT_ID=[CLOUDFLARE_ACCOUNT_ID]
- ./terraformer import cloudflare --resources=firewall,dns
+./terraformer import cloudflare --resources=dns,firewall,ruleset,access,storage
 ```
 
 or using a Cloudflare API Token:
@@ -13,17 +13,29 @@ or using a Cloudflare API Token:
 ```
 export CLOUDFLARE_API_TOKEN=[CLOUDFLARE_API_TOKEN]
 export CLOUDFLARE_ACCOUNT_ID=[CLOUDFLARE_ACCOUNT_ID]
- ./terraformer import cloudflare --resources=firewall,dns
+./terraformer import cloudflare --resources=dns,firewall,ruleset,access,storage
 ```
 
 List of supported Cloudflare services:
 
 * `access`
-  * `cloudflare_access_application`
+  * `cloudflare_zero_trust_access_application`
+  * `cloudflare_zero_trust_access_custom_page`
+  * `cloudflare_zero_trust_access_group`
+  * `cloudflare_zero_trust_access_identity_provider`
+  * `cloudflare_zero_trust_access_mtls_certificate`
+  * `cloudflare_zero_trust_access_policy`
+  * `cloudflare_zero_trust_access_service_token`
+  * `cloudflare_zero_trust_access_tag`
 * `account_member`
   * `cloudflare_account_member`
+* `certificates`
+  * `cloudflare_certificate_pack`
+  * `cloudflare_custom_hostname`
+  * `cloudflare_mtls_certificate`
+  * `cloudflare_origin_ca_certificate`
 * `dns`
-  * `cloudflare_record`
+  * `cloudflare_dns_record`
   * `cloudflare_zone`
 * `firewall`
   * `cloudflare_access_rule`
@@ -31,5 +43,44 @@ List of supported Cloudflare services:
   * `cloudflare_firewall_rule`
   * `cloudflare_rate_limit`
   * `cloudflare_zone_lockdown`
+* `lists`
+  * `cloudflare_list`
+* `load_balancing`
+  * `cloudflare_healthcheck`
+  * `cloudflare_load_balancer`
+  * `cloudflare_load_balancer_monitor`
+  * `cloudflare_load_balancer_pool`
+* `logpush`
+  * `cloudflare_logpush_job`
+* `magic_wan`
+  * `cloudflare_magic_wan_gre_tunnel`
+  * `cloudflare_magic_wan_ipsec_tunnel`
+  * `cloudflare_magic_wan_static_route`
+* `notifications`
+  * `cloudflare_notification_policy`
+  * `cloudflare_notification_policy_webhooks`
 * `page_rule`
   * `cloudflare_page_rule`
+* `pages`
+  * `cloudflare_pages_domain`
+  * `cloudflare_pages_project`
+* `ruleset`
+  * `cloudflare_ruleset`
+* `storage`
+  * `cloudflare_d1_database`
+  * `cloudflare_queue`
+  * `cloudflare_r2_bucket`
+  * `cloudflare_workers_kv_namespace`
+* `turnstile`
+  * `cloudflare_turnstile_widget`
+* `tunnel`
+  * `cloudflare_zero_trust_tunnel_cloudflared`
+  * `cloudflare_zero_trust_tunnel_cloudflared_virtual_network`
+* `waiting_room`
+  * `cloudflare_waiting_room`
+  * `cloudflare_waiting_room_event`
+  * `cloudflare_waiting_room_rules`
+* `web_analytics`
+  * `cloudflare_web_analytics_site`
+* `workers`
+  * `cloudflare_workers_route`

--- a/providers/cloudflare/access.go
+++ b/providers/cloudflare/access.go
@@ -4,7 +4,11 @@ package cloudflare
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
+	"net/http"
+	"net/url"
+	"strconv"
 
 	"github.com/chenrui333/terraformer/terraformutils"
 	cf "github.com/cloudflare/cloudflare-go"
@@ -157,7 +161,7 @@ func (g *AccessGenerator) appendAccessMTLSCertificateResources(
 }
 
 func (g *AccessGenerator) appendAccessServiceTokenResources(ctx context.Context, api *cf.API, rc *cf.ResourceContainer, scopeType string) error {
-	serviceTokens, _, err := api.ListAccessServiceTokens(ctx, rc, cf.ListAccessServiceTokensParams{})
+	serviceTokens, err := listAccessServiceTokens(ctx, api, rc)
 	if err != nil {
 		return err
 	}
@@ -173,6 +177,34 @@ func (g *AccessGenerator) appendAccessServiceTokenResources(ctx context.Context,
 		))
 	}
 	return nil
+}
+
+func listAccessServiceTokens(ctx context.Context, api *cf.API, rc *cf.ResourceContainer) ([]cf.AccessServiceToken, error) {
+	var serviceTokens []cf.AccessServiceToken
+	for page := 1; ; page++ {
+		values := url.Values{}
+		values.Set("page", strconv.Itoa(page))
+		values.Set("per_page", strconv.Itoa(cloudflarePageSize))
+		response, err := api.Raw(
+			ctx,
+			http.MethodGet,
+			fmt.Sprintf("/%s/%s/access/service_tokens?%s", rc.Level, rc.Identifier, values.Encode()),
+			nil,
+			nil,
+		)
+		if err != nil {
+			return nil, err
+		}
+		var pageTokens []cf.AccessServiceToken
+		if err := json.Unmarshal(response.Result, &pageTokens); err != nil {
+			return nil, err
+		}
+		serviceTokens = append(serviceTokens, pageTokens...)
+		if response.ResultInfo == nil || !response.ResultInfo.HasMorePages() {
+			break
+		}
+	}
+	return serviceTokens, nil
 }
 
 func (g *AccessGenerator) appendAccountAccessPolicyResources(ctx context.Context, api *cf.API, accountID string) error {

--- a/providers/cloudflare/access.go
+++ b/providers/cloudflare/access.go
@@ -14,50 +14,267 @@ type AccessGenerator struct {
 	CloudflareService
 }
 
-func (g *AccessGenerator) createAccessApplications(api *cf.API, zoneID string) ([]terraformutils.Resource, error) {
-	resources := []terraformutils.Resource{}
-	accessApplications, _, err := api.ListAccessApplications(context.Background(), cf.ZoneIdentifier(zoneID), cf.ListAccessApplicationsParams{})
-	if err != nil {
-		return []terraformutils.Resource{}, err
+func accessScopeAttributes(scopeType, scopeID string) map[string]string {
+	if scopeType == "accounts" {
+		return map[string]string{"account_id": scopeID}
 	}
+	return map[string]string{"zone_id": scopeID}
+}
 
-	for _, app := range accessApplications {
-		resources = append(resources, terraformutils.NewResource(
-			app.ID,
-			fmt.Sprintf("%s_%s", app.Name, app.ID),
-			"cloudflare_access_application",
+func (g *AccessGenerator) appendAccessApplicationResources(
+	ctx context.Context,
+	api *cf.API,
+	rc *cf.ResourceContainer,
+	scopeType string,
+) error {
+	params := cf.ListAccessApplicationsParams{ResultInfo: cf.ResultInfo{Page: 1, PerPage: cloudflarePageSize}}
+	for {
+		applications, info, err := api.ListAccessApplications(ctx, rc, params)
+		if err != nil {
+			return err
+		}
+		for _, app := range applications {
+			g.Resources = append(g.Resources, terraformutils.NewResource(
+				app.ID,
+				cloudflareResourceName(scopeType, rc.Identifier, app.Name, app.ID),
+				"cloudflare_zero_trust_access_application",
+				"cloudflare",
+				accessScopeAttributes(scopeType, rc.Identifier),
+				[]string{},
+				map[string]interface{}{},
+			))
+		}
+		if info == nil || !info.HasMorePages() {
+			break
+		}
+		params.ResultInfo = info.Next()
+	}
+	return nil
+}
+
+func (g *AccessGenerator) appendAccessGroupResources(
+	ctx context.Context,
+	api *cf.API,
+	rc *cf.ResourceContainer,
+	scopeType string,
+) error {
+	params := cf.ListAccessGroupsParams{ResultInfo: cf.ResultInfo{Page: 1, PerPage: cloudflarePageSize}}
+	for {
+		groups, info, err := api.ListAccessGroups(ctx, rc, params)
+		if err != nil {
+			return err
+		}
+		for _, group := range groups {
+			g.Resources = append(g.Resources, terraformutils.NewResource(
+				group.ID,
+				cloudflareResourceName(scopeType, rc.Identifier, group.Name, group.ID),
+				"cloudflare_zero_trust_access_group",
+				"cloudflare",
+				accessScopeAttributes(scopeType, rc.Identifier),
+				[]string{},
+				map[string]interface{}{},
+			))
+		}
+		if info == nil || !info.HasMorePages() {
+			break
+		}
+		params.ResultInfo = info.Next()
+	}
+	return nil
+}
+
+func (g *AccessGenerator) appendAccessIdentityProviderResources(
+	ctx context.Context,
+	api *cf.API,
+	rc *cf.ResourceContainer,
+	scopeType string,
+) error {
+	params := cf.ListAccessIdentityProvidersParams{ResultInfo: cf.ResultInfo{Page: 1, PerPage: cloudflarePageSize}}
+	for {
+		providers, info, err := api.ListAccessIdentityProviders(ctx, rc, params)
+		if err != nil {
+			return err
+		}
+		for _, provider := range providers {
+			g.Resources = append(g.Resources, terraformutils.NewResource(
+				provider.ID,
+				cloudflareResourceName(scopeType, rc.Identifier, provider.Name, provider.ID),
+				"cloudflare_zero_trust_access_identity_provider",
+				"cloudflare",
+				accessScopeAttributes(scopeType, rc.Identifier),
+				[]string{},
+				map[string]interface{}{},
+			))
+		}
+		if info == nil || !info.HasMorePages() {
+			break
+		}
+		params.ResultInfo = info.Next()
+	}
+	return nil
+}
+
+func (g *AccessGenerator) appendAccessMTLSCertificateResources(
+	ctx context.Context,
+	api *cf.API,
+	rc *cf.ResourceContainer,
+	scopeType string,
+) error {
+	params := cf.ListAccessMutualTLSCertificatesParams{ResultInfo: cf.ResultInfo{Page: 1, PerPage: cloudflarePageSize}}
+	for {
+		certificates, info, err := api.ListAccessMutualTLSCertificates(ctx, rc, params)
+		if err != nil {
+			return err
+		}
+		for _, certificate := range certificates {
+			g.Resources = append(g.Resources, terraformutils.NewResource(
+				certificate.ID,
+				cloudflareResourceName(scopeType, rc.Identifier, certificate.Name, certificate.ID),
+				"cloudflare_zero_trust_access_mtls_certificate",
+				"cloudflare",
+				accessScopeAttributes(scopeType, rc.Identifier),
+				[]string{},
+				map[string]interface{}{},
+			))
+		}
+		if info == nil || !info.HasMorePages() {
+			break
+		}
+		params.ResultInfo = info.Next()
+	}
+	return nil
+}
+
+func (g *AccessGenerator) appendAccessServiceTokenResources(ctx context.Context, api *cf.API, rc *cf.ResourceContainer, scopeType string) error {
+	serviceTokens, _, err := api.ListAccessServiceTokens(ctx, rc, cf.ListAccessServiceTokensParams{})
+	if err != nil {
+		return err
+	}
+	for _, token := range serviceTokens {
+		g.Resources = append(g.Resources, terraformutils.NewResource(
+			token.ID,
+			cloudflareResourceName(scopeType, rc.Identifier, token.Name, token.ID),
+			"cloudflare_zero_trust_access_service_token",
 			"cloudflare",
-			map[string]string{
-				"zone_id": zoneID,
-				"name":    app.Name,
-			},
+			accessScopeAttributes(scopeType, rc.Identifier),
 			[]string{},
 			map[string]interface{}{},
 		))
 	}
+	return nil
+}
 
-	return resources, nil
+func (g *AccessGenerator) appendAccountAccessPolicyResources(ctx context.Context, api *cf.API, accountID string) error {
+	params := cf.ListAccessPoliciesParams{ResultInfo: cf.ResultInfo{Page: 1, PerPage: cloudflarePageSize}}
+	for {
+		policies, info, err := api.ListAccessPolicies(ctx, cf.AccountIdentifier(accountID), params)
+		if err != nil {
+			return err
+		}
+		for _, policy := range policies {
+			g.Resources = append(g.Resources, terraformutils.NewResource(
+				policy.ID,
+				cloudflareResourceName("accounts", accountID, policy.Name, policy.ID),
+				"cloudflare_zero_trust_access_policy",
+				"cloudflare",
+				map[string]string{"account_id": accountID},
+				[]string{},
+				map[string]interface{}{},
+			))
+		}
+		if info == nil || !info.HasMorePages() {
+			break
+		}
+		params.ResultInfo = info.Next()
+	}
+	return nil
+}
+
+func (g *AccessGenerator) appendAccountAccessCustomPageResources(ctx context.Context, api *cf.API, accountID string) error {
+	pages, err := api.ListAccessCustomPages(ctx, cf.AccountIdentifier(accountID), cf.ListAccessCustomPagesParams{})
+	if err != nil {
+		return err
+	}
+	for _, page := range pages {
+		g.Resources = append(g.Resources, terraformutils.NewResource(
+			page.UID,
+			cloudflareResourceName("accounts", accountID, page.Name, page.UID),
+			"cloudflare_zero_trust_access_custom_page",
+			"cloudflare",
+			map[string]string{"account_id": accountID, "uid": page.UID},
+			[]string{},
+			map[string]interface{}{},
+		))
+	}
+	return nil
+}
+
+func (g *AccessGenerator) appendAccountAccessTagResources(ctx context.Context, api *cf.API, accountID string) error {
+	tags, err := api.ListAccessTags(ctx, cf.AccountIdentifier(accountID), cf.ListAccessTagsParams{})
+	if err != nil {
+		return err
+	}
+	for _, tag := range tags {
+		g.Resources = append(g.Resources, terraformutils.NewResource(
+			tag.Name,
+			cloudflareResourceName("accounts", accountID, tag.Name),
+			"cloudflare_zero_trust_access_tag",
+			"cloudflare",
+			map[string]string{"account_id": accountID, "name": tag.Name},
+			[]string{},
+			map[string]interface{}{},
+		))
+	}
+	return nil
+}
+
+func (g *AccessGenerator) appendScopedAccessResources(ctx context.Context, api *cf.API, rc *cf.ResourceContainer, scopeType string) error {
+	for _, f := range []func(context.Context, *cf.API, *cf.ResourceContainer, string) error{
+		g.appendAccessApplicationResources,
+		g.appendAccessGroupResources,
+		g.appendAccessIdentityProviderResources,
+		g.appendAccessMTLSCertificateResources,
+		g.appendAccessServiceTokenResources,
+	} {
+		if err := f(ctx, api, rc, scopeType); err != nil {
+			return fmt.Errorf("%s/%s: %w", scopeType, rc.Identifier, err)
+		}
+	}
+	return nil
 }
 
 func (g *AccessGenerator) InitResources() error {
+	ctx := context.Background()
 	api, err := g.initializeAPI()
 	if err != nil {
 		return err
 	}
 
-	zones, err := api.ListZones(context.Background())
+	accountID := g.accountID()
+	if accountID != "" {
+		account := cf.AccountIdentifier(accountID)
+		if err := g.appendScopedAccessResources(ctx, api, account, "accounts"); err != nil {
+			return err
+		}
+		for _, f := range []func(context.Context, *cf.API, string) error{
+			g.appendAccountAccessPolicyResources,
+			g.appendAccountAccessCustomPageResources,
+			g.appendAccountAccessTagResources,
+		} {
+			if err := f(ctx, api, accountID); err != nil {
+				return err
+			}
+		}
+	}
+
+	zones, err := cloudflareZones(ctx, api)
 	if err != nil {
 		return err
 	}
-
 	for _, zone := range zones {
-		tmpRes, err := g.createAccessApplications(api, zone.ID)
-		if err != nil {
+		if err := g.appendScopedAccessResources(ctx, api, cf.ZoneIdentifier(zone.ID), "zones"); err != nil {
 			return err
 		}
-
-		g.Resources = append(g.Resources, tmpRes...)
 	}
-
 	return nil
 }

--- a/providers/cloudflare/access.go
+++ b/providers/cloudflare/access.go
@@ -127,12 +127,23 @@ func (g *AccessGenerator) appendAccessMTLSCertificateResources(
 			return err
 		}
 		for _, certificate := range certificates {
+			if certificate.Certificate == "" {
+				certificate, err = api.GetAccessMutualTLSCertificate(ctx, rc, certificate.ID)
+				if err != nil {
+					return err
+				}
+			}
+			if certificate.Certificate == "" {
+				continue
+			}
+			attributes := accessScopeAttributes(scopeType, rc.Identifier)
+			attributes["certificate"] = certificate.Certificate
 			g.Resources = append(g.Resources, terraformutils.NewResource(
 				certificate.ID,
 				cloudflareResourceName(scopeType, rc.Identifier, certificate.Name, certificate.ID),
 				"cloudflare_zero_trust_access_mtls_certificate",
 				"cloudflare",
-				accessScopeAttributes(scopeType, rc.Identifier),
+				attributes,
 				[]string{},
 				map[string]interface{}{},
 			))

--- a/providers/cloudflare/access.go
+++ b/providers/cloudflare/access.go
@@ -234,7 +234,7 @@ func (g *AccessGenerator) appendAccountAccessPolicyResources(ctx context.Context
 }
 
 func (g *AccessGenerator) appendAccountAccessCustomPageResources(ctx context.Context, api *cf.API, accountID string) error {
-	pages, err := api.ListAccessCustomPages(ctx, cf.AccountIdentifier(accountID), cf.ListAccessCustomPagesParams{})
+	pages, err := listAccessCustomPages(ctx, api, cf.AccountIdentifier(accountID))
 	if err != nil {
 		return err
 	}
@@ -252,8 +252,34 @@ func (g *AccessGenerator) appendAccountAccessCustomPageResources(ctx context.Con
 	return nil
 }
 
+func listAccessCustomPages(ctx context.Context, api *cf.API, rc *cf.ResourceContainer) ([]cf.AccessCustomPage, error) {
+	var pages []cf.AccessCustomPage
+	page, cursor := 1, ""
+	for {
+		response, err := api.Raw(
+			ctx,
+			http.MethodGet,
+			fmt.Sprintf("/%s/%s/access/custom_pages?%s", rc.Level, rc.Identifier, cloudflarePaginationQuery(page, cursor)),
+			nil,
+			nil,
+		)
+		if err != nil {
+			return nil, err
+		}
+		var pageCustomPages []cf.AccessCustomPage
+		if err := json.Unmarshal(response.Result, &pageCustomPages); err != nil {
+			return nil, err
+		}
+		pages = append(pages, pageCustomPages...)
+		if !cloudflareAdvancePagination(response.ResultInfo, &page, &cursor) {
+			break
+		}
+	}
+	return pages, nil
+}
+
 func (g *AccessGenerator) appendAccountAccessTagResources(ctx context.Context, api *cf.API, accountID string) error {
-	tags, err := api.ListAccessTags(ctx, cf.AccountIdentifier(accountID), cf.ListAccessTagsParams{})
+	tags, err := listAccessTags(ctx, api, cf.AccountIdentifier(accountID))
 	if err != nil {
 		return err
 	}
@@ -269,6 +295,32 @@ func (g *AccessGenerator) appendAccountAccessTagResources(ctx context.Context, a
 		))
 	}
 	return nil
+}
+
+func listAccessTags(ctx context.Context, api *cf.API, rc *cf.ResourceContainer) ([]cf.AccessTag, error) {
+	var tags []cf.AccessTag
+	page, cursor := 1, ""
+	for {
+		response, err := api.Raw(
+			ctx,
+			http.MethodGet,
+			fmt.Sprintf("/%s/%s/access/tags?%s", rc.Level, rc.Identifier, cloudflarePaginationQuery(page, cursor)),
+			nil,
+			nil,
+		)
+		if err != nil {
+			return nil, err
+		}
+		var pageTags []cf.AccessTag
+		if err := json.Unmarshal(response.Result, &pageTags); err != nil {
+			return nil, err
+		}
+		tags = append(tags, pageTags...)
+		if !cloudflareAdvancePagination(response.ResultInfo, &page, &cursor) {
+			break
+		}
+	}
+	return tags, nil
 }
 
 func (g *AccessGenerator) appendScopedAccessResources(ctx context.Context, api *cf.API, rc *cf.ResourceContainer, scopeType string) error {

--- a/providers/cloudflare/account_member.go
+++ b/providers/cloudflare/account_member.go
@@ -37,6 +37,7 @@ func (g *AccountMemberGenerator) createAccountMemberResources(api *cf.API) ([]te
 				"cloudflare_account_member",
 				"cloudflare",
 				map[string]string{
+					"account_id":    g.accountID(),
 					"email_address": member.User.Email,
 				},
 				[]string{},

--- a/providers/cloudflare/account_member.go
+++ b/providers/cloudflare/account_member.go
@@ -26,25 +26,20 @@ func (g *AccountMemberGenerator) createAccountMemberResources(api *cf.API) ([]te
 		}
 
 		for _, member := range members {
-			var roleIDs []string
-			for _, role := range member.Roles {
-				roleIDs = append(roleIDs, role.ID)
-			}
-
-			resources = append(resources, terraformutils.NewResource(
+			resource := terraformutils.NewResource(
 				member.ID,
 				member.ID,
 				"cloudflare_account_member",
 				"cloudflare",
 				map[string]string{
-					"account_id":    g.accountID(),
-					"email_address": member.User.Email,
+					"account_id": g.accountID(),
+					"email":      member.User.Email,
 				},
 				[]string{},
-				map[string]interface{}{
-					"role_ids": roleIDs,
-				},
-			))
+				accountMemberAdditionalFields(member),
+			)
+			setCloudflareImportID(&resource, g.accountID()+"/"+member.ID)
+			resources = append(resources, resource)
 		}
 
 		if pageOpt.Page < info.TotalPages {
@@ -55,6 +50,59 @@ func (g *AccountMemberGenerator) createAccountMemberResources(api *cf.API) ([]te
 	}
 
 	return resources, nil
+}
+
+func accountMemberAdditionalFields(member cf.AccountMember) map[string]interface{} {
+	if len(member.Policies) > 0 {
+		return map[string]interface{}{
+			"policies": accountMemberPolicyAdditionalFields(member.Policies),
+		}
+	}
+
+	roleIDs := make([]string, 0, len(member.Roles))
+	for _, role := range member.Roles {
+		roleIDs = append(roleIDs, role.ID)
+	}
+	if len(roleIDs) == 0 {
+		return map[string]interface{}{}
+	}
+
+	return map[string]interface{}{
+		"roles": roleIDs,
+	}
+}
+
+func accountMemberPolicyAdditionalFields(policies []cf.Policy) []map[string]interface{} {
+	fields := make([]map[string]interface{}, 0, len(policies))
+	for _, policy := range policies {
+		field := map[string]interface{}{
+			"access":            policy.Access,
+			"permission_groups": accountMemberPermissionGroupAdditionalFields(policy.PermissionGroups),
+			"resource_groups":   accountMemberResourceGroupAdditionalFields(policy.ResourceGroups),
+		}
+		fields = append(fields, field)
+	}
+	return fields
+}
+
+func accountMemberPermissionGroupAdditionalFields(permissionGroups []cf.PermissionGroup) []map[string]interface{} {
+	fields := make([]map[string]interface{}, 0, len(permissionGroups))
+	for _, group := range permissionGroups {
+		fields = append(fields, map[string]interface{}{
+			"id": group.ID,
+		})
+	}
+	return fields
+}
+
+func accountMemberResourceGroupAdditionalFields(resourceGroups []cf.ResourceGroup) []map[string]interface{} {
+	fields := make([]map[string]interface{}, 0, len(resourceGroups))
+	for _, group := range resourceGroups {
+		fields = append(fields, map[string]interface{}{
+			"id": group.ID,
+		})
+	}
+	return fields
 }
 
 func (g *AccountMemberGenerator) InitResources() error {

--- a/providers/cloudflare/certificates.go
+++ b/providers/cloudflare/certificates.go
@@ -1,0 +1,129 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package cloudflare
+
+import (
+	"context"
+
+	"github.com/chenrui333/terraformer/terraformutils"
+	cf "github.com/cloudflare/cloudflare-go"
+)
+
+type CertificatesGenerator struct {
+	CloudflareService
+}
+
+func (g *CertificatesGenerator) appendMTLSCertificateResources(ctx context.Context, api *cf.API, accountID string) error {
+	params := cf.ListMTLSCertificatesParams{PaginationOptions: cf.PaginationOptions{Page: 1, PerPage: cloudflarePageSize}}
+	for {
+		certificates, info, err := api.ListMTLSCertificates(ctx, cf.AccountIdentifier(accountID), params)
+		if err != nil {
+			return err
+		}
+		for _, certificate := range certificates {
+			g.Resources = append(g.Resources, terraformutils.NewResource(
+				certificate.ID,
+				cloudflareResourceName(accountID, certificate.Name, certificate.ID),
+				"cloudflare_mtls_certificate",
+				"cloudflare",
+				map[string]string{"account_id": accountID},
+				[]string{},
+				map[string]interface{}{},
+			))
+		}
+		if !info.HasMorePages() {
+			break
+		}
+		params.Page++
+	}
+	return nil
+}
+
+func (g *CertificatesGenerator) appendOriginCACertificateResources(ctx context.Context, api *cf.API) error {
+	certificates, err := api.ListOriginCACertificates(ctx, cf.ListOriginCertificatesParams{})
+	if err != nil {
+		return err
+	}
+	for _, certificate := range certificates {
+		g.Resources = append(g.Resources, terraformutils.NewSimpleResource(
+			certificate.ID,
+			cloudflareResourceName(certificate.ID),
+			"cloudflare_origin_ca_certificate",
+			"cloudflare",
+			[]string{},
+		))
+	}
+	return nil
+}
+
+func (g *CertificatesGenerator) appendCertificatePackResources(ctx context.Context, api *cf.API, zone cf.Zone) error {
+	certificatePacks, err := api.ListCertificatePacks(ctx, zone.ID)
+	if err != nil {
+		return err
+	}
+	for _, certificatePack := range certificatePacks {
+		g.Resources = append(g.Resources, terraformutils.NewResource(
+			certificatePack.ID,
+			cloudflareResourceName(zone.Name, certificatePack.Type, certificatePack.ID),
+			"cloudflare_certificate_pack",
+			"cloudflare",
+			map[string]string{"zone_id": zone.ID},
+			[]string{},
+			map[string]interface{}{},
+		))
+	}
+	return nil
+}
+
+func (g *CertificatesGenerator) appendCustomHostnameResources(ctx context.Context, api *cf.API, zone cf.Zone) error {
+	for page := 1; ; page++ {
+		customHostnames, info, err := api.CustomHostnames(ctx, zone.ID, page, cf.CustomHostname{})
+		if err != nil {
+			return err
+		}
+		for _, customHostname := range customHostnames {
+			g.Resources = append(g.Resources, terraformutils.NewResource(
+				customHostname.ID,
+				cloudflareResourceName(zone.Name, customHostname.Hostname, customHostname.ID),
+				"cloudflare_custom_hostname",
+				"cloudflare",
+				map[string]string{"zone_id": zone.ID},
+				[]string{},
+				map[string]interface{}{},
+			))
+		}
+		if !info.HasMorePages() {
+			break
+		}
+	}
+	return nil
+}
+
+func (g *CertificatesGenerator) InitResources() error {
+	ctx := context.Background()
+	api, err := g.initializeAPI()
+	if err != nil {
+		return err
+	}
+	if g.accountID() != "" {
+		if err := g.appendMTLSCertificateResources(ctx, api, g.accountID()); err != nil {
+			return err
+		}
+	}
+	if err := g.appendOriginCACertificateResources(ctx, api); err != nil {
+		return err
+	}
+	zones, err := cloudflareZones(ctx, api)
+	if err != nil {
+		return err
+	}
+	for _, zone := range zones {
+		if err := g.appendCertificatePackResources(ctx, api, zone); err != nil {
+			return err
+		}
+		if err := g.appendCustomHostnameResources(ctx, api, zone); err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/providers/cloudflare/certificates.go
+++ b/providers/cloudflare/certificates.go
@@ -39,42 +39,6 @@ func (g *CertificatesGenerator) appendMTLSCertificateResources(ctx context.Conte
 	return nil
 }
 
-func (g *CertificatesGenerator) appendOriginCACertificateResources(ctx context.Context, api *cf.API) error {
-	certificates, err := api.ListOriginCACertificates(ctx, cf.ListOriginCertificatesParams{})
-	if err != nil {
-		return err
-	}
-	for _, certificate := range certificates {
-		g.Resources = append(g.Resources, terraformutils.NewSimpleResource(
-			certificate.ID,
-			cloudflareResourceName(certificate.ID),
-			"cloudflare_origin_ca_certificate",
-			"cloudflare",
-			[]string{},
-		))
-	}
-	return nil
-}
-
-func (g *CertificatesGenerator) appendCertificatePackResources(ctx context.Context, api *cf.API, zone cf.Zone) error {
-	certificatePacks, err := api.ListCertificatePacks(ctx, zone.ID)
-	if err != nil {
-		return err
-	}
-	for _, certificatePack := range certificatePacks {
-		g.Resources = append(g.Resources, terraformutils.NewResource(
-			certificatePack.ID,
-			cloudflareResourceName(zone.Name, certificatePack.Type, certificatePack.ID),
-			"cloudflare_certificate_pack",
-			"cloudflare",
-			map[string]string{"zone_id": zone.ID},
-			[]string{},
-			map[string]interface{}{},
-		))
-	}
-	return nil
-}
-
 func (g *CertificatesGenerator) appendCustomHostnameResources(ctx context.Context, api *cf.API, zone cf.Zone) error {
 	for page := 1; ; page++ {
 		customHostnames, info, err := api.CustomHostnames(ctx, zone.ID, page, cf.CustomHostname{})
@@ -110,17 +74,11 @@ func (g *CertificatesGenerator) InitResources() error {
 			return err
 		}
 	}
-	if err := g.appendOriginCACertificateResources(ctx, api); err != nil {
-		return err
-	}
 	zones, err := cloudflareZones(ctx, api)
 	if err != nil {
 		return err
 	}
 	for _, zone := range zones {
-		if err := g.appendCertificatePackResources(ctx, api, zone); err != nil {
-			return err
-		}
 		if err := g.appendCustomHostnameResources(ctx, api, zone); err != nil {
 			return err
 		}

--- a/providers/cloudflare/cloudflare_provider.go
+++ b/providers/cloudflare/cloudflare_provider.go
@@ -35,6 +35,20 @@ func (p *CloudflareProvider) GetSupportedService() map[string]terraformutils.Ser
 		"firewall":       &FirewallGenerator{},
 		"page_rule":      &PageRulesGenerator{},
 		"account_member": &AccountMemberGenerator{},
+		"certificates":   &CertificatesGenerator{},
+		"lists":          &ListsGenerator{},
+		"load_balancing": &LoadBalancingGenerator{},
+		"logpush":        &LogpushGenerator{},
+		"magic_wan":      &MagicWANGenerator{},
+		"notifications":  &NotificationsGenerator{},
+		"pages":          &PagesGenerator{},
+		"ruleset":        &RulesetGenerator{},
+		"storage":        &StorageGenerator{},
+		"turnstile":      &TurnstileGenerator{},
+		"tunnel":         &TunnelGenerator{},
+		"waiting_room":   &WaitingRoomGenerator{},
+		"web_analytics":  &WebAnalyticsGenerator{},
+		"workers":        &WorkersGenerator{},
 	}
 }
 

--- a/providers/cloudflare/cloudflare_service.go
+++ b/providers/cloudflare/cloudflare_service.go
@@ -7,7 +7,9 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"net/url"
 	"os"
+	"strconv"
 	"strings"
 
 	"github.com/chenrui333/terraformer/terraformutils"
@@ -65,6 +67,42 @@ func setCloudflareImportID(resource *terraformutils.Resource, importID string) {
 		resource.InstanceState.Meta = map[string]interface{}{}
 	}
 	resource.InstanceState.Meta["import_id"] = importID
+}
+
+func cloudflarePaginationQuery(page int, cursor string) string {
+	values := url.Values{}
+	values.Set("per_page", strconv.Itoa(cloudflarePageSize))
+	if cursor != "" {
+		values.Set("cursor", cursor)
+	} else {
+		values.Set("page", strconv.Itoa(page))
+	}
+	return values.Encode()
+}
+
+func cloudflareAdvancePagination(info *cf.ResultInfo, page *int, cursor *string) bool {
+	if info == nil {
+		return false
+	}
+	if info.Cursors.After != "" {
+		if info.Cursors.After == *cursor {
+			return false
+		}
+		*cursor = info.Cursors.After
+		return true
+	}
+	if info.Cursor != "" {
+		if info.Cursor == *cursor {
+			return false
+		}
+		*cursor = info.Cursor
+		return true
+	}
+	if info.HasMorePages() {
+		*page++
+		return true
+	}
+	return false
 }
 
 func cloudflareZones(ctx context.Context, api *cf.API) ([]cf.Zone, error) {

--- a/providers/cloudflare/cloudflare_service.go
+++ b/providers/cloudflare/cloudflare_service.go
@@ -60,6 +60,13 @@ func cloudflareResourceName(parts ...string) string {
 	return strings.Join(filtered, "_")
 }
 
+func setCloudflareImportID(resource *terraformutils.Resource, importID string) {
+	if resource.InstanceState.Meta == nil {
+		resource.InstanceState.Meta = map[string]interface{}{}
+	}
+	resource.InstanceState.Meta["import_id"] = importID
+}
+
 func cloudflareZones(ctx context.Context, api *cf.API) ([]cf.Zone, error) {
 	return api.ListZones(ctx)
 }

--- a/providers/cloudflare/cloudflare_service.go
+++ b/providers/cloudflare/cloudflare_service.go
@@ -4,13 +4,17 @@
 package cloudflare
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"os"
+	"strings"
 
 	"github.com/chenrui333/terraformer/terraformutils"
 	cf "github.com/cloudflare/cloudflare-go"
 )
+
+const cloudflarePageSize = 50
 
 type CloudflareService struct { //nolint
 	terraformutils.Service
@@ -36,4 +40,26 @@ func (s *CloudflareService) initializeAPI() (*cf.API, error) {
 
 func (s *CloudflareService) accountID() string {
 	return os.Getenv("CLOUDFLARE_ACCOUNT_ID")
+}
+
+func (s *CloudflareService) accountResourceContainer() (*cf.ResourceContainer, error) {
+	accountID := s.accountID()
+	if accountID == "" {
+		return nil, errors.New("set CLOUDFLARE_ACCOUNT_ID env var")
+	}
+	return cf.AccountIdentifier(accountID), nil
+}
+
+func cloudflareResourceName(parts ...string) string {
+	filtered := make([]string, 0, len(parts))
+	for _, part := range parts {
+		if part != "" {
+			filtered = append(filtered, part)
+		}
+	}
+	return strings.Join(filtered, "_")
+}
+
+func cloudflareZones(ctx context.Context, api *cf.API) ([]cf.Zone, error) {
+	return api.ListZones(ctx)
 }

--- a/providers/cloudflare/dns.go
+++ b/providers/cloudflare/dns.go
@@ -57,6 +57,7 @@ func (*DNSGenerator) createRecordsResources(api *cf.API, zoneID, zoneName string
 			map[string]interface{}{},
 		)
 
+		setCloudflareImportID(&r, zoneID+"/"+record.ID)
 		r.IgnoreKeys = append(r.IgnoreKeys, "^metadata")
 		resources = append(resources, r)
 	}

--- a/providers/cloudflare/dns.go
+++ b/providers/cloudflare/dns.go
@@ -93,14 +93,15 @@ func (g *DNSGenerator) InitResources() error {
 }
 
 func (g *DNSGenerator) PostConvertHook() error {
-	// 'record' resource have 'data' and 'value' is mutual-exclude
+	// 'record' resource have 'data' and 'content' is mutual-exclude
 	// delete which one have empty value
 	for i, resource := range g.Resources {
 		if resource.InstanceInfo.Type == "cloudflare_dns_record" {
-			if val, ok := resource.Item["data"]; ok && len(val.(map[string]interface{})) == 0 {
+			if val, ok := resource.Item["data"].(map[string]interface{}); ok && len(val) == 0 {
 				delete(g.Resources[i].Item, "data")
-			} else if val, ok := resource.Item["value"]; ok && len(val.(string)) == 0 {
-				delete(g.Resources[i].Item, "value")
+			}
+			if val, ok := resource.Item["content"].(string); ok && val == "" {
+				delete(g.Resources[i].Item, "content")
 			}
 		}
 	}

--- a/providers/cloudflare/dns.go
+++ b/providers/cloudflare/dns.go
@@ -47,11 +47,10 @@ func (*DNSGenerator) createRecordsResources(api *cf.API, zoneID, zoneName string
 		r := terraformutils.NewResource(
 			record.ID,
 			fmt.Sprintf("%s_%s_%s", record.Type, zoneName, record.ID),
-			"cloudflare_record",
+			"cloudflare_dns_record",
 			"cloudflare",
 			map[string]string{
 				"zone_id": zoneID,
-				"domain":  zoneName,
 				"name":    record.Name,
 			},
 			[]string{},
@@ -97,7 +96,7 @@ func (g *DNSGenerator) PostConvertHook() error {
 	// 'record' resource have 'data' and 'value' is mutual-exclude
 	// delete which one have empty value
 	for i, resource := range g.Resources {
-		if resource.InstanceInfo.Type == "cloudflare_record" {
+		if resource.InstanceInfo.Type == "cloudflare_dns_record" {
 			if val, ok := resource.Item["data"]; ok && len(val.(map[string]interface{})) == 0 {
 				delete(g.Resources[i].Item, "data")
 			} else if val, ok := resource.Item["value"]; ok && len(val.(string)) == 0 {

--- a/providers/cloudflare/firewall.go
+++ b/providers/cloudflare/firewall.go
@@ -23,7 +23,7 @@ func (*FirewallGenerator) createZoneLockdownsResources(api *cf.API, zoneID, zone
 		return resources, err
 	}
 	for _, zonelockdown := range zonelockdowns {
-		resources = append(resources, terraformutils.NewResource(
+		resource := terraformutils.NewResource(
 			zonelockdown.ID,
 			fmt.Sprintf("%s_%s", zoneName, zonelockdown.ID),
 			"cloudflare_zone_lockdown",
@@ -34,7 +34,9 @@ func (*FirewallGenerator) createZoneLockdownsResources(api *cf.API, zoneID, zone
 			},
 			[]string{},
 			map[string]interface{}{},
-		))
+		)
+		setCloudflareImportID(&resource, zoneID+"/"+zonelockdown.ID)
+		resources = append(resources, resource)
 	}
 
 	return resources, nil
@@ -50,13 +52,17 @@ func (g *FirewallGenerator) createAccountAccessRuleResources(api *cf.API) ([]ter
 
 	totalPages := rules.TotalPages
 	for _, rule := range rules.Result {
-		resources = append(resources, terraformutils.NewSimpleResource(
+		resource := terraformutils.NewResource(
 			rule.ID,
-			rule.ID,
+			cloudflareResourceName("accounts", accountID, rule.ID),
 			"cloudflare_access_rule",
 			"cloudflare",
+			map[string]string{"account_id": accountID},
 			[]string{},
-		))
+			map[string]interface{}{},
+		)
+		setCloudflareImportID(&resource, "accounts/"+accountID+"/"+rule.ID)
+		resources = append(resources, resource)
 	}
 
 	for page := 2; page <= totalPages; page++ {
@@ -65,13 +71,17 @@ func (g *FirewallGenerator) createAccountAccessRuleResources(api *cf.API) ([]ter
 			return resources, err
 		}
 		for _, rule := range rules.Result {
-			resources = append(resources, terraformutils.NewSimpleResource(
+			resource := terraformutils.NewResource(
 				rule.ID,
-				rule.ID,
+				cloudflareResourceName("accounts", accountID, rule.ID),
 				"cloudflare_access_rule",
 				"cloudflare",
+				map[string]string{"account_id": accountID},
 				[]string{},
-			))
+				map[string]interface{}{},
+			)
+			setCloudflareImportID(&resource, "accounts/"+accountID+"/"+rule.ID)
+			resources = append(resources, resource)
 		}
 	}
 
@@ -88,7 +98,7 @@ func (*FirewallGenerator) createZoneAccessRuleResources(api *cf.API, zoneID, zon
 	totalPages := rules.TotalPages
 	for _, r := range rules.Result {
 		if strings.Compare(r.Scope.Type, "organization") != 0 {
-			resources = append(resources, terraformutils.NewResource(
+			resource := terraformutils.NewResource(
 				r.ID,
 				fmt.Sprintf("%s_%s", zoneName, r.ID),
 				"cloudflare_access_rule",
@@ -98,7 +108,9 @@ func (*FirewallGenerator) createZoneAccessRuleResources(api *cf.API, zoneID, zon
 				},
 				[]string{},
 				map[string]interface{}{},
-			))
+			)
+			setCloudflareImportID(&resource, "zones/"+zoneID+"/"+r.ID)
+			resources = append(resources, resource)
 		}
 	}
 
@@ -109,7 +121,7 @@ func (*FirewallGenerator) createZoneAccessRuleResources(api *cf.API, zoneID, zon
 		}
 		for _, r := range rules.Result {
 			if strings.Compare(r.Scope.Type, "organization") != 0 {
-				resources = append(resources, terraformutils.NewResource(
+				resource := terraformutils.NewResource(
 					r.ID,
 					fmt.Sprintf("%s_%s", zoneName, r.ID),
 					"cloudflare_access_rule",
@@ -119,7 +131,9 @@ func (*FirewallGenerator) createZoneAccessRuleResources(api *cf.API, zoneID, zon
 					},
 					[]string{},
 					map[string]interface{}{},
-				))
+				)
+				setCloudflareImportID(&resource, "zones/"+zoneID+"/"+r.ID)
+				resources = append(resources, resource)
 			}
 		}
 	}
@@ -135,7 +149,7 @@ func (*FirewallGenerator) createFilterResources(api *cf.API, zoneID, zoneName st
 	}
 
 	for _, filter := range filters {
-		resources = append(resources, terraformutils.NewResource(
+		resource := terraformutils.NewResource(
 			filter.ID,
 			fmt.Sprintf("%s_%s", zoneName, filter.ID),
 			"cloudflare_filter",
@@ -145,7 +159,9 @@ func (*FirewallGenerator) createFilterResources(api *cf.API, zoneID, zoneName st
 			},
 			[]string{},
 			map[string]interface{}{},
-		))
+		)
+		setCloudflareImportID(&resource, zoneID+"/"+filter.ID)
+		resources = append(resources, resource)
 	}
 
 	return resources, nil
@@ -159,7 +175,7 @@ func (*FirewallGenerator) createFirewallRuleResources(api *cf.API, zoneID, zoneN
 		return resources, err
 	}
 	for _, rule := range fwrules {
-		resources = append(resources, terraformutils.NewResource(
+		resource := terraformutils.NewResource(
 			rule.ID,
 			fmt.Sprintf("%s_%s", zoneName, rule.ID),
 			"cloudflare_firewall_rule",
@@ -169,7 +185,9 @@ func (*FirewallGenerator) createFirewallRuleResources(api *cf.API, zoneID, zoneN
 			},
 			[]string{},
 			map[string]interface{}{},
-		))
+		)
+		setCloudflareImportID(&resource, zoneID+"/"+rule.ID)
+		resources = append(resources, resource)
 	}
 
 	return resources, nil
@@ -183,12 +201,17 @@ func (g *FirewallGenerator) createRateLimitResources(api *cf.API, zoneID, _ stri
 		return resources, err
 	}
 	for _, rateLimit := range rateLimits {
-		resources = append(resources, terraformutils.NewSimpleResource(
+		resource := terraformutils.NewResource(
 			rateLimit.ID,
 			fmt.Sprintf("%s_%s", zoneID, rateLimit.ID),
 			"cloudflare_rate_limit",
 			"cloudflare",
-			[]string{}))
+			map[string]string{"zone_id": zoneID},
+			[]string{},
+			map[string]interface{}{},
+		)
+		setCloudflareImportID(&resource, zoneID+"/"+rateLimit.ID)
+		resources = append(resources, resource)
 	}
 
 	return resources, nil

--- a/providers/cloudflare/lists.go
+++ b/providers/cloudflare/lists.go
@@ -4,6 +4,8 @@ package cloudflare
 
 import (
 	"context"
+	"fmt"
+	"strconv"
 
 	"github.com/chenrui333/terraformer/terraformutils"
 	cf "github.com/cloudflare/cloudflare-go"
@@ -11,6 +13,57 @@ import (
 
 type ListsGenerator struct {
 	CloudflareService
+}
+
+func addListItemAttributes(attributes map[string]string, index int, item cf.ListItem) {
+	prefix := fmt.Sprintf("items.%d", index)
+	if item.IP != nil {
+		attributes[prefix+".ip"] = *item.IP
+	}
+	if item.ASN != nil {
+		attributes[prefix+".asn"] = strconv.FormatUint(uint64(*item.ASN), 10)
+	}
+	if item.Comment != "" {
+		attributes[prefix+".comment"] = item.Comment
+	}
+	if item.Hostname != nil {
+		attributes[prefix+".hostname.url_hostname"] = item.Hostname.UrlHostname
+	}
+	if item.Redirect != nil {
+		attributes[prefix+".redirect.source_url"] = item.Redirect.SourceUrl
+		attributes[prefix+".redirect.target_url"] = item.Redirect.TargetUrl
+		if item.Redirect.IncludeSubdomains != nil {
+			attributes[prefix+".redirect.include_subdomains"] = strconv.FormatBool(*item.Redirect.IncludeSubdomains)
+		}
+		if item.Redirect.PreservePathSuffix != nil {
+			attributes[prefix+".redirect.preserve_path_suffix"] = strconv.FormatBool(*item.Redirect.PreservePathSuffix)
+		}
+		if item.Redirect.PreserveQueryString != nil {
+			attributes[prefix+".redirect.preserve_query_string"] = strconv.FormatBool(*item.Redirect.PreserveQueryString)
+		}
+		if item.Redirect.StatusCode != nil {
+			attributes[prefix+".redirect.status_code"] = strconv.Itoa(*item.Redirect.StatusCode)
+		}
+		if item.Redirect.SubpathMatching != nil {
+			attributes[prefix+".redirect.subpath_matching"] = strconv.FormatBool(*item.Redirect.SubpathMatching)
+		}
+	}
+}
+
+func listAttributes(ctx context.Context, api *cf.API, account *cf.ResourceContainer, list cf.List) (map[string]string, error) {
+	attributes := map[string]string{"account_id": account.Identifier}
+	items, err := api.ListListItems(ctx, account, cf.ListListItemsParams{ID: list.ID, PerPage: cloudflarePageSize})
+	if err != nil {
+		return nil, err
+	}
+	if len(items) == 0 {
+		return attributes, nil
+	}
+	attributes["items.#"] = strconv.Itoa(len(items))
+	for index, item := range items {
+		addListItemAttributes(attributes, index, item)
+	}
+	return attributes, nil
 }
 
 func (g *ListsGenerator) InitResources() error {
@@ -28,12 +81,16 @@ func (g *ListsGenerator) InitResources() error {
 		return err
 	}
 	for _, list := range lists {
+		attributes, err := listAttributes(ctx, api, account, list)
+		if err != nil {
+			return err
+		}
 		g.Resources = append(g.Resources, terraformutils.NewResource(
 			list.ID,
 			cloudflareResourceName(account.Identifier, list.Name, list.ID),
 			"cloudflare_list",
 			"cloudflare",
-			map[string]string{"account_id": account.Identifier},
+			attributes,
 			[]string{},
 			map[string]interface{}{},
 		))

--- a/providers/cloudflare/lists.go
+++ b/providers/cloudflare/lists.go
@@ -101,6 +101,32 @@ func listAttributes(ctx context.Context, api *cf.API, account *cf.ResourceContai
 	return attributes, nil
 }
 
+func listAllLists(ctx context.Context, api *cf.API, account *cf.ResourceContainer) ([]cf.List, error) {
+	lists := []cf.List{}
+	page, cursor := 1, ""
+	for {
+		response, err := api.Raw(
+			ctx,
+			http.MethodGet,
+			fmt.Sprintf("/accounts/%s/rules/lists?%s", account.Identifier, cloudflarePaginationQuery(page, cursor)),
+			nil,
+			nil,
+		)
+		if err != nil {
+			return nil, err
+		}
+		var pageLists []cf.List
+		if err := json.Unmarshal(response.Result, &pageLists); err != nil {
+			return nil, err
+		}
+		lists = append(lists, pageLists...)
+		if !cloudflareAdvancePagination(response.ResultInfo, &page, &cursor) {
+			break
+		}
+	}
+	return lists, nil
+}
+
 func (g *ListsGenerator) InitResources() error {
 	ctx := context.Background()
 	api, err := g.initializeAPI()
@@ -111,7 +137,7 @@ func (g *ListsGenerator) InitResources() error {
 	if err != nil {
 		return err
 	}
-	lists, err := api.ListLists(ctx, account, cf.ListListsParams{})
+	lists, err := listAllLists(ctx, api, account)
 	if err != nil {
 		return err
 	}

--- a/providers/cloudflare/lists.go
+++ b/providers/cloudflare/lists.go
@@ -4,7 +4,10 @@ package cloudflare
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
+	"net/http"
+	"net/url"
 	"strconv"
 
 	"github.com/chenrui333/terraformer/terraformutils"
@@ -50,9 +53,41 @@ func addListItemAttributes(attributes map[string]string, index int, item cf.List
 	}
 }
 
+func listAllListItems(ctx context.Context, api *cf.API, account *cf.ResourceContainer, listID string) ([]cf.ListItem, error) {
+	items := []cf.ListItem{}
+	cursor := ""
+	for {
+		values := url.Values{}
+		values.Set("per_page", strconv.Itoa(cloudflarePageSize))
+		if cursor != "" {
+			values.Set("cursor", cursor)
+		}
+		response, err := api.Raw(
+			ctx,
+			http.MethodGet,
+			fmt.Sprintf("/accounts/%s/rules/lists/%s/items?%s", account.Identifier, listID, values.Encode()),
+			nil,
+			nil,
+		)
+		if err != nil {
+			return nil, err
+		}
+		var pageItems []cf.ListItem
+		if err := json.Unmarshal(response.Result, &pageItems); err != nil {
+			return nil, err
+		}
+		items = append(items, pageItems...)
+		if response.ResultInfo == nil || response.ResultInfo.Cursors.After == "" {
+			break
+		}
+		cursor = response.ResultInfo.Cursors.After
+	}
+	return items, nil
+}
+
 func listAttributes(ctx context.Context, api *cf.API, account *cf.ResourceContainer, list cf.List) (map[string]string, error) {
 	attributes := map[string]string{"account_id": account.Identifier}
-	items, err := api.ListListItems(ctx, account, cf.ListListItemsParams{ID: list.ID, PerPage: cloudflarePageSize})
+	items, err := listAllListItems(ctx, api, account, list.ID)
 	if err != nil {
 		return nil, err
 	}

--- a/providers/cloudflare/lists.go
+++ b/providers/cloudflare/lists.go
@@ -1,0 +1,42 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package cloudflare
+
+import (
+	"context"
+
+	"github.com/chenrui333/terraformer/terraformutils"
+	cf "github.com/cloudflare/cloudflare-go"
+)
+
+type ListsGenerator struct {
+	CloudflareService
+}
+
+func (g *ListsGenerator) InitResources() error {
+	ctx := context.Background()
+	api, err := g.initializeAPI()
+	if err != nil {
+		return err
+	}
+	account, err := g.accountResourceContainer()
+	if err != nil {
+		return err
+	}
+	lists, err := api.ListLists(ctx, account, cf.ListListsParams{})
+	if err != nil {
+		return err
+	}
+	for _, list := range lists {
+		g.Resources = append(g.Resources, terraformutils.NewResource(
+			list.ID,
+			cloudflareResourceName(account.Identifier, list.Name, list.ID),
+			"cloudflare_list",
+			"cloudflare",
+			map[string]string{"account_id": account.Identifier},
+			[]string{},
+			map[string]interface{}{},
+		))
+	}
+	return nil
+}

--- a/providers/cloudflare/load_balancing.go
+++ b/providers/cloudflare/load_balancing.go
@@ -5,6 +5,7 @@ package cloudflare
 import (
 	"context"
 	"fmt"
+	"strconv"
 
 	"github.com/chenrui333/terraformer/terraformutils"
 	cf "github.com/cloudflare/cloudflare-go"
@@ -12,6 +13,224 @@ import (
 
 type LoadBalancingGenerator struct {
 	CloudflareService
+}
+
+func addStringAttribute(attributes map[string]string, key, value string) {
+	if value != "" {
+		attributes[key] = value
+	}
+}
+
+func addStringListAttributes(attributes map[string]string, key string, values []string) {
+	if len(values) == 0 {
+		return
+	}
+	attributes[key+".#"] = strconv.Itoa(len(values))
+	for index, value := range values {
+		attributes[fmt.Sprintf("%s.%d", key, index)] = value
+	}
+}
+
+func addPrimitiveMapAttributes[T ~float64](attributes map[string]string, key string, values map[string]T) {
+	if len(values) == 0 {
+		return
+	}
+	attributes[key+".%"] = strconv.Itoa(len(values))
+	for mapKey, value := range values {
+		attributes[key+"."+mapKey] = strconv.FormatFloat(float64(value), 'f', -1, 64)
+	}
+}
+
+func addLoadBalancerRuleFixedResponseAttributes(attributes map[string]string, prefix string, response *cf.LoadBalancerFixedResponseData) {
+	if response == nil {
+		return
+	}
+	addStringAttribute(attributes, prefix+".content_type", response.ContentType)
+	addStringAttribute(attributes, prefix+".location", response.Location)
+	addStringAttribute(attributes, prefix+".message_body", response.MessageBody)
+	if response.StatusCode != 0 {
+		attributes[prefix+".status_code"] = strconv.Itoa(response.StatusCode)
+	}
+}
+
+func addLoadBalancerRuleOverrideAttributes(attributes map[string]string, prefix string, overrides cf.LoadBalancerRuleOverrides) {
+	if overrides.AdaptiveRouting != nil && overrides.AdaptiveRouting.FailoverAcrossPools != nil {
+		attributes[prefix+".adaptive_routing.failover_across_pools"] = strconv.FormatBool(*overrides.AdaptiveRouting.FailoverAcrossPools)
+	}
+	addStringAttribute(attributes, prefix+".fallback_pool", overrides.FallbackPool)
+	if overrides.LocationStrategy != nil {
+		addStringAttribute(attributes, prefix+".location_strategy.mode", overrides.LocationStrategy.Mode)
+		addStringAttribute(attributes, prefix+".location_strategy.prefer_ecs", overrides.LocationStrategy.PreferECS)
+	}
+	if overrides.RandomSteering != nil {
+		attributes[prefix+".random_steering.default_weight"] = strconv.FormatFloat(overrides.RandomSteering.DefaultWeight, 'f', -1, 64)
+		addPrimitiveMapAttributes(attributes, prefix+".random_steering.pool_weights", overrides.RandomSteering.PoolWeights)
+	}
+	addStringListAttributes(attributes, prefix+".default_pools", overrides.DefaultPools)
+	addStringAttribute(attributes, prefix+".session_affinity", overrides.Persistence)
+	if overrides.PersistenceTTL != nil {
+		attributes[prefix+".session_affinity_ttl"] = strconv.FormatUint(uint64(*overrides.PersistenceTTL), 10)
+	}
+	addLoadBalancerRuleSessionAffinityAttributes(attributes, prefix+".session_affinity_attributes", overrides.SessionAffinityAttrs)
+	addStringAttribute(attributes, prefix+".steering_policy", overrides.SteeringPolicy)
+	if overrides.TTL != 0 {
+		attributes[prefix+".ttl"] = strconv.FormatUint(uint64(overrides.TTL), 10)
+	}
+}
+
+func addLoadBalancerRuleSessionAffinityAttributes(
+	attributes map[string]string,
+	prefix string,
+	sessionAffinity *cf.LoadBalancerRuleOverridesSessionAffinityAttrs,
+) {
+	if sessionAffinity == nil {
+		return
+	}
+	addStringListAttributes(attributes, prefix+".headers", sessionAffinity.Headers)
+	if sessionAffinity.RequireAllHeaders != nil {
+		attributes[prefix+".require_all_headers"] = strconv.FormatBool(*sessionAffinity.RequireAllHeaders)
+	}
+	addStringAttribute(attributes, prefix+".samesite", sessionAffinity.SameSite)
+	addStringAttribute(attributes, prefix+".secure", sessionAffinity.Secure)
+	addStringAttribute(attributes, prefix+".zero_downtime_failover", sessionAffinity.ZeroDowntimeFailover)
+}
+
+func addLoadBalancerRulesAttributes(attributes map[string]string, rules []*cf.LoadBalancerRule) {
+	if len(rules) == 0 {
+		return
+	}
+	attributes["rules.#"] = strconv.Itoa(len(rules))
+	for index, rule := range rules {
+		prefix := fmt.Sprintf("rules.%d", index)
+		addStringAttribute(attributes, prefix+".condition", rule.Condition)
+		attributes[prefix+".disabled"] = strconv.FormatBool(rule.Disabled)
+		addLoadBalancerRuleFixedResponseAttributes(attributes, prefix+".fixed_response", rule.FixedResponse)
+		addStringAttribute(attributes, prefix+".name", rule.Name)
+		addLoadBalancerRuleOverrideAttributes(attributes, prefix+".overrides", rule.Overrides)
+		attributes[prefix+".priority"] = strconv.Itoa(rule.Priority)
+		attributes[prefix+".terminates"] = strconv.FormatBool(rule.Terminates)
+	}
+}
+
+func loadBalancerRuleAdditionalFields(rules []*cf.LoadBalancerRule) []map[string]interface{} {
+	fields := make([]map[string]interface{}, 0, len(rules))
+	for _, rule := range rules {
+		field := map[string]interface{}{
+			"condition":  rule.Condition,
+			"disabled":   rule.Disabled,
+			"name":       rule.Name,
+			"priority":   rule.Priority,
+			"terminates": rule.Terminates,
+		}
+		if rule.FixedResponse != nil {
+			field["fixed_response"] = loadBalancerFixedResponseAdditionalFields(rule.FixedResponse)
+		}
+		if overrides := loadBalancerOverrideAdditionalFields(rule.Overrides); len(overrides) > 0 {
+			field["overrides"] = overrides
+		}
+		fields = append(fields, field)
+	}
+	return fields
+}
+
+func loadBalancerFixedResponseAdditionalFields(response *cf.LoadBalancerFixedResponseData) map[string]interface{} {
+	fields := map[string]interface{}{}
+	if response.ContentType != "" {
+		fields["content_type"] = response.ContentType
+	}
+	if response.Location != "" {
+		fields["location"] = response.Location
+	}
+	if response.MessageBody != "" {
+		fields["message_body"] = response.MessageBody
+	}
+	if response.StatusCode != 0 {
+		fields["status_code"] = response.StatusCode
+	}
+	return fields
+}
+
+func loadBalancerOverrideAdditionalFields(overrides cf.LoadBalancerRuleOverrides) map[string]interface{} {
+	fields := map[string]interface{}{}
+	if overrides.AdaptiveRouting != nil && overrides.AdaptiveRouting.FailoverAcrossPools != nil {
+		fields["adaptive_routing"] = map[string]interface{}{"failover_across_pools": *overrides.AdaptiveRouting.FailoverAcrossPools}
+	}
+	if len(overrides.CountryPools) > 0 {
+		fields["country_pools"] = overrides.CountryPools
+	}
+	if len(overrides.DefaultPools) > 0 {
+		fields["default_pools"] = overrides.DefaultPools
+	}
+	if overrides.FallbackPool != "" {
+		fields["fallback_pool"] = overrides.FallbackPool
+	}
+	if overrides.LocationStrategy != nil {
+		fields["location_strategy"] = loadBalancerLocationStrategyAdditionalFields(overrides.LocationStrategy)
+	}
+	if len(overrides.PoPPools) > 0 {
+		fields["pop_pools"] = overrides.PoPPools
+	}
+	if overrides.RandomSteering != nil {
+		fields["random_steering"] = loadBalancerRandomSteeringAdditionalFields(overrides.RandomSteering)
+	}
+	if len(overrides.RegionPools) > 0 {
+		fields["region_pools"] = overrides.RegionPools
+	}
+	if overrides.Persistence != "" {
+		fields["session_affinity"] = overrides.Persistence
+	}
+	if overrides.SessionAffinityAttrs != nil {
+		fields["session_affinity_attributes"] = loadBalancerSessionAffinityAdditionalFields(overrides.SessionAffinityAttrs)
+	}
+	if overrides.PersistenceTTL != nil {
+		fields["session_affinity_ttl"] = *overrides.PersistenceTTL
+	}
+	if overrides.SteeringPolicy != "" {
+		fields["steering_policy"] = overrides.SteeringPolicy
+	}
+	if overrides.TTL != 0 {
+		fields["ttl"] = overrides.TTL
+	}
+	return fields
+}
+
+func loadBalancerLocationStrategyAdditionalFields(strategy *cf.LocationStrategy) map[string]interface{} {
+	fields := map[string]interface{}{}
+	if strategy.Mode != "" {
+		fields["mode"] = strategy.Mode
+	}
+	if strategy.PreferECS != "" {
+		fields["prefer_ecs"] = strategy.PreferECS
+	}
+	return fields
+}
+
+func loadBalancerRandomSteeringAdditionalFields(randomSteering *cf.RandomSteering) map[string]interface{} {
+	fields := map[string]interface{}{"default_weight": randomSteering.DefaultWeight}
+	if len(randomSteering.PoolWeights) > 0 {
+		fields["pool_weights"] = randomSteering.PoolWeights
+	}
+	return fields
+}
+
+func loadBalancerSessionAffinityAdditionalFields(sessionAffinity *cf.LoadBalancerRuleOverridesSessionAffinityAttrs) map[string]interface{} {
+	fields := map[string]interface{}{}
+	if len(sessionAffinity.Headers) > 0 {
+		fields["headers"] = sessionAffinity.Headers
+	}
+	if sessionAffinity.RequireAllHeaders != nil {
+		fields["require_all_headers"] = *sessionAffinity.RequireAllHeaders
+	}
+	if sessionAffinity.SameSite != "" {
+		fields["samesite"] = sessionAffinity.SameSite
+	}
+	if sessionAffinity.Secure != "" {
+		fields["secure"] = sessionAffinity.Secure
+	}
+	if sessionAffinity.ZeroDowntimeFailover != "" {
+		fields["zero_downtime_failover"] = sessionAffinity.ZeroDowntimeFailover
+	}
+	return fields
 }
 
 func (g *LoadBalancingGenerator) appendLoadBalancerResources(ctx context.Context, api *cf.API, zone cf.Zone) error {
@@ -22,14 +241,20 @@ func (g *LoadBalancingGenerator) appendLoadBalancerResources(ctx context.Context
 			return err
 		}
 		for _, loadBalancer := range loadBalancers {
+			attributes := map[string]string{"zone_id": zone.ID}
+			addLoadBalancerRulesAttributes(attributes, loadBalancer.Rules)
+			additionalFields := map[string]interface{}{}
+			if len(loadBalancer.Rules) > 0 {
+				additionalFields["rules"] = loadBalancerRuleAdditionalFields(loadBalancer.Rules)
+			}
 			g.Resources = append(g.Resources, terraformutils.NewResource(
 				loadBalancer.ID,
 				cloudflareResourceName(zone.Name, loadBalancer.Name, loadBalancer.ID),
 				"cloudflare_load_balancer",
 				"cloudflare",
-				map[string]string{"zone_id": zone.ID},
+				attributes,
 				[]string{},
-				map[string]interface{}{},
+				additionalFields,
 			))
 		}
 		if len(loadBalancers) < cloudflarePageSize {

--- a/providers/cloudflare/load_balancing.go
+++ b/providers/cloudflare/load_balancing.go
@@ -1,0 +1,143 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package cloudflare
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/chenrui333/terraformer/terraformutils"
+	cf "github.com/cloudflare/cloudflare-go"
+)
+
+type LoadBalancingGenerator struct {
+	CloudflareService
+}
+
+func (g *LoadBalancingGenerator) appendLoadBalancerResources(ctx context.Context, api *cf.API, zone cf.Zone) error {
+	params := cf.ListLoadBalancerParams{PaginationOptions: cf.PaginationOptions{Page: 1, PerPage: cloudflarePageSize}}
+	for {
+		loadBalancers, err := api.ListLoadBalancers(ctx, cf.ZoneIdentifier(zone.ID), params)
+		if err != nil {
+			return err
+		}
+		for _, loadBalancer := range loadBalancers {
+			g.Resources = append(g.Resources, terraformutils.NewResource(
+				loadBalancer.ID,
+				cloudflareResourceName(zone.Name, loadBalancer.Name, loadBalancer.ID),
+				"cloudflare_load_balancer",
+				"cloudflare",
+				map[string]string{"zone_id": zone.ID},
+				[]string{},
+				map[string]interface{}{},
+			))
+		}
+		if len(loadBalancers) < cloudflarePageSize {
+			break
+		}
+		params.Page++
+	}
+	return nil
+}
+
+func (g *LoadBalancingGenerator) appendHealthcheckResources(ctx context.Context, api *cf.API, zone cf.Zone) error {
+	healthchecks, err := api.Healthchecks(ctx, zone.ID)
+	if err != nil {
+		return err
+	}
+	for _, healthcheck := range healthchecks {
+		g.Resources = append(g.Resources, terraformutils.NewResource(
+			healthcheck.ID,
+			cloudflareResourceName(zone.Name, healthcheck.Name, healthcheck.ID),
+			"cloudflare_healthcheck",
+			"cloudflare",
+			map[string]string{"zone_id": zone.ID},
+			[]string{},
+			map[string]interface{}{},
+		))
+	}
+	return nil
+}
+
+func (g *LoadBalancingGenerator) appendLoadBalancerPoolResources(ctx context.Context, api *cf.API, accountID string) error {
+	params := cf.ListLoadBalancerPoolParams{PaginationOptions: cf.PaginationOptions{Page: 1, PerPage: cloudflarePageSize}}
+	for {
+		pools, err := api.ListLoadBalancerPools(ctx, cf.AccountIdentifier(accountID), params)
+		if err != nil {
+			return err
+		}
+		for _, pool := range pools {
+			g.Resources = append(g.Resources, terraformutils.NewResource(
+				pool.ID,
+				cloudflareResourceName(accountID, pool.Name, pool.ID),
+				"cloudflare_load_balancer_pool",
+				"cloudflare",
+				map[string]string{"account_id": accountID},
+				[]string{},
+				map[string]interface{}{},
+			))
+		}
+		if len(pools) < cloudflarePageSize {
+			break
+		}
+		params.Page++
+	}
+	return nil
+}
+
+func (g *LoadBalancingGenerator) appendLoadBalancerMonitorResources(ctx context.Context, api *cf.API, accountID string) error {
+	params := cf.ListLoadBalancerMonitorParams{PaginationOptions: cf.PaginationOptions{Page: 1, PerPage: cloudflarePageSize}}
+	for {
+		monitors, err := api.ListLoadBalancerMonitors(ctx, cf.AccountIdentifier(accountID), params)
+		if err != nil {
+			return err
+		}
+		for _, monitor := range monitors {
+			g.Resources = append(g.Resources, terraformutils.NewResource(
+				monitor.ID,
+				cloudflareResourceName(accountID, monitor.Description, monitor.ID),
+				"cloudflare_load_balancer_monitor",
+				"cloudflare",
+				map[string]string{"account_id": accountID},
+				[]string{},
+				map[string]interface{}{},
+			))
+		}
+		if len(monitors) < cloudflarePageSize {
+			break
+		}
+		params.Page++
+	}
+	return nil
+}
+
+func (g *LoadBalancingGenerator) InitResources() error {
+	ctx := context.Background()
+	api, err := g.initializeAPI()
+	if err != nil {
+		return err
+	}
+
+	if g.accountID() != "" {
+		if err := g.appendLoadBalancerPoolResources(ctx, api, g.accountID()); err != nil {
+			return err
+		}
+		if err := g.appendLoadBalancerMonitorResources(ctx, api, g.accountID()); err != nil {
+			return err
+		}
+	}
+
+	zones, err := cloudflareZones(ctx, api)
+	if err != nil {
+		return err
+	}
+	for _, zone := range zones {
+		if err := g.appendLoadBalancerResources(ctx, api, zone); err != nil {
+			return fmt.Errorf("zone %s load balancers: %w", zone.ID, err)
+		}
+		if err := g.appendHealthcheckResources(ctx, api, zone); err != nil {
+			return fmt.Errorf("zone %s healthchecks: %w", zone.ID, err)
+		}
+	}
+	return nil
+}

--- a/providers/cloudflare/load_balancing.go
+++ b/providers/cloudflare/load_balancing.go
@@ -362,12 +362,22 @@ func (g *LoadBalancingGenerator) appendLoadBalancerMonitorResources(ctx context.
 			return err
 		}
 		for _, monitor := range monitors {
+			attributes := map[string]string{"account_id": accountID}
+			if monitor.ConsecutiveUp != 0 {
+				attributes["consecutive_up"] = strconv.Itoa(monitor.ConsecutiveUp)
+			}
+			if monitor.ConsecutiveDown != 0 {
+				attributes["consecutive_down"] = strconv.Itoa(monitor.ConsecutiveDown)
+			}
+			if monitor.Port != 0 {
+				attributes["port"] = strconv.FormatUint(uint64(monitor.Port), 10)
+			}
 			g.Resources = append(g.Resources, terraformutils.NewResource(
 				monitor.ID,
 				cloudflareResourceName(accountID, monitor.Description, monitor.ID),
 				"cloudflare_load_balancer_monitor",
 				"cloudflare",
-				map[string]string{"account_id": accountID},
+				attributes,
 				[]string{},
 				map[string]interface{}{},
 			))

--- a/providers/cloudflare/load_balancing.go
+++ b/providers/cloudflare/load_balancing.go
@@ -257,6 +257,11 @@ func (g *LoadBalancingGenerator) appendLoadBalancerResources(ctx context.Context
 			return err
 		}
 		for _, loadBalancer := range loadBalancers {
+			loadBalancerDetails, err := api.GetLoadBalancer(ctx, cf.ZoneIdentifier(zone.ID), loadBalancer.ID)
+			if err != nil {
+				return fmt.Errorf("get load balancer %q in zone %q: %w", loadBalancer.ID, zone.ID, err)
+			}
+			loadBalancer = loadBalancerDetails
 			attributes := map[string]string{"zone_id": zone.ID}
 			addLoadBalancerRulesAttributes(attributes, loadBalancer.Rules)
 			additionalFields := map[string]interface{}{}

--- a/providers/cloudflare/load_balancing.go
+++ b/providers/cloudflare/load_balancing.go
@@ -41,6 +41,16 @@ func addPrimitiveMapAttributes[T ~float64](attributes map[string]string, key str
 	}
 }
 
+func addStringListMapAttributes(attributes map[string]string, key string, values map[string][]string) {
+	if len(values) == 0 {
+		return
+	}
+	attributes[key+".%"] = strconv.Itoa(len(values))
+	for mapKey, list := range values {
+		addStringListAttributes(attributes, key+"."+mapKey, list)
+	}
+}
+
 func addLoadBalancerRuleFixedResponseAttributes(attributes map[string]string, prefix string, response *cf.LoadBalancerFixedResponseData) {
 	if response == nil {
 		return
@@ -66,7 +76,10 @@ func addLoadBalancerRuleOverrideAttributes(attributes map[string]string, prefix 
 		attributes[prefix+".random_steering.default_weight"] = strconv.FormatFloat(overrides.RandomSteering.DefaultWeight, 'f', -1, 64)
 		addPrimitiveMapAttributes(attributes, prefix+".random_steering.pool_weights", overrides.RandomSteering.PoolWeights)
 	}
+	addStringListMapAttributes(attributes, prefix+".country_pools", overrides.CountryPools)
 	addStringListAttributes(attributes, prefix+".default_pools", overrides.DefaultPools)
+	addStringListMapAttributes(attributes, prefix+".pop_pools", overrides.PoPPools)
+	addStringListMapAttributes(attributes, prefix+".region_pools", overrides.RegionPools)
 	addStringAttribute(attributes, prefix+".session_affinity", overrides.Persistence)
 	if overrides.PersistenceTTL != nil {
 		attributes[prefix+".session_affinity_ttl"] = strconv.FormatUint(uint64(*overrides.PersistenceTTL), 10)

--- a/providers/cloudflare/load_balancing.go
+++ b/providers/cloudflare/load_balancing.go
@@ -4,7 +4,10 @@ package cloudflare
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
+	"net/http"
+	"net/url"
 	"strconv"
 
 	"github.com/chenrui333/terraformer/terraformutils"
@@ -278,8 +281,36 @@ func (g *LoadBalancingGenerator) appendLoadBalancerResources(ctx context.Context
 	return nil
 }
 
+func listHealthchecks(ctx context.Context, api *cf.API, zoneID string) ([]cf.Healthcheck, error) {
+	healthchecks := []cf.Healthcheck{}
+	for page := 1; ; page++ {
+		values := url.Values{}
+		values.Set("page", strconv.Itoa(page))
+		values.Set("per_page", strconv.Itoa(cloudflarePageSize))
+		response, err := api.Raw(
+			ctx,
+			http.MethodGet,
+			fmt.Sprintf("/zones/%s/healthchecks?%s", zoneID, values.Encode()),
+			nil,
+			nil,
+		)
+		if err != nil {
+			return nil, err
+		}
+		var pageHealthchecks []cf.Healthcheck
+		if err := json.Unmarshal(response.Result, &pageHealthchecks); err != nil {
+			return nil, err
+		}
+		healthchecks = append(healthchecks, pageHealthchecks...)
+		if response.ResultInfo == nil || !response.ResultInfo.HasMorePages() {
+			break
+		}
+	}
+	return healthchecks, nil
+}
+
 func (g *LoadBalancingGenerator) appendHealthcheckResources(ctx context.Context, api *cf.API, zone cf.Zone) error {
-	healthchecks, err := api.Healthchecks(ctx, zone.ID)
+	healthchecks, err := listHealthchecks(ctx, api, zone.ID)
 	if err != nil {
 		return err
 	}

--- a/providers/cloudflare/logpush.go
+++ b/providers/cloudflare/logpush.go
@@ -4,6 +4,9 @@ package cloudflare
 
 import (
 	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
 	"strconv"
 
 	"github.com/chenrui333/terraformer/terraformutils"
@@ -15,7 +18,7 @@ type LogpushGenerator struct {
 }
 
 func (g *LogpushGenerator) appendLogpushJobResources(ctx context.Context, api *cf.API, rc *cf.ResourceContainer, scopeType string) error {
-	jobs, err := api.ListLogpushJobs(ctx, rc, cf.ListLogpushJobsParams{})
+	jobs, err := listLogpushJobs(ctx, api, rc)
 	if err != nil {
 		return err
 	}
@@ -32,6 +35,32 @@ func (g *LogpushGenerator) appendLogpushJobResources(ctx context.Context, api *c
 		))
 	}
 	return nil
+}
+
+func listLogpushJobs(ctx context.Context, api *cf.API, rc *cf.ResourceContainer) ([]cf.LogpushJob, error) {
+	var jobs []cf.LogpushJob
+	page, cursor := 1, ""
+	for {
+		response, err := api.Raw(
+			ctx,
+			http.MethodGet,
+			fmt.Sprintf("/%s/%s/logpush/jobs?%s", rc.Level, rc.Identifier, cloudflarePaginationQuery(page, cursor)),
+			nil,
+			nil,
+		)
+		if err != nil {
+			return nil, err
+		}
+		var pageJobs []cf.LogpushJob
+		if err := json.Unmarshal(response.Result, &pageJobs); err != nil {
+			return nil, err
+		}
+		jobs = append(jobs, pageJobs...)
+		if !cloudflareAdvancePagination(response.ResultInfo, &page, &cursor) {
+			break
+		}
+	}
+	return jobs, nil
 }
 
 func (g *LogpushGenerator) InitResources() error {

--- a/providers/cloudflare/logpush.go
+++ b/providers/cloudflare/logpush.go
@@ -1,0 +1,58 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package cloudflare
+
+import (
+	"context"
+	"strconv"
+
+	"github.com/chenrui333/terraformer/terraformutils"
+	cf "github.com/cloudflare/cloudflare-go"
+)
+
+type LogpushGenerator struct {
+	CloudflareService
+}
+
+func (g *LogpushGenerator) appendLogpushJobResources(ctx context.Context, api *cf.API, rc *cf.ResourceContainer, scopeType string) error {
+	jobs, err := api.ListLogpushJobs(ctx, rc, cf.ListLogpushJobsParams{})
+	if err != nil {
+		return err
+	}
+	for _, job := range jobs {
+		jobID := strconv.Itoa(job.ID)
+		g.Resources = append(g.Resources, terraformutils.NewResource(
+			jobID,
+			cloudflareResourceName(scopeType, rc.Identifier, job.Name, jobID),
+			"cloudflare_logpush_job",
+			"cloudflare",
+			accessScopeAttributes(scopeType, rc.Identifier),
+			[]string{},
+			map[string]interface{}{},
+		))
+	}
+	return nil
+}
+
+func (g *LogpushGenerator) InitResources() error {
+	ctx := context.Background()
+	api, err := g.initializeAPI()
+	if err != nil {
+		return err
+	}
+	if g.accountID() != "" {
+		if err := g.appendLogpushJobResources(ctx, api, cf.AccountIdentifier(g.accountID()), "accounts"); err != nil {
+			return err
+		}
+	}
+	zones, err := cloudflareZones(ctx, api)
+	if err != nil {
+		return err
+	}
+	for _, zone := range zones {
+		if err := g.appendLogpushJobResources(ctx, api, cf.ZoneIdentifier(zone.ID), "zones"); err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/providers/cloudflare/magic_wan.go
+++ b/providers/cloudflare/magic_wan.go
@@ -20,14 +20,13 @@ func magicWANGRETunnelAttributes(accountID string, tunnel cf.MagicTransitGRETunn
 		return nil, false
 	}
 	attributes := map[string]string{
-		"account_id":               accountID,
-		"cloudflare_gre_endpoint":  tunnel.CloudflareGREEndpoint,
-		"customer_gre_endpoint":    tunnel.CustomerGREEndpoint,
-		"interface_address":        tunnel.InterfaceAddress,
-		"name":                     tunnel.Name,
-		"mtu":                      strconv.FormatUint(uint64(tunnel.MTU), 10),
-		"ttl":                      strconv.FormatUint(uint64(tunnel.TTL), 10),
-		"automatic_return_routing": "false",
+		"account_id":              accountID,
+		"cloudflare_gre_endpoint": tunnel.CloudflareGREEndpoint,
+		"customer_gre_endpoint":   tunnel.CustomerGREEndpoint,
+		"interface_address":       tunnel.InterfaceAddress,
+		"name":                    tunnel.Name,
+		"mtu":                     strconv.FormatUint(uint64(tunnel.MTU), 10),
+		"ttl":                     strconv.FormatUint(uint64(tunnel.TTL), 10),
 	}
 	addStringAttribute(attributes, "description", tunnel.Description)
 	if tunnel.HealthCheck != nil {
@@ -43,12 +42,11 @@ func magicWANIPsecTunnelAttributes(accountID string, tunnel cf.MagicTransitIPsec
 		return nil, false
 	}
 	attributes := map[string]string{
-		"account_id":               accountID,
-		"cloudflare_endpoint":      tunnel.CloudflareEndpoint,
-		"interface_address":        tunnel.InterfaceAddress,
-		"name":                     tunnel.Name,
-		"allow_null_cipher":        strconv.FormatBool(tunnel.AllowNullCipher),
-		"automatic_return_routing": "false",
+		"account_id":          accountID,
+		"cloudflare_endpoint": tunnel.CloudflareEndpoint,
+		"interface_address":   tunnel.InterfaceAddress,
+		"name":                tunnel.Name,
+		"allow_null_cipher":   strconv.FormatBool(tunnel.AllowNullCipher),
 	}
 	addStringAttribute(attributes, "customer_endpoint", tunnel.CustomerEndpoint)
 	addStringAttribute(attributes, "description", tunnel.Description)

--- a/providers/cloudflare/magic_wan.go
+++ b/providers/cloudflare/magic_wan.go
@@ -151,7 +151,7 @@ func (g *MagicWANGenerator) InitResources() error {
 		}
 		g.Resources = append(g.Resources, terraformutils.NewResource(
 			route.ID,
-			cloudflareResourceName(accountID, route.Prefix, route.ID),
+			cloudflareResourceName(accountID, route.ID),
 			"cloudflare_magic_wan_static_route",
 			"cloudflare",
 			attributes,

--- a/providers/cloudflare/magic_wan.go
+++ b/providers/cloudflare/magic_wan.go
@@ -1,0 +1,75 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package cloudflare
+
+import (
+	"context"
+
+	"github.com/chenrui333/terraformer/terraformutils"
+)
+
+type MagicWANGenerator struct {
+	CloudflareService
+}
+
+func (g *MagicWANGenerator) InitResources() error {
+	ctx := context.Background()
+	api, err := g.initializeAPI()
+	if err != nil {
+		return err
+	}
+	account, err := g.accountResourceContainer()
+	if err != nil {
+		return err
+	}
+	accountID := account.Identifier
+
+	greTunnels, err := api.ListMagicTransitGRETunnels(ctx, accountID)
+	if err != nil {
+		return err
+	}
+	for _, tunnel := range greTunnels {
+		g.Resources = append(g.Resources, terraformutils.NewResource(
+			tunnel.ID,
+			cloudflareResourceName(accountID, tunnel.Name, tunnel.ID),
+			"cloudflare_magic_wan_gre_tunnel",
+			"cloudflare",
+			map[string]string{"account_id": accountID},
+			[]string{},
+			map[string]interface{}{},
+		))
+	}
+
+	ipsecTunnels, err := api.ListMagicTransitIPsecTunnels(ctx, accountID)
+	if err != nil {
+		return err
+	}
+	for _, tunnel := range ipsecTunnels {
+		g.Resources = append(g.Resources, terraformutils.NewResource(
+			tunnel.ID,
+			cloudflareResourceName(accountID, tunnel.Name, tunnel.ID),
+			"cloudflare_magic_wan_ipsec_tunnel",
+			"cloudflare",
+			map[string]string{"account_id": accountID},
+			[]string{},
+			map[string]interface{}{},
+		))
+	}
+
+	staticRoutes, err := api.ListMagicTransitStaticRoutes(ctx, accountID)
+	if err != nil {
+		return err
+	}
+	for _, route := range staticRoutes {
+		g.Resources = append(g.Resources, terraformutils.NewResource(
+			route.ID,
+			cloudflareResourceName(accountID, route.Prefix, route.ID),
+			"cloudflare_magic_wan_static_route",
+			"cloudflare",
+			map[string]string{"account_id": accountID},
+			[]string{},
+			map[string]interface{}{},
+		))
+	}
+	return nil
+}

--- a/providers/cloudflare/magic_wan.go
+++ b/providers/cloudflare/magic_wan.go
@@ -4,12 +4,90 @@ package cloudflare
 
 import (
 	"context"
+	"strconv"
 
 	"github.com/chenrui333/terraformer/terraformutils"
+	cf "github.com/cloudflare/cloudflare-go"
 )
 
 type MagicWANGenerator struct {
 	CloudflareService
+}
+
+func magicWANGRETunnelAttributes(accountID string, tunnel cf.MagicTransitGRETunnel) (map[string]string, bool) {
+	if tunnel.Name == "" || tunnel.CloudflareGREEndpoint == "" ||
+		tunnel.CustomerGREEndpoint == "" || tunnel.InterfaceAddress == "" {
+		return nil, false
+	}
+	attributes := map[string]string{
+		"account_id":               accountID,
+		"cloudflare_gre_endpoint":  tunnel.CloudflareGREEndpoint,
+		"customer_gre_endpoint":    tunnel.CustomerGREEndpoint,
+		"interface_address":        tunnel.InterfaceAddress,
+		"name":                     tunnel.Name,
+		"mtu":                      strconv.FormatUint(uint64(tunnel.MTU), 10),
+		"ttl":                      strconv.FormatUint(uint64(tunnel.TTL), 10),
+		"automatic_return_routing": "false",
+	}
+	addStringAttribute(attributes, "description", tunnel.Description)
+	if tunnel.HealthCheck != nil {
+		attributes["health_check.enabled"] = strconv.FormatBool(tunnel.HealthCheck.Enabled)
+		addStringAttribute(attributes, "health_check.target.saved", tunnel.HealthCheck.Target)
+		addStringAttribute(attributes, "health_check.type", tunnel.HealthCheck.Type)
+	}
+	return attributes, true
+}
+
+func magicWANIPsecTunnelAttributes(accountID string, tunnel cf.MagicTransitIPsecTunnel) (map[string]string, bool) {
+	if tunnel.Name == "" || tunnel.CloudflareEndpoint == "" || tunnel.InterfaceAddress == "" {
+		return nil, false
+	}
+	attributes := map[string]string{
+		"account_id":               accountID,
+		"cloudflare_endpoint":      tunnel.CloudflareEndpoint,
+		"interface_address":        tunnel.InterfaceAddress,
+		"name":                     tunnel.Name,
+		"allow_null_cipher":        strconv.FormatBool(tunnel.AllowNullCipher),
+		"automatic_return_routing": "false",
+	}
+	addStringAttribute(attributes, "customer_endpoint", tunnel.CustomerEndpoint)
+	addStringAttribute(attributes, "description", tunnel.Description)
+	addStringAttribute(attributes, "psk", tunnel.Psk)
+	if tunnel.ReplayProtection != nil {
+		attributes["replay_protection"] = strconv.FormatBool(*tunnel.ReplayProtection)
+	} else {
+		attributes["replay_protection"] = "false"
+	}
+	if tunnel.RemoteIdentities != nil {
+		addStringAttribute(attributes, "custom_remote_identities.fqdn_id", tunnel.RemoteIdentities.FQDNID)
+	}
+	if tunnel.HealthCheck != nil {
+		attributes["health_check.enabled"] = strconv.FormatBool(tunnel.HealthCheck.Enabled)
+		addStringAttribute(attributes, "health_check.direction", tunnel.HealthCheck.Direction)
+		addStringAttribute(attributes, "health_check.rate", tunnel.HealthCheck.Rate)
+		addStringAttribute(attributes, "health_check.target.saved", tunnel.HealthCheck.Target)
+		addStringAttribute(attributes, "health_check.type", tunnel.HealthCheck.Type)
+	}
+	return attributes, true
+}
+
+func magicWANStaticRouteAttributes(accountID string, route cf.MagicTransitStaticRoute) (map[string]string, bool) {
+	if route.Nexthop == "" || route.Prefix == "" {
+		return nil, false
+	}
+	attributes := map[string]string{
+		"account_id": accountID,
+		"nexthop":    route.Nexthop,
+		"prefix":     route.Prefix,
+		"priority":   strconv.Itoa(route.Priority),
+	}
+	addStringAttribute(attributes, "description", route.Description)
+	if route.Weight != 0 {
+		attributes["weight"] = strconv.Itoa(route.Weight)
+	}
+	addStringListAttributes(attributes, "scope.colo_names", route.Scope.ColoNames)
+	addStringListAttributes(attributes, "scope.colo_regions", route.Scope.ColoRegions)
+	return attributes, true
 }
 
 func (g *MagicWANGenerator) InitResources() error {
@@ -29,12 +107,16 @@ func (g *MagicWANGenerator) InitResources() error {
 		return err
 	}
 	for _, tunnel := range greTunnels {
+		attributes, ok := magicWANGRETunnelAttributes(accountID, tunnel)
+		if !ok {
+			continue
+		}
 		g.Resources = append(g.Resources, terraformutils.NewResource(
 			tunnel.ID,
 			cloudflareResourceName(accountID, tunnel.Name, tunnel.ID),
 			"cloudflare_magic_wan_gre_tunnel",
 			"cloudflare",
-			map[string]string{"account_id": accountID},
+			attributes,
 			[]string{},
 			map[string]interface{}{},
 		))
@@ -45,12 +127,16 @@ func (g *MagicWANGenerator) InitResources() error {
 		return err
 	}
 	for _, tunnel := range ipsecTunnels {
+		attributes, ok := magicWANIPsecTunnelAttributes(accountID, tunnel)
+		if !ok {
+			continue
+		}
 		g.Resources = append(g.Resources, terraformutils.NewResource(
 			tunnel.ID,
 			cloudflareResourceName(accountID, tunnel.Name, tunnel.ID),
 			"cloudflare_magic_wan_ipsec_tunnel",
 			"cloudflare",
-			map[string]string{"account_id": accountID},
+			attributes,
 			[]string{},
 			map[string]interface{}{},
 		))
@@ -61,12 +147,16 @@ func (g *MagicWANGenerator) InitResources() error {
 		return err
 	}
 	for _, route := range staticRoutes {
+		attributes, ok := magicWANStaticRouteAttributes(accountID, route)
+		if !ok {
+			continue
+		}
 		g.Resources = append(g.Resources, terraformutils.NewResource(
 			route.ID,
 			cloudflareResourceName(accountID, route.Prefix, route.ID),
 			"cloudflare_magic_wan_static_route",
 			"cloudflare",
-			map[string]string{"account_id": accountID},
+			attributes,
 			[]string{},
 			map[string]interface{}{},
 		))

--- a/providers/cloudflare/notifications.go
+++ b/providers/cloudflare/notifications.go
@@ -1,0 +1,59 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package cloudflare
+
+import (
+	"context"
+
+	"github.com/chenrui333/terraformer/terraformutils"
+)
+
+type NotificationsGenerator struct {
+	CloudflareService
+}
+
+func (g *NotificationsGenerator) InitResources() error {
+	ctx := context.Background()
+	api, err := g.initializeAPI()
+	if err != nil {
+		return err
+	}
+	account, err := g.accountResourceContainer()
+	if err != nil {
+		return err
+	}
+	accountID := account.Identifier
+
+	policies, err := api.ListNotificationPolicies(ctx, accountID)
+	if err != nil {
+		return err
+	}
+	for _, policy := range policies.Result {
+		g.Resources = append(g.Resources, terraformutils.NewResource(
+			policy.ID,
+			cloudflareResourceName(accountID, policy.Name, policy.ID),
+			"cloudflare_notification_policy",
+			"cloudflare",
+			map[string]string{"account_id": accountID},
+			[]string{},
+			map[string]interface{}{},
+		))
+	}
+
+	webhooks, err := api.ListNotificationWebhooks(ctx, accountID)
+	if err != nil {
+		return err
+	}
+	for _, webhook := range webhooks.Result {
+		g.Resources = append(g.Resources, terraformutils.NewResource(
+			webhook.ID,
+			cloudflareResourceName(accountID, webhook.Name, webhook.ID),
+			"cloudflare_notification_policy_webhooks",
+			"cloudflare",
+			map[string]string{"account_id": accountID},
+			[]string{},
+			map[string]interface{}{},
+		))
+	}
+	return nil
+}

--- a/providers/cloudflare/notifications.go
+++ b/providers/cloudflare/notifications.go
@@ -9,6 +9,7 @@ import (
 	"net/http"
 	"net/url"
 	"strconv"
+	"time"
 
 	"github.com/chenrui333/terraformer/terraformutils"
 	cf "github.com/cloudflare/cloudflare-go"
@@ -75,7 +76,9 @@ func listNotificationWebhooks(ctx context.Context, api *cf.API, accountID string
 }
 
 func (g *NotificationsGenerator) InitResources() error {
-	ctx := context.Background()
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
+	defer cancel()
+
 	api, err := g.initializeAPI()
 	if err != nil {
 		return err

--- a/providers/cloudflare/notifications.go
+++ b/providers/cloudflare/notifications.go
@@ -4,12 +4,74 @@ package cloudflare
 
 import (
 	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/url"
+	"strconv"
 
 	"github.com/chenrui333/terraformer/terraformutils"
+	cf "github.com/cloudflare/cloudflare-go"
 )
 
 type NotificationsGenerator struct {
 	CloudflareService
+}
+
+func listNotificationPolicies(ctx context.Context, api *cf.API, accountID string) ([]cf.NotificationPolicy, error) {
+	policies := []cf.NotificationPolicy{}
+	for page := 1; ; page++ {
+		values := url.Values{}
+		values.Set("page", strconv.Itoa(page))
+		values.Set("per_page", strconv.Itoa(cloudflarePageSize))
+		response, err := api.Raw(
+			ctx,
+			http.MethodGet,
+			fmt.Sprintf("/accounts/%s/alerting/v3/policies?%s", accountID, values.Encode()),
+			nil,
+			nil,
+		)
+		if err != nil {
+			return nil, err
+		}
+		var pagePolicies []cf.NotificationPolicy
+		if err := json.Unmarshal(response.Result, &pagePolicies); err != nil {
+			return nil, err
+		}
+		policies = append(policies, pagePolicies...)
+		if response.ResultInfo == nil || !response.ResultInfo.HasMorePages() {
+			break
+		}
+	}
+	return policies, nil
+}
+
+func listNotificationWebhooks(ctx context.Context, api *cf.API, accountID string) ([]cf.NotificationWebhookIntegration, error) {
+	webhooks := []cf.NotificationWebhookIntegration{}
+	for page := 1; ; page++ {
+		values := url.Values{}
+		values.Set("page", strconv.Itoa(page))
+		values.Set("per_page", strconv.Itoa(cloudflarePageSize))
+		response, err := api.Raw(
+			ctx,
+			http.MethodGet,
+			fmt.Sprintf("/accounts/%s/alerting/v3/destinations/webhooks?%s", accountID, values.Encode()),
+			nil,
+			nil,
+		)
+		if err != nil {
+			return nil, err
+		}
+		var pageWebhooks []cf.NotificationWebhookIntegration
+		if err := json.Unmarshal(response.Result, &pageWebhooks); err != nil {
+			return nil, err
+		}
+		webhooks = append(webhooks, pageWebhooks...)
+		if response.ResultInfo == nil || !response.ResultInfo.HasMorePages() {
+			break
+		}
+	}
+	return webhooks, nil
 }
 
 func (g *NotificationsGenerator) InitResources() error {
@@ -24,11 +86,11 @@ func (g *NotificationsGenerator) InitResources() error {
 	}
 	accountID := account.Identifier
 
-	policies, err := api.ListNotificationPolicies(ctx, accountID)
+	policies, err := listNotificationPolicies(ctx, api, accountID)
 	if err != nil {
 		return err
 	}
-	for _, policy := range policies.Result {
+	for _, policy := range policies {
 		g.Resources = append(g.Resources, terraformutils.NewResource(
 			policy.ID,
 			cloudflareResourceName(accountID, policy.Name, policy.ID),
@@ -40,11 +102,11 @@ func (g *NotificationsGenerator) InitResources() error {
 		))
 	}
 
-	webhooks, err := api.ListNotificationWebhooks(ctx, accountID)
+	webhooks, err := listNotificationWebhooks(ctx, api, accountID)
 	if err != nil {
 		return err
 	}
-	for _, webhook := range webhooks.Result {
+	for _, webhook := range webhooks {
 		g.Resources = append(g.Resources, terraformutils.NewResource(
 			webhook.ID,
 			cloudflareResourceName(accountID, webhook.Name, webhook.ID),

--- a/providers/cloudflare/pages.go
+++ b/providers/cloudflare/pages.go
@@ -1,0 +1,67 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package cloudflare
+
+import (
+	"context"
+
+	"github.com/chenrui333/terraformer/terraformutils"
+	cf "github.com/cloudflare/cloudflare-go"
+)
+
+type PagesGenerator struct {
+	CloudflareService
+}
+
+func (g *PagesGenerator) InitResources() error {
+	ctx := context.Background()
+	api, err := g.initializeAPI()
+	if err != nil {
+		return err
+	}
+	account, err := g.accountResourceContainer()
+	if err != nil {
+		return err
+	}
+	accountID := account.Identifier
+
+	params := cf.ListPagesProjectsParams{PaginationOptions: cf.PaginationOptions{Page: 1, PerPage: cloudflarePageSize}}
+	for {
+		projects, info, err := api.ListPagesProjects(ctx, account, params)
+		if err != nil {
+			return err
+		}
+		for _, project := range projects {
+			g.Resources = append(g.Resources, terraformutils.NewResource(
+				project.Name,
+				cloudflareResourceName(accountID, project.Name),
+				"cloudflare_pages_project",
+				"cloudflare",
+				map[string]string{"account_id": accountID, "name": project.Name},
+				[]string{},
+				map[string]interface{}{},
+			))
+
+			domains, err := api.GetPagesDomains(ctx, cf.PagesDomainsParameters{AccountID: accountID, ProjectName: project.Name})
+			if err != nil {
+				return err
+			}
+			for _, domain := range domains {
+				g.Resources = append(g.Resources, terraformutils.NewResource(
+					domain.Name,
+					cloudflareResourceName(accountID, project.Name, domain.Name),
+					"cloudflare_pages_domain",
+					"cloudflare",
+					map[string]string{"account_id": accountID, "project_name": project.Name, "name": domain.Name},
+					[]string{},
+					map[string]interface{}{},
+				))
+			}
+		}
+		if !info.HasMorePages() {
+			break
+		}
+		params.Page++
+	}
+	return nil
+}

--- a/providers/cloudflare/pages.go
+++ b/providers/cloudflare/pages.go
@@ -4,6 +4,9 @@ package cloudflare
 
 import (
 	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
 
 	"github.com/chenrui333/terraformer/terraformutils"
 	cf "github.com/cloudflare/cloudflare-go"
@@ -44,7 +47,7 @@ func (g *PagesGenerator) InitResources() error {
 			setCloudflareImportID(&projectResource, accountID+"/"+project.Name)
 			g.Resources = append(g.Resources, projectResource)
 
-			domains, err := api.GetPagesDomains(ctx, cf.PagesDomainsParameters{AccountID: accountID, ProjectName: project.Name})
+			domains, err := listPagesDomains(ctx, api, accountID, project.Name)
 			if err != nil {
 				return err
 			}
@@ -68,4 +71,30 @@ func (g *PagesGenerator) InitResources() error {
 		params.Page++
 	}
 	return nil
+}
+
+func listPagesDomains(ctx context.Context, api *cf.API, accountID, projectName string) ([]cf.PagesDomain, error) {
+	var domains []cf.PagesDomain
+	page, cursor := 1, ""
+	for {
+		response, err := api.Raw(
+			ctx,
+			http.MethodGet,
+			fmt.Sprintf("/accounts/%s/pages/projects/%s/domains?%s", accountID, projectName, cloudflarePaginationQuery(page, cursor)),
+			nil,
+			nil,
+		)
+		if err != nil {
+			return nil, err
+		}
+		var pageDomains []cf.PagesDomain
+		if err := json.Unmarshal(response.Result, &pageDomains); err != nil {
+			return nil, err
+		}
+		domains = append(domains, pageDomains...)
+		if !cloudflareAdvancePagination(response.ResultInfo, &page, &cursor) {
+			break
+		}
+	}
+	return domains, nil
 }

--- a/providers/cloudflare/pages.go
+++ b/providers/cloudflare/pages.go
@@ -32,7 +32,7 @@ func (g *PagesGenerator) InitResources() error {
 			return err
 		}
 		for _, project := range projects {
-			g.Resources = append(g.Resources, terraformutils.NewResource(
+			projectResource := terraformutils.NewResource(
 				project.Name,
 				cloudflareResourceName(accountID, project.Name),
 				"cloudflare_pages_project",
@@ -40,14 +40,16 @@ func (g *PagesGenerator) InitResources() error {
 				map[string]string{"account_id": accountID, "name": project.Name},
 				[]string{},
 				map[string]interface{}{},
-			))
+			)
+			setCloudflareImportID(&projectResource, accountID+"/"+project.Name)
+			g.Resources = append(g.Resources, projectResource)
 
 			domains, err := api.GetPagesDomains(ctx, cf.PagesDomainsParameters{AccountID: accountID, ProjectName: project.Name})
 			if err != nil {
 				return err
 			}
 			for _, domain := range domains {
-				g.Resources = append(g.Resources, terraformutils.NewResource(
+				domainResource := terraformutils.NewResource(
 					domain.Name,
 					cloudflareResourceName(accountID, project.Name, domain.Name),
 					"cloudflare_pages_domain",
@@ -55,7 +57,9 @@ func (g *PagesGenerator) InitResources() error {
 					map[string]string{"account_id": accountID, "project_name": project.Name, "name": domain.Name},
 					[]string{},
 					map[string]interface{}{},
-				))
+				)
+				setCloudflareImportID(&domainResource, accountID+"/"+project.Name+"/"+domain.Name)
+				g.Resources = append(g.Resources, domainResource)
 			}
 		}
 		if !info.HasMorePages() {

--- a/providers/cloudflare/ruleset.go
+++ b/providers/cloudflare/ruleset.go
@@ -1,0 +1,59 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package cloudflare
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/chenrui333/terraformer/terraformutils"
+	cf "github.com/cloudflare/cloudflare-go"
+)
+
+type RulesetGenerator struct {
+	CloudflareService
+}
+
+func (g *RulesetGenerator) appendRulesetResources(ctx context.Context, api *cf.API, rc *cf.ResourceContainer, scopeType string) error {
+	rulesets, err := api.ListRulesets(ctx, rc, cf.ListRulesetsParams{})
+	if err != nil {
+		return fmt.Errorf("%s/%s: %w", scopeType, rc.Identifier, err)
+	}
+	for _, ruleset := range rulesets {
+		g.Resources = append(g.Resources, terraformutils.NewResource(
+			ruleset.ID,
+			cloudflareResourceName(scopeType, rc.Identifier, ruleset.Name, ruleset.ID),
+			"cloudflare_ruleset",
+			"cloudflare",
+			accessScopeAttributes(scopeType, rc.Identifier),
+			[]string{},
+			map[string]interface{}{},
+		))
+	}
+	return nil
+}
+
+func (g *RulesetGenerator) InitResources() error {
+	ctx := context.Background()
+	api, err := g.initializeAPI()
+	if err != nil {
+		return err
+	}
+
+	if g.accountID() != "" {
+		if err := g.appendRulesetResources(ctx, api, cf.AccountIdentifier(g.accountID()), "accounts"); err != nil {
+			return err
+		}
+	}
+
+	zones, err := cloudflareZones(ctx, api)
+	if err != nil {
+		return err
+	}
+	for _, zone := range zones {
+		if err := g.appendRulesetResources(ctx, api, cf.ZoneIdentifier(zone.ID), "zones"); err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/providers/cloudflare/ruleset.go
+++ b/providers/cloudflare/ruleset.go
@@ -20,6 +20,9 @@ func (g *RulesetGenerator) appendRulesetResources(ctx context.Context, api *cf.A
 		return fmt.Errorf("%s/%s: %w", scopeType, rc.Identifier, err)
 	}
 	for _, ruleset := range rulesets {
+		if ruleset.Kind == string(cf.RulesetKindManaged) {
+			continue
+		}
 		g.Resources = append(g.Resources, terraformutils.NewResource(
 			ruleset.ID,
 			cloudflareResourceName(scopeType, rc.Identifier, ruleset.Name, ruleset.ID),

--- a/providers/cloudflare/ruleset.go
+++ b/providers/cloudflare/ruleset.go
@@ -5,6 +5,7 @@ package cloudflare
 import (
 	"context"
 	"fmt"
+	"time"
 
 	"github.com/chenrui333/terraformer/terraformutils"
 	cf "github.com/cloudflare/cloudflare-go"
@@ -37,7 +38,9 @@ func (g *RulesetGenerator) appendRulesetResources(ctx context.Context, api *cf.A
 }
 
 func (g *RulesetGenerator) InitResources() error {
-	ctx := context.Background()
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
+	defer cancel()
+
 	api, err := g.initializeAPI()
 	if err != nil {
 		return err

--- a/providers/cloudflare/ruleset.go
+++ b/providers/cloudflare/ruleset.go
@@ -4,7 +4,9 @@ package cloudflare
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
+	"net/http"
 	"time"
 
 	"github.com/chenrui333/terraformer/terraformutils"
@@ -16,7 +18,7 @@ type RulesetGenerator struct {
 }
 
 func (g *RulesetGenerator) appendRulesetResources(ctx context.Context, api *cf.API, rc *cf.ResourceContainer, scopeType string) error {
-	rulesets, err := api.ListRulesets(ctx, rc, cf.ListRulesetsParams{})
+	rulesets, err := listRulesets(ctx, api, rc)
 	if err != nil {
 		return fmt.Errorf("%s/%s: %w", scopeType, rc.Identifier, err)
 	}
@@ -35,6 +37,32 @@ func (g *RulesetGenerator) appendRulesetResources(ctx context.Context, api *cf.A
 		))
 	}
 	return nil
+}
+
+func listRulesets(ctx context.Context, api *cf.API, rc *cf.ResourceContainer) ([]cf.Ruleset, error) {
+	var rulesets []cf.Ruleset
+	page, cursor := 1, ""
+	for {
+		response, err := api.Raw(
+			ctx,
+			http.MethodGet,
+			fmt.Sprintf("/%s/%s/rulesets?%s", rc.Level, rc.Identifier, cloudflarePaginationQuery(page, cursor)),
+			nil,
+			nil,
+		)
+		if err != nil {
+			return nil, err
+		}
+		var pageRulesets []cf.Ruleset
+		if err := json.Unmarshal(response.Result, &pageRulesets); err != nil {
+			return nil, err
+		}
+		rulesets = append(rulesets, pageRulesets...)
+		if !cloudflareAdvancePagination(response.ResultInfo, &page, &cursor) {
+			break
+		}
+	}
+	return rulesets, nil
 }
 
 func (g *RulesetGenerator) InitResources() error {

--- a/providers/cloudflare/storage.go
+++ b/providers/cloudflare/storage.go
@@ -74,10 +74,10 @@ func listR2BucketsInJurisdiction(
 		}
 		buckets = append(buckets, result.Buckets...)
 
-		if len(result.Buckets) < cloudflarePageSize || response.ResultInfo == nil || response.ResultInfo.Cursors.After == "" {
+		if len(result.Buckets) < cloudflarePageSize || response.ResultInfo == nil || response.ResultInfo.Cursor == "" {
 			break
 		}
-		cursor = response.ResultInfo.Cursors.After
+		cursor = response.ResultInfo.Cursor
 	}
 	return buckets, nil
 }

--- a/providers/cloudflare/storage.go
+++ b/providers/cloudflare/storage.go
@@ -1,0 +1,138 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package cloudflare
+
+import (
+	"context"
+
+	"github.com/chenrui333/terraformer/terraformutils"
+	cf "github.com/cloudflare/cloudflare-go"
+)
+
+type StorageGenerator struct {
+	CloudflareService
+}
+
+func (g *StorageGenerator) appendWorkersKVNamespaceResources(ctx context.Context, api *cf.API, accountID string) error {
+	params := cf.ListWorkersKVNamespacesParams{ResultInfo: cf.ResultInfo{Page: 1, PerPage: cloudflarePageSize}}
+	for {
+		namespaces, info, err := api.ListWorkersKVNamespaces(ctx, cf.AccountIdentifier(accountID), params)
+		if err != nil {
+			return err
+		}
+		for _, namespace := range namespaces {
+			g.Resources = append(g.Resources, terraformutils.NewResource(
+				namespace.ID,
+				cloudflareResourceName(accountID, namespace.Title, namespace.ID),
+				"cloudflare_workers_kv_namespace",
+				"cloudflare",
+				map[string]string{"account_id": accountID},
+				[]string{},
+				map[string]interface{}{},
+			))
+		}
+		if info == nil || !info.HasMorePages() {
+			break
+		}
+		params.ResultInfo = info.Next()
+	}
+	return nil
+}
+
+func (g *StorageGenerator) appendQueueResources(ctx context.Context, api *cf.API, accountID string) error {
+	params := cf.ListQueuesParams{ResultInfo: cf.ResultInfo{Page: 1, PerPage: cloudflarePageSize}}
+	for {
+		queues, info, err := api.ListQueues(ctx, cf.AccountIdentifier(accountID), params)
+		if err != nil {
+			return err
+		}
+		for _, queue := range queues {
+			g.Resources = append(g.Resources, terraformutils.NewResource(
+				queue.ID,
+				cloudflareResourceName(accountID, queue.Name, queue.ID),
+				"cloudflare_queue",
+				"cloudflare",
+				map[string]string{"account_id": accountID, "queue_id": queue.ID},
+				[]string{},
+				map[string]interface{}{},
+			))
+		}
+		if info == nil || !info.HasMorePages() {
+			break
+		}
+		params.ResultInfo = info.Next()
+	}
+	return nil
+}
+
+func (g *StorageGenerator) appendR2BucketResources(ctx context.Context, api *cf.API, accountID string) error {
+	buckets, err := api.ListR2Buckets(ctx, cf.AccountIdentifier(accountID), cf.ListR2BucketsParams{PerPage: cloudflarePageSize})
+	if err != nil {
+		return err
+	}
+	for _, bucket := range buckets {
+		g.Resources = append(g.Resources, terraformutils.NewResource(
+			bucket.Name,
+			cloudflareResourceName(accountID, bucket.Name),
+			"cloudflare_r2_bucket",
+			"cloudflare",
+			map[string]string{
+				"account_id":   accountID,
+				"name":         bucket.Name,
+				"jurisdiction": "default",
+			},
+			[]string{},
+			map[string]interface{}{},
+		))
+	}
+	return nil
+}
+
+func (g *StorageGenerator) appendD1DatabaseResources(ctx context.Context, api *cf.API, accountID string) error {
+	params := cf.ListD1DatabasesParams{ResultInfo: cf.ResultInfo{Page: 1, PerPage: cloudflarePageSize}}
+	for {
+		databases, info, err := api.ListD1Databases(ctx, cf.AccountIdentifier(accountID), params)
+		if err != nil {
+			return err
+		}
+		for _, database := range databases {
+			g.Resources = append(g.Resources, terraformutils.NewResource(
+				database.UUID,
+				cloudflareResourceName(accountID, database.Name, database.UUID),
+				"cloudflare_d1_database",
+				"cloudflare",
+				map[string]string{"account_id": accountID, "uuid": database.UUID},
+				[]string{},
+				map[string]interface{}{},
+			))
+		}
+		if info == nil || !info.HasMorePages() {
+			break
+		}
+		params.ResultInfo = info.Next()
+	}
+	return nil
+}
+
+func (g *StorageGenerator) InitResources() error {
+	ctx := context.Background()
+	api, err := g.initializeAPI()
+	if err != nil {
+		return err
+	}
+	account, err := g.accountResourceContainer()
+	if err != nil {
+		return err
+	}
+	for _, f := range []func(context.Context, *cf.API, string) error{
+		g.appendWorkersKVNamespaceResources,
+		g.appendQueueResources,
+		g.appendR2BucketResources,
+		g.appendD1DatabaseResources,
+	} {
+		if err := f(ctx, api, account.Identifier); err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/providers/cloudflare/storage.go
+++ b/providers/cloudflare/storage.go
@@ -10,6 +10,7 @@ import (
 	"net/http"
 	"net/url"
 	"strconv"
+	"strings"
 
 	"github.com/chenrui333/terraformer/terraformutils"
 	cf "github.com/cloudflare/cloudflare-go"
@@ -25,17 +26,32 @@ type r2BucketListResult struct {
 	Buckets []cf.R2Bucket
 }
 
-func cloudflareClientSkipError(err error) bool {
-	var authErr *cf.AuthenticationError
-	if errors.As(err, &authErr) {
-		return true
-	}
+func cloudflareUnsupportedJurisdictionError(err error) bool {
 	var notFoundErr *cf.NotFoundError
 	if errors.As(err, &notFoundErr) {
-		return true
+		return cloudflareErrorIndicatesUnsupportedJurisdiction(notFoundErr.Error(), notFoundErr.ErrorMessages())
 	}
 	var requestErr *cf.RequestError
-	return errors.As(err, &requestErr)
+	if errors.As(err, &requestErr) {
+		return cloudflareErrorIndicatesUnsupportedJurisdiction(requestErr.Error(), requestErr.ErrorMessages())
+	}
+	return false
+}
+
+func cloudflareErrorIndicatesUnsupportedJurisdiction(message string, errorMessages []string) bool {
+	messages := append([]string{message}, errorMessages...)
+	for _, msg := range messages {
+		normalized := strings.ToLower(msg)
+		if !strings.Contains(normalized, "jurisdiction") {
+			continue
+		}
+		for _, marker := range []string{"not enabled", "not found", "not supported", "unsupported", "invalid", "unknown"} {
+			if strings.Contains(normalized, marker) {
+				return true
+			}
+		}
+	}
+	return false
 }
 
 func listR2BucketsInJurisdiction(
@@ -62,7 +78,7 @@ func listR2BucketsInJurisdiction(
 			headers,
 		)
 		if err != nil {
-			if jurisdiction != "default" && cloudflareClientSkipError(err) {
+			if jurisdiction != "default" && cloudflareUnsupportedJurisdictionError(err) {
 				return buckets, nil
 			}
 			return nil, err

--- a/providers/cloudflare/storage.go
+++ b/providers/cloudflare/storage.go
@@ -106,7 +106,7 @@ func (g *StorageGenerator) appendWorkersKVNamespaceResources(ctx context.Context
 			return err
 		}
 		for _, namespace := range namespaces {
-			g.Resources = append(g.Resources, terraformutils.NewResource(
+			resource := terraformutils.NewResource(
 				namespace.ID,
 				cloudflareResourceName(accountID, namespace.Title, namespace.ID),
 				"cloudflare_workers_kv_namespace",
@@ -114,7 +114,9 @@ func (g *StorageGenerator) appendWorkersKVNamespaceResources(ctx context.Context
 				map[string]string{"account_id": accountID},
 				[]string{},
 				map[string]interface{}{},
-			))
+			)
+			setCloudflareImportID(&resource, accountID+"/"+namespace.ID)
+			g.Resources = append(g.Resources, resource)
 		}
 		if info == nil || !info.HasMorePages() {
 			break
@@ -132,7 +134,7 @@ func (g *StorageGenerator) appendQueueResources(ctx context.Context, api *cf.API
 			return err
 		}
 		for _, queue := range queues {
-			g.Resources = append(g.Resources, terraformutils.NewResource(
+			resource := terraformutils.NewResource(
 				queue.ID,
 				cloudflareResourceName(accountID, queue.Name, queue.ID),
 				"cloudflare_queue",
@@ -140,7 +142,9 @@ func (g *StorageGenerator) appendQueueResources(ctx context.Context, api *cf.API
 				map[string]string{"account_id": accountID, "queue_id": queue.ID},
 				[]string{},
 				map[string]interface{}{},
-			))
+			)
+			setCloudflareImportID(&resource, accountID+"/"+queue.ID)
+			g.Resources = append(g.Resources, resource)
 		}
 		if info == nil || !info.HasMorePages() {
 			break
@@ -157,7 +161,7 @@ func (g *StorageGenerator) appendR2BucketResources(ctx context.Context, api *cf.
 			return err
 		}
 		for _, bucket := range buckets {
-			g.Resources = append(g.Resources, terraformutils.NewResource(
+			resource := terraformutils.NewResource(
 				bucket.Name,
 				cloudflareResourceName(accountID, jurisdiction, bucket.Name),
 				"cloudflare_r2_bucket",
@@ -169,7 +173,9 @@ func (g *StorageGenerator) appendR2BucketResources(ctx context.Context, api *cf.
 				},
 				[]string{},
 				map[string]interface{}{},
-			))
+			)
+			setCloudflareImportID(&resource, accountID+"/"+bucket.Name+"/"+jurisdiction)
+			g.Resources = append(g.Resources, resource)
 		}
 	}
 	return nil
@@ -183,7 +189,7 @@ func (g *StorageGenerator) appendD1DatabaseResources(ctx context.Context, api *c
 			return err
 		}
 		for _, database := range databases {
-			g.Resources = append(g.Resources, terraformutils.NewResource(
+			resource := terraformutils.NewResource(
 				database.UUID,
 				cloudflareResourceName(accountID, database.Name, database.UUID),
 				"cloudflare_d1_database",
@@ -191,7 +197,9 @@ func (g *StorageGenerator) appendD1DatabaseResources(ctx context.Context, api *c
 				map[string]string{"account_id": accountID, "uuid": database.UUID},
 				[]string{},
 				map[string]interface{}{},
-			))
+			)
+			setCloudflareImportID(&resource, accountID+"/"+database.UUID)
+			g.Resources = append(g.Resources, resource)
 		}
 		if info == nil || !info.HasMorePages() {
 			break

--- a/providers/cloudflare/storage.go
+++ b/providers/cloudflare/storage.go
@@ -4,6 +4,12 @@ package cloudflare
 
 import (
 	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/url"
+	"strconv"
 
 	"github.com/chenrui333/terraformer/terraformutils"
 	cf "github.com/cloudflare/cloudflare-go"
@@ -11,6 +17,69 @@ import (
 
 type StorageGenerator struct {
 	CloudflareService
+}
+
+var r2BucketJurisdictions = []string{"default", "eu", "fedramp"}
+
+type r2BucketListResult struct {
+	Buckets []cf.R2Bucket
+}
+
+func cloudflareClientSkipError(err error) bool {
+	var authErr *cf.AuthenticationError
+	if errors.As(err, &authErr) {
+		return true
+	}
+	var notFoundErr *cf.NotFoundError
+	if errors.As(err, &notFoundErr) {
+		return true
+	}
+	var requestErr *cf.RequestError
+	return errors.As(err, &requestErr)
+}
+
+func listR2BucketsInJurisdiction(
+	ctx context.Context,
+	api *cf.API,
+	accountID string,
+	jurisdiction string,
+) ([]cf.R2Bucket, error) {
+	var buckets []cf.R2Bucket
+	cursor := ""
+	for {
+		values := url.Values{}
+		values.Set("per_page", strconv.Itoa(cloudflarePageSize))
+		if cursor != "" {
+			values.Set("cursor", cursor)
+		}
+		headers := http.Header{}
+		headers.Set("cf-r2-jurisdiction", jurisdiction)
+		response, err := api.Raw(
+			ctx,
+			http.MethodGet,
+			fmt.Sprintf("/accounts/%s/r2/buckets?%s", accountID, values.Encode()),
+			nil,
+			headers,
+		)
+		if err != nil {
+			if jurisdiction != "default" && cloudflareClientSkipError(err) {
+				return buckets, nil
+			}
+			return nil, err
+		}
+
+		var result r2BucketListResult
+		if err := json.Unmarshal(response.Result, &result); err != nil {
+			return nil, err
+		}
+		buckets = append(buckets, result.Buckets...)
+
+		if len(result.Buckets) < cloudflarePageSize || response.ResultInfo == nil || response.ResultInfo.Cursors.After == "" {
+			break
+		}
+		cursor = response.ResultInfo.Cursors.After
+	}
+	return buckets, nil
 }
 
 func (g *StorageGenerator) appendWorkersKVNamespaceResources(ctx context.Context, api *cf.API, accountID string) error {
@@ -66,24 +135,26 @@ func (g *StorageGenerator) appendQueueResources(ctx context.Context, api *cf.API
 }
 
 func (g *StorageGenerator) appendR2BucketResources(ctx context.Context, api *cf.API, accountID string) error {
-	buckets, err := api.ListR2Buckets(ctx, cf.AccountIdentifier(accountID), cf.ListR2BucketsParams{PerPage: cloudflarePageSize})
-	if err != nil {
-		return err
-	}
-	for _, bucket := range buckets {
-		g.Resources = append(g.Resources, terraformutils.NewResource(
-			bucket.Name,
-			cloudflareResourceName(accountID, bucket.Name),
-			"cloudflare_r2_bucket",
-			"cloudflare",
-			map[string]string{
-				"account_id":   accountID,
-				"name":         bucket.Name,
-				"jurisdiction": "default",
-			},
-			[]string{},
-			map[string]interface{}{},
-		))
+	for _, jurisdiction := range r2BucketJurisdictions {
+		buckets, err := listR2BucketsInJurisdiction(ctx, api, accountID, jurisdiction)
+		if err != nil {
+			return err
+		}
+		for _, bucket := range buckets {
+			g.Resources = append(g.Resources, terraformutils.NewResource(
+				bucket.Name,
+				cloudflareResourceName(accountID, jurisdiction, bucket.Name),
+				"cloudflare_r2_bucket",
+				"cloudflare",
+				map[string]string{
+					"account_id":   accountID,
+					"name":         bucket.Name,
+					"jurisdiction": jurisdiction,
+				},
+				[]string{},
+				map[string]interface{}{},
+			))
+		}
 	}
 	return nil
 }

--- a/providers/cloudflare/tunnel.go
+++ b/providers/cloudflare/tunnel.go
@@ -1,0 +1,87 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package cloudflare
+
+import (
+	"context"
+
+	"github.com/chenrui333/terraformer/terraformutils"
+	cf "github.com/cloudflare/cloudflare-go"
+)
+
+type TunnelGenerator struct {
+	CloudflareService
+}
+
+func (g *TunnelGenerator) appendTunnelResources(ctx context.Context, api *cf.API, accountID string) error {
+	isDeleted := false
+	params := cf.TunnelListParams{IsDeleted: &isDeleted, ResultInfo: cf.ResultInfo{Page: 1, PerPage: cloudflarePageSize}}
+	for {
+		tunnels, info, err := api.ListTunnels(ctx, cf.AccountIdentifier(accountID), params)
+		if err != nil {
+			return err
+		}
+		for _, tunnel := range tunnels {
+			g.Resources = append(g.Resources, terraformutils.NewResource(
+				tunnel.ID,
+				cloudflareResourceName(accountID, tunnel.Name, tunnel.ID),
+				"cloudflare_zero_trust_tunnel_cloudflared",
+				"cloudflare",
+				map[string]string{"account_id": accountID},
+				[]string{},
+				map[string]interface{}{},
+			))
+		}
+		if info == nil || !info.HasMorePages() {
+			break
+		}
+		params.ResultInfo = info.Next()
+	}
+	return nil
+}
+
+func (g *TunnelGenerator) appendTunnelVirtualNetworkResources(ctx context.Context, api *cf.API, accountID string) error {
+	isDeleted := false
+	params := cf.TunnelVirtualNetworksListParams{
+		IsDeleted:         &isDeleted,
+		PaginationOptions: cf.PaginationOptions{Page: 1, PerPage: cloudflarePageSize},
+	}
+	for {
+		virtualNetworks, err := api.ListTunnelVirtualNetworks(ctx, cf.AccountIdentifier(accountID), params)
+		if err != nil {
+			return err
+		}
+		for _, virtualNetwork := range virtualNetworks {
+			g.Resources = append(g.Resources, terraformutils.NewResource(
+				virtualNetwork.ID,
+				cloudflareResourceName(accountID, virtualNetwork.Name, virtualNetwork.ID),
+				"cloudflare_zero_trust_tunnel_cloudflared_virtual_network",
+				"cloudflare",
+				map[string]string{"account_id": accountID},
+				[]string{},
+				map[string]interface{}{},
+			))
+		}
+		if len(virtualNetworks) < cloudflarePageSize {
+			break
+		}
+		params.Page++
+	}
+	return nil
+}
+
+func (g *TunnelGenerator) InitResources() error {
+	ctx := context.Background()
+	api, err := g.initializeAPI()
+	if err != nil {
+		return err
+	}
+	account, err := g.accountResourceContainer()
+	if err != nil {
+		return err
+	}
+	if err := g.appendTunnelResources(ctx, api, account.Identifier); err != nil {
+		return err
+	}
+	return g.appendTunnelVirtualNetworkResources(ctx, api, account.Identifier)
+}

--- a/providers/cloudflare/tunnel.go
+++ b/providers/cloudflare/tunnel.go
@@ -22,12 +22,16 @@ func (g *TunnelGenerator) appendTunnelResources(ctx context.Context, api *cf.API
 			return err
 		}
 		for _, tunnel := range tunnels {
+			attributes := map[string]string{
+				"account_id": accountID,
+				"config_src": tunnelConfigSource(tunnel.RemoteConfig),
+			}
 			g.Resources = append(g.Resources, terraformutils.NewResource(
 				tunnel.ID,
 				cloudflareResourceName(accountID, tunnel.Name, tunnel.ID),
 				"cloudflare_zero_trust_tunnel_cloudflared",
 				"cloudflare",
-				map[string]string{"account_id": accountID},
+				attributes,
 				[]string{},
 				map[string]interface{}{},
 			))
@@ -38,6 +42,13 @@ func (g *TunnelGenerator) appendTunnelResources(ctx context.Context, api *cf.API
 		params.ResultInfo = info.Next()
 	}
 	return nil
+}
+
+func tunnelConfigSource(remoteConfig bool) string {
+	if remoteConfig {
+		return "cloudflare"
+	}
+	return "local"
 }
 
 func (g *TunnelGenerator) appendTunnelVirtualNetworkResources(ctx context.Context, api *cf.API, accountID string) error {

--- a/providers/cloudflare/turnstile.go
+++ b/providers/cloudflare/turnstile.go
@@ -1,0 +1,49 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package cloudflare
+
+import (
+	"context"
+
+	"github.com/chenrui333/terraformer/terraformutils"
+	cf "github.com/cloudflare/cloudflare-go"
+)
+
+type TurnstileGenerator struct {
+	CloudflareService
+}
+
+func (g *TurnstileGenerator) InitResources() error {
+	ctx := context.Background()
+	api, err := g.initializeAPI()
+	if err != nil {
+		return err
+	}
+	account, err := g.accountResourceContainer()
+	if err != nil {
+		return err
+	}
+	params := cf.ListTurnstileWidgetParams{ResultInfo: cf.ResultInfo{Page: 1, PerPage: cloudflarePageSize}}
+	for {
+		widgets, info, err := api.ListTurnstileWidgets(ctx, account, params)
+		if err != nil {
+			return err
+		}
+		for _, widget := range widgets {
+			g.Resources = append(g.Resources, terraformutils.NewResource(
+				widget.SiteKey,
+				cloudflareResourceName(account.Identifier, widget.Name, widget.SiteKey),
+				"cloudflare_turnstile_widget",
+				"cloudflare",
+				map[string]string{"account_id": account.Identifier, "sitekey": widget.SiteKey},
+				[]string{},
+				map[string]interface{}{},
+			))
+		}
+		if info == nil || !info.HasMorePages() {
+			break
+		}
+		params.ResultInfo = info.Next()
+	}
+	return nil
+}

--- a/providers/cloudflare/waiting_room.go
+++ b/providers/cloudflare/waiting_room.go
@@ -4,6 +4,9 @@ package cloudflare
 
 import (
 	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
 
 	"github.com/chenrui333/terraformer/terraformutils"
 	cf "github.com/cloudflare/cloudflare-go"
@@ -24,7 +27,7 @@ func (g *WaitingRoomGenerator) InitResources() error {
 		return err
 	}
 	for _, zone := range zones {
-		waitingRooms, err := api.ListWaitingRooms(ctx, zone.ID)
+		waitingRooms, err := listWaitingRooms(ctx, api, zone.ID)
 		if err != nil {
 			return err
 		}
@@ -59,7 +62,7 @@ func (g *WaitingRoomGenerator) InitResources() error {
 				g.Resources = append(g.Resources, waitingRoomRulesResource)
 			}
 
-			events, err := api.ListWaitingRoomEvents(ctx, zone.ID, waitingRoom.ID)
+			events, err := listWaitingRoomEvents(ctx, api, zone.ID, waitingRoom.ID)
 			if err != nil {
 				return err
 			}
@@ -79,4 +82,56 @@ func (g *WaitingRoomGenerator) InitResources() error {
 		}
 	}
 	return nil
+}
+
+func listWaitingRooms(ctx context.Context, api *cf.API, zoneID string) ([]cf.WaitingRoom, error) {
+	var waitingRooms []cf.WaitingRoom
+	page, cursor := 1, ""
+	for {
+		response, err := api.Raw(
+			ctx,
+			http.MethodGet,
+			fmt.Sprintf("/zones/%s/waiting_rooms?%s", zoneID, cloudflarePaginationQuery(page, cursor)),
+			nil,
+			nil,
+		)
+		if err != nil {
+			return nil, err
+		}
+		var pageWaitingRooms []cf.WaitingRoom
+		if err := json.Unmarshal(response.Result, &pageWaitingRooms); err != nil {
+			return nil, err
+		}
+		waitingRooms = append(waitingRooms, pageWaitingRooms...)
+		if !cloudflareAdvancePagination(response.ResultInfo, &page, &cursor) {
+			break
+		}
+	}
+	return waitingRooms, nil
+}
+
+func listWaitingRoomEvents(ctx context.Context, api *cf.API, zoneID, waitingRoomID string) ([]cf.WaitingRoomEvent, error) {
+	var events []cf.WaitingRoomEvent
+	page, cursor := 1, ""
+	for {
+		response, err := api.Raw(
+			ctx,
+			http.MethodGet,
+			fmt.Sprintf("/zones/%s/waiting_rooms/%s/events?%s", zoneID, waitingRoomID, cloudflarePaginationQuery(page, cursor)),
+			nil,
+			nil,
+		)
+		if err != nil {
+			return nil, err
+		}
+		var pageEvents []cf.WaitingRoomEvent
+		if err := json.Unmarshal(response.Result, &pageEvents); err != nil {
+			return nil, err
+		}
+		events = append(events, pageEvents...)
+		if !cloudflareAdvancePagination(response.ResultInfo, &page, &cursor) {
+			break
+		}
+	}
+	return events, nil
 }

--- a/providers/cloudflare/waiting_room.go
+++ b/providers/cloudflare/waiting_room.go
@@ -1,0 +1,67 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package cloudflare
+
+import (
+	"context"
+
+	"github.com/chenrui333/terraformer/terraformutils"
+)
+
+type WaitingRoomGenerator struct {
+	CloudflareService
+}
+
+func (g *WaitingRoomGenerator) InitResources() error {
+	ctx := context.Background()
+	api, err := g.initializeAPI()
+	if err != nil {
+		return err
+	}
+	zones, err := cloudflareZones(ctx, api)
+	if err != nil {
+		return err
+	}
+	for _, zone := range zones {
+		waitingRooms, err := api.ListWaitingRooms(ctx, zone.ID)
+		if err != nil {
+			return err
+		}
+		for _, waitingRoom := range waitingRooms {
+			g.Resources = append(g.Resources, terraformutils.NewResource(
+				waitingRoom.ID,
+				cloudflareResourceName(zone.Name, waitingRoom.Name, waitingRoom.ID),
+				"cloudflare_waiting_room",
+				"cloudflare",
+				map[string]string{"zone_id": zone.ID},
+				[]string{},
+				map[string]interface{}{},
+			))
+			g.Resources = append(g.Resources, terraformutils.NewResource(
+				waitingRoom.ID,
+				cloudflareResourceName(zone.Name, waitingRoom.Name, waitingRoom.ID, "rules"),
+				"cloudflare_waiting_room_rules",
+				"cloudflare",
+				map[string]string{"zone_id": zone.ID, "waiting_room_id": waitingRoom.ID},
+				[]string{},
+				map[string]interface{}{},
+			))
+			events, err := api.ListWaitingRoomEvents(ctx, zone.ID, waitingRoom.ID)
+			if err != nil {
+				return err
+			}
+			for _, event := range events {
+				g.Resources = append(g.Resources, terraformutils.NewResource(
+					event.ID,
+					cloudflareResourceName(zone.Name, waitingRoom.Name, event.Name, event.ID),
+					"cloudflare_waiting_room_event",
+					"cloudflare",
+					map[string]string{"zone_id": zone.ID, "waiting_room_id": waitingRoom.ID},
+					[]string{},
+					map[string]interface{}{},
+				))
+			}
+		}
+	}
+	return nil
+}

--- a/providers/cloudflare/waiting_room.go
+++ b/providers/cloudflare/waiting_room.go
@@ -28,7 +28,7 @@ func (g *WaitingRoomGenerator) InitResources() error {
 			return err
 		}
 		for _, waitingRoom := range waitingRooms {
-			g.Resources = append(g.Resources, terraformutils.NewResource(
+			waitingRoomResource := terraformutils.NewResource(
 				waitingRoom.ID,
 				cloudflareResourceName(zone.Name, waitingRoom.Name, waitingRoom.ID),
 				"cloudflare_waiting_room",
@@ -36,8 +36,11 @@ func (g *WaitingRoomGenerator) InitResources() error {
 				map[string]string{"zone_id": zone.ID},
 				[]string{},
 				map[string]interface{}{},
-			))
-			g.Resources = append(g.Resources, terraformutils.NewResource(
+			)
+			setCloudflareImportID(&waitingRoomResource, zone.ID+"/"+waitingRoom.ID)
+			g.Resources = append(g.Resources, waitingRoomResource)
+
+			waitingRoomRulesResource := terraformutils.NewResource(
 				waitingRoom.ID,
 				cloudflareResourceName(zone.Name, waitingRoom.Name, waitingRoom.ID, "rules"),
 				"cloudflare_waiting_room_rules",
@@ -45,13 +48,16 @@ func (g *WaitingRoomGenerator) InitResources() error {
 				map[string]string{"zone_id": zone.ID, "waiting_room_id": waitingRoom.ID},
 				[]string{},
 				map[string]interface{}{},
-			))
+			)
+			setCloudflareImportID(&waitingRoomRulesResource, zone.ID+"/"+waitingRoom.ID)
+			g.Resources = append(g.Resources, waitingRoomRulesResource)
+
 			events, err := api.ListWaitingRoomEvents(ctx, zone.ID, waitingRoom.ID)
 			if err != nil {
 				return err
 			}
 			for _, event := range events {
-				g.Resources = append(g.Resources, terraformutils.NewResource(
+				waitingRoomEventResource := terraformutils.NewResource(
 					event.ID,
 					cloudflareResourceName(zone.Name, waitingRoom.Name, event.Name, event.ID),
 					"cloudflare_waiting_room_event",
@@ -59,7 +65,9 @@ func (g *WaitingRoomGenerator) InitResources() error {
 					map[string]string{"zone_id": zone.ID, "waiting_room_id": waitingRoom.ID},
 					[]string{},
 					map[string]interface{}{},
-				))
+				)
+				setCloudflareImportID(&waitingRoomEventResource, zone.ID+"/"+waitingRoom.ID+"/"+event.ID)
+				g.Resources = append(g.Resources, waitingRoomEventResource)
 			}
 		}
 	}

--- a/providers/cloudflare/waiting_room.go
+++ b/providers/cloudflare/waiting_room.go
@@ -6,6 +6,7 @@ import (
 	"context"
 
 	"github.com/chenrui333/terraformer/terraformutils"
+	cf "github.com/cloudflare/cloudflare-go"
 )
 
 type WaitingRoomGenerator struct {
@@ -40,17 +41,23 @@ func (g *WaitingRoomGenerator) InitResources() error {
 			setCloudflareImportID(&waitingRoomResource, zone.ID+"/"+waitingRoom.ID)
 			g.Resources = append(g.Resources, waitingRoomResource)
 
-			waitingRoomRulesResource := terraformutils.NewResource(
-				waitingRoom.ID,
-				cloudflareResourceName(zone.Name, waitingRoom.Name, waitingRoom.ID, "rules"),
-				"cloudflare_waiting_room_rules",
-				"cloudflare",
-				map[string]string{"zone_id": zone.ID, "waiting_room_id": waitingRoom.ID},
-				[]string{},
-				map[string]interface{}{},
-			)
-			setCloudflareImportID(&waitingRoomRulesResource, zone.ID+"/"+waitingRoom.ID)
-			g.Resources = append(g.Resources, waitingRoomRulesResource)
+			rules, err := api.ListWaitingRoomRules(ctx, cf.ZoneIdentifier(zone.ID), cf.ListWaitingRoomRuleParams{WaitingRoomID: waitingRoom.ID})
+			if err != nil {
+				return err
+			}
+			if len(rules) > 0 {
+				waitingRoomRulesResource := terraformutils.NewResource(
+					waitingRoom.ID,
+					cloudflareResourceName(zone.Name, waitingRoom.Name, waitingRoom.ID, "rules"),
+					"cloudflare_waiting_room_rules",
+					"cloudflare",
+					map[string]string{"zone_id": zone.ID, "waiting_room_id": waitingRoom.ID},
+					[]string{},
+					map[string]interface{}{},
+				)
+				setCloudflareImportID(&waitingRoomRulesResource, zone.ID+"/"+waitingRoom.ID)
+				g.Resources = append(g.Resources, waitingRoomRulesResource)
+			}
 
 			events, err := api.ListWaitingRoomEvents(ctx, zone.ID, waitingRoom.ID)
 			if err != nil {

--- a/providers/cloudflare/web_analytics.go
+++ b/providers/cloudflare/web_analytics.go
@@ -1,0 +1,49 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package cloudflare
+
+import (
+	"context"
+
+	"github.com/chenrui333/terraformer/terraformutils"
+	cf "github.com/cloudflare/cloudflare-go"
+)
+
+type WebAnalyticsGenerator struct {
+	CloudflareService
+}
+
+func (g *WebAnalyticsGenerator) InitResources() error {
+	ctx := context.Background()
+	api, err := g.initializeAPI()
+	if err != nil {
+		return err
+	}
+	account, err := g.accountResourceContainer()
+	if err != nil {
+		return err
+	}
+	params := cf.ListWebAnalyticsSitesParams{ResultInfo: cf.ResultInfo{Page: 1, PerPage: cloudflarePageSize}}
+	for {
+		sites, info, err := api.ListWebAnalyticsSites(ctx, account, params)
+		if err != nil {
+			return err
+		}
+		for _, site := range sites {
+			g.Resources = append(g.Resources, terraformutils.NewResource(
+				site.SiteTag,
+				cloudflareResourceName(account.Identifier, site.SiteTag),
+				"cloudflare_web_analytics_site",
+				"cloudflare",
+				map[string]string{"account_id": account.Identifier, "site_tag": site.SiteTag},
+				[]string{},
+				map[string]interface{}{},
+			))
+		}
+		if info == nil || !info.HasMorePages() {
+			break
+		}
+		params.ResultInfo = info.Next()
+	}
+	return nil
+}

--- a/providers/cloudflare/workers.go
+++ b/providers/cloudflare/workers.go
@@ -4,6 +4,9 @@ package cloudflare
 
 import (
 	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
 
 	"github.com/chenrui333/terraformer/terraformutils"
 	cf "github.com/cloudflare/cloudflare-go"
@@ -24,11 +27,11 @@ func (g *WorkersGenerator) InitResources() error {
 		return err
 	}
 	for _, zone := range zones {
-		response, err := api.ListWorkerRoutes(ctx, cf.ZoneIdentifier(zone.ID), cf.ListWorkerRoutesParams{})
+		routes, err := listWorkerRoutes(ctx, api, zone.ID)
 		if err != nil {
 			return err
 		}
-		for _, route := range response.Routes {
+		for _, route := range routes {
 			g.Resources = append(g.Resources, terraformutils.NewResource(
 				route.ID,
 				cloudflareResourceName(zone.Name, route.Pattern, route.ID),
@@ -41,4 +44,30 @@ func (g *WorkersGenerator) InitResources() error {
 		}
 	}
 	return nil
+}
+
+func listWorkerRoutes(ctx context.Context, api *cf.API, zoneID string) ([]cf.WorkerRoute, error) {
+	var routes []cf.WorkerRoute
+	page, cursor := 1, ""
+	for {
+		response, err := api.Raw(
+			ctx,
+			http.MethodGet,
+			fmt.Sprintf("/zones/%s/workers/routes?%s", zoneID, cloudflarePaginationQuery(page, cursor)),
+			nil,
+			nil,
+		)
+		if err != nil {
+			return nil, err
+		}
+		var pageRoutes []cf.WorkerRoute
+		if err := json.Unmarshal(response.Result, &pageRoutes); err != nil {
+			return nil, err
+		}
+		routes = append(routes, pageRoutes...)
+		if !cloudflareAdvancePagination(response.ResultInfo, &page, &cursor) {
+			break
+		}
+	}
+	return routes, nil
 }

--- a/providers/cloudflare/workers.go
+++ b/providers/cloudflare/workers.go
@@ -1,0 +1,44 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package cloudflare
+
+import (
+	"context"
+
+	"github.com/chenrui333/terraformer/terraformutils"
+	cf "github.com/cloudflare/cloudflare-go"
+)
+
+type WorkersGenerator struct {
+	CloudflareService
+}
+
+func (g *WorkersGenerator) InitResources() error {
+	ctx := context.Background()
+	api, err := g.initializeAPI()
+	if err != nil {
+		return err
+	}
+	zones, err := cloudflareZones(ctx, api)
+	if err != nil {
+		return err
+	}
+	for _, zone := range zones {
+		response, err := api.ListWorkerRoutes(ctx, cf.ZoneIdentifier(zone.ID), cf.ListWorkerRoutesParams{})
+		if err != nil {
+			return err
+		}
+		for _, route := range response.Routes {
+			g.Resources = append(g.Resources, terraformutils.NewResource(
+				route.ID,
+				cloudflareResourceName(zone.Name, route.Pattern, route.ID),
+				"cloudflare_workers_route",
+				"cloudflare",
+				map[string]string{"zone_id": zone.ID},
+				[]string{},
+				map[string]interface{}{},
+			))
+		}
+	}
+	return nil
+}

--- a/terraformutils/flatmap.go
+++ b/terraformutils/flatmap.go
@@ -219,7 +219,19 @@ func (p *FlatmapParser) fromFlatmapMap(prefix string, ty cty.Type) (map[string]i
 		if p.isAttributeIgnored(fullKey) {
 			continue
 		}
-		value, err := p.fromFlatmapValue(fullKey, ty)
+
+		valueKey := fullKey
+		if !ty.IsPrimitiveType() {
+			if dot := strings.IndexByte(key, '.'); dot != -1 {
+				key = key[:dot]
+				valueKey = prefix + key
+			}
+		}
+		if _, exists := values[key]; exists {
+			continue
+		}
+
+		value, err := p.fromFlatmapValue(valueKey, ty)
 		if err != nil {
 			return nil, err
 		}

--- a/terraformutils/flatmap.go
+++ b/terraformutils/flatmap.go
@@ -222,10 +222,7 @@ func (p *FlatmapParser) fromFlatmapMap(prefix string, ty cty.Type) (map[string]i
 
 		valueKey := fullKey
 		if !ty.IsPrimitiveType() {
-			if dot := strings.IndexByte(key, '.'); dot != -1 {
-				key = key[:dot]
-				valueKey = prefix + key
-			}
+			key, valueKey = p.fromFlatmapMapElementKey(prefix, key, ty)
 		}
 		if _, exists := values[key]; exists {
 			continue
@@ -243,6 +240,68 @@ func (p *FlatmapParser) fromFlatmapMap(prefix string, ty cty.Type) (map[string]i
 		return nil, nil
 	}
 	return values, nil
+}
+
+func (p *FlatmapParser) fromFlatmapMapElementKey(prefix, key string, ty cty.Type) (string, string) {
+	for _, candidate := range flatmapMapKeyCandidates(key) {
+		valueKey := prefix + candidate
+		if p.flatmapValueExists(valueKey, ty) {
+			return candidate, valueKey
+		}
+	}
+
+	if dot := strings.IndexByte(key, '.'); dot != -1 {
+		key = key[:dot]
+	}
+	return key, prefix + key
+}
+
+func flatmapMapKeyCandidates(key string) []string {
+	candidates := []string{key}
+	for dot := strings.LastIndexByte(key, '.'); dot != -1; dot = strings.LastIndexByte(key[:dot], '.') {
+		if dot == 0 {
+			continue
+		}
+		candidates = append(candidates, key[:dot])
+	}
+	return candidates
+}
+
+func (p *FlatmapParser) flatmapValueExists(key string, ty cty.Type) bool {
+	if p.attributes[key] == tfcompat.UnknownVariableValue {
+		return true
+	}
+
+	switch {
+	case ty.IsPrimitiveType():
+		_, exists := p.attributes[key]
+		return exists
+	case ty.IsObjectType():
+		return p.flatmapObjectValueExists(key+".", ty.AttributeTypes())
+	case ty.IsTupleType(), ty.IsListType(), ty.IsSetType():
+		_, exists := p.attributes[key+".#"]
+		return exists
+	case ty.IsMapType():
+		_, exists := p.attributes[key+".%"]
+		return exists
+	default:
+		return false
+	}
+}
+
+func (p *FlatmapParser) flatmapObjectValueExists(prefix string, tys map[string]cty.Type) bool {
+	for name, ty := range tys {
+		key := prefix + name
+		if p.flatmapValueExists(key, ty) {
+			return true
+		}
+		for attributeKey := range p.attributes {
+			if strings.HasPrefix(attributeKey, key+".") {
+				return true
+			}
+		}
+	}
+	return false
 }
 
 func (p *FlatmapParser) fromFlatmapList(prefix string, ty cty.Type) ([]interface{}, error) {

--- a/terraformutils/flatmap.go
+++ b/terraformutils/flatmap.go
@@ -268,20 +268,25 @@ func flatmapMapKeyCandidates(key string) []string {
 }
 
 func (p *FlatmapParser) flatmapValueExists(key string, ty cty.Type) bool {
-	if p.attributes[key] == tfcompat.UnknownVariableValue {
-		return true
-	}
-
 	switch {
 	case ty.IsPrimitiveType():
+		if p.attributes[key] == tfcompat.UnknownVariableValue {
+			return true
+		}
 		_, exists := p.attributes[key]
 		return exists
 	case ty.IsObjectType():
 		return p.flatmapObjectValueExists(key+".", ty.AttributeTypes())
 	case ty.IsTupleType(), ty.IsListType(), ty.IsSetType():
+		if p.attributes[key] == tfcompat.UnknownVariableValue {
+			return true
+		}
 		_, exists := p.attributes[key+".#"]
 		return exists
 	case ty.IsMapType():
+		if p.attributes[key] == tfcompat.UnknownVariableValue {
+			return true
+		}
 		_, exists := p.attributes[key+".%"]
 		return exists
 	default:

--- a/terraformutils/flatmap.go
+++ b/terraformutils/flatmap.go
@@ -249,10 +249,7 @@ func (p *FlatmapParser) fromFlatmapMapElementKey(prefix, key string, ty cty.Type
 	}
 	for _, candidate := range candidates {
 		valueKey := prefix + candidate
-		if p.attributes[valueKey] == tfcompat.UnknownVariableValue {
-			return candidate, valueKey
-		}
-		if ty.IsObjectType() && !flatmapMapObjectElementPathMatches(key, candidate, ty.AttributeTypes()) {
+		if !flatmapMapElementPathMatches(key, candidate, ty) {
 			continue
 		}
 		if p.flatmapValueExists(valueKey, ty) {
@@ -291,6 +288,16 @@ func flatmapObjectMapKeyCandidates(key string) []string {
 	return candidates
 }
 
+func flatmapMapElementPathMatches(key, candidate string, ty cty.Type) bool {
+	if ty.IsObjectType() {
+		return flatmapMapObjectElementPathMatches(key, candidate, ty.AttributeTypes())
+	}
+	if !strings.HasPrefix(key, candidate+".") {
+		return false
+	}
+	return flatmapMapValuePathMatches(key[len(candidate)+1:], ty)
+}
+
 func flatmapMapObjectElementPathMatches(key, candidate string, tys map[string]cty.Type) bool {
 	if !strings.HasPrefix(key, candidate+".") {
 		return false
@@ -304,20 +311,80 @@ func flatmapObjectAttributePathMatches(path string, tys map[string]cty.Type) boo
 			return true
 		}
 		if strings.HasPrefix(path, name+".") {
-			return flatmapNestedObjectAttributePathMatches(path[len(name)+1:], ty)
+			return flatmapMapValuePathMatches(path[len(name)+1:], ty)
 		}
 	}
 	return false
 }
 
-func flatmapNestedObjectAttributePathMatches(path string, ty cty.Type) bool {
-	if ty.IsPrimitiveType() {
+func flatmapMapValuePathMatches(path string, ty cty.Type) bool {
+	switch {
+	case ty.IsPrimitiveType(), ty == cty.DynamicPseudoType:
+		return path == ""
+	case ty.IsObjectType():
+		return flatmapObjectAttributePathMatches(path, ty.AttributeTypes())
+	case ty.IsTupleType():
+		return flatmapTuplePathMatches(path, ty.TupleElementTypes())
+	case ty.IsListType():
+		return flatmapSeqPathMatches(path, ty.ElementType(), true)
+	case ty.IsSetType():
+		return flatmapSeqPathMatches(path, ty.ElementType(), false)
+	case ty.IsMapType():
+		return flatmapNestedMapPathMatches(path, ty.ElementType())
+	default:
 		return false
 	}
-	if ty.IsObjectType() {
-		return flatmapObjectAttributePathMatches(path, ty.AttributeTypes())
+}
+
+func flatmapTuplePathMatches(path string, tys []cty.Type) bool {
+	if path == "#" {
+		return true
 	}
-	return true
+	segment, rest, hasRest := strings.Cut(path, ".")
+	index, err := strconv.Atoi(segment)
+	if err != nil || index < 0 || index >= len(tys) {
+		return false
+	}
+	if !hasRest {
+		return tys[index].IsPrimitiveType() || tys[index] == cty.DynamicPseudoType
+	}
+	return flatmapMapValuePathMatches(rest, tys[index])
+}
+
+func flatmapSeqPathMatches(path string, ty cty.Type, requireIndex bool) bool {
+	if path == "#" {
+		return true
+	}
+	segment, rest, hasRest := strings.Cut(path, ".")
+	if segment == "" {
+		return false
+	}
+	if requireIndex {
+		if _, err := strconv.Atoi(segment); err != nil {
+			return false
+		}
+	}
+	if !hasRest {
+		return ty.IsPrimitiveType() || ty == cty.DynamicPseudoType
+	}
+	return flatmapMapValuePathMatches(rest, ty)
+}
+
+func flatmapNestedMapPathMatches(path string, ty cty.Type) bool {
+	if path == "%" {
+		return true
+	}
+	if path == "" {
+		return false
+	}
+	if ty.IsPrimitiveType() || ty == cty.DynamicPseudoType {
+		return true
+	}
+	_, rest, hasRest := strings.Cut(path, ".")
+	if !hasRest {
+		return false
+	}
+	return flatmapMapValuePathMatches(rest, ty)
 }
 
 func (p *FlatmapParser) flatmapValueExists(key string, ty cty.Type) bool {

--- a/terraformutils/flatmap.go
+++ b/terraformutils/flatmap.go
@@ -243,8 +243,18 @@ func (p *FlatmapParser) fromFlatmapMap(prefix string, ty cty.Type) (map[string]i
 }
 
 func (p *FlatmapParser) fromFlatmapMapElementKey(prefix, key string, ty cty.Type) (string, string) {
-	for _, candidate := range flatmapMapKeyCandidates(key) {
+	candidates := flatmapMapKeyCandidates(key)
+	if ty.IsObjectType() {
+		candidates = flatmapObjectMapKeyCandidates(key)
+	}
+	for _, candidate := range candidates {
 		valueKey := prefix + candidate
+		if p.attributes[valueKey] == tfcompat.UnknownVariableValue {
+			return candidate, valueKey
+		}
+		if ty.IsObjectType() && !flatmapMapObjectElementPathMatches(key, candidate, ty.AttributeTypes()) {
+			continue
+		}
 		if p.flatmapValueExists(valueKey, ty) {
 			return candidate, valueKey
 		}
@@ -265,6 +275,49 @@ func flatmapMapKeyCandidates(key string) []string {
 		candidates = append(candidates, key[:dot])
 	}
 	return candidates
+}
+
+func flatmapObjectMapKeyCandidates(key string) []string {
+	var candidates []string
+	for dot := strings.IndexByte(key, '.'); dot != -1; {
+		candidates = append(candidates, key[:dot])
+		next := strings.IndexByte(key[dot+1:], '.')
+		if next == -1 {
+			break
+		}
+		dot += next + 1
+	}
+	candidates = append(candidates, key)
+	return candidates
+}
+
+func flatmapMapObjectElementPathMatches(key, candidate string, tys map[string]cty.Type) bool {
+	if !strings.HasPrefix(key, candidate+".") {
+		return false
+	}
+	return flatmapObjectAttributePathMatches(key[len(candidate)+1:], tys)
+}
+
+func flatmapObjectAttributePathMatches(path string, tys map[string]cty.Type) bool {
+	for name, ty := range tys {
+		if path == name {
+			return true
+		}
+		if strings.HasPrefix(path, name+".") {
+			return flatmapNestedObjectAttributePathMatches(path[len(name)+1:], ty)
+		}
+	}
+	return false
+}
+
+func flatmapNestedObjectAttributePathMatches(path string, ty cty.Type) bool {
+	if ty.IsPrimitiveType() {
+		return false
+	}
+	if ty.IsObjectType() {
+		return flatmapObjectAttributePathMatches(path, ty.AttributeTypes())
+	}
+	return true
 }
 
 func (p *FlatmapParser) flatmapValueExists(key string, ty cty.Type) bool {

--- a/terraformutils/flatmap_test.go
+++ b/terraformutils/flatmap_test.go
@@ -195,6 +195,46 @@ func TestFromFlatmapMapOfObjectsWithDottedUnknownKey(t *testing.T) {
 	}
 }
 
+func TestFromFlatmapMapOfObjectsWithPrefixCollidingDottedKeys(t *testing.T) {
+	attributes := map[string]string{
+		"headers.%":           "2",
+		"headers.X.name":      "short",
+		"headers.X.name.name": "long",
+	}
+	parser := NewFlatmapParser(attributes, nil, nil)
+	ty := cty.Object(map[string]cty.Type{
+		"headers": cty.Map(cty.Object(map[string]cty.Type{
+			"name": cty.String,
+		})),
+	})
+
+	result, err := parser.Parse(ty)
+	if err != nil {
+		t.Fatalf("Parse error: %v", err)
+	}
+	headers, ok := result["headers"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("headers is not map[string]interface{}, got %T", result["headers"])
+	}
+	if len(headers) != 2 {
+		t.Fatalf("headers length = %d, want 2: %#v", len(headers), headers)
+	}
+	short, ok := headers["X"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("headers[X] is not map[string]interface{}, got %T", headers["X"])
+	}
+	if short["name"] != "short" {
+		t.Errorf("headers[X].name = %v, want %q", short["name"], "short")
+	}
+	dotted, ok := headers["X.name"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("headers[X.name] is not map[string]interface{}, got %T", headers["X.name"])
+	}
+	if dotted["name"] != "long" {
+		t.Errorf("headers[X.name].name = %v, want %q", dotted["name"], "long")
+	}
+}
+
 func TestFromFlatmapSet(t *testing.T) {
 	attributes := map[string]string{
 		"ingress.#":               "1",

--- a/terraformutils/flatmap_test.go
+++ b/terraformutils/flatmap_test.go
@@ -114,12 +114,14 @@ func TestFromFlatmapMap(t *testing.T) {
 
 func TestFromFlatmapMapOfLists(t *testing.T) {
 	attributes := map[string]string{
-		"pools.%":    "2",
-		"pools.EU.#": "1",
-		"pools.EU.0": "pool-eu",
-		"pools.US.#": "2",
-		"pools.US.0": "pool-us-a",
-		"pools.US.1": "pool-us-b",
+		"pools.%":       "3",
+		"pools.EU.#":    "1",
+		"pools.EU.0":    "pool-eu",
+		"pools.US.#":    "2",
+		"pools.US.0":    "pool-us-a",
+		"pools.US.1":    "pool-us-b",
+		"pools.X.Foo.#": "1",
+		"pools.X.Foo.0": "pool-dotted-key",
 	}
 	parser := NewFlatmapParser(attributes, nil, nil)
 	ty := cty.Object(map[string]cty.Type{
@@ -147,6 +149,16 @@ func TestFromFlatmapMapOfLists(t *testing.T) {
 	}
 	if len(eu) != 1 {
 		t.Errorf("pools[EU] length = %d, want 1", len(eu))
+	}
+	dotted, ok := pools["X.Foo"].([]interface{})
+	if !ok {
+		t.Fatalf("pools[X.Foo] is not []interface{}, got %T", pools["X.Foo"])
+	}
+	if len(dotted) != 1 {
+		t.Errorf("pools[X.Foo] length = %d, want 1", len(dotted))
+	}
+	if dotted[0] != "pool-dotted-key" {
+		t.Errorf("pools[X.Foo][0] = %v, want %q", dotted[0], "pool-dotted-key")
 	}
 }
 

--- a/terraformutils/flatmap_test.go
+++ b/terraformutils/flatmap_test.go
@@ -163,6 +163,40 @@ func TestFromFlatmapMapOfLists(t *testing.T) {
 	}
 }
 
+func TestFromFlatmapMapOfListsWithUnknownElement(t *testing.T) {
+	attributes := map[string]string{
+		"pools.%":       "1",
+		"pools.X.Foo.#": "1",
+		"pools.X.Foo.0": tfcompat.UnknownVariableValue,
+	}
+	parser := NewFlatmapParser(attributes, nil, nil)
+	ty := cty.Object(map[string]cty.Type{
+		"pools": cty.Map(cty.List(cty.String)),
+	})
+
+	result, err := parser.Parse(ty)
+	if err != nil {
+		t.Fatalf("Parse error: %v", err)
+	}
+	pools, ok := result["pools"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("pools is not map[string]interface{}, got %T", result["pools"])
+	}
+	if _, ok := pools["X.Foo.0"]; ok {
+		t.Fatal("pools unexpectedly contains unknown list element as map key X.Foo.0")
+	}
+	dotted, ok := pools["X.Foo"].([]interface{})
+	if !ok {
+		t.Fatalf("pools[X.Foo] is not []interface{}, got %T", pools["X.Foo"])
+	}
+	if len(dotted) != 1 {
+		t.Fatalf("pools[X.Foo] length = %d, want 1", len(dotted))
+	}
+	if dotted[0] != tfcompat.UnknownVariableValue {
+		t.Errorf("pools[X.Foo][0] = %v, want %q", dotted[0], tfcompat.UnknownVariableValue)
+	}
+}
+
 func TestFromFlatmapMapOfObjectsWithDottedUnknownKey(t *testing.T) {
 	attributes := map[string]string{
 		"headers.%":          "1",

--- a/terraformutils/flatmap_test.go
+++ b/terraformutils/flatmap_test.go
@@ -6,6 +6,7 @@ import (
 	"regexp"
 	"testing"
 
+	"github.com/chenrui333/terraformer/terraformutils/tfcompat"
 	"github.com/zclconf/go-cty/cty"
 )
 
@@ -159,6 +160,38 @@ func TestFromFlatmapMapOfLists(t *testing.T) {
 	}
 	if dotted[0] != "pool-dotted-key" {
 		t.Errorf("pools[X.Foo][0] = %v, want %q", dotted[0], "pool-dotted-key")
+	}
+}
+
+func TestFromFlatmapMapOfObjectsWithDottedUnknownKey(t *testing.T) {
+	attributes := map[string]string{
+		"headers.%":          "1",
+		"headers.X.Foo.name": tfcompat.UnknownVariableValue,
+	}
+	parser := NewFlatmapParser(attributes, nil, nil)
+	ty := cty.Object(map[string]cty.Type{
+		"headers": cty.Map(cty.Object(map[string]cty.Type{
+			"name": cty.String,
+		})),
+	})
+
+	result, err := parser.Parse(ty)
+	if err != nil {
+		t.Fatalf("Parse error: %v", err)
+	}
+	headers, ok := result["headers"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("headers is not map[string]interface{}, got %T", result["headers"])
+	}
+	if _, ok := headers["X.Foo.name"]; ok {
+		t.Fatal("headers unexpectedly contains nested attribute path as map key X.Foo.name")
+	}
+	dotted, ok := headers["X.Foo"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("headers[X.Foo] is not map[string]interface{}, got %T", headers["X.Foo"])
+	}
+	if dotted["name"] != tfcompat.UnknownVariableValue {
+		t.Errorf("headers[X.Foo].name = %v, want %q", dotted["name"], tfcompat.UnknownVariableValue)
 	}
 }
 

--- a/terraformutils/flatmap_test.go
+++ b/terraformutils/flatmap_test.go
@@ -112,6 +112,44 @@ func TestFromFlatmapMap(t *testing.T) {
 	}
 }
 
+func TestFromFlatmapMapOfLists(t *testing.T) {
+	attributes := map[string]string{
+		"pools.%":    "2",
+		"pools.EU.#": "1",
+		"pools.EU.0": "pool-eu",
+		"pools.US.#": "2",
+		"pools.US.0": "pool-us-a",
+		"pools.US.1": "pool-us-b",
+	}
+	parser := NewFlatmapParser(attributes, nil, nil)
+	ty := cty.Object(map[string]cty.Type{
+		"pools": cty.Map(cty.List(cty.String)),
+	})
+
+	result, err := parser.Parse(ty)
+	if err != nil {
+		t.Fatalf("Parse error: %v", err)
+	}
+	pools, ok := result["pools"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("pools is not map[string]interface{}, got %T", result["pools"])
+	}
+	us, ok := pools["US"].([]interface{})
+	if !ok {
+		t.Fatalf("pools[US] is not []interface{}, got %T", pools["US"])
+	}
+	if len(us) != 2 {
+		t.Errorf("pools[US] length = %d, want 2", len(us))
+	}
+	eu, ok := pools["EU"].([]interface{})
+	if !ok {
+		t.Fatalf("pools[EU] is not []interface{}, got %T", pools["EU"])
+	}
+	if len(eu) != 1 {
+		t.Errorf("pools[EU] length = %d, want 1", len(eu))
+	}
+}
+
 func TestFromFlatmapSet(t *testing.T) {
 	attributes := map[string]string{
 		"ingress.#":               "1",

--- a/terraformutils/providerwrapper/provider.go
+++ b/terraformutils/providerwrapper/provider.go
@@ -186,6 +186,11 @@ func (p *ProviderWrapper) importResourceState(info *tfcompat.InstanceInfo, state
 	id := ""
 	if state != nil {
 		id = state.ID
+		if state.Meta != nil {
+			if metaImportID, ok := state.Meta["import_id"].(string); ok && metaImportID != "" {
+				id = metaImportID
+			}
+		}
 	}
 	importResponse := p.Provider.ImportResourceState(providerproto.ImportResourceStateRequest{
 		TypeName: info.Type,

--- a/terraformutils/tfcompat/flatmap.go
+++ b/terraformutils/tfcompat/flatmap.go
@@ -329,20 +329,25 @@ func hcl2ValueFromFlatmapMapKeyCandidates(key string) []string {
 }
 
 func hcl2ValueFromFlatmapValueExists(m map[string]string, key string, ty cty.Type) bool {
-	if m[key] == UnknownVariableValue {
-		return true
-	}
-
 	switch {
 	case ty.IsPrimitiveType():
+		if m[key] == UnknownVariableValue {
+			return true
+		}
 		_, exists := m[key]
 		return exists
 	case ty.IsObjectType():
 		return hcl2ValueFromFlatmapObjectValueExists(m, key+".", ty.AttributeTypes())
 	case ty.IsTupleType(), ty.IsListType(), ty.IsSetType():
+		if m[key] == UnknownVariableValue {
+			return true
+		}
 		_, exists := m[key+".#"]
 		return exists
 	case ty.IsMapType():
+		if m[key] == UnknownVariableValue {
+			return true
+		}
 		_, exists := m[key+".%"]
 		return exists
 	default:

--- a/terraformutils/tfcompat/flatmap.go
+++ b/terraformutils/tfcompat/flatmap.go
@@ -276,18 +276,24 @@ func hcl2ValueFromFlatmapMap(m map[string]string, prefix string, ty cty.Type) (c
 			continue
 		}
 
-		// The flatmap format doesn't allow us to distinguish between keys
-		// that contain periods and nested objects, so by convention a
-		// map is only ever of primitive type in flatmap, and we just assume
-		// that the remainder of the raw key (dots and all) is the key we
-		// want in the result value.
 		key := fullKey[len(prefix):]
 		if key == "%" {
 			// Ignore the "count" key
 			continue
 		}
 
-		val, err := hcl2ValueFromFlatmapValue(m, fullKey, ety)
+		valueKey := fullKey
+		if !ety.IsPrimitiveType() {
+			if dot := strings.IndexByte(key, '.'); dot != -1 {
+				key = key[:dot]
+				valueKey = prefix + key
+			}
+		}
+		if _, exists := vals[key]; exists {
+			continue
+		}
+
+		val, err := hcl2ValueFromFlatmapValue(m, valueKey, ety)
 		if err != nil {
 			return cty.DynamicVal, err
 		}

--- a/terraformutils/tfcompat/flatmap.go
+++ b/terraformutils/tfcompat/flatmap.go
@@ -310,10 +310,7 @@ func hcl2ValueFromFlatmapMapElementKey(m map[string]string, prefix, key string, 
 	}
 	for _, candidate := range candidates {
 		valueKey := prefix + candidate
-		if m[valueKey] == UnknownVariableValue {
-			return candidate, valueKey
-		}
-		if ty.IsObjectType() && !hcl2ValueFromFlatmapMapObjectElementPathMatches(key, candidate, ty.AttributeTypes()) {
+		if !hcl2ValueFromFlatmapMapElementPathMatches(key, candidate, ty) {
 			continue
 		}
 		if hcl2ValueFromFlatmapValueExists(m, valueKey, ty) {
@@ -352,6 +349,16 @@ func hcl2ValueFromFlatmapObjectMapKeyCandidates(key string) []string {
 	return candidates
 }
 
+func hcl2ValueFromFlatmapMapElementPathMatches(key, candidate string, ty cty.Type) bool {
+	if ty.IsObjectType() {
+		return hcl2ValueFromFlatmapMapObjectElementPathMatches(key, candidate, ty.AttributeTypes())
+	}
+	if !strings.HasPrefix(key, candidate+".") {
+		return false
+	}
+	return hcl2ValueFromFlatmapMapValuePathMatches(key[len(candidate)+1:], ty)
+}
+
 func hcl2ValueFromFlatmapMapObjectElementPathMatches(key, candidate string, atys map[string]cty.Type) bool {
 	if !strings.HasPrefix(key, candidate+".") {
 		return false
@@ -365,20 +372,80 @@ func hcl2ValueFromFlatmapObjectAttributePathMatches(path string, atys map[string
 			return true
 		}
 		if strings.HasPrefix(path, name+".") {
-			return hcl2ValueFromFlatmapNestedObjectAttributePathMatches(path[len(name)+1:], aty)
+			return hcl2ValueFromFlatmapMapValuePathMatches(path[len(name)+1:], aty)
 		}
 	}
 	return false
 }
 
-func hcl2ValueFromFlatmapNestedObjectAttributePathMatches(path string, aty cty.Type) bool {
-	if aty.IsPrimitiveType() {
+func hcl2ValueFromFlatmapMapValuePathMatches(path string, ty cty.Type) bool {
+	switch {
+	case ty.IsPrimitiveType(), ty == cty.DynamicPseudoType:
+		return path == ""
+	case ty.IsObjectType():
+		return hcl2ValueFromFlatmapObjectAttributePathMatches(path, ty.AttributeTypes())
+	case ty.IsTupleType():
+		return hcl2ValueFromFlatmapTuplePathMatches(path, ty.TupleElementTypes())
+	case ty.IsListType():
+		return hcl2ValueFromFlatmapSeqPathMatches(path, ty.ElementType(), true)
+	case ty.IsSetType():
+		return hcl2ValueFromFlatmapSeqPathMatches(path, ty.ElementType(), false)
+	case ty.IsMapType():
+		return hcl2ValueFromFlatmapNestedMapPathMatches(path, ty.ElementType())
+	default:
 		return false
 	}
-	if aty.IsObjectType() {
-		return hcl2ValueFromFlatmapObjectAttributePathMatches(path, aty.AttributeTypes())
+}
+
+func hcl2ValueFromFlatmapTuplePathMatches(path string, etys []cty.Type) bool {
+	if path == "#" {
+		return true
 	}
-	return true
+	segment, rest, hasRest := strings.Cut(path, ".")
+	index, err := strconv.Atoi(segment)
+	if err != nil || index < 0 || index >= len(etys) {
+		return false
+	}
+	if !hasRest {
+		return etys[index].IsPrimitiveType() || etys[index] == cty.DynamicPseudoType
+	}
+	return hcl2ValueFromFlatmapMapValuePathMatches(rest, etys[index])
+}
+
+func hcl2ValueFromFlatmapSeqPathMatches(path string, ety cty.Type, requireIndex bool) bool {
+	if path == "#" {
+		return true
+	}
+	segment, rest, hasRest := strings.Cut(path, ".")
+	if segment == "" {
+		return false
+	}
+	if requireIndex {
+		if _, err := strconv.Atoi(segment); err != nil {
+			return false
+		}
+	}
+	if !hasRest {
+		return ety.IsPrimitiveType() || ety == cty.DynamicPseudoType
+	}
+	return hcl2ValueFromFlatmapMapValuePathMatches(rest, ety)
+}
+
+func hcl2ValueFromFlatmapNestedMapPathMatches(path string, ety cty.Type) bool {
+	if path == "%" {
+		return true
+	}
+	if path == "" {
+		return false
+	}
+	if ety.IsPrimitiveType() || ety == cty.DynamicPseudoType {
+		return true
+	}
+	_, rest, hasRest := strings.Cut(path, ".")
+	if !hasRest {
+		return false
+	}
+	return hcl2ValueFromFlatmapMapValuePathMatches(rest, ety)
 }
 
 func hcl2ValueFromFlatmapValueExists(m map[string]string, key string, ty cty.Type) bool {

--- a/terraformutils/tfcompat/flatmap.go
+++ b/terraformutils/tfcompat/flatmap.go
@@ -304,8 +304,18 @@ func hcl2ValueFromFlatmapMap(m map[string]string, prefix string, ty cty.Type) (c
 }
 
 func hcl2ValueFromFlatmapMapElementKey(m map[string]string, prefix, key string, ty cty.Type) (string, string) {
-	for _, candidate := range hcl2ValueFromFlatmapMapKeyCandidates(key) {
+	candidates := hcl2ValueFromFlatmapMapKeyCandidates(key)
+	if ty.IsObjectType() {
+		candidates = hcl2ValueFromFlatmapObjectMapKeyCandidates(key)
+	}
+	for _, candidate := range candidates {
 		valueKey := prefix + candidate
+		if m[valueKey] == UnknownVariableValue {
+			return candidate, valueKey
+		}
+		if ty.IsObjectType() && !hcl2ValueFromFlatmapMapObjectElementPathMatches(key, candidate, ty.AttributeTypes()) {
+			continue
+		}
 		if hcl2ValueFromFlatmapValueExists(m, valueKey, ty) {
 			return candidate, valueKey
 		}
@@ -326,6 +336,49 @@ func hcl2ValueFromFlatmapMapKeyCandidates(key string) []string {
 		candidates = append(candidates, key[:dot])
 	}
 	return candidates
+}
+
+func hcl2ValueFromFlatmapObjectMapKeyCandidates(key string) []string {
+	var candidates []string
+	for dot := strings.IndexByte(key, '.'); dot != -1; {
+		candidates = append(candidates, key[:dot])
+		next := strings.IndexByte(key[dot+1:], '.')
+		if next == -1 {
+			break
+		}
+		dot += next + 1
+	}
+	candidates = append(candidates, key)
+	return candidates
+}
+
+func hcl2ValueFromFlatmapMapObjectElementPathMatches(key, candidate string, atys map[string]cty.Type) bool {
+	if !strings.HasPrefix(key, candidate+".") {
+		return false
+	}
+	return hcl2ValueFromFlatmapObjectAttributePathMatches(key[len(candidate)+1:], atys)
+}
+
+func hcl2ValueFromFlatmapObjectAttributePathMatches(path string, atys map[string]cty.Type) bool {
+	for name, aty := range atys {
+		if path == name {
+			return true
+		}
+		if strings.HasPrefix(path, name+".") {
+			return hcl2ValueFromFlatmapNestedObjectAttributePathMatches(path[len(name)+1:], aty)
+		}
+	}
+	return false
+}
+
+func hcl2ValueFromFlatmapNestedObjectAttributePathMatches(path string, aty cty.Type) bool {
+	if aty.IsPrimitiveType() {
+		return false
+	}
+	if aty.IsObjectType() {
+		return hcl2ValueFromFlatmapObjectAttributePathMatches(path, aty.AttributeTypes())
+	}
+	return true
 }
 
 func hcl2ValueFromFlatmapValueExists(m map[string]string, key string, ty cty.Type) bool {

--- a/terraformutils/tfcompat/flatmap.go
+++ b/terraformutils/tfcompat/flatmap.go
@@ -284,10 +284,7 @@ func hcl2ValueFromFlatmapMap(m map[string]string, prefix string, ty cty.Type) (c
 
 		valueKey := fullKey
 		if !ety.IsPrimitiveType() {
-			if dot := strings.IndexByte(key, '.'); dot != -1 {
-				key = key[:dot]
-				valueKey = prefix + key
-			}
+			key, valueKey = hcl2ValueFromFlatmapMapElementKey(m, prefix, key, ety)
 		}
 		if _, exists := vals[key]; exists {
 			continue
@@ -304,6 +301,68 @@ func hcl2ValueFromFlatmapMap(m map[string]string, prefix string, ty cty.Type) (c
 		return cty.MapValEmpty(ety), nil
 	}
 	return cty.MapVal(vals), nil
+}
+
+func hcl2ValueFromFlatmapMapElementKey(m map[string]string, prefix, key string, ty cty.Type) (string, string) {
+	for _, candidate := range hcl2ValueFromFlatmapMapKeyCandidates(key) {
+		valueKey := prefix + candidate
+		if hcl2ValueFromFlatmapValueExists(m, valueKey, ty) {
+			return candidate, valueKey
+		}
+	}
+
+	if dot := strings.IndexByte(key, '.'); dot != -1 {
+		key = key[:dot]
+	}
+	return key, prefix + key
+}
+
+func hcl2ValueFromFlatmapMapKeyCandidates(key string) []string {
+	candidates := []string{key}
+	for dot := strings.LastIndexByte(key, '.'); dot != -1; dot = strings.LastIndexByte(key[:dot], '.') {
+		if dot == 0 {
+			continue
+		}
+		candidates = append(candidates, key[:dot])
+	}
+	return candidates
+}
+
+func hcl2ValueFromFlatmapValueExists(m map[string]string, key string, ty cty.Type) bool {
+	if m[key] == UnknownVariableValue {
+		return true
+	}
+
+	switch {
+	case ty.IsPrimitiveType():
+		_, exists := m[key]
+		return exists
+	case ty.IsObjectType():
+		return hcl2ValueFromFlatmapObjectValueExists(m, key+".", ty.AttributeTypes())
+	case ty.IsTupleType(), ty.IsListType(), ty.IsSetType():
+		_, exists := m[key+".#"]
+		return exists
+	case ty.IsMapType():
+		_, exists := m[key+".%"]
+		return exists
+	default:
+		return false
+	}
+}
+
+func hcl2ValueFromFlatmapObjectValueExists(m map[string]string, prefix string, atys map[string]cty.Type) bool {
+	for name, aty := range atys {
+		key := prefix + name
+		if hcl2ValueFromFlatmapValueExists(m, key, aty) {
+			return true
+		}
+		for attributeKey := range m {
+			if strings.HasPrefix(attributeKey, key+".") {
+				return true
+			}
+		}
+	}
+	return false
 }
 
 func hcl2ValueFromFlatmapList(m map[string]string, prefix string, ty cty.Type) (cty.Value, error) {

--- a/terraformutils/tfcompat/flatmap_test.go
+++ b/terraformutils/tfcompat/flatmap_test.go
@@ -119,6 +119,40 @@ func TestHCL2ValueFromFlatmapMapUnknown(t *testing.T) {
 	}
 }
 
+func TestHCL2ValueFromFlatmapMapOfLists(t *testing.T) {
+	m := map[string]string{
+		"pools.%":    "2",
+		"pools.EU.#": "1",
+		"pools.EU.0": "pool-eu",
+		"pools.US.#": "2",
+		"pools.US.0": "pool-us-a",
+		"pools.US.1": "pool-us-b",
+	}
+	ty := cty.Object(map[string]cty.Type{"pools": cty.Map(cty.List(cty.String))})
+
+	val, err := HCL2ValueFromFlatmap(m, ty)
+	if err != nil {
+		t.Fatalf("error: %v", err)
+	}
+	pools := val.GetAttr("pools")
+	if !pools.IsKnown() {
+		t.Fatal("pools is unknown")
+	}
+	if pools.IsNull() {
+		t.Fatal("pools is null")
+	}
+	poolMap := pools.AsValueMap()
+	if len(poolMap) != 2 {
+		t.Fatalf("pools length = %d, want 2", len(poolMap))
+	}
+	if poolMap["US"].LengthInt() != 2 {
+		t.Errorf("pools[US] length = %d, want 2", poolMap["US"].LengthInt())
+	}
+	if poolMap["EU"].LengthInt() != 1 {
+		t.Errorf("pools[EU] length = %d, want 1", poolMap["EU"].LengthInt())
+	}
+}
+
 func TestHCL2ValueFromFlatmapSet(t *testing.T) {
 	m := map[string]string{"ids.#": "2", "ids.12345": "a", "ids.67890": "b"}
 	ty := cty.Object(map[string]cty.Type{"ids": cty.Set(cty.String)})

--- a/terraformutils/tfcompat/flatmap_test.go
+++ b/terraformutils/tfcompat/flatmap_test.go
@@ -198,6 +198,42 @@ func TestHCL2ValueFromFlatmapMapOfObjectsWithDottedUnknownKey(t *testing.T) {
 	}
 }
 
+func TestHCL2ValueFromFlatmapMapOfObjectsWithPrefixCollidingDottedKeys(t *testing.T) {
+	m := map[string]string{
+		"headers.%":           "2",
+		"headers.X.name":      "short",
+		"headers.X.name.name": "long",
+	}
+	ty := cty.Object(map[string]cty.Type{
+		"headers": cty.Map(cty.Object(map[string]cty.Type{
+			"name": cty.String,
+		})),
+	})
+
+	val, err := HCL2ValueFromFlatmap(m, ty)
+	if err != nil {
+		t.Fatalf("error: %v", err)
+	}
+	headers := val.GetAttr("headers").AsValueMap()
+	if len(headers) != 2 {
+		t.Fatalf("headers length = %d, want 2", len(headers))
+	}
+	short, ok := headers["X"]
+	if !ok {
+		t.Fatal("headers does not contain key X")
+	}
+	if name := short.GetAttr("name").AsString(); name != "short" {
+		t.Errorf("headers[X].name = %q, want %q", name, "short")
+	}
+	dotted, ok := headers["X.name"]
+	if !ok {
+		t.Fatal("headers does not contain dotted key X.name")
+	}
+	if name := dotted.GetAttr("name").AsString(); name != "long" {
+		t.Errorf("headers[X.name].name = %q, want %q", name, "long")
+	}
+}
+
 func TestHCL2ValueFromFlatmapSet(t *testing.T) {
 	m := map[string]string{"ids.#": "2", "ids.12345": "a", "ids.67890": "b"}
 	ty := cty.Object(map[string]cty.Type{"ids": cty.Set(cty.String)})

--- a/terraformutils/tfcompat/flatmap_test.go
+++ b/terraformutils/tfcompat/flatmap_test.go
@@ -156,13 +156,45 @@ func TestHCL2ValueFromFlatmapMapOfLists(t *testing.T) {
 	if _, ok := poolMap["X"]; ok {
 		t.Fatal("pools unexpectedly contains truncated key X")
 	}
-	dotted := poolMap["X.Foo"]
+	dotted, ok := poolMap["X.Foo"]
+	if !ok {
+		t.Fatal("pools does not contain dotted key X.Foo")
+	}
 	if dotted.LengthInt() != 1 {
 		t.Errorf("pools[X.Foo] length = %d, want 1", dotted.LengthInt())
 	}
 	dottedValues := dotted.AsValueSlice()
 	if dottedValues[0].AsString() != "pool-dotted-key" {
 		t.Errorf("pools[X.Foo][0] = %q, want %q", dottedValues[0].AsString(), "pool-dotted-key")
+	}
+}
+
+func TestHCL2ValueFromFlatmapMapOfObjectsWithDottedUnknownKey(t *testing.T) {
+	m := map[string]string{
+		"headers.%":          "1",
+		"headers.X.Foo.name": UnknownVariableValue,
+	}
+	ty := cty.Object(map[string]cty.Type{
+		"headers": cty.Map(cty.Object(map[string]cty.Type{
+			"name": cty.String,
+		})),
+	})
+
+	val, err := HCL2ValueFromFlatmap(m, ty)
+	if err != nil {
+		t.Fatalf("error: %v", err)
+	}
+	headers := val.GetAttr("headers").AsValueMap()
+	if _, ok := headers["X.Foo.name"]; ok {
+		t.Fatal("headers unexpectedly contains nested attribute path as map key X.Foo.name")
+	}
+	dotted, ok := headers["X.Foo"]
+	if !ok {
+		t.Fatal("headers does not contain dotted key X.Foo")
+	}
+	name := dotted.GetAttr("name")
+	if name.IsKnown() {
+		t.Fatal("headers[X.Foo].name should be unknown")
 	}
 }
 

--- a/terraformutils/tfcompat/flatmap_test.go
+++ b/terraformutils/tfcompat/flatmap_test.go
@@ -121,12 +121,14 @@ func TestHCL2ValueFromFlatmapMapUnknown(t *testing.T) {
 
 func TestHCL2ValueFromFlatmapMapOfLists(t *testing.T) {
 	m := map[string]string{
-		"pools.%":    "2",
-		"pools.EU.#": "1",
-		"pools.EU.0": "pool-eu",
-		"pools.US.#": "2",
-		"pools.US.0": "pool-us-a",
-		"pools.US.1": "pool-us-b",
+		"pools.%":       "3",
+		"pools.EU.#":    "1",
+		"pools.EU.0":    "pool-eu",
+		"pools.US.#":    "2",
+		"pools.US.0":    "pool-us-a",
+		"pools.US.1":    "pool-us-b",
+		"pools.X.Foo.#": "1",
+		"pools.X.Foo.0": "pool-dotted-key",
 	}
 	ty := cty.Object(map[string]cty.Type{"pools": cty.Map(cty.List(cty.String))})
 
@@ -142,14 +144,25 @@ func TestHCL2ValueFromFlatmapMapOfLists(t *testing.T) {
 		t.Fatal("pools is null")
 	}
 	poolMap := pools.AsValueMap()
-	if len(poolMap) != 2 {
-		t.Fatalf("pools length = %d, want 2", len(poolMap))
+	if len(poolMap) != 3 {
+		t.Fatalf("pools length = %d, want 3", len(poolMap))
 	}
 	if poolMap["US"].LengthInt() != 2 {
 		t.Errorf("pools[US] length = %d, want 2", poolMap["US"].LengthInt())
 	}
 	if poolMap["EU"].LengthInt() != 1 {
 		t.Errorf("pools[EU] length = %d, want 1", poolMap["EU"].LengthInt())
+	}
+	if _, ok := poolMap["X"]; ok {
+		t.Fatal("pools unexpectedly contains truncated key X")
+	}
+	dotted := poolMap["X.Foo"]
+	if dotted.LengthInt() != 1 {
+		t.Errorf("pools[X.Foo] length = %d, want 1", dotted.LengthInt())
+	}
+	dottedValues := dotted.AsValueSlice()
+	if dottedValues[0].AsString() != "pool-dotted-key" {
+		t.Errorf("pools[X.Foo][0] = %q, want %q", dottedValues[0].AsString(), "pool-dotted-key")
 	}
 }
 

--- a/terraformutils/tfcompat/flatmap_test.go
+++ b/terraformutils/tfcompat/flatmap_test.go
@@ -169,6 +169,35 @@ func TestHCL2ValueFromFlatmapMapOfLists(t *testing.T) {
 	}
 }
 
+func TestHCL2ValueFromFlatmapMapOfListsWithUnknownElement(t *testing.T) {
+	m := map[string]string{
+		"pools.%":       "1",
+		"pools.X.Foo.#": "1",
+		"pools.X.Foo.0": UnknownVariableValue,
+	}
+	ty := cty.Object(map[string]cty.Type{"pools": cty.Map(cty.List(cty.String))})
+
+	val, err := HCL2ValueFromFlatmap(m, ty)
+	if err != nil {
+		t.Fatalf("error: %v", err)
+	}
+	pools := val.GetAttr("pools").AsValueMap()
+	if _, ok := pools["X.Foo.0"]; ok {
+		t.Fatal("pools unexpectedly contains unknown list element as map key X.Foo.0")
+	}
+	dotted, ok := pools["X.Foo"]
+	if !ok {
+		t.Fatal("pools does not contain dotted key X.Foo")
+	}
+	if dotted.LengthInt() != 1 {
+		t.Fatalf("pools[X.Foo] length = %d, want 1", dotted.LengthInt())
+	}
+	values := dotted.AsValueSlice()
+	if values[0].IsKnown() {
+		t.Fatal("pools[X.Foo][0] should be unknown")
+	}
+}
+
 func TestHCL2ValueFromFlatmapMapOfObjectsWithDottedUnknownKey(t *testing.T) {
 	m := map[string]string{
 		"headers.%":          "1",


### PR DESCRIPTION
Summary
- expand Cloudflare import coverage from the legacy core set to 47 current provider resource types
- migrate DNS and Access imports to current Cloudflare provider v5 resource names
- document the new resource groups and bump the Cloudflare provider floor to v5.19.1

Notes
- this focuses on resources that have list/read paths available through the current cloudflare-go client and stable Terraform provider import/read state
- intentionally leaves resources with missing list paths or conflicting ownership models for a follow-up assessment pass


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added many Cloudflare service generators (Pages, Load Balancing, Logpush, Storage, Rulesets, Workers, Magic WAN, Turnstile, Waiting Rooms, Web Analytics, Lists, Certificates, Notifications, Tunnels, etc.) and expanded Zero Trust access coverage.

* **Documentation**
  * Updated Cloudflare docs/examples; removed a broken-note from README TOC, bumped provider minimum version, and updated provider download link.

* **Bug Fixes**
  * Standardized DNS record naming and improved import ID fallback behavior.

* **Tests**
  * Added unit tests validating flatmap parsing for map-of-lists.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->