### PR TITLE
feat(kubernetes): import node taints

### DIFF
--- a/docs/kubernetes.md
+++ b/docs/kubernetes.md
@@ -56,6 +56,8 @@ Common supported resources include:
     * `kubernetes_namespace_v1`
 *   `networkpolicies`
     * `kubernetes_network_policy_v1`
+*   `nodetaints`
+    * `kubernetes_node_taint`
 *   `persistentvolumes`
     * `kubernetes_persistent_volume_v1`
 *   `persistentvolumeclaims`

--- a/providers/kubernetes/kubernetes_provider.go
+++ b/providers/kubernetes/kubernetes_provider.go
@@ -131,6 +131,10 @@ func (p *KubernetesProvider) GetSupportedService() map[string]terraformutils.Ser
 		_, exists := resp.ResourceTypes[name]
 		return exists
 	})
+	addNodeTaintService(resources, clientset, listableResources, func(name string) bool {
+		_, exists := resp.ResourceTypes[name]
+		return exists
+	})
 	return resources
 }
 
@@ -183,6 +187,27 @@ func addDefaultServiceAccountService(
 
 	resources[defaultServiceAccountServiceName] = &DefaultServiceAccount{
 		TerraformType: terraformResourceName,
+	}
+}
+
+func addNodeTaintService(
+	resources map[string]terraformutils.ServiceGenerator,
+	clientset k8sclient.Interface,
+	listableResources map[kubernetesResourceID]struct{},
+	hasResourceType func(string) bool,
+) {
+	if _, ok := listableResources[kubernetesResourceID{version: "v1", kind: "Node"}]; !ok {
+		return
+	}
+	if !supportsTypedClientResource(clientset, "", "v1", "Node") {
+		return
+	}
+	if !hasResourceType(nodeTaintTerraformType) {
+		return
+	}
+
+	resources[nodeTaintServiceName] = &NodeTaint{
+		TerraformType: nodeTaintTerraformType,
 	}
 }
 

--- a/providers/kubernetes/kubernetes_provider_test.go
+++ b/providers/kubernetes/kubernetes_provider_test.go
@@ -63,6 +63,59 @@ func TestAddDefaultServiceAccountServiceRequiresServiceAccountAPI(t *testing.T) 
 	}
 }
 
