### PR TITLE
fix(myrasec): propagate concurrent discovery errors

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -238,7 +238,7 @@ require (
 	go.mongodb.org/mongo-driver v1.17.9 // indirect
 	golang.org/x/crypto v0.50.0 // indirect
 	golang.org/x/net v0.53.0 // indirect
-	golang.org/x/sync v0.20.0 // indirect
+	golang.org/x/sync v0.20.0
 	golang.org/x/sys v0.43.0 // indirect
 	golang.org/x/term v0.42.0 // indirect
 	golang.org/x/time v0.15.0 // indirect

--- a/providers/myrasec/cache_setting.go
+++ b/providers/myrasec/cache_setting.go
@@ -4,7 +4,6 @@ package myrasec
 import (
 	"fmt"
 	"strconv"
-	"sync"
 
 	mgo "github.com/Myra-Security-GmbH/myrasec-go/v2"
 	"github.com/chenrui333/terraformer/terraformutils"
@@ -16,9 +15,7 @@ type CacheSettingGenerator struct {
 }
 
 // createCacheSettingResources
-func (g *CacheSettingGenerator) createCacheSettingResources(api *mgo.API, domainId int, vhost mgo.VHost, wg *sync.WaitGroup) error {
-	defer wg.Done()
-
+func (g *CacheSettingGenerator) createCacheSettingResources(api *mgo.API, domainId int, vhost mgo.VHost) error {
 	page := 1
 	pageSize := 250
 	params := map[string]string{
@@ -48,7 +45,7 @@ func (g *CacheSettingGenerator) createCacheSettingResources(api *mgo.API, domain
 				map[string]interface{}{},
 			)
 			r.IgnoreKeys = append(r.IgnoreKeys, "^Metadata")
-			g.Resources = append(g.Resources, r)
+			g.appendResource(r)
 		}
 		if len(settings) < pageSize {
 			break
@@ -60,22 +57,18 @@ func (g *CacheSettingGenerator) createCacheSettingResources(api *mgo.API, domain
 
 // InitResources
 func (g *CacheSettingGenerator) InitResources() error {
-	wg := sync.WaitGroup{}
-
 	api, err := g.initializeAPI()
 	if err != nil {
 		return err
 	}
 
-	funcs := []func(*mgo.API, int, mgo.VHost, *sync.WaitGroup) error{
+	funcs := []func(*mgo.API, int, mgo.VHost) error{
 		g.createCacheSettingResources,
 	}
-	err = createResourcesPerSubDomain(api, funcs, &wg, true)
+	err = createResourcesPerSubDomain(api, funcs, true)
 	if err != nil {
 		return err
 	}
-
-	wg.Wait()
 
 	return nil
 }

--- a/providers/myrasec/dns_record.go
+++ b/providers/myrasec/dns_record.go
@@ -4,7 +4,6 @@ package myrasec
 import (
 	"fmt"
 	"strconv"
-	"sync"
 
 	mgo "github.com/Myra-Security-GmbH/myrasec-go/v2"
 	"github.com/chenrui333/terraformer/terraformutils"
@@ -16,9 +15,7 @@ type DNSGenerator struct {
 }
 
 // createDnsResources
-func (g *DNSGenerator) createDnsResources(api *mgo.API, domain mgo.Domain, wg *sync.WaitGroup) error {
-	defer wg.Done()
-
+func (g *DNSGenerator) createDnsResources(api *mgo.API, domain mgo.Domain) error {
 	page := 1
 	pageSize := 250
 	params := map[string]string{
@@ -48,7 +45,7 @@ func (g *DNSGenerator) createDnsResources(api *mgo.API, domain mgo.Domain, wg *s
 			)
 
 			r.IgnoreKeys = append(r.IgnoreKeys, "^metadata")
-			g.Resources = append(g.Resources, r)
+			g.appendResource(r)
 		}
 		if len(records) < pageSize {
 			break
@@ -61,23 +58,19 @@ func (g *DNSGenerator) createDnsResources(api *mgo.API, domain mgo.Domain, wg *s
 
 // InitResources
 func (g *DNSGenerator) InitResources() error {
-	wg := sync.WaitGroup{}
-
 	api, err := g.initializeAPI()
 	if err != nil {
 		return err
 	}
 
-	funcs := []func(*mgo.API, mgo.Domain, *sync.WaitGroup) error{
+	funcs := []func(*mgo.API, mgo.Domain) error{
 		g.createDnsResources,
 	}
 
-	err = createResourcesPerDomain(api, funcs, &wg)
+	err = createResourcesPerDomain(api, funcs)
 	if err != nil {
 		return err
 	}
-
-	wg.Wait()
 
 	return nil
 }

--- a/providers/myrasec/domain.go
+++ b/providers/myrasec/domain.go
@@ -2,13 +2,12 @@ package myrasec
 
 import (
 	"fmt"
-	"log"
 	"runtime"
 	"strconv"
-	"sync"
 
 	mgo "github.com/Myra-Security-GmbH/myrasec-go/v2"
 	"github.com/chenrui333/terraformer/terraformutils"
+	"golang.org/x/sync/errgroup"
 )
 
 // DomainGenerator
@@ -17,9 +16,7 @@ type DomainGenerator struct {
 }
 
 // createDomainResource
-func (g *DomainGenerator) createDomainResource(_ *mgo.API, domain mgo.Domain, wg *sync.WaitGroup) error {
-	defer wg.Done()
-
+func (g *DomainGenerator) createDomainResource(_ *mgo.API, domain mgo.Domain) error {
 	d := terraformutils.NewResource(
 		strconv.Itoa(domain.ID),
 		fmt.Sprintf("%s_%d", domain.Name, domain.ID),
@@ -31,35 +28,32 @@ func (g *DomainGenerator) createDomainResource(_ *mgo.API, domain mgo.Domain, wg
 	)
 
 	d.IgnoreKeys = append(d.IgnoreKeys, "^metadata")
-	g.Resources = append(g.Resources, d)
+	g.appendResource(d)
 
 	return nil
 }
 
 // InitResources
 func (g *DomainGenerator) InitResources() error {
-	var wg = sync.WaitGroup{}
-
 	api, err := g.initializeAPI()
 	if err != nil {
 		return err
 	}
 
-	funcs := []func(*mgo.API, mgo.Domain, *sync.WaitGroup) error{
+	funcs := []func(*mgo.API, mgo.Domain) error{
 		g.createDomainResource,
 	}
 
-	err = createResourcesPerDomain(api, funcs, &wg)
+	err = createResourcesPerDomain(api, funcs)
 	if err != nil {
 		return err
 	}
-	wg.Wait()
 
 	return nil
 }
 
 // createResourcesPerDomain
-func createResourcesPerDomain(api *mgo.API, funcs []func(*mgo.API, mgo.Domain, *sync.WaitGroup) error, wg *sync.WaitGroup) error {
+func createResourcesPerDomain(api *mgo.API, funcs []func(*mgo.API, mgo.Domain) error) error {
 	page := 1
 	pageSize := 250
 	params := map[string]string{
@@ -75,10 +69,9 @@ func createResourcesPerDomain(api *mgo.API, funcs []func(*mgo.API, mgo.Domain, *
 			return err
 		}
 
-		wg.Add(len(domains) * len(funcs))
 		for _, d := range domains {
 			for _, f := range funcs {
-				if err := f(api, d, wg); err != nil {
+				if err := f(api, d); err != nil {
 					return err
 				}
 			}
@@ -91,12 +84,16 @@ func createResourcesPerDomain(api *mgo.API, funcs []func(*mgo.API, mgo.Domain, *
 	return nil
 }
 
-func getWaitChannel() chan struct{} {
-	return make(chan struct{}, runtime.NumCPU()/2)
+func maxConcurrentMyrasecRequests() int {
+	limit := runtime.NumCPU() / 2
+	if limit < 1 {
+		return 1
+	}
+	return limit
 }
 
 // createResourcesPerSubDomain
-func createResourcesPerSubDomain(api *mgo.API, funcs []func(*mgo.API, int, mgo.VHost, *sync.WaitGroup) error, wg *sync.WaitGroup, onDomainLevel bool) error {
+func createResourcesPerSubDomain(api *mgo.API, funcs []func(*mgo.API, int, mgo.VHost) error, onDomainLevel bool) error {
 	page := 1
 	pageSize := 250
 	params := map[string]string{
@@ -104,7 +101,7 @@ func createResourcesPerSubDomain(api *mgo.API, funcs []func(*mgo.API, int, mgo.V
 		"page":     strconv.Itoa(page),
 	}
 
-	waitChan := getWaitChannel()
+	limit := maxConcurrentMyrasecRequests()
 	for {
 		params["page"] = strconv.Itoa(page)
 
@@ -113,26 +110,32 @@ func createResourcesPerSubDomain(api *mgo.API, funcs []func(*mgo.API, int, mgo.V
 			return err
 		}
 
-		wg.Add(len(domains))
+		group := errgroup.Group{}
+		group.SetLimit(limit)
 		for _, d := range domains {
+			domain := d
+
 			// try to load data for ALL-{domainId}.
 			if onDomainLevel {
-				wg.Add(len(funcs))
 				for _, f := range funcs {
-					go func(f func(*mgo.API, int, mgo.VHost, *sync.WaitGroup) error) {
-						if err := f(api, d.ID, mgo.VHost{Label: fmt.Sprintf("ALL-%d.", d.ID)}, wg); err != nil {
-							log.Print(err)
+					createResource := f
+					group.Go(func() error {
+						if err := createResource(api, domain.ID, mgo.VHost{Label: fmt.Sprintf("ALL-%d.", domain.ID)}); err != nil {
+							return fmt.Errorf("create domain-level resources for domain %d: %w", domain.ID, err)
 						}
-					}(f)
+						return nil
+					})
 				}
 			}
-			waitChan <- struct{}{}
-			go func(d mgo.Domain) {
-				if err := createResourcesPerVHost(api, d, funcs, wg); err != nil {
-					log.Print(err)
+			group.Go(func() error {
+				if err := createResourcesPerVHost(api, domain, funcs); err != nil {
+					return fmt.Errorf("create subdomain resources for domain %d: %w", domain.ID, err)
 				}
-				<-waitChan
-			}(d)
+				return nil
+			})
+		}
+		if err := group.Wait(); err != nil {
+			return err
 		}
 		if len(domains) < pageSize {
 			break
@@ -143,9 +146,7 @@ func createResourcesPerSubDomain(api *mgo.API, funcs []func(*mgo.API, int, mgo.V
 }
 
 // createResourcesPerVHost
-func createResourcesPerVHost(api *mgo.API, domain mgo.Domain, funcs []func(*mgo.API, int, mgo.VHost, *sync.WaitGroup) error, wg *sync.WaitGroup) error {
-	defer wg.Done()
-
+func createResourcesPerVHost(api *mgo.API, domain mgo.Domain, funcs []func(*mgo.API, int, mgo.VHost) error) error {
 	page := 1
 	pageSize := 250
 	params := map[string]string{
@@ -153,7 +154,7 @@ func createResourcesPerVHost(api *mgo.API, domain mgo.Domain, funcs []func(*mgo.
 		"page":     strconv.Itoa(page),
 	}
 
-	waitChan := getWaitChannel()
+	limit := maxConcurrentMyrasecRequests()
 	for {
 		params["page"] = strconv.Itoa(page)
 
@@ -162,17 +163,22 @@ func createResourcesPerVHost(api *mgo.API, domain mgo.Domain, funcs []func(*mgo.
 			return err
 		}
 
-		wg.Add(len(vhosts) * len(funcs))
+		group := errgroup.Group{}
+		group.SetLimit(limit)
 		for _, v := range vhosts {
+			vhost := v
 			for _, f := range funcs {
-				waitChan <- struct{}{}
-				go func(v mgo.VHost, f func(*mgo.API, int, mgo.VHost, *sync.WaitGroup) error) {
-					if err := f(api, domain.ID, v, wg); err != nil {
-						log.Print(err)
+				createResource := f
+				group.Go(func() error {
+					if err := createResource(api, domain.ID, vhost); err != nil {
+						return fmt.Errorf("create subdomain resources for domain %d subdomain %q: %w", domain.ID, vhost.Label, err)
 					}
-					<-waitChan
-				}(v, f)
+					return nil
+				})
 			}
+		}
+		if err := group.Wait(); err != nil {
+			return err
 		}
 		if len(vhosts) < pageSize {
 			break

--- a/providers/myrasec/error_page.go
+++ b/providers/myrasec/error_page.go
@@ -3,7 +3,6 @@ package myrasec
 import (
 	"fmt"
 	"strconv"
-	"sync"
 
 	mgo "github.com/Myra-Security-GmbH/myrasec-go/v2"
 	"github.com/chenrui333/terraformer/terraformutils"
@@ -15,9 +14,7 @@ type ErrorPageGenerator struct {
 }
 
 // createErrorPageResources
-func (g *ErrorPageGenerator) createErrorPageResources(api *mgo.API, domain mgo.Domain, wg *sync.WaitGroup) error {
-	defer wg.Done()
-
+func (g *ErrorPageGenerator) createErrorPageResources(api *mgo.API, domain mgo.Domain) error {
 	page := 1
 	pageSize := 250
 	params := map[string]string{
@@ -48,7 +45,7 @@ func (g *ErrorPageGenerator) createErrorPageResources(api *mgo.API, domain mgo.D
 				map[string]interface{}{},
 			)
 			r.IgnoreKeys = append(r.IgnoreKeys, "^metadata")
-			g.Resources = append(g.Resources, r)
+			g.appendResource(r)
 		}
 		if len(pages) < pageSize {
 			break
@@ -60,21 +57,17 @@ func (g *ErrorPageGenerator) createErrorPageResources(api *mgo.API, domain mgo.D
 
 // InitResources
 func (g *ErrorPageGenerator) InitResources() error {
-	wg := sync.WaitGroup{}
-
 	api, err := g.initializeAPI()
 	if err != nil {
 		return err
 	}
 
-	funcs := []func(*mgo.API, mgo.Domain, *sync.WaitGroup) error{
+	funcs := []func(*mgo.API, mgo.Domain) error{
 		g.createErrorPageResources,
 	}
-	err = createResourcesPerDomain(api, funcs, &wg)
+	err = createResourcesPerDomain(api, funcs)
 	if err != nil {
 		return err
 	}
-	wg.Wait()
-
 	return nil
 }

--- a/providers/myrasec/ip_filter.go
+++ b/providers/myrasec/ip_filter.go
@@ -2,7 +2,6 @@
 package myrasec
 
 import (
-	"errors"
 	"fmt"
 	"strconv"
 
@@ -28,7 +27,7 @@ func (g *IPFilterGenerator) createIPFilterResources(api *mgo.API, domainId int, 
 		params["page"] = strconv.Itoa(page)
 
 		filters, err := api.ListIPFilters(domainId, vhost.Label, params)
-		if !errors.Is(err, err) {
+		if err != nil {
 			return err
 		}
 

--- a/providers/myrasec/ip_filter.go
+++ b/providers/myrasec/ip_filter.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"fmt"
 	"strconv"
-	"sync"
 
 	mgo "github.com/Myra-Security-GmbH/myrasec-go/v2"
 	"github.com/chenrui333/terraformer/terraformutils"
@@ -17,9 +16,7 @@ type IPFilterGenerator struct {
 }
 
 // createIPFilterResources
-func (g *IPFilterGenerator) createIPFilterResources(api *mgo.API, domainId int, vhost mgo.VHost, wg *sync.WaitGroup) error {
-	defer wg.Done()
-
+func (g *IPFilterGenerator) createIPFilterResources(api *mgo.API, domainId int, vhost mgo.VHost) error {
 	page := 1
 	pageSize := 250
 	params := map[string]string{
@@ -47,7 +44,7 @@ func (g *IPFilterGenerator) createIPFilterResources(api *mgo.API, domainId int, 
 				[]string{},
 				map[string]interface{}{},
 			)
-			g.Resources = append(g.Resources, r)
+			g.appendResource(r)
 		}
 		if len(filters) < pageSize {
 			break
@@ -59,23 +56,19 @@ func (g *IPFilterGenerator) createIPFilterResources(api *mgo.API, domainId int, 
 
 // InitResources
 func (g *IPFilterGenerator) InitResources() error {
-	wg := sync.WaitGroup{}
-
 	api, err := g.initializeAPI()
 	if err != nil {
 		return err
 	}
 
-	funcs := []func(*mgo.API, int, mgo.VHost, *sync.WaitGroup) error{
+	funcs := []func(*mgo.API, int, mgo.VHost) error{
 		g.createIPFilterResources,
 	}
 
-	err = createResourcesPerSubDomain(api, funcs, &wg, true)
+	err = createResourcesPerSubDomain(api, funcs, true)
 	if err != nil {
 		return err
 	}
-
-	wg.Wait()
 
 	return nil
 }

--- a/providers/myrasec/maintenance.go
+++ b/providers/myrasec/maintenance.go
@@ -4,7 +4,6 @@ package myrasec
 import (
 	"fmt"
 	"strconv"
-	"sync"
 
 	mgo "github.com/Myra-Security-GmbH/myrasec-go/v2"
 	"github.com/chenrui333/terraformer/terraformutils"
@@ -16,9 +15,7 @@ type MaintenanceGenerator struct {
 }
 
 // createMaintenanceResources
-func (g *MaintenanceGenerator) createMaintenanceResources(api *mgo.API, domainId int, vhost mgo.VHost, wg *sync.WaitGroup) error {
-	defer wg.Done()
-
+func (g *MaintenanceGenerator) createMaintenanceResources(api *mgo.API, domainId int, vhost mgo.VHost) error {
 	page := 1
 	pageSize := 250
 	params := map[string]string{
@@ -46,7 +43,7 @@ func (g *MaintenanceGenerator) createMaintenanceResources(api *mgo.API, domainId
 				[]string{},
 				map[string]interface{}{},
 			)
-			g.Resources = append(g.Resources, r)
+			g.appendResource(r)
 		}
 		if len(maintenance) < pageSize {
 			break
@@ -58,23 +55,19 @@ func (g *MaintenanceGenerator) createMaintenanceResources(api *mgo.API, domainId
 
 // InitResources
 func (g *MaintenanceGenerator) InitResources() error {
-	wg := sync.WaitGroup{}
-
 	api, err := g.initializeAPI()
 	if err != nil {
 		return err
 	}
 
-	funcs := []func(*mgo.API, int, mgo.VHost, *sync.WaitGroup) error{
+	funcs := []func(*mgo.API, int, mgo.VHost) error{
 		g.createMaintenanceResources,
 	}
 
-	err = createResourcesPerSubDomain(api, funcs, &wg, false)
+	err = createResourcesPerSubDomain(api, funcs, false)
 	if err != nil {
 		return err
 	}
-
-	wg.Wait()
 
 	return nil
 }

--- a/providers/myrasec/myrasec_service.go
+++ b/providers/myrasec/myrasec_service.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"sync"
 
 	mgo "github.com/Myra-Security-GmbH/myrasec-go/v2"
 	"github.com/chenrui333/terraformer/terraformutils"
@@ -13,6 +14,14 @@ import (
 // MyrasecService ...
 type MyrasecService struct {
 	terraformutils.Service
+	resourcesMu sync.Mutex
+}
+
+func (s *MyrasecService) appendResource(resource terraformutils.Resource) {
+	s.resourcesMu.Lock()
+	defer s.resourcesMu.Unlock()
+
+	s.Resources = append(s.Resources, resource)
 }
 
 // initializeAPI ...

--- a/providers/myrasec/redirect.go
+++ b/providers/myrasec/redirect.go
@@ -4,7 +4,6 @@ package myrasec
 import (
 	"fmt"
 	"strconv"
-	"sync"
 
 	mgo "github.com/Myra-Security-GmbH/myrasec-go/v2"
 	"github.com/chenrui333/terraformer/terraformutils"
@@ -16,9 +15,7 @@ type RedirectGenerator struct {
 }
 
 // createRedirectResources
-func (g *RedirectGenerator) createRedirectResources(api *mgo.API, domainId int, vhost mgo.VHost, wg *sync.WaitGroup) error {
-	defer wg.Done()
-
+func (g *RedirectGenerator) createRedirectResources(api *mgo.API, domainId int, vhost mgo.VHost) error {
 	page := 1
 	pageSize := 250
 	params := map[string]string{
@@ -46,7 +43,7 @@ func (g *RedirectGenerator) createRedirectResources(api *mgo.API, domainId int, 
 				[]string{},
 				map[string]interface{}{},
 			)
-			g.Resources = append(g.Resources, r)
+			g.appendResource(r)
 		}
 		if len(redirects) < pageSize {
 			break
@@ -58,22 +55,18 @@ func (g *RedirectGenerator) createRedirectResources(api *mgo.API, domainId int, 
 
 // InitResources
 func (g *RedirectGenerator) InitResources() error {
-	wg := sync.WaitGroup{}
-
 	api, err := g.initializeAPI()
 	if err != nil {
 		return err
 	}
 
-	funcs := []func(*mgo.API, int, mgo.VHost, *sync.WaitGroup) error{
+	funcs := []func(*mgo.API, int, mgo.VHost) error{
 		g.createRedirectResources,
 	}
-	err = createResourcesPerSubDomain(api, funcs, &wg, true)
+	err = createResourcesPerSubDomain(api, funcs, true)
 	if err != nil {
 		return err
 	}
-
-	wg.Wait()
 
 	return nil
 }

--- a/providers/myrasec/settings.go
+++ b/providers/myrasec/settings.go
@@ -4,7 +4,6 @@ package myrasec
 import (
 	"fmt"
 	"strconv"
-	"sync"
 
 	mgo "github.com/Myra-Security-GmbH/myrasec-go/v2"
 	"github.com/chenrui333/terraformer/terraformutils"
@@ -16,9 +15,7 @@ type SettingsGenerator struct {
 }
 
 // createSettingResources
-func (g *SettingsGenerator) createSettingResources(api *mgo.API, domainId int, vhost mgo.VHost, wg *sync.WaitGroup) error {
-	defer wg.Done()
-
+func (g *SettingsGenerator) createSettingResources(api *mgo.API, domainId int, vhost mgo.VHost) error {
 	params := map[string]string{}
 
 	s, err := api.ListSettings(domainId, vhost.Label, params)
@@ -38,29 +35,25 @@ func (g *SettingsGenerator) createSettingResources(api *mgo.API, domainId int, v
 		[]string{},
 		map[string]interface{}{},
 	)
-	g.Resources = append(g.Resources, r)
+	g.appendResource(r)
 	return nil
 }
 
 // InitResources
 func (g *SettingsGenerator) InitResources() error {
-	wg := sync.WaitGroup{}
-
 	api, err := g.initializeAPI()
 	if err != nil {
 		return err
 	}
 
-	funcs := []func(*mgo.API, int, mgo.VHost, *sync.WaitGroup) error{
+	funcs := []func(*mgo.API, int, mgo.VHost) error{
 		g.createSettingResources,
 	}
 
-	err = createResourcesPerSubDomain(api, funcs, &wg, true)
+	err = createResourcesPerSubDomain(api, funcs, true)
 	if err != nil {
 		return err
 	}
-
-	wg.Wait()
 
 	return nil
 }

--- a/providers/myrasec/waf_rule.go
+++ b/providers/myrasec/waf_rule.go
@@ -4,7 +4,6 @@ package myrasec
 import (
 	"fmt"
 	"strconv"
-	"sync"
 
 	mgo "github.com/Myra-Security-GmbH/myrasec-go/v2"
 	"github.com/chenrui333/terraformer/terraformutils"
@@ -16,9 +15,7 @@ type WafRuleGenerator struct {
 }
 
 // createWafRuleResources
-func (g *WafRuleGenerator) createWafRuleResources(api *mgo.API, domainId int, vhost mgo.VHost, wg *sync.WaitGroup) error {
-	defer wg.Done()
-
+func (g *WafRuleGenerator) createWafRuleResources(api *mgo.API, domainId int, vhost mgo.VHost) error {
 	page := 1
 	pageSize := 250
 	params := map[string]string{
@@ -49,7 +46,7 @@ func (g *WafRuleGenerator) createWafRuleResources(api *mgo.API, domainId int, vh
 				[]string{},
 				map[string]interface{}{},
 			)
-			g.Resources = append(g.Resources, r)
+			g.appendResource(r)
 		}
 
 		if len(waf) < pageSize {
@@ -63,23 +60,19 @@ func (g *WafRuleGenerator) createWafRuleResources(api *mgo.API, domainId int, vh
 
 // InitResources
 func (g *WafRuleGenerator) InitResources() error {
-	wg := sync.WaitGroup{}
-
 	api, err := g.initializeAPI()
 	if err != nil {
 		return err
 	}
 
-	funcs := []func(*mgo.API, int, mgo.VHost, *sync.WaitGroup) error{
+	funcs := []func(*mgo.API, int, mgo.VHost) error{
 		g.createWafRuleResources,
 	}
 
-	err = createResourcesPerSubDomain(api, funcs, &wg, true)
+	err = createResourcesPerSubDomain(api, funcs, true)
 	if err != nil {
 		return err
 	}
-
-	wg.Wait()
 
 	return nil
 }


### PR DESCRIPTION
## Summary

- Return MyraSec subdomain/domain discovery failures from concurrent resource loaders instead of logging and continuing.
- Replace ad hoc goroutine waiting with errgroup while keeping the existing concurrency cap.
- Guard MyraSec resource appends during concurrent discovery.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Propagates MyraSec domain, subdomain, and IP filter discovery errors instead of logging and continuing. Switches to bounded `errgroup` concurrency and makes resource appends thread-safe.

- **Bug Fixes**
  - Return errors from domain-level, vhost, and IP filter discovery so failures surface.
  - Add clear error context for domain IDs and vhost labels.

- **Refactors**
  - Replace `sync.WaitGroup` and custom channels with `errgroup` and `SetLimit` based on CPU count.
  - Introduce `MyrasecService.appendResource` with a mutex; generators now use `g.appendResource`.
  - Update function signatures to drop `*sync.WaitGroup`; make `golang.org/x/sync v0.20.0` a direct dependency.

<sup>Written for commit 4c28a44b66b95d1793a5977ebb3948e5f0785bed. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated concurrency mechanism for resource creation with enhanced error propagation in domain and subdomain processing
  * Improved thread-safety for resource accumulation operations

<!-- end of auto-generated comment: release notes by coderabbit.ai -->