### PR TITLE
aws(sqs): add queue attribute resources

### DIFF
--- a/docs/aws.md
+++ b/docs/aws.md
@@ -410,6 +410,9 @@ terraformer import aws --resources=sg --regions=us-east-1
     * `aws_sns_topic_subscription`
 *   `sqs`
     * `aws_sqs_queue`
+    * `aws_sqs_queue_policy`
+    * `aws_sqs_queue_redrive_allow_policy`
+    * `aws_sqs_queue_redrive_policy`
 *   `ssm`
     * `aws_ssm_activation`
     * `aws_ssm_association`

--- a/providers/aws/sqs.go
+++ b/providers/aws/sqs.go
@@ -137,7 +137,11 @@ func (g *SqsGenerator) addQueueAttributeResources(svc *sqs.Client, queueURL, que
 		if !sqsQueueAttributeConfigured(value) {
 			continue
 		}
-		g.Resources = append(g.Resources, newSqsQueueAttributeResource(queueURL, queueName, value, resource))
+		queueAttributeResource := newSqsQueueAttributeResource(queueURL, queueName, value, resource)
+		if !g.shouldAppendQueueAttributeResource(resource, queueAttributeResource) {
+			continue
+		}
+		g.Resources = append(g.Resources, queueAttributeResource)
 	}
 
 	return nil
@@ -161,6 +165,24 @@ func (g *SqsGenerator) shouldLoadQueueAttributeResources(queueResource terraform
 		return !g.hasTypedNonIDQueueFilter()
 	}
 	return g.queueMatchesAnySqsChildInitialFilter(queueResource)