+func TestAddNodeTaintService(t *testing.T) {
+	resources := map[string]terraformutils.ServiceGenerator{}
+	clientset := fake.NewSimpleClientset()
+	listableResources := map[kubernetesResourceID]struct{}{
+		{version: "v1", kind: "Node"}: {},
+	}
+
+	addNodeTaintService(resources, clientset, listableResources, func(name string) bool {
+		return name == nodeTaintTerraformType
+	})
+
+	service, ok := resources[nodeTaintServiceName]
+	if !ok {
+		t.Fatalf("resources[%q] was not registered", nodeTaintServiceName)
+	}
+	nodeTaint, ok := service.(*NodeTaint)
+	if !ok {
+		t.Fatalf("service type = %T, want *NodeTaint", service)
+	}
+	if nodeTaint.TerraformType != nodeTaintTerraformType {
+		t.Fatalf("TerraformType = %q, want %q", nodeTaint.TerraformType, nodeTaintTerraformType)
+	}
+}
+
+func TestAddNodeTaintServiceRequiresProviderType(t *testing.T) {
+	resources := map[string]terraformutils.ServiceGenerator{}
+	clientset := fake.NewSimpleClientset()
+	listableResources := map[kubernetesResourceID]struct{}{
+		{version: "v1", kind: "Node"}: {},
+	}
+
+	addNodeTaintService(resources, clientset, listableResources, func(string) bool {
+		return false
+	})
+
+	if _, ok := resources[nodeTaintServiceName]; ok {
+		t.Fatalf("resources[%q] was registered without provider type support", nodeTaintServiceName)
+	}
+}
+
+func TestAddNodeTaintServiceRequiresNodeAPI(t *testing.T) {
+	resources := map[string]terraformutils.ServiceGenerator{}
+	clientset := fake.NewSimpleClientset()
+
+	addNodeTaintService(resources, clientset, map[kubernetesResourceID]struct{}{}, func(name string) bool {
+		return name == nodeTaintTerraformType
+	})
+
+	if _, ok := resources[nodeTaintServiceName]; ok {
+		t.Fatalf("resources[%q] was registered without nodes API support", nodeTaintServiceName)
+	}
+}
+
 func TestAddKubernetesResourceServiceDisambiguatesManifestPluralCollisions(t *testing.T) {
 	resources := map[string]terraformutils.ServiceGenerator{}
 	resource := metav1.APIResource{

--- a/providers/kubernetes/node_taint.go
+++ b/providers/kubernetes/node_taint.go
@@ -1,0 +1,95 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package kubernetes
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+
+	"github.com/chenrui333/terraformer/terraformutils"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+)
+
+const (
+	nodeTaintServiceName       = "nodetaints"
+	nodeTaintTerraformType     = "kubernetes_node_taint"
+	nodeTaintAllowEmptyPattern = `^taint\.[0-9]+\.value$`
+)
+
+type NodeTaint struct {
+	KubernetesService
+	TerraformType string
+}
+
+func (n *NodeTaint) InitResources() error {
+	config, _, err := initClientAndConfig()
+	if err != nil {
+		return err
+	}
+
+	clientset, err := kubernetes.NewForConfig(config)
+	if err != nil {
+		return err
+	}
+
+	return n.initResources(clientset)
+}
+
+func (n *NodeTaint) initResources(clientset kubernetes.Interface) error {
+	nodes, err := clientset.CoreV1().Nodes().List(context.Background(), metav1.ListOptions{})
+	if err != nil {
+		return err
+	}
+
+	terraformType := n.TerraformType
+	if terraformType == "" {
+		terraformType = nodeTaintTerraformType
+	}
+
+	for i := range nodes.Items {
+		node := nodes.Items[i]
+		if len(node.Spec.Taints) == 0 {
+			continue
+		}
+
+		attributes := nodeTaintAttributes(node.Name, node.Spec.Taints)
+		n.Resources = append(n.Resources, terraformutils.NewResource(
+			attributes["id"],
+			node.Name,
+			terraformType,
+			"kubernetes",
+			attributes,
+			[]string{nodeTaintAllowEmptyPattern},
+			map[string]interface{}{},
+		))
+	}
+	return nil
+}
+
+func nodeTaintAttributes(nodeName string, taints []corev1.Taint) map[string]string {
+	attributes := map[string]string{
+		"id":              nodeTaintID(nodeName, taints),
+		"metadata.#":      "1",
+		"metadata.0.name": nodeName,
+		"taint.#":         strconv.Itoa(len(taints)),
+	}
+	for i, taint := range taints {
+		prefix := "taint." + strconv.Itoa(i) + "."
+		attributes[prefix+"effect"] = string(taint.Effect)
+		attributes[prefix+"key"] = taint.Key
+		attributes[prefix+"value"] = taint.Value
+	}
+	return attributes
+}
+
+func nodeTaintID(nodeName string, taints []corev1.Taint) string {
+	id := nodeName
+	for _, taint := range taints {
+		id += fmt.Sprintf(",%s=%s:%s", taint.Key, taint.Value, taint.Effect)
+	}
+	return id
+}

--- a/providers/kubernetes/node_taint_test.go
+++ b/providers/kubernetes/node_taint_test.go
@@ -1,0 +1,161 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package kubernetes
+
+import (
+	"testing"
+
+	"github.com/chenrui333/terraformer/terraformutils/tfcompat"
+	"github.com/chenrui333/terraformer/terraformutils/tfcompat/configschema"
+	"github.com/zclconf/go-cty/cty"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/fake"
+)
+
+func TestNodeTaintInitResources(t *testing.T) {
+	clientset := fake.NewSimpleClientset(
+		&corev1.Node{
+			ObjectMeta: metav1.ObjectMeta{Name: "worker-a"},
+			Spec: corev1.NodeSpec{
+				Taints: []corev1.Taint{
+					{
+						Key:    "dedicated",
+						Value:  "gpu",
+						Effect: corev1.TaintEffectNoSchedule,
+					},
+					{
+						Key:    "node-role.kubernetes.io/control-plane",
+						Effect: corev1.TaintEffectNoSchedule,
+					},
+				},
+			},
+		},
+		&corev1.Node{
+			ObjectMeta: metav1.ObjectMeta{Name: "worker-b"},
+		},
+	)
+
+	service := &NodeTaint{}
+	if err := service.initResources(clientset); err != nil {
+		t.Fatalf("initResources() error = %v", err)
+	}
+
+	if len(service.Resources) != 1 {
+		t.Fatalf("Resources len = %d, want 1", len(service.Resources))
+	}
+	resource := service.Resources[0]
+	if resource.InstanceInfo.Type != nodeTaintTerraformType {
+		t.Fatalf("resource type = %q, want %q", resource.InstanceInfo.Type, nodeTaintTerraformType)
+	}
+	wantID := "worker-a,dedicated=gpu:NoSchedule,node-role.kubernetes.io/control-plane=:NoSchedule"
+	if resource.InstanceState.ID != wantID {
+		t.Fatalf("resource ID = %q, want %q", resource.InstanceState.ID, wantID)
+	}
+	if resource.ResourceName != "tfer--worker-a" {
+		t.Fatalf("resource name = %q, want %q", resource.ResourceName, "tfer--worker-a")
+	}
+
+	attributes := resource.InstanceState.Attributes
+	for key, want := range map[string]string{
+		"id":             wantID,
+		"metadata.#":     "1",
+		"taint.#":        "2",
+		"taint.0.key":    "dedicated",
+		"taint.0.value":  "gpu",
+		"taint.0.effect": "NoSchedule",
+		"taint.1.key":    "node-role.kubernetes.io/control-plane",
+		"taint.1.value":  "",
+		"taint.1.effect": "NoSchedule",
+	} {
+		if got := attributes[key]; got != want {
+			t.Fatalf("attribute %q = %q, want %q", key, got, want)
+		}
+	}
+	if len(resource.AllowEmptyValues) != 1 || resource.AllowEmptyValues[0] != nodeTaintAllowEmptyPattern {
+		t.Fatalf("AllowEmptyValues = %#v, want %#v", resource.AllowEmptyValues, []string{nodeTaintAllowEmptyPattern})
+	}
+	if _, err := tfcompat.HCL2ValueFromFlatmap(attributes, nodeTaintTestBlock().ImpliedType()); err != nil {
+		t.Fatalf("node taint flatmap does not decode into provider schema: %v", err)
+	}
+}
+
+func TestNodeTaintInitResourcesUsesConfiguredTerraformType(t *testing.T) {
+	clientset := fake.NewSimpleClientset(&corev1.Node{
+		ObjectMeta: metav1.ObjectMeta{Name: "worker-a"},
+		Spec: corev1.NodeSpec{
+			Taints: []corev1.Taint{{
+				Key:    "dedicated",
+				Value:  "gpu",
+				Effect: corev1.TaintEffectNoSchedule,
+			}},
+		},
+	})
+	service := &NodeTaint{TerraformType: "custom_node_taint"}
+
+	if err := service.initResources(clientset); err != nil {
+		t.Fatalf("initResources() error = %v", err)
+	}
+
+	if len(service.Resources) != 1 {
+		t.Fatalf("Resources len = %d, want 1", len(service.Resources))
+	}
+	if service.Resources[0].InstanceInfo.Type != "custom_node_taint" {
+		t.Fatalf("resource type = %q, want %q", service.Resources[0].InstanceInfo.Type, "custom_node_taint")
+	}
+}
+
+func nodeTaintTestBlock() *configschema.Block {
+	return &configschema.Block{
+		Attributes: map[string]*configschema.Attribute{
+			"id": {
+				Type:     cty.String,
+				Computed: true,
+			},
+			"field_manager": {
+				Type:     cty.String,
+				Optional: true,
+			},
+			"force": {
+				Type:     cty.Bool,
+				Optional: true,
+			},
+		},
+		BlockTypes: map[string]*configschema.NestedBlock{
+			"metadata": {
+				Nesting:  configschema.NestingList,
+				MinItems: 1,
+				MaxItems: 1,
+				Block: configschema.Block{
+					Attributes: map[string]*configschema.Attribute{
+						"name": {
+							Type:     cty.String,
+							Required: true,
+						},
+					},
+				},
+			},
+			"taint": {
+				Nesting:  configschema.NestingList,
+				MinItems: 1,
+				Block: configschema.Block{
+					Attributes: map[string]*configschema.Attribute{
+						"effect": {
+							Type:     cty.String,
+							Required: true,
+						},
+						"key": {
+							Type:     cty.String,
+							Required: true,
+						},
+						"value": {
+							Type:     cty.String,
+							Required: true,
+						},
+					},
+				},
+			},
+		},
+	}
+}


### PR DESCRIPTION
Summary
- add a Kubernetes nodetaints service backed by the Terraform kubernetes_node_taint resource
- derive node taint resources from listable core/v1 Nodes and seed provider-readable metadata/taint state
- document nodetaints in the Kubernetes provider resource list

Notes
- only nodes with existing taints are emitted
- empty taint values are preserved for common taints such as control-plane NoSchedule


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a `nodetaints` service to import Kubernetes node taints as `kubernetes_node_taint` resources. Only nodes with taints are emitted, with empty taint values preserved.

- **New Features**
  - New `nodetaints` service that generates `kubernetes_node_taint` resources from listable Nodes.
  - Preserves empty taint values (e.g., control-plane NoSchedule) via an allow-empty pattern.
  - Registers only when the Nodes API is available and the provider supports the resource type.
  - Updates docs and adds tests for service registration and schema decoding.

<sup>Written for commit 2cdad68964503052ad4117d8aa0f9030727f3121. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

