### PR TITLE
fix(providers): return ignored nested read errors

### DIFF
--- a/providers/aws/cloud9.go
+++ b/providers/aws/cloud9.go
@@ -4,6 +4,7 @@ package aws
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/aws/aws-sdk-go-v2/service/cloud9"
 	"github.com/aws/aws-sdk-go-v2/service/cloud9/types"
@@ -27,9 +28,12 @@ func (g *Cloud9Generator) InitResources() error {
 		return err
 	}
 	for _, environmentID := range output.EnvironmentIds {
-		details, _ := svc.DescribeEnvironmentStatus(context.TODO(), &cloud9.DescribeEnvironmentStatusInput{
+		details, err := svc.DescribeEnvironmentStatus(context.TODO(), &cloud9.DescribeEnvironmentStatusInput{
 			EnvironmentId: &environmentID,
 		})
+		if err != nil {
+			return fmt.Errorf("describe Cloud9 environment status for %s: %w", environmentID, err)
+		}
 		if details.Status == types.EnvironmentStatusError ||
 			details.Status == types.EnvironmentStatusDeleting {
 			continue

--- a/providers/aws/ebs.go
+++ b/providers/aws/ebs.go
@@ -51,9 +51,17 @@ func (g *EbsGenerator) InitResources() error {
 			isRootDevice := false // Let's leave root device configuration to be done in ec2_instance resources
 
 			for _, attachment := range volume.Attachments {
-				instances, _ := svc.DescribeInstances(context.TODO(), &ec2.DescribeInstancesInput{
+				instances, err := svc.DescribeInstances(context.TODO(), &ec2.DescribeInstancesInput{
 					InstanceIds: []string{StringValue(attachment.InstanceId)},
 				})
+				if err != nil {
+					return fmt.Errorf(
+						"describe EC2 instance %s for EBS volume %s: %w",
+						StringValue(attachment.InstanceId),
+						StringValue(volume.VolumeId),
+						err,
+					)
+				}
 				for _, reservation := range instances.Reservations {
 					for _, instance := range reservation.Instances {
 						if StringValue(instance.RootDeviceName) == StringValue(attachment.Device) {

--- a/providers/honeycombio/burn_alert.go
+++ b/providers/honeycombio/burn_alert.go
@@ -28,7 +28,15 @@ func (g *BurnAlertGenerator) InitResources() error {
 		}
 
 		for _, slo := range slos {
-			bas, _ := client.BurnAlerts.ListForSLO(context.TODO(), dataset.Slug, slo.ID)
+			bas, err := client.BurnAlerts.ListForSLO(context.TODO(), dataset.Slug, slo.ID)
+			if err != nil {
+				return fmt.Errorf(
+					"unable to list Honeycomb burn alerts for dataset %q SLO %q: %w",
+					dataset.Slug,
+					slo.ID,
+					err,
+				)
+			}
 			for _, ba := range bas {
 				g.Resources = append(g.Resources, terraformutils.NewResource(
 					ba.ID,

--- a/providers/ibm/ibm_kp.go
+++ b/providers/ibm/ibm_kp.go
@@ -153,7 +153,10 @@ func (g *KPGenerator) InitResources() error {
 				g.Resources = append(g.Resources, fnObjt(key.CRN, alias, dependsOn))
 			}
 
-			policies, _ := client.GetPolicies(context.Background(), key.ID)
+			policies, err := client.GetPolicies(context.Background(), key.ID)
+			if err != nil {
+				return fmt.Errorf("unable to get Key Protect policies for key %q: %w", key.ID, err)
+			}
 			funObjt := g.loadKpKeyPolicies()
 			for range policies {
 				g.Resources = append(g.Resources, funObjt(key.CRN, dependsOn))


### PR DESCRIPTION
## Summary

- Return AWS Cloud9 status and EBS instance lookup errors instead of discarding nested read failures.
- Return Honeycomb burn alert and IBM Key Protect policy read failures with resource context.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Expose nested read failures across providers so we fail fast with clear error context instead of silently skipping resources. Improves debugging for AWS Cloud9/EBS, Honeycomb burn alerts, and IBM Key Protect.

- **Bug Fixes**
  - `providers/aws/cloud9`: return DescribeEnvironmentStatus errors with environment ID.
  - `providers/aws/ebs`: return DescribeInstances errors with instance and volume IDs.
  - `providers/honeycombio/burn_alert`: return ListForSLO errors with dataset slug and SLO ID.
  - `providers/ibm/ibm_kp`: return GetPolicies errors with key ID.

<sup>Written for commit 8bb1ea36eaa313b9b941986fdc709c1f290b9448. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