+}
+
+func (g *SqsGenerator) shouldAppendQueueAttributeResource(resource sqsQueueAttributeResource, queueAttributeResource terraformutils.Resource) bool {
+	if !g.hasTypedSqsChildFilter() {
+		return true
+	}
+
+	hasTypedResourceFilter := false
+	for _, filter := range g.Filter {
+		if filter.ServiceName == "" || !filter.IsApplicable(resource.serviceName) {
+			continue
+		}
+		hasTypedResourceFilter = true
+		if !filter.Filter(queueAttributeResource) {
+			return false
+		}
+	}
+	return hasTypedResourceFilter
 }
 
 func (g *SqsGenerator) queueMatchesInitialIDFilters(queueResource terraformutils.Resource) bool {

--- a/providers/aws/sqs.go
+++ b/providers/aws/sqs.go
@@ -4,19 +4,49 @@ package aws
 
 import (
 	"context"
+	"errors"
 	"fmt"
+	"log"
 	"os"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
-	"github.com/chenrui333/terraformer/terraformutils"
-
 	"github.com/aws/aws-sdk-go-v2/service/sqs"
+	sqstypes "github.com/aws/aws-sdk-go-v2/service/sqs/types"
+	"github.com/chenrui333/terraformer/terraformutils"
 )
 
 var sqsAllowEmptyValues = []string{"tags."}
 
 type SqsGenerator struct {
 	AWSService
+}
+
+type sqsQueueAttributeResource struct {
+	attributeName sqstypes.QueueAttributeName
+	attributeKey  string
+	resourceType  string
+	serviceName   string
+}
+
+var sqsQueueAttributeResources = []sqsQueueAttributeResource{
+	{
+		attributeName: sqstypes.QueueAttributeNamePolicy,
+		attributeKey:  "policy",
+		resourceType:  "aws_sqs_queue_policy",
+		serviceName:   "sqs_queue_policy",
+	},
+	{
+		attributeName: sqstypes.QueueAttributeNameRedrivePolicy,
+		attributeKey:  "redrive_policy",
+		resourceType:  "aws_sqs_queue_redrive_policy",
+		serviceName:   "sqs_queue_redrive_policy",
+	},
+	{
+		attributeName: sqstypes.QueueAttributeNameRedriveAllowPolicy,
+		attributeKey:  "redrive_allow_policy",
+		resourceType:  "aws_sqs_queue_redrive_allow_policy",
+		serviceName:   "sqs_queue_redrive_allow_policy",
+	},
 }
 
 func (g *SqsGenerator) InitResources() error {
@@ -41,30 +71,233 @@ func (g *SqsGenerator) InitResources() error {
 
 	for _, queueURL := range queuesList.QueueUrls {
 		queueName := arnLastSegment(queueURL, "/")
+		queueResource := newSqsQueueResource(queueURL, queueName)
 
-		g.Resources = append(g.Resources, terraformutils.NewSimpleResource(
-			queueURL,
-			queueName,
-			"aws_sqs_queue",
-			"aws",
-			sqsAllowEmptyValues,
-		))
+		if g.shouldAppendQueueResource(queueResource) {
+			g.Resources = append(g.Resources, queueResource)
+		}
+
+		if !g.shouldLoadQueueAttributeResources(queueResource) {
+			continue
+		}
+		if err := g.addQueueAttributeResources(svc, queueURL, queueName); err != nil {
+			if sqsQueueMissing(err) {
+				continue
+			}
+			log.Printf("Skipping SQS queue attribute resources for %s: %v", queueURL, err)
+		}
 	}
 
 	return nil
 }
 
+func newSqsQueueResource(queueURL, queueName string) terraformutils.Resource {
+	return terraformutils.NewSimpleResource(
+		queueURL,
+		queueName,
+		"aws_sqs_queue",
+		"aws",
+		sqsAllowEmptyValues,
+	)
+}
+
+func newSqsQueueAttributeResource(queueURL, queueName, value string, resource sqsQueueAttributeResource) terraformutils.Resource {
+	return terraformutils.NewResource(
+		queueURL,
+		queueName,
+		resource.resourceType,
+		"aws",
+		map[string]string{
+			"queue_url":           queueURL,
+			resource.attributeKey: value,
+		},
+		sqsAllowEmptyValues,
+		map[string]interface{}{},
+	)
+}
+
+func (g *SqsGenerator) addQueueAttributeResources(svc *sqs.Client, queueURL, queueName string) error {
+	output, err := svc.GetQueueAttributes(context.TODO(), &sqs.GetQueueAttributesInput{
+		AttributeNames: []sqstypes.QueueAttributeName{
+			sqstypes.QueueAttributeNamePolicy,
+			sqstypes.QueueAttributeNameRedrivePolicy,
+			sqstypes.QueueAttributeNameRedriveAllowPolicy,
+		},
+		QueueUrl: aws.String(queueURL),
+	})
+	if err != nil {
+		return err
+	}
+	if output == nil || len(output.Attributes) == 0 {
+		return nil
+	}
+
+	for _, resource := range sqsQueueAttributeResources {
+		value := output.Attributes[string(resource.attributeName)]
+		if !sqsQueueAttributeConfigured(value) {
+			continue
+		}
+		g.Resources = append(g.Resources, newSqsQueueAttributeResource(queueURL, queueName, value, resource))
+	}
+
+	return nil
+}
+
+func (g *SqsGenerator) shouldAppendQueueResource(queueResource terraformutils.Resource) bool {
+	if !g.queueMatchesInitialIDFilters(queueResource) {
+		return false
+	}
+	if g.hasTypedSqsChildFilter() && !g.hasTypedFilterFor("sqs_queue") && !g.hasUntypedIDFilter() {
+		return false
+	}
+	return true
+}
+
+func (g *SqsGenerator) shouldLoadQueueAttributeResources(queueResource terraformutils.Resource) bool {
+	if !g.queueMatchesInitialIDFilters(queueResource) {
+		return false
+	}
+	if !g.hasTypedSqsChildFilter() {
+		return !g.hasTypedNonIDQueueFilter()
+	}
+	return g.queueMatchesAnySqsChildInitialFilter(queueResource)
+}
+
+func (g *SqsGenerator) queueMatchesInitialIDFilters(queueResource terraformutils.Resource) bool {
+	for _, filter := range g.Filter {
+		if filter.FieldPath != "id" || !filter.IsApplicable("sqs_queue") {
+			continue
+		}
+		if !filter.Filter(queueResource) {
+			return false
+		}
+	}
+	return true
+}
+
+func (g *SqsGenerator) queueMatchesAnySqsChildInitialFilter(queueResource terraformutils.Resource) bool {
+	for _, resource := range sqsQueueAttributeResources {
+		childResource := newSqsQueueAttributeResource(queueResource.InstanceState.ID, queueResource.ResourceName, "", resource)
+		childHasFilter := false
+		childMatches := true
+		for _, filter := range g.Filter {
+			if filter.ServiceName == "" || !filter.IsApplicable(resource.serviceName) {
+				continue
+			}
+			childHasFilter = true
+			if filter.FieldPath != "id" {
+				return true
+			}
+			if !filter.Filter(childResource) {
+				childMatches = false
+				break
+			}
+		}
+		if childHasFilter && childMatches {
+			return true
+		}
+	}
+	return false
+}
+
+func (g *SqsGenerator) hasTypedSqsChildFilter() bool {
+	for _, resource := range sqsQueueAttributeResources {
+		if g.hasTypedFilterFor(resource.serviceName) {
+			return true
+		}
+	}
+	return false
+}
+
+func (g *SqsGenerator) hasTypedFilterFor(serviceName string) bool {
+	for _, filter := range g.Filter {
+		if filter.ServiceName == serviceName {
+			return true
+		}
+	}
+	return false
+}
+
+func (g *SqsGenerator) hasTypedNonIDQueueFilter() bool {
+	for _, filter := range g.Filter {
+		if filter.ServiceName == "sqs_queue" && filter.FieldPath != "id" {
+			return true
+		}
+	}
+	return false
+}
+
+func (g *SqsGenerator) hasUntypedIDFilter() bool {
+	for _, filter := range g.Filter {
+		if filter.ServiceName == "" && filter.FieldPath == "id" {
+			return true
+		}
+	}
+	return false
+}
+
 // PostConvertHook for add policy json as heredoc
 func (g *SqsGenerator) PostConvertHook() error {
+	splitAttributesByQueueURL := g.sqsSplitAttributesByQueueURL()
+
 	for i, resource := range g.Resources {
-		if resource.InstanceInfo.Type == "aws_sqs_queue" {
-			if val, ok := g.Resources[i].Item["policy"]; ok {
-				policy := g.escapeAwsInterpolation(val.(string))
-				g.Resources[i].Item["policy"] = fmt.Sprintf(`<<POLICY
-%s
-POLICY`, policy)
+		switch resource.InstanceInfo.Type {
+		case "aws_sqs_queue":
+			for attributeKey := range splitAttributesByQueueURL[resource.InstanceState.ID] {
+				delete(g.Resources[i].Item, attributeKey)
 			}
+			g.wrapSqsJSONField(i, "policy")
+		case "aws_sqs_queue_policy":
+			g.wrapSqsJSONField(i, "policy")
+		case "aws_sqs_queue_redrive_policy":
+			g.wrapSqsJSONField(i, "redrive_policy")
+		case "aws_sqs_queue_redrive_allow_policy":
+			g.wrapSqsJSONField(i, "redrive_allow_policy")
 		}
 	}
 	return nil
+}
+
+func (g *SqsGenerator) sqsSplitAttributesByQueueURL() map[string]map[string]struct{} {
+	attributesByQueueURL := map[string]map[string]struct{}{}
+	for _, resource := range g.Resources {
+		var attributeKey string
+		switch resource.InstanceInfo.Type {
+		case "aws_sqs_queue_policy":
+			attributeKey = "policy"
+		case "aws_sqs_queue_redrive_policy":
+			attributeKey = "redrive_policy"
+		case "aws_sqs_queue_redrive_allow_policy":
+			attributeKey = "redrive_allow_policy"
+		default:
+			continue
+		}
+
+		queueURL := resource.InstanceState.ID
+		if queueURL == "" {
+			continue
+		}
+		if _, ok := attributesByQueueURL[queueURL]; !ok {
+			attributesByQueueURL[queueURL] = map[string]struct{}{}
+		}
+		attributesByQueueURL[queueURL][attributeKey] = struct{}{}
+	}
+	return attributesByQueueURL
+}
+
+func (g *SqsGenerator) wrapSqsJSONField(resourceIndex int, field string) {
+	value, ok := g.Resources[resourceIndex].Item[field].(string)
+	if !ok || value == "" {
+		return
+	}
+	g.Resources[resourceIndex].Item[field] = fmt.Sprintf("<<POLICY\n%s\nPOLICY", g.escapeAwsInterpolation(value))
+}
+
+func sqsQueueAttributeConfigured(value string) bool {
+	return value != ""
+}
+
+func sqsQueueMissing(err error) bool {
+	var notFound *sqstypes.QueueDoesNotExist
+	return errors.As(err, &notFound)
 }

--- a/providers/aws/sqs_test.go
+++ b/providers/aws/sqs_test.go
@@ -184,6 +184,76 @@ func TestSqsFilterGatesQueueAndChildDiscovery(t *testing.T) {
 	}
 }
 
+func TestSqsFilterGatesSplitAttributeAppend(t *testing.T) {
+	queueURL := "https://sqs.us-east-1.amazonaws.com/123456789012/orders"
+	policyResource := sqsQueueAttributeResources[0]
+	redrivePolicyResource := sqsQueueAttributeResources[1]
+	redriveAllowPolicyResource := sqsQueueAttributeResources[2]
+	policy := newSqsQueueAttributeResource(queueURL, "orders", "{\"Version\":\"2012-10-17\"}", policyResource)
+	redrivePolicy := newSqsQueueAttributeResource(queueURL, "orders", "{\"maxReceiveCount\":5}", redrivePolicyResource)
+	redriveAllowPolicy := newSqsQueueAttributeResource(queueURL, "orders", "{\"redrivePermission\":\"allowAll\"}", redriveAllowPolicyResource)
+
+	tests := []struct {
+		name                string
+		filters             []terraformutils.ResourceFilter
+		appendPolicy        bool
+		appendRedrivePolicy bool
+		appendAllowPolicy   bool
+	}{
+		{
+			name:                "no typed child filter appends all configured split resources",
+			appendPolicy:        true,
+			appendRedrivePolicy: true,
+			appendAllowPolicy:   true,
+		},
+		{
+			name: "typed redrive policy id filter only appends redrive policy",
+			filters: []terraformutils.ResourceFilter{
+				{ServiceName: "sqs_queue_redrive_policy", FieldPath: "id", AcceptableValues: []string{queueURL}},
+			},
+			appendRedrivePolicy: true,
+		},
+		{
+			name: "typed policy and allow policy filters append only requested siblings",
+			filters: []terraformutils.ResourceFilter{
+				{ServiceName: "sqs_queue_policy", FieldPath: "id", AcceptableValues: []string{queueURL}},
+				{ServiceName: "sqs_queue_redrive_allow_policy", FieldPath: "id", AcceptableValues: []string{queueURL}},
+			},
+			appendPolicy:      true,
+			appendAllowPolicy: true,
+		},
+		{
+			name: "typed child non-id filter checks the candidate resource",
+			filters: []terraformutils.ResourceFilter{
+				{ServiceName: "sqs_queue_redrive_allow_policy", FieldPath: "redrive_allow_policy", AcceptableValues: []string{"{\"redrivePermission\":\"allowAll\"}"}},
+			},
+			appendAllowPolicy: true,
+		},
+		{
+			name: "typed child id filter with different queue skips all siblings",
+			filters: []terraformutils.ResourceFilter{
+				{ServiceName: "sqs_queue_redrive_policy", FieldPath: "id", AcceptableValues: []string{"https://sqs.us-east-1.amazonaws.com/123456789012/other"}},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := SqsGenerator{}
+			g.Filter = tt.filters
+			if got := g.shouldAppendQueueAttributeResource(policyResource, policy); got != tt.appendPolicy {
+				t.Fatalf("shouldAppendQueueAttributeResource(policy) = %t, want %t", got, tt.appendPolicy)
+			}
+			if got := g.shouldAppendQueueAttributeResource(redrivePolicyResource, redrivePolicy); got != tt.appendRedrivePolicy {
+				t.Fatalf("shouldAppendQueueAttributeResource(redrive_policy) = %t, want %t", got, tt.appendRedrivePolicy)
+			}
+			if got := g.shouldAppendQueueAttributeResource(redriveAllowPolicyResource, redriveAllowPolicy); got != tt.appendAllowPolicy {
+				t.Fatalf("shouldAppendQueueAttributeResource(redrive_allow_policy) = %t, want %t", got, tt.appendAllowPolicy)
+			}
+		})
+	}
+}
+
 func TestSqsQueueMissing(t *testing.T) {
 	tests := []struct {
 		name string

--- a/providers/aws/sqs_test.go
+++ b/providers/aws/sqs_test.go
@@ -1,0 +1,218 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package aws
+
+import (
+	"errors"
+	"strings"
+	"testing"
+
+	sqstypes "github.com/aws/aws-sdk-go-v2/service/sqs/types"
+	"github.com/chenrui333/terraformer/terraformutils"
+)
+
+func TestSqsPostConvertHookMovesSplitAttributesOutOfQueue(t *testing.T) {
+	queueURL := "https://sqs.us-east-1.amazonaws.com/123456789012/orders"
+	queue := terraformutils.NewSimpleResource(queueURL, "orders", "aws_sqs_queue", "aws", sqsAllowEmptyValues)
+	queue.Item = map[string]interface{}{
+		"policy":                     "{\"Version\":\"2012-10-17\"}",
+		"redrive_policy":             "{\"deadLetterTargetArn\":\"arn:aws:sqs:us-east-1:123456789012:orders-dlq\",\"maxReceiveCount\":5}",
+		"redrive_allow_policy":       "{\"redrivePermission\":\"allowAll\"}",
+		"visibility_timeout_seconds": 30,
+	}
+
+	queuePolicy := terraformutils.NewResource(
+		queueURL,
+		"orders",
+		"aws_sqs_queue_policy",
+		"aws",
+		map[string]string{"queue_url": queueURL, "policy": "{\"Version\":\"2012-10-17\"}"},
+		sqsAllowEmptyValues,
+		map[string]interface{}{},
+	)
+	queuePolicy.Item = map[string]interface{}{"queue_url": queueURL, "policy": "{\"Version\":\"2012-10-17\"}"}
+
+	redrivePolicy := terraformutils.NewResource(
+		queueURL,
+		"orders",
+		"aws_sqs_queue_redrive_policy",
+		"aws",
+		map[string]string{"queue_url": queueURL, "redrive_policy": "{\"deadLetterTargetArn\":\"arn:aws:sqs:us-east-1:123456789012:orders-dlq\",\"maxReceiveCount\":5}"},
+		sqsAllowEmptyValues,
+		map[string]interface{}{},
+	)
+	redrivePolicy.Item = map[string]interface{}{"queue_url": queueURL, "redrive_policy": "{\"deadLetterTargetArn\":\"arn:aws:sqs:us-east-1:123456789012:orders-dlq\",\"maxReceiveCount\":5}"}
+
+	redriveAllowPolicy := terraformutils.NewResource(
+		queueURL,
+		"orders",
+		"aws_sqs_queue_redrive_allow_policy",
+		"aws",
+		map[string]string{"queue_url": queueURL, "redrive_allow_policy": "{\"redrivePermission\":\"allowAll\"}"},
+		sqsAllowEmptyValues,
+		map[string]interface{}{},
+	)
+	redriveAllowPolicy.Item = map[string]interface{}{"queue_url": queueURL, "redrive_allow_policy": "{\"redrivePermission\":\"allowAll\"}"}
+
+	g := SqsGenerator{}
+	g.Resources = []terraformutils.Resource{queue, queuePolicy, redrivePolicy, redriveAllowPolicy}
+
+	if err := g.PostConvertHook(); err != nil {
+		t.Fatalf("PostConvertHook() error = %v", err)
+	}
+
+	for _, key := range []string{"policy", "redrive_policy", "redrive_allow_policy"} {
+		if _, ok := g.Resources[0].Item[key]; ok {
+			t.Fatalf("queue inline %s should be removed when split resource exists", key)
+		}
+	}
+	if _, ok := g.Resources[0].Item["visibility_timeout_seconds"]; !ok {
+		t.Fatal("unrelated queue attributes should be preserved")
+	}
+
+	assertSqsHeredoc(t, g.Resources[1].Item["policy"])
+	assertSqsHeredoc(t, g.Resources[2].Item["redrive_policy"])
+	assertSqsHeredoc(t, g.Resources[3].Item["redrive_allow_policy"])
+}
+
+func TestSqsPostConvertHookKeepsInlinePolicyWithoutSplitResource(t *testing.T) {
+	queueURL := "https://sqs.us-east-1.amazonaws.com/123456789012/orders"
+	queue := terraformutils.NewSimpleResource(queueURL, "orders", "aws_sqs_queue", "aws", sqsAllowEmptyValues)
+	queue.Item = map[string]interface{}{"policy": "{\"Version\":\"2012-10-17\"}"}
+
+	g := SqsGenerator{}
+	g.Resources = []terraformutils.Resource{queue}
+
+	if err := g.PostConvertHook(); err != nil {
+		t.Fatalf("PostConvertHook() error = %v", err)
+	}
+
+	assertSqsHeredoc(t, g.Resources[0].Item["policy"])
+}
+
+func TestSqsQueueAttributeConfigured(t *testing.T) {
+	tests := []struct {
+		name  string
+		value string
+		want  bool
+	}{
+		{name: "empty", value: "", want: false},
+		{name: "json object", value: "{}", want: true},
+		{name: "json policy", value: "{\"Version\":\"2012-10-17\"}", want: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := sqsQueueAttributeConfigured(tt.value); got != tt.want {
+				t.Fatalf("sqsQueueAttributeConfigured(%q) = %t, want %t", tt.value, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestSqsFilterGatesQueueAndChildDiscovery(t *testing.T) {
+	queueURL := "https://sqs.us-east-1.amazonaws.com/123456789012/orders"
+	otherURL := "https://sqs.us-east-1.amazonaws.com/123456789012/other"
+	queue := newSqsQueueResource(queueURL, "orders")
+	otherQueue := newSqsQueueResource(otherURL, "other")
+
+	tests := []struct {
+		name           string
+		filters        []terraformutils.ResourceFilter
+		appendQueue    bool
+		appendOther    bool
+		loadQueueChild bool
+		loadOtherChild bool
+	}{
+		{
+			name:           "no filters imports queue and children",
+			appendQueue:    true,
+			appendOther:    true,
+			loadQueueChild: true,
+			loadOtherChild: true,
+		},
+		{
+			name: "typed queue id filter limits queue and children",
+			filters: []terraformutils.ResourceFilter{
+				{ServiceName: "sqs_queue", FieldPath: "id", AcceptableValues: []string{queueURL}},
+			},
+			appendQueue:    true,
+			loadQueueChild: true,
+		},
+		{
+			name: "typed child id filter does not import parent queues",
+			filters: []terraformutils.ResourceFilter{
+				{ServiceName: "sqs_queue_policy", FieldPath: "id", AcceptableValues: []string{queueURL}},
+			},
+			loadQueueChild: true,
+		},
+		{
+			name: "untyped id filter limits all same-id resources",
+			filters: []terraformutils.ResourceFilter{
+				{FieldPath: "id", AcceptableValues: []string{queueURL}},
+			},
+			appendQueue:    true,
+			loadQueueChild: true,
+		},
+		{
+			name: "typed non-id queue filter does not pre-load children",
+			filters: []terraformutils.ResourceFilter{
+				{ServiceName: "sqs_queue", FieldPath: "tags.env", AcceptableValues: []string{"prod"}},
+			},
+			appendQueue: true,
+			appendOther: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := SqsGenerator{}
+			g.Filter = tt.filters
+			if got := g.shouldAppendQueueResource(queue); got != tt.appendQueue {
+				t.Fatalf("shouldAppendQueueResource(queue) = %t, want %t", got, tt.appendQueue)
+			}
+			if got := g.shouldAppendQueueResource(otherQueue); got != tt.appendOther {
+				t.Fatalf("shouldAppendQueueResource(other) = %t, want %t", got, tt.appendOther)
+			}
+			if got := g.shouldLoadQueueAttributeResources(queue); got != tt.loadQueueChild {
+				t.Fatalf("shouldLoadQueueAttributeResources(queue) = %t, want %t", got, tt.loadQueueChild)
+			}
+			if got := g.shouldLoadQueueAttributeResources(otherQueue); got != tt.loadOtherChild {
+				t.Fatalf("shouldLoadQueueAttributeResources(other) = %t, want %t", got, tt.loadOtherChild)
+			}
+		})
+	}
+}
+
+func TestSqsQueueMissing(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{name: "nil", err: nil, want: false},
+		{name: "typed missing", err: &sqstypes.QueueDoesNotExist{}, want: true},
+		{name: "wrapped typed missing", err: errors.Join(errors.New("wrapper"), &sqstypes.QueueDoesNotExist{}), want: true},
+		{name: "generic", err: errors.New("boom"), want: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := sqsQueueMissing(tt.err); got != tt.want {
+				t.Fatalf("sqsQueueMissing(%v) = %t, want %t", tt.err, got, tt.want)
+			}
+		})
+	}
+}
+
+func assertSqsHeredoc(t *testing.T, value interface{}) {
+	t.Helper()
+
+	policy, ok := value.(string)
+	if !ok {
+		t.Fatalf("value has type %T, want string", value)
+	}
+	if !strings.HasPrefix(policy, "<<POLICY\n") || !strings.HasSuffix(policy, "\nPOLICY") {
+		t.Fatalf("value %q is not wrapped as a POLICY heredoc", policy)
+	}
+}


### PR DESCRIPTION
## Summary

- add SQS discovery for queue policy, redrive policy, and redrive allow policy split resources
- seed required queue attribute resource state and keep attribute discovery best-effort for deleted or inaccessible queues
- avoid duplicate inline queue policy/redrive fields when split resources are emitted, and cover filter behavior with focused tests
