### PR TITLE
feat(kubernetes): import config map data

### DIFF
--- a/docs/kubernetes.md
+++ b/docs/kubernetes.md
@@ -10,6 +10,7 @@ Example:
 Terraformer discovers Kubernetes API resources from the active cluster and imports resources that are available through either the typed Kubernetes client or an explicit dynamic-client import path, and the installed Terraform Kubernetes provider schema.
 Discovered CRDs and other untyped API extensions without a first-class Terraform Kubernetes provider type can be imported through `kubernetes_manifest` when the API resource is manageable and the installed provider supports that resource.
 Manifest-backed custom resources use a group/version-qualified resource selector such as `example.com/v1/widgets` to avoid collisions between CRDs that share the same plural name.
+When `configmaps` and `configmapdata` are selected together, Terraformer keeps the full `configmaps` import and skips overlapping data-only resources to avoid duplicate Terraform ownership of the same ConfigMap data.
 
 Common supported resources include:
 
@@ -23,6 +24,8 @@ Common supported resources include:
     * `kubernetes_cluster_role_binding_v1`
 *   `configmaps`
     * `kubernetes_config_map_v1`
+*   `configmapdata`
+    * `kubernetes_config_map_v1_data`
 *   `cronjobs`
     * `kubernetes_cron_job_v1`
 *   `csidrivers`

