### PR TITLE
fix(gcp): return monitoring iterator errors

### DIFF
--- a/providers/gcp/monitoring.go
+++ b/providers/gcp/monitoring.go
@@ -6,7 +6,7 @@ package gcp
 import (
 	"context"
 	"errors"
-	"log"
+	"fmt"
 
 	"github.com/chenrui333/terraformer/terraformutils"
 
@@ -42,8 +42,7 @@ func (g *MonitoringGenerator) loadAlerts(ctx context.Context, project string) er
 			break
 		}
 		if err != nil {
-			log.Println("error with alert:", err)
-			continue
+			return fmt.Errorf("list GCP monitoring alert policies: %w", err)
 		}
 		g.Resources = append(g.Resources, terraformutils.NewResource(
 			alert.Name,
@@ -78,8 +77,7 @@ func (g *MonitoringGenerator) loadGroups(ctx context.Context, project string) er
 			break
 		}
 		if err != nil {
-			log.Println("error with group:", err)
-			continue
+			return fmt.Errorf("list GCP monitoring groups: %w", err)
 		}
 		g.Resources = append(g.Resources, terraformutils.NewResource(
 			group.Name,
@@ -114,8 +112,7 @@ func (g *MonitoringGenerator) loadNotificationChannel(ctx context.Context, proje
 			break
 		}
 		if err != nil {
-			log.Println("error with notification Channel:", err)
-			continue
+			return fmt.Errorf("list GCP monitoring notification channels: %w", err)
 		}
 		g.Resources = append(g.Resources, terraformutils.NewResource(
 			notificationChannel.Name,
@@ -149,8 +146,7 @@ func (g *MonitoringGenerator) loadUptimeCheck(ctx context.Context, project strin
 			break
 		}
 		if err != nil {
-			log.Println("error with uptimeCheckConfigs:", err)
-			continue
+			return fmt.Errorf("list GCP monitoring uptime check configs: %w", err)
 		}
 		g.Resources = append(g.Resources, terraformutils.NewResource(
 			uptimeCheckConfigs.Name,


### PR DESCRIPTION
## Summary

- Return GCP monitoring iterator errors for alert policies, groups, notification channels, and uptime checks.
- Include resource-specific context instead of logging and continuing after discovery failures.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Propagates GCP Monitoring discovery errors (alerts, groups, notification channels, uptime checks) instead of logging and continuing, so callers can handle failures and avoid partial imports. Adds clear, resource-specific context to the returned errors.

- **Bug Fixes**
  - Return iterator errors for alert policies, groups, notification channels, and uptime check configs.
  - Replace `log.Println` with contextual `fmt.Errorf` messages (e.g., "list GCP monitoring ...").
  - Fail fast on discovery errors to prevent silent partial results.

<sup>Written for commit 8d2f1680e1b759d4c588361f658f59111c905335. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling for GCP monitoring operations. The system now properly halts operations when data retrieval errors occur, rather than silently continuing with incomplete data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->