### PR TITLE
aws(secretsmanager): add policy and rotation resources

### DIFF
--- a/docs/aws.md
+++ b/docs/aws.md
@@ -386,6 +386,8 @@ terraformer import aws --resources=sg --regions=us-east-1
     * `aws_s3_bucket_website_configuration`
 *   `secretsmanager`
     * `aws_secretsmanager_secret`
+    * `aws_secretsmanager_secret_policy`
+    * `aws_secretsmanager_secret_rotation`
 *   `securityhub`
     * `aws_securityhub_account`
     * `aws_securityhub_member`

--- a/providers/aws/secretsmanager.go
+++ b/providers/aws/secretsmanager.go
@@ -60,7 +60,7 @@ func (g *SecretsManagerGenerator) InitResources() error {
 			if g.shouldLoadSecretChildResource("secretsmanager_secret_policy", policyResource) {
 				if err := g.addSecretPolicy(svc, secretArn, secretName); err != nil {
 					if !secretsManagerResourceMissing(err) {
-						log.Printf("Skipping Secrets Manager secret policy for %s: %v", secretArn, err)
+						log.Printf("Error adding Secrets Manager policy for %s (%s): %v", secretName, secretArn, err)
 					}
 				}
 			}
@@ -135,9 +135,6 @@ func (g *SecretsManagerGenerator) addSecretRotation(secret secretstypes.SecretLi
 	}
 	secretArn := StringValue(secret.ARN)
 	secretName := StringValue(secret.Name)
-	if secretArn == "" || secretName == "" {
-		return
-	}
 
 	resource := newSecretsManagerSecretRotationResource(secretArn, secretName)
 	if g.shouldAppendSecretChildResource("secretsmanager_secret_rotation", resource) {

--- a/providers/aws/secretsmanager.go
+++ b/providers/aws/secretsmanager.go
@@ -150,13 +150,13 @@ func (g *SecretsManagerGenerator) shouldAppendSecretResource(secretResource terr
 }
 
 func (g *SecretsManagerGenerator) shouldLoadSecretChildren(secretResource terraformutils.Resource) bool {
+	if g.hasTypedSecretsManagerChildFilter() {
+		return g.secretMatchesAnyChildInitialFilter(secretResource)
+	}
 	if !g.secretMatchesInitialIDFilters(secretResource) {
 		return false
 	}
-	if !g.hasTypedSecretsManagerChildFilter() {
-		return !g.hasTypedNonIDSecretFilter()
-	}
-	return g.secretMatchesAnyChildInitialFilter(secretResource)
+	return !g.hasTypedNonIDSecretFilter()
 }
 
 func (g *SecretsManagerGenerator) shouldAppendSecretChildResource(serviceName string, resource terraformutils.Resource) bool {

--- a/providers/aws/secretsmanager.go
+++ b/providers/aws/secretsmanager.go
@@ -4,8 +4,14 @@ package aws
 
 import (
 	"context"
+	"errors"
+	"fmt"
+	"log"
+	"strings"
 
+	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/secretsmanager"
+	secretstypes "github.com/aws/aws-sdk-go-v2/service/secretsmanager/types"
 	"github.com/chenrui333/terraformer/terraformutils"
 )
 
@@ -15,6 +21,15 @@ type SecretsManagerGenerator struct {
 	AWSService
 }
 
+type secretsManagerChildResource struct {
+	serviceName string
+}
+
+var secretsManagerChildResources = []secretsManagerChildResource{
+	{serviceName: "secretsmanager_secret_policy"},
+	{serviceName: "secretsmanager_secret_rotation"},
+}
+
 func (g *SecretsManagerGenerator) InitResources() error {
 	config, e := g.generateConfig()
 	if e != nil {
@@ -22,7 +37,6 @@ func (g *SecretsManagerGenerator) InitResources() error {
 	}
 	svc := secretsmanager.NewFromConfig(config)
 	p := secretsmanager.NewListSecretsPaginator(svc, &secretsmanager.ListSecretsInput{})
-	var resources []terraformutils.Resource
 	for p.HasMorePages() {
 		page, err := p.NextPage(context.TODO())
 		if err != nil {
@@ -31,14 +45,271 @@ func (g *SecretsManagerGenerator) InitResources() error {
 		for _, secret := range page.SecretList {
 			secretArn := StringValue(secret.ARN)
 			secretName := StringValue(secret.Name)
-			resources = append(resources, terraformutils.NewSimpleResource(
-				secretArn,
-				secretName,
-				"aws_secretsmanager_secret",
-				"aws",
-				secretsmanagerAllowEmptyValues))
+			if secretArn == "" || secretName == "" {
+				continue
+			}
+			secretResource := newSecretsManagerSecretResource(secretArn, secretName)
+			if g.shouldAppendSecretResource(secretResource) {
+				g.Resources = append(g.Resources, secretResource)
+			}
+
+			if !g.shouldLoadSecretChildren(secretResource) {
+				continue
+			}
+			if err := g.addSecretPolicy(svc, secretArn, secretName); err != nil {
+				if !secretsManagerResourceMissing(err) {
+					log.Printf("Skipping Secrets Manager secret policy for %s: %v", secretArn, err)
+				}
+			}
+			g.addSecretRotation(secret)
 		}
 	}
-	g.Resources = resources
 	return nil
+}
+
+func newSecretsManagerSecretResource(secretArn, secretName string) terraformutils.Resource {
+	return terraformutils.NewSimpleResource(
+		secretArn,
+		secretName,
+		"aws_secretsmanager_secret",
+		"aws",
+		secretsmanagerAllowEmptyValues)
+}
+
+func newSecretsManagerSecretPolicyResource(secretArn, secretName, policy string) terraformutils.Resource {
+	return terraformutils.NewResource(
+		secretArn,
+		secretName,
+		"aws_secretsmanager_secret_policy",
+		"aws",
+		map[string]string{
+			"secret_arn": secretArn,
+			"policy":     policy,
+		},
+		secretsmanagerAllowEmptyValues,
+		map[string]interface{}{})
+}
+
+func newSecretsManagerSecretRotationResource(secretArn, secretName string) terraformutils.Resource {
+	return terraformutils.NewResource(
+		secretArn,
+		secretName,
+		"aws_secretsmanager_secret_rotation",
+		"aws",
+		map[string]string{"secret_id": secretArn},
+		secretsmanagerAllowEmptyValues,
+		map[string]interface{}{})
+}
+
+func (g *SecretsManagerGenerator) addSecretPolicy(svc *secretsmanager.Client, secretArn, secretName string) error {
+	output, err := svc.GetResourcePolicy(context.TODO(), &secretsmanager.GetResourcePolicyInput{
+		SecretId: aws.String(secretArn),
+	})
+	if err != nil {
+		return err
+	}
+	if output == nil {
+		return nil
+	}
+	policy := StringValue(output.ResourcePolicy)
+	if policy == "" {
+		return nil
+	}
+
+	resource := newSecretsManagerSecretPolicyResource(secretArn, secretName, policy)
+	if g.shouldAppendSecretChildResource("secretsmanager_secret_policy", resource) {
+		g.Resources = append(g.Resources, resource)
+	}
+	return nil
+}
+
+func (g *SecretsManagerGenerator) addSecretRotation(secret secretstypes.SecretListEntry) {
+	if !secretsManagerSecretRotationConfigured(secret) {
+		return
+	}
+	secretArn := StringValue(secret.ARN)
+	secretName := StringValue(secret.Name)
+	if secretArn == "" || secretName == "" {
+		return
+	}
+
+	resource := newSecretsManagerSecretRotationResource(secretArn, secretName)
+	if g.shouldAppendSecretChildResource("secretsmanager_secret_rotation", resource) {
+		g.Resources = append(g.Resources, resource)
+	}
+}
+
+func (g *SecretsManagerGenerator) shouldAppendSecretResource(secretResource terraformutils.Resource) bool {
+	if !g.secretMatchesInitialIDFilters(secretResource) {
+		return false
+	}
+	if g.hasTypedSecretsManagerChildFilter() && !g.hasTypedFilterFor("secretsmanager_secret") && !g.hasUntypedIDFilter() {
+		return false
+	}
+	return true
+}
+
+func (g *SecretsManagerGenerator) shouldLoadSecretChildren(secretResource terraformutils.Resource) bool {
+	if !g.secretMatchesInitialIDFilters(secretResource) {
+		return false
+	}
+	if !g.hasTypedSecretsManagerChildFilter() {
+		return !g.hasTypedNonIDSecretFilter()
+	}
+	return g.secretMatchesAnyChildInitialFilter(secretResource)
+}
+
+func (g *SecretsManagerGenerator) shouldAppendSecretChildResource(serviceName string, resource terraformutils.Resource) bool {
+	if !g.hasTypedSecretsManagerChildFilter() {
+		return true
+	}
+
+	hasTypedResourceFilter := false
+	for _, filter := range g.Filter {
+		if filter.ServiceName == "" || !filter.IsApplicable(serviceName) {
+			continue
+		}
+		hasTypedResourceFilter = true
+		if filter.FieldPath == "id" && !filter.Filter(resource) {
+			return false
+		}
+	}
+	return hasTypedResourceFilter
+}
+
+func (g *SecretsManagerGenerator) secretMatchesInitialIDFilters(secretResource terraformutils.Resource) bool {
+	for _, filter := range g.Filter {
+		if filter.FieldPath != "id" || !filter.IsApplicable("secretsmanager_secret") {
+			continue
+		}
+		if !filter.Filter(secretResource) {
+			return false
+		}
+	}
+	return true
+}
+
+func (g *SecretsManagerGenerator) secretMatchesAnyChildInitialFilter(secretResource terraformutils.Resource) bool {
+	for _, child := range secretsManagerChildResources {
+		var childResource terraformutils.Resource
+		switch child.serviceName {
+		case "secretsmanager_secret_policy":
+			childResource = newSecretsManagerSecretPolicyResource(secretResource.InstanceState.ID, secretResource.ResourceName, "")
+		case "secretsmanager_secret_rotation":
+			childResource = newSecretsManagerSecretRotationResource(secretResource.InstanceState.ID, secretResource.ResourceName)
+		default:
+			continue
+		}
+
+		childHasFilter := false
+		childMatches := true
+		for _, filter := range g.Filter {
+			if filter.ServiceName == "" || !filter.IsApplicable(child.serviceName) {
+				continue
+			}
+			childHasFilter = true
+			if filter.FieldPath != "id" {
+				return true
+			}
+			if !filter.Filter(childResource) {
+				childMatches = false
+				break
+			}
+		}
+		if childHasFilter && childMatches {
+			return true
+		}
+	}
+	return false
+}
+
+func (g *SecretsManagerGenerator) hasTypedSecretsManagerChildFilter() bool {
+	for _, child := range secretsManagerChildResources {
+		if g.hasTypedFilterFor(child.serviceName) {
+			return true
+		}
+	}
+	return false
+}
+
+func (g *SecretsManagerGenerator) hasTypedFilterFor(serviceName string) bool {
+	for _, filter := range g.Filter {
+		if filter.ServiceName == serviceName {
+			return true
+		}
+	}
+	return false
+}
+
+func (g *SecretsManagerGenerator) hasTypedNonIDSecretFilter() bool {
+	for _, filter := range g.Filter {
+		if filter.ServiceName == "secretsmanager_secret" && filter.FieldPath != "id" {
+			return true
+		}
+	}
+	return false
+}
+
+func (g *SecretsManagerGenerator) hasUntypedIDFilter() bool {
+	for _, filter := range g.Filter {
+		if filter.ServiceName == "" && filter.FieldPath == "id" {
+			return true
+		}
+	}
+	return false
+}
+
+func (g *SecretsManagerGenerator) PostConvertHook() error {
+	policyResourcesBySecretARN := map[string]struct{}{}
+	for _, resource := range g.Resources {
+		if resource.InstanceInfo.Type == "aws_secretsmanager_secret_policy" {
+			policyResourcesBySecretARN[resource.InstanceState.ID] = struct{}{}
+		}
+	}
+
+	for i, resource := range g.Resources {
+		switch resource.InstanceInfo.Type {
+		case "aws_secretsmanager_secret":
+			if _, ok := policyResourcesBySecretARN[resource.InstanceState.ID]; ok {
+				delete(g.Resources[i].Item, "policy")
+			} else {
+				g.wrapSecretsManagerPolicy(i, "policy")
+			}
+		case "aws_secretsmanager_secret_policy":
+			g.wrapSecretsManagerPolicy(i, "policy")
+		}
+	}
+	return nil
+}
+
+func (g *SecretsManagerGenerator) wrapSecretsManagerPolicy(resourceIndex int, field string) {
+	policy, ok := g.Resources[resourceIndex].Item[field].(string)
+	if !ok || policy == "" {
+		return
+	}
+	g.Resources[resourceIndex].Item[field] = fmt.Sprintf("<<POLICY\n%s\nPOLICY", g.escapeAwsInterpolation(policy))
+}
+
+func secretsManagerSecretRotationConfigured(secret secretstypes.SecretListEntry) bool {
+	if !aws.ToBool(secret.RotationEnabled) || secret.RotationRules == nil {
+		return false
+	}
+	return secretsManagerRotationRulesConfigured(secret.RotationRules)
+}
+
+func secretsManagerRotationRulesConfigured(rules *secretstypes.RotationRulesType) bool {
+	if rules == nil {
+		return false
+	}
+	return rules.AutomaticallyAfterDays != nil || StringValue(rules.Duration) != "" || StringValue(rules.ScheduleExpression) != ""
+}
+
+func secretsManagerResourceMissing(err error) bool {
+	var notFound *secretstypes.ResourceNotFoundException
+	if errors.As(err, &notFound) {
+		return true
+	}
+
+	var invalidRequest *secretstypes.InvalidRequestException
+	return errors.As(err, &invalidRequest) && strings.Contains(invalidRequest.ErrorMessage(), "marked for deletion")
 }

--- a/providers/aws/secretsmanager.go
+++ b/providers/aws/secretsmanager.go
@@ -56,12 +56,18 @@ func (g *SecretsManagerGenerator) InitResources() error {
 			if !g.shouldLoadSecretChildren(secretResource) {
 				continue
 			}
-			if err := g.addSecretPolicy(svc, secretArn, secretName); err != nil {
-				if !secretsManagerResourceMissing(err) {
-					log.Printf("Skipping Secrets Manager secret policy for %s: %v", secretArn, err)
+			policyResource := newSecretsManagerSecretPolicyResource(secretArn, secretName, "")
+			if g.shouldLoadSecretChildResource("secretsmanager_secret_policy", policyResource) {
+				if err := g.addSecretPolicy(svc, secretArn, secretName); err != nil {
+					if !secretsManagerResourceMissing(err) {
+						log.Printf("Skipping Secrets Manager secret policy for %s: %v", secretArn, err)
+					}
 				}
 			}
-			g.addSecretRotation(secret)
+			rotationResource := newSecretsManagerSecretRotationResource(secretArn, secretName)
+			if g.shouldLoadSecretChildResource("secretsmanager_secret_rotation", rotationResource) {
+				g.addSecretRotation(secret)
+			}
 		}
 	}
 	return nil
@@ -160,21 +166,17 @@ func (g *SecretsManagerGenerator) shouldLoadSecretChildren(secretResource terraf
 }
 
 func (g *SecretsManagerGenerator) shouldAppendSecretChildResource(serviceName string, resource terraformutils.Resource) bool {
-	if !g.hasTypedSecretsManagerChildFilter() {
-		return true
+	if g.hasTypedSecretsManagerChildFilter() && !g.hasTypedFilterFor(serviceName) {
+		return false
 	}
+	return g.secretChildMatchesInitialIDFilters(serviceName, resource)
+}
 
-	hasTypedResourceFilter := false
-	for _, filter := range g.Filter {
-		if filter.ServiceName == "" || !filter.IsApplicable(serviceName) {
-			continue
-		}
-		hasTypedResourceFilter = true
-		if filter.FieldPath == "id" && !filter.Filter(resource) {
-			return false
-		}
+func (g *SecretsManagerGenerator) shouldLoadSecretChildResource(serviceName string, resource terraformutils.Resource) bool {
+	if g.hasTypedSecretsManagerChildFilter() && !g.hasTypedFilterFor(serviceName) {
+		return false
 	}
-	return hasTypedResourceFilter
+	return g.secretChildMatchesInitialIDFilters(serviceName, resource)
 }
 
 func (g *SecretsManagerGenerator) secretMatchesInitialIDFilters(secretResource terraformutils.Resource) bool {
@@ -201,26 +203,23 @@ func (g *SecretsManagerGenerator) secretMatchesAnyChildInitialFilter(secretResou
 			continue
 		}
 
-		childHasFilter := false
-		childMatches := true
-		for _, filter := range g.Filter {
-			if filter.ServiceName == "" || !filter.IsApplicable(child.serviceName) {
-				continue
-			}
-			childHasFilter = true
-			if filter.FieldPath != "id" {
-				return true
-			}
-			if !filter.Filter(childResource) {
-				childMatches = false
-				break
-			}
-		}
-		if childHasFilter && childMatches {
+		if g.shouldLoadSecretChildResource(child.serviceName, childResource) {
 			return true
 		}
 	}
 	return false
+}
+
+func (g *SecretsManagerGenerator) secretChildMatchesInitialIDFilters(serviceName string, resource terraformutils.Resource) bool {
+	for _, filter := range g.Filter {
+		if filter.FieldPath != "id" || !filter.IsApplicable(serviceName) {
+			continue
+		}
+		if !filter.Filter(resource) {
+			return false
+		}
+	}
+	return true
 }
 
 func (g *SecretsManagerGenerator) hasTypedSecretsManagerChildFilter() bool {

--- a/providers/aws/secretsmanager_test.go
+++ b/providers/aws/secretsmanager_test.go
@@ -121,6 +121,14 @@ func TestSecretsManagerFilterGatesSecretAndChildDiscovery(t *testing.T) {
 			loadChildren: true,
 		},
 		{
+			name: "global id filter constrains typed child discovery",
+			filters: []terraformutils.ResourceFilter{
+				{FieldPath: "id", AcceptableValues: []string{otherARN}},
+				{ServiceName: "secretsmanager_secret_policy", FieldPath: "id", AcceptableValues: []string{secretARN}},
+			},
+			appendOther: true,
+		},
+		{
 			name: "untyped id filter limits same-id resources",
 			filters: []terraformutils.ResourceFilter{
 				{FieldPath: "id", AcceptableValues: []string{secretARN}},
@@ -160,6 +168,7 @@ func TestSecretsManagerFilterGatesSecretAndChildDiscovery(t *testing.T) {
 
 func TestSecretsManagerFilterGatesChildAppend(t *testing.T) {
 	secretARN := "arn:aws:secretsmanager:us-east-1:123456789012:secret:orders-abc123"
+	otherARN := "arn:aws:secretsmanager:us-east-1:123456789012:secret:other-abc123"
 	policy := newSecretsManagerSecretPolicyResource(secretARN, "orders", "{\"Version\":\"2012-10-17\"}")
 	rotation := newSecretsManagerSecretRotationResource(secretARN, "orders")
 
@@ -197,6 +206,21 @@ func TestSecretsManagerFilterGatesChildAppend(t *testing.T) {
 			},
 			appendPolicy: true,
 		},
+		{
+			name: "global id filter constrains typed policy child",
+			filters: []terraformutils.ResourceFilter{
+				{FieldPath: "id", AcceptableValues: []string{secretARN}},
+				{ServiceName: "secretsmanager_secret_policy", FieldPath: "id", AcceptableValues: []string{secretARN}},
+			},
+			appendPolicy: true,
+		},
+		{
+			name: "global id filter rejects typed policy child outside scope",
+			filters: []terraformutils.ResourceFilter{
+				{FieldPath: "id", AcceptableValues: []string{otherARN}},
+				{ServiceName: "secretsmanager_secret_policy", FieldPath: "id", AcceptableValues: []string{secretARN}},
+			},
+		},
 	}
 
 	for _, tt := range tests {
@@ -208,6 +232,12 @@ func TestSecretsManagerFilterGatesChildAppend(t *testing.T) {
 			}
 			if got := g.shouldAppendSecretChildResource("secretsmanager_secret_rotation", rotation); got != tt.appendRotation {
 				t.Fatalf("shouldAppendSecretChildResource(rotation) = %t, want %t", got, tt.appendRotation)
+			}
+			if got := g.shouldLoadSecretChildResource("secretsmanager_secret_policy", policy); got != tt.appendPolicy {
+				t.Fatalf("shouldLoadSecretChildResource(policy) = %t, want %t", got, tt.appendPolicy)
+			}
+			if got := g.shouldLoadSecretChildResource("secretsmanager_secret_rotation", rotation); got != tt.appendRotation {
+				t.Fatalf("shouldLoadSecretChildResource(rotation) = %t, want %t", got, tt.appendRotation)
 			}
 		})
 	}

--- a/providers/aws/secretsmanager_test.go
+++ b/providers/aws/secretsmanager_test.go
@@ -112,6 +112,15 @@ func TestSecretsManagerFilterGatesSecretAndChildDiscovery(t *testing.T) {
 			loadChildren: true,
 		},
 		{
+			name: "typed parent and child id filters load matching child outside parent filter",
+			filters: []terraformutils.ResourceFilter{
+				{ServiceName: "secretsmanager_secret", FieldPath: "id", AcceptableValues: []string{otherARN}},
+				{ServiceName: "secretsmanager_secret_policy", FieldPath: "id", AcceptableValues: []string{secretARN}},
+			},
+			appendOther:  true,
+			loadChildren: true,
+		},
+		{
 			name: "untyped id filter limits same-id resources",
 			filters: []terraformutils.ResourceFilter{
 				{FieldPath: "id", AcceptableValues: []string{secretARN}},

--- a/providers/aws/secretsmanager_test.go
+++ b/providers/aws/secretsmanager_test.go
@@ -1,0 +1,240 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package aws
+
+import (
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	secretstypes "github.com/aws/aws-sdk-go-v2/service/secretsmanager/types"
+	"github.com/chenrui333/terraformer/terraformutils"
+)
+
+func TestSecretsManagerPostConvertHookMovesSplitPolicyOutOfSecret(t *testing.T) {
+	secretARN := "arn:aws:secretsmanager:us-east-1:123456789012:secret:orders-abc123"
+	secret := newSecretsManagerSecretResource(secretARN, "orders")
+	secret.Item = map[string]interface{}{
+		"name":   "orders",
+		"policy": "{\"Version\":\"2012-10-17\"}",
+	}
+	policy := newSecretsManagerSecretPolicyResource(secretARN, "orders", "{\"Version\":\"2012-10-17\"}")
+	policy.Item = map[string]interface{}{
+		"secret_arn": secretARN,
+		"policy":     "{\"Version\":\"2012-10-17\"}",
+	}
+
+	g := SecretsManagerGenerator{}
+	g.Resources = []terraformutils.Resource{secret, policy}
+
+	if err := g.PostConvertHook(); err != nil {
+		t.Fatalf("PostConvertHook() error = %v", err)
+	}
+	if _, ok := g.Resources[0].Item["policy"]; ok {
+		t.Fatal("secret inline policy should be removed when split policy resource exists")
+	}
+	assertSecretsManagerPolicyHeredoc(t, g.Resources[1].Item["policy"])
+}
+
+func TestSecretsManagerPostConvertHookKeepsInlinePolicyWithoutSplitResource(t *testing.T) {
+	secretARN := "arn:aws:secretsmanager:us-east-1:123456789012:secret:orders-abc123"
+	secret := newSecretsManagerSecretResource(secretARN, "orders")
+	secret.Item = map[string]interface{}{"policy": "{\"Version\":\"2012-10-17\"}"}
+
+	g := SecretsManagerGenerator{}
+	g.Resources = []terraformutils.Resource{secret}
+
+	if err := g.PostConvertHook(); err != nil {
+		t.Fatalf("PostConvertHook() error = %v", err)
+	}
+	assertSecretsManagerPolicyHeredoc(t, g.Resources[0].Item["policy"])
+}
+
+func TestSecretsManagerSecretRotationConfigured(t *testing.T) {
+	days := int64(30)
+	tests := []struct {
+		name   string
+		secret secretstypes.SecretListEntry
+		want   bool
+	}{
+		{name: "disabled", secret: secretstypes.SecretListEntry{RotationEnabled: aws.Bool(false), RotationRules: &secretstypes.RotationRulesType{AutomaticallyAfterDays: &days}}, want: false},
+		{name: "enabled without rules", secret: secretstypes.SecretListEntry{RotationEnabled: aws.Bool(true)}, want: false},
+		{name: "enabled with empty rules", secret: secretstypes.SecretListEntry{RotationEnabled: aws.Bool(true), RotationRules: &secretstypes.RotationRulesType{}}, want: false},
+		{name: "enabled with days", secret: secretstypes.SecretListEntry{RotationEnabled: aws.Bool(true), RotationRules: &secretstypes.RotationRulesType{AutomaticallyAfterDays: &days}}, want: true},
+		{name: "enabled with schedule", secret: secretstypes.SecretListEntry{RotationEnabled: aws.Bool(true), RotationRules: &secretstypes.RotationRulesType{ScheduleExpression: aws.String("rate(10 days)")}}, want: true},
+		{name: "enabled with duration", secret: secretstypes.SecretListEntry{RotationEnabled: aws.Bool(true), RotationRules: &secretstypes.RotationRulesType{Duration: aws.String("3h")}}, want: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := secretsManagerSecretRotationConfigured(tt.secret); got != tt.want {
+				t.Fatalf("secretsManagerSecretRotationConfigured() = %t, want %t", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestSecretsManagerFilterGatesSecretAndChildDiscovery(t *testing.T) {
+	secretARN := "arn:aws:secretsmanager:us-east-1:123456789012:secret:orders-abc123"
+	otherARN := "arn:aws:secretsmanager:us-east-1:123456789012:secret:other-abc123"
+	secret := newSecretsManagerSecretResource(secretARN, "orders")
+	other := newSecretsManagerSecretResource(otherARN, "other")
+
+	tests := []struct {
+		name           string
+		filters        []terraformutils.ResourceFilter
+		appendSecret   bool
+		appendOther    bool
+		loadChildren   bool
+		loadOtherChild bool
+	}{
+		{
+			name:           "no filters imports secrets and children",
+			appendSecret:   true,
+			appendOther:    true,
+			loadChildren:   true,
+			loadOtherChild: true,
+		},
+		{
+			name: "typed secret id filter limits secret and children",
+			filters: []terraformutils.ResourceFilter{
+				{ServiceName: "secretsmanager_secret", FieldPath: "id", AcceptableValues: []string{secretARN}},
+			},
+			appendSecret: true,
+			loadChildren: true,
+		},
+		{
+			name: "typed child id filter does not import parent secrets",
+			filters: []terraformutils.ResourceFilter{
+				{ServiceName: "secretsmanager_secret_policy", FieldPath: "id", AcceptableValues: []string{secretARN}},
+			},
+			loadChildren: true,
+		},
+		{
+			name: "untyped id filter limits same-id resources",
+			filters: []terraformutils.ResourceFilter{
+				{FieldPath: "id", AcceptableValues: []string{secretARN}},
+			},
+			appendSecret: true,
+			loadChildren: true,
+		},
+		{
+			name: "typed non-id secret filter does not pre-load children",
+			filters: []terraformutils.ResourceFilter{
+				{ServiceName: "secretsmanager_secret", FieldPath: "tags.env", AcceptableValues: []string{"prod"}},
+			},
+			appendSecret: true,
+			appendOther:  true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := SecretsManagerGenerator{}
+			g.Filter = tt.filters
+			if got := g.shouldAppendSecretResource(secret); got != tt.appendSecret {
+				t.Fatalf("shouldAppendSecretResource(secret) = %t, want %t", got, tt.appendSecret)
+			}
+			if got := g.shouldAppendSecretResource(other); got != tt.appendOther {
+				t.Fatalf("shouldAppendSecretResource(other) = %t, want %t", got, tt.appendOther)
+			}
+			if got := g.shouldLoadSecretChildren(secret); got != tt.loadChildren {
+				t.Fatalf("shouldLoadSecretChildren(secret) = %t, want %t", got, tt.loadChildren)
+			}
+			if got := g.shouldLoadSecretChildren(other); got != tt.loadOtherChild {
+				t.Fatalf("shouldLoadSecretChildren(other) = %t, want %t", got, tt.loadOtherChild)
+			}
+		})
+	}
+}
+
+func TestSecretsManagerFilterGatesChildAppend(t *testing.T) {
+	secretARN := "arn:aws:secretsmanager:us-east-1:123456789012:secret:orders-abc123"
+	policy := newSecretsManagerSecretPolicyResource(secretARN, "orders", "{\"Version\":\"2012-10-17\"}")
+	rotation := newSecretsManagerSecretRotationResource(secretARN, "orders")
+
+	tests := []struct {
+		name           string
+		filters        []terraformutils.ResourceFilter
+		appendPolicy   bool
+		appendRotation bool
+	}{
+		{name: "no typed child filter appends all configured children", appendPolicy: true, appendRotation: true},
+		{
+			name: "typed policy id filter appends only policy",
+			filters: []terraformutils.ResourceFilter{
+				{ServiceName: "secretsmanager_secret_policy", FieldPath: "id", AcceptableValues: []string{secretARN}},
+			},
+			appendPolicy: true,
+		},
+		{
+			name: "typed rotation id filter appends only rotation",
+			filters: []terraformutils.ResourceFilter{
+				{ServiceName: "secretsmanager_secret_rotation", FieldPath: "id", AcceptableValues: []string{secretARN}},
+			},
+			appendRotation: true,
+		},
+		{
+			name: "typed child id filter with different secret skips all siblings",
+			filters: []terraformutils.ResourceFilter{
+				{ServiceName: "secretsmanager_secret_policy", FieldPath: "id", AcceptableValues: []string{"arn:aws:secretsmanager:us-east-1:123456789012:secret:other-abc123"}},
+			},
+		},
+		{
+			name: "typed child non-id filter allows requested child type",
+			filters: []terraformutils.ResourceFilter{
+				{ServiceName: "secretsmanager_secret_policy", FieldPath: "policy", AcceptableValues: []string{"{\"Version\":\"2012-10-17\"}"}},
+			},
+			appendPolicy: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := SecretsManagerGenerator{}
+			g.Filter = tt.filters
+			if got := g.shouldAppendSecretChildResource("secretsmanager_secret_policy", policy); got != tt.appendPolicy {
+				t.Fatalf("shouldAppendSecretChildResource(policy) = %t, want %t", got, tt.appendPolicy)
+			}
+			if got := g.shouldAppendSecretChildResource("secretsmanager_secret_rotation", rotation); got != tt.appendRotation {
+				t.Fatalf("shouldAppendSecretChildResource(rotation) = %t, want %t", got, tt.appendRotation)
+			}
+		})
+	}
+}
+
+func TestSecretsManagerResourceMissing(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{name: "nil", err: nil, want: false},
+		{name: "typed not found", err: &secretstypes.ResourceNotFoundException{}, want: true},
+		{name: "wrapped not found", err: errors.Join(errors.New("wrapper"), &secretstypes.ResourceNotFoundException{}), want: true},
+		{name: "marked for deletion", err: &secretstypes.InvalidRequestException{Message: aws.String("You can't perform this operation on the secret because it was marked for deletion")}, want: true},
+		{name: "generic invalid request", err: &secretstypes.InvalidRequestException{Message: aws.String("other invalid request")}, want: false},
+		{name: "generic", err: errors.New("boom"), want: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := secretsManagerResourceMissing(tt.err); got != tt.want {
+				t.Fatalf("secretsManagerResourceMissing(%v) = %t, want %t", tt.err, got, tt.want)
+			}
+		})
+	}
+}
+
+func assertSecretsManagerPolicyHeredoc(t *testing.T, value interface{}) {
+	t.Helper()
+
+	policy, ok := value.(string)
+	if !ok {
+		t.Fatalf("value has type %T, want string", value)
+	}
+	if !strings.HasPrefix(policy, "<<POLICY\n") || !strings.HasSuffix(policy, "\nPOLICY") {
+		t.Fatalf("value %q is not wrapped as a POLICY heredoc", policy)
+	}
+}


### PR DESCRIPTION
## Summary

- add Secrets Manager discovery for aws_secretsmanager_secret_policy and aws_secretsmanager_secret_rotation
- keep policy lookup best-effort and avoid importing secret versions because secret values are not safely reconstructable
- remove duplicated inline secret policy fields when split policy resources are emitted, with focused filter and helper tests

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add discovery for Secrets Manager `aws_secretsmanager_secret_policy` and `aws_secretsmanager_secret_rotation`. Policies are fetched best-effort, rotation is added only when configured, filters correctly scope parents and children (including global ID filters), and optional errors are handled cleanly.

- **New Features**
  - Discover `aws_secretsmanager_secret_policy` (best-effort) and `aws_secretsmanager_secret_rotation` (only when rotation is configured).
  - Remove duplicated inline policy from `aws_secretsmanager_secret` when a split policy exists; wrap policy JSON in a POLICY heredoc.
  - Skip policy lookups for resources not found or marked for deletion; do not import secret versions.

- **Bug Fixes**
  - Decouple child filters from parent: typed child filters can import only children by id, and typed non-id parent filters no longer pre-load children.
  - Preserve global ID filters when discovering secrets and their child resources.
  - Clarify optional policy errors: treat not found and marked-for-deletion as expected; log other errors only.

<sup>Written for commit 4a30d4f419cd7770b65145e196ded1cd895bd97f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Import AWS Secrets Manager secret policies and secret rotations as separate resources
  * Better handling for large secret inventories (improved pagination)
  * Inline secret policies preserved or converted to standalone resources as appropriate

* **Bug Fixes**
  * Improved detection/classification of missing or deleted Secrets Manager resources

* **Documentation**
  * Updated AWS docs to list the new Secrets Manager resource types

* **Tests**
  * Added tests covering policy handling, rotation detection, filtering, and missing-resource logic
<!-- end of auto-generated comment: release notes by coderabbit.ai -->