--- a/providers/kubernetes/config_map_data.go
+++ b/providers/kubernetes/config_map_data.go
@@ -5,6 +5,7 @@ package kubernetes
 import (
 	"context"
 	"strconv"
+	"time"
 
 	"github.com/chenrui333/terraformer/terraformutils"
 
@@ -17,6 +18,7 @@ const (
 	configMapDataServiceName       = "configmapdata"
 	configMapDataTerraformType     = "kubernetes_config_map_v1_data"
 	configMapDataAllowEmptyPattern = `^data\.`
+	configMapDataListTimeout       = 30 * time.Second
 )
 
 type ConfigMapData struct {
@@ -39,7 +41,10 @@ func (c *ConfigMapData) InitResources() error {
 }
 
 func (c *ConfigMapData) initResources(clientset kubernetes.Interface) error {
-	configMaps, err := clientset.CoreV1().ConfigMaps(metav1.NamespaceAll).List(context.Background(), metav1.ListOptions{})
+	ctx, cancel := context.WithTimeout(context.Background(), configMapDataListTimeout)
+	defer cancel()
+
+	configMaps, err := clientset.CoreV1().ConfigMaps(metav1.NamespaceAll).List(ctx, metav1.ListOptions{})
 	if err != nil {
 		return err
 	}

--- a/providers/kubernetes/config_map_data.go
+++ b/providers/kubernetes/config_map_data.go
@@ -51,7 +51,7 @@ func (c *ConfigMapData) initResources(clientset kubernetes.Interface) error {
 
 	for i := range configMaps.Items {
 		configMap := configMaps.Items[i]
-		if len(configMap.Data) == 0 {
+		if len(configMap.Data) == 0 || len(configMap.OwnerReferences) > 0 {
 			continue
 		}
 

--- a/providers/kubernetes/config_map_data.go
+++ b/providers/kubernetes/config_map_data.go
@@ -1,0 +1,84 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package kubernetes
+
+import (
+	"context"
+	"strconv"
+
+	"github.com/chenrui333/terraformer/terraformutils"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+)
+
+const (
+	configMapDataServiceName       = "configmapdata"
+	configMapDataTerraformType     = "kubernetes_config_map_v1_data"
+	configMapDataAllowEmptyPattern = `^data\.`
+)
+
+type ConfigMapData struct {
+	KubernetesService
+	TerraformType string
+}
+
+func (c *ConfigMapData) InitResources() error {
+	config, _, err := initClientAndConfig()
+	if err != nil {
+		return err
+	}
+
+	clientset, err := kubernetes.NewForConfig(config)
+	if err != nil {
+		return err
+	}
+
+	return c.initResources(clientset)
+}
+
+func (c *ConfigMapData) initResources(clientset kubernetes.Interface) error {
+	configMaps, err := clientset.CoreV1().ConfigMaps(metav1.NamespaceAll).List(context.Background(), metav1.ListOptions{})
+	if err != nil {
+		return err
+	}
+
+	terraformType := c.TerraformType
+	if terraformType == "" {
+		terraformType = configMapDataTerraformType
+	}
+
+	for i := range configMaps.Items {
+		configMap := configMaps.Items[i]
+		if len(configMap.Data) == 0 {
+			continue
+		}
+
+		name := configMap.Namespace + "/" + configMap.Name
+		c.Resources = append(c.Resources, terraformutils.NewResource(
+			name,
+			name,
+			terraformType,
+			"kubernetes",
+			configMapDataAttributes(configMap),
+			[]string{configMapDataAllowEmptyPattern},
+			map[string]interface{}{},
+		))
+	}
+	return nil
+}
+
+func configMapDataAttributes(configMap corev1.ConfigMap) map[string]string {
+	attributes := map[string]string{
+		"id":                   configMap.Namespace + "/" + configMap.Name,
+		"metadata.#":           "1",
+		"metadata.0.name":      configMap.Name,
+		"metadata.0.namespace": configMap.Namespace,
+		"data.%":               strconv.Itoa(len(configMap.Data)),
+	}
+	for key, value := range configMap.Data {
+		attributes["data."+key] = value
+	}
+	return attributes
+}

--- a/providers/kubernetes/config_map_data_test.go
+++ b/providers/kubernetes/config_map_data_test.go
@@ -1,0 +1,140 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package kubernetes
+
+import (
+	"testing"
+
+	"github.com/chenrui333/terraformer/terraformutils/tfcompat"
+	"github.com/chenrui333/terraformer/terraformutils/tfcompat/configschema"
+	"github.com/zclconf/go-cty/cty"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/fake"
+)
+
+func TestConfigMapDataInitResources(t *testing.T) {
+	clientset := fake.NewSimpleClientset(
+		&corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: "default",
+				Name:      "app-config",
+			},
+			Data: map[string]string{
+				"empty": "",
+				"key":   "value",
+			},
+		},
+		&corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: "default",
+				Name:      "no-data",
+			},
+		},
+	)
+
+	service := &ConfigMapData{}
+	if err := service.initResources(clientset); err != nil {
+		t.Fatalf("initResources() error = %v", err)
+	}
+
+	if len(service.Resources) != 1 {
+		t.Fatalf("Resources len = %d, want 1", len(service.Resources))
+	}
+	resource := service.Resources[0]
+	if resource.InstanceInfo.Type != configMapDataTerraformType {
+		t.Fatalf("resource type = %q, want %q", resource.InstanceInfo.Type, configMapDataTerraformType)
+	}
+	if resource.InstanceState.ID != "default/app-config" {
+		t.Fatalf("resource ID = %q, want %q", resource.InstanceState.ID, "default/app-config")
+	}
+	if resource.ResourceName != "tfer--default-002F-app-config" {
+		t.Fatalf("resource name = %q, want %q", resource.ResourceName, "tfer--default-002F-app-config")
+	}
+
+	attributes := resource.InstanceState.Attributes
+	for key, want := range map[string]string{
+		"id":                   "default/app-config",
+		"metadata.#":           "1",
+		"metadata.0.name":      "app-config",
+		"metadata.0.namespace": "default",
+		"data.%":               "2",
+		"data.empty":           "",
+		"data.key":             "value",
+	} {
+		if got := attributes[key]; got != want {
+			t.Fatalf("attribute %q = %q, want %q", key, got, want)
+		}
+	}
+	if len(resource.AllowEmptyValues) != 1 || resource.AllowEmptyValues[0] != configMapDataAllowEmptyPattern {
+		t.Fatalf("AllowEmptyValues = %#v, want %#v", resource.AllowEmptyValues, []string{configMapDataAllowEmptyPattern})
+	}
+	if _, err := tfcompat.HCL2ValueFromFlatmap(attributes, configMapDataTestBlock().ImpliedType()); err != nil {
+		t.Fatalf("config map data flatmap does not decode into provider schema: %v", err)
+	}
+}
+
+func TestConfigMapDataInitResourcesUsesConfiguredTerraformType(t *testing.T) {
+	clientset := fake.NewSimpleClientset(&corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "default",
+			Name:      "app-config",
+		},
+		Data: map[string]string{"key": "value"},
+	})
+	service := &ConfigMapData{TerraformType: "custom_config_map_data"}
+
+	if err := service.initResources(clientset); err != nil {
+		t.Fatalf("initResources() error = %v", err)
+	}
+
+	if len(service.Resources) != 1 {
+		t.Fatalf("Resources len = %d, want 1", len(service.Resources))
+	}
+	if service.Resources[0].InstanceInfo.Type != "custom_config_map_data" {
+		t.Fatalf("resource type = %q, want %q", service.Resources[0].InstanceInfo.Type, "custom_config_map_data")
+	}
+}
+
+func configMapDataTestBlock() *configschema.Block {
+	return &configschema.Block{
+		Attributes: map[string]*configschema.Attribute{
+			"id": {
+				Type:     cty.String,
+				Computed: true,
+			},
+			"data": {
+				Type:     cty.Map(cty.String),
+				Required: true,
+			},
+			"field_manager": {
+				Type:     cty.String,
+				Optional: true,
+			},
+			"force": {
+				Type:     cty.Bool,
+				Optional: true,
+			},
+		},
+		BlockTypes: map[string]*configschema.NestedBlock{
+			"metadata": {
+				Nesting:  configschema.NestingList,
+				MinItems: 1,
+				MaxItems: 1,
+				Block: configschema.Block{
+					Attributes: map[string]*configschema.Attribute{
+						"name": {
+							Type:     cty.String,
+							Required: true,
+						},
+						"namespace": {
+							Type:     cty.String,
+							Optional: true,
+						},
+					},
+				},
+			},
+		},
+	}
+}

--- a/providers/kubernetes/config_map_data_test.go
+++ b/providers/kubernetes/config_map_data_test.go
@@ -32,6 +32,19 @@ func TestConfigMapDataInitResources(t *testing.T) {
 				Name:      "no-data",
 			},
 		},
+		&corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: "default",
+				Name:      "owned-config",
+				OwnerReferences: []metav1.OwnerReference{{
+					APIVersion: "v1",
+					Kind:       "Pod",
+					Name:       "owner",
+					UID:        "owner-uid",
+				}},
+			},
+			Data: map[string]string{"key": "value"},
+		},
 	)
 
 	service := &ConfigMapData{}

--- a/providers/kubernetes/kubernetes_provider.go
+++ b/providers/kubernetes/kubernetes_provider.go
@@ -276,7 +276,7 @@ func removeConfigMapDataDuplicates(resourcesByService map[string][]terraformutil
 	}
 	configMapIDs := map[string]struct{}{}
 	for _, resource := range configMaps {
-		if isConfigMapResource(resource) && resource.InstanceState != nil {
+		if resource.InstanceState != nil {
 			configMapIDs[resource.InstanceState.ID] = struct{}{}
 		}
 	}
@@ -316,13 +316,6 @@ func isDefaultServiceAccountDuplicate(resource terraformutils.Resource, defaultS
 	}
 	_, ok := defaultServiceAccountIDs[resource.InstanceState.ID]
 	return ok
-}
-
-func isConfigMapResource(resource terraformutils.Resource) bool {
-	if resource.InstanceInfo == nil {
-		return false
-	}
-	return resource.InstanceInfo.Type == "kubernetes_config_map" || resource.InstanceInfo.Type == "kubernetes_config_map_v1"
 }
 
 // InitClientAndConfig uses the KUBECONFIG environment variable to create

--- a/providers/kubernetes/kubernetes_provider.go
+++ b/providers/kubernetes/kubernetes_provider.go
@@ -135,6 +135,10 @@ func (p *KubernetesProvider) GetSupportedService() map[string]terraformutils.Ser
 		_, exists := resp.ResourceTypes[name]
 		return exists
 	})
+	addConfigMapDataService(resources, clientset, listableResources, func(name string) bool {
+		_, exists := resp.ResourceTypes[name]
+		return exists
+	})
 	return resources
 }
 
@@ -211,7 +215,34 @@ func addNodeTaintService(
 	}
 }
 
+func addConfigMapDataService(
+	resources map[string]terraformutils.ServiceGenerator,
+	clientset k8sclient.Interface,
+	listableResources map[kubernetesResourceID]struct{},
+	hasResourceType func(string) bool,
+) {
+	if _, ok := listableResources[kubernetesResourceID{version: "v1", kind: "ConfigMap"}]; !ok {
+		return
+	}
+	if !supportsTypedClientResource(clientset, "", "v1", "ConfigMap") {
+		return
+	}
+	if !hasResourceType(configMapDataTerraformType) {
+		return
+	}
+
+	resources[configMapDataServiceName] = &ConfigMapData{
+		TerraformType: configMapDataTerraformType,
+	}
+}
+
 func (p KubernetesProvider) PostProcessImportResources(resourcesByService map[string][]terraformutils.Resource) map[string][]terraformutils.Resource {
+	resourcesByService = removeDefaultServiceAccountDuplicates(resourcesByService)
+	resourcesByService = removeConfigMapDataDuplicates(resourcesByService)
+	return resourcesByService
+}
+
+func removeDefaultServiceAccountDuplicates(resourcesByService map[string][]terraformutils.Resource) map[string][]terraformutils.Resource {
 	defaultServiceAccountIDs := map[string]struct{}{}
 	for _, resource := range resourcesByService[defaultServiceAccountServiceName] {
 		if resource.InstanceState == nil {
@@ -238,6 +269,44 @@ func (p KubernetesProvider) PostProcessImportResources(resourcesByService map[st
 	return resourcesByService
 }
 
+func removeConfigMapDataDuplicates(resourcesByService map[string][]terraformutils.Resource) map[string][]terraformutils.Resource {
+	configMaps, ok := resourcesByService["configmaps"]
+	if !ok {
+		return resourcesByService
+	}
+	configMapIDs := map[string]struct{}{}
+	for _, resource := range configMaps {
+		if isConfigMapResource(resource) && resource.InstanceState != nil {
+			configMapIDs[resource.InstanceState.ID] = struct{}{}
+		}
+	}
+	if len(configMapIDs) == 0 {
+		return resourcesByService
+	}
+
+	configMapData, ok := resourcesByService[configMapDataServiceName]
+	if !ok {
+		return resourcesByService
+	}
+	filtered := configMapData[:0]
+	for _, resource := range configMapData {
+		if resource.InstanceState == nil {
+			filtered = append(filtered, resource)
+			continue
+		}
+		if _, duplicate := configMapIDs[resource.InstanceState.ID]; duplicate {
+			continue
+		}
+		filtered = append(filtered, resource)
+	}
+	if len(filtered) == 0 {
+		delete(resourcesByService, configMapDataServiceName)
+		return resourcesByService
+	}
+	resourcesByService[configMapDataServiceName] = filtered
+	return resourcesByService
+}
+
 func isDefaultServiceAccountDuplicate(resource terraformutils.Resource, defaultServiceAccountIDs map[string]struct{}) bool {
 	if resource.InstanceInfo == nil || resource.InstanceState == nil {
 		return false
@@ -247,6 +316,13 @@ func isDefaultServiceAccountDuplicate(resource terraformutils.Resource, defaultS
 	}
 	_, ok := defaultServiceAccountIDs[resource.InstanceState.ID]
 	return ok
+}
+
+func isConfigMapResource(resource terraformutils.Resource) bool {
+	if resource.InstanceInfo == nil {
+		return false
+	}
+	return resource.InstanceInfo.Type == "kubernetes_config_map" || resource.InstanceInfo.Type == "kubernetes_config_map_v1"
 }
 
 // InitClientAndConfig uses the KUBECONFIG environment variable to create

--- a/providers/kubernetes/kubernetes_provider_test.go
+++ b/providers/kubernetes/kubernetes_provider_test.go
@@ -116,6 +116,59 @@ func TestAddNodeTaintServiceRequiresNodeAPI(t *testing.T) {
 	}
 }
 
+func TestAddConfigMapDataService(t *testing.T) {
+	resources := map[string]terraformutils.ServiceGenerator{}
+	clientset := fake.NewSimpleClientset()
+	listableResources := map[kubernetesResourceID]struct{}{
+		{version: "v1", kind: "ConfigMap"}: {},
+	}
+
+	addConfigMapDataService(resources, clientset, listableResources, func(name string) bool {
+		return name == configMapDataTerraformType
+	})
+
+	service, ok := resources[configMapDataServiceName]
+	if !ok {
+		t.Fatalf("resources[%q] was not registered", configMapDataServiceName)
+	}
+	configMapData, ok := service.(*ConfigMapData)
+	if !ok {
+		t.Fatalf("service type = %T, want *ConfigMapData", service)
+	}
+	if configMapData.TerraformType != configMapDataTerraformType {
+		t.Fatalf("TerraformType = %q, want %q", configMapData.TerraformType, configMapDataTerraformType)
+	}
+}
+
+func TestAddConfigMapDataServiceRequiresProviderType(t *testing.T) {
+	resources := map[string]terraformutils.ServiceGenerator{}
+	clientset := fake.NewSimpleClientset()
+	listableResources := map[kubernetesResourceID]struct{}{
+		{version: "v1", kind: "ConfigMap"}: {},
+	}
+
+	addConfigMapDataService(resources, clientset, listableResources, func(string) bool {
+		return false
+	})
+
+	if _, ok := resources[configMapDataServiceName]; ok {
+		t.Fatalf("resources[%q] was registered without provider type support", configMapDataServiceName)
+	}
+}
+
+func TestAddConfigMapDataServiceRequiresConfigMapAPI(t *testing.T) {
+	resources := map[string]terraformutils.ServiceGenerator{}
+	clientset := fake.NewSimpleClientset()
+
+	addConfigMapDataService(resources, clientset, map[kubernetesResourceID]struct{}{}, func(name string) bool {
+		return name == configMapDataTerraformType
+	})
+
+	if _, ok := resources[configMapDataServiceName]; ok {
+		t.Fatalf("resources[%q] was registered without configmaps API support", configMapDataServiceName)
+	}
+}
+
 func TestAddKubernetesResourceServiceDisambiguatesManifestPluralCollisions(t *testing.T) {
 	resources := map[string]terraformutils.ServiceGenerator{}
 	resource := metav1.APIResource{
@@ -207,6 +260,55 @@ func TestPostProcessImportResourcesDoesNotAddServiceAccountsService(t *testing.T
 
 	if _, ok := got["serviceaccounts"]; ok {
 		t.Fatal("serviceaccounts service was added")
+	}
+}
+
+func TestPostProcessImportResourcesRemovesOverlappingConfigMapData(t *testing.T) {
+	provider := KubernetesProvider{}
+	resourcesByService := map[string][]terraformutils.Resource{
+		"configmaps": {
+			terraformutils.NewSimpleResource("default/app-config", "default/app-config", "kubernetes_config_map_v1", "kubernetes", nil),
+		},
+		configMapDataServiceName: {
+			terraformutils.NewSimpleResource("default/app-config", "default/app-config", configMapDataTerraformType, "kubernetes", nil),
+			terraformutils.NewSimpleResource("default/other-config", "default/other-config", configMapDataTerraformType, "kubernetes", nil),
+		},
+	}
+
+	got := provider.PostProcessImportResources(resourcesByService)
+
+	assertResourceIDs(t, got["configmaps"], []string{"default/app-config"})
+	assertResourceIDs(t, got[configMapDataServiceName], []string{"default/other-config"})
+}
+
+func TestPostProcessImportResourcesKeepsConfigMapDataWithoutConfigMapsImport(t *testing.T) {
+	provider := KubernetesProvider{}
+	resourcesByService := map[string][]terraformutils.Resource{
+		configMapDataServiceName: {
+			terraformutils.NewSimpleResource("default/app-config", "default/app-config", configMapDataTerraformType, "kubernetes", nil),
+		},
+	}
+
+	got := provider.PostProcessImportResources(resourcesByService)
+
+	assertResourceIDs(t, got[configMapDataServiceName], []string{"default/app-config"})
+}
+
+func TestPostProcessImportResourcesRemovesConfigMapDataServiceWhenAllOverlap(t *testing.T) {
+	provider := KubernetesProvider{}
+	resourcesByService := map[string][]terraformutils.Resource{
+		"configmaps": {
+			terraformutils.NewSimpleResource("default/app-config", "default/app-config", "kubernetes_config_map_v1", "kubernetes", nil),
+		},
+		configMapDataServiceName: {
+			terraformutils.NewSimpleResource("default/app-config", "default/app-config", configMapDataTerraformType, "kubernetes", nil),
+		},
+	}
+
+	got := provider.PostProcessImportResources(resourcesByService)
+
+	if _, ok := got[configMapDataServiceName]; ok {
+		t.Fatalf("resources[%q] was not removed after all entries overlapped configmaps", configMapDataServiceName)
 	}
 }
 


### PR DESCRIPTION
Summary
- add a Kubernetes configmapdata service backed by kubernetes_config_map_v1_data
- seed metadata and data flatmap state from listable core/v1 ConfigMaps with data
- skip overlapping data-only resources when configmaps are imported too, avoiding duplicate ownership

Notes
- empty ConfigMap data values are preserved through the generated resource state

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a `configmapdata` service to import ConfigMap key/value data into Terraform via `kubernetes_config_map_v1_data`. Prevents duplicate ownership when `configmaps` are also imported.

- **New Features**
  - Imports only ConfigMaps with `data` and skips ones with `ownerReferences`.
  - Preserves empty `data` values and builds flatmap state compatible with the provider schema.
  - Deduplicates against `configmaps` imports; removes `configmapdata` if all entries overlap.
  - Registers only when `core/v1 ConfigMap` is available and the provider supports `kubernetes_config_map_v1_data`; docs updated to explain coexistence.

- **Bug Fixes**
  - Bounds the ConfigMap list call with a 30s timeout to prevent hangs.

<sup>Written for commit d0aa81ce63a241465a14121ea093cdf4df57aabf. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Import ConfigMap data as separate Terraform resources; only non-empty, unowned ConfigMaps are emitted and overlapping data is deduplicated when full ConfigMaps are imported.

* **Documentation**
  * Kubernetes provider docs updated to include the ConfigMap data resource mapping.

* **Tests**
  * Added tests for import generation, configured type usage, and deduplication behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->