### PR TITLE
fix(gcp): return region lookup errors

### DIFF
--- a/providers/gcp/gcp_provider.go
+++ b/providers/gcp/gcp_provider.go
@@ -19,8 +19,12 @@ type GCPProvider struct { //nolint
 	providerType string
 }
 
+var newComputeService = func(ctx context.Context) (*compute.Service, error) {
+	return compute.NewService(ctx)
+}
+
 func GetRegions(project string) []string {
-	computeService, err := compute.NewService(context.Background())
+	computeService, err := newComputeService(context.Background())
 	if err != nil {
 		return []string{}
 	}
@@ -39,7 +43,7 @@ func getRegion(project, regionName string) (*compute.Region, error) {
 	if regionName == "global" {
 		return &compute.Region{}, nil
 	}
-	computeService, err := compute.NewService(context.Background())
+	computeService, err := newComputeService(context.Background())
 	if err != nil {
 		return nil, fmt.Errorf("initialize GCP compute service: %w", err)
 	}

--- a/providers/gcp/gcp_provider.go
+++ b/providers/gcp/gcp_provider.go
@@ -5,7 +5,7 @@ package gcp
 import (
 	"context"
 	"errors"
-	"log"
+	"fmt"
 	"os"
 
 	"github.com/chenrui333/terraformer/terraformutils"
@@ -35,22 +35,20 @@ func GetRegions(project string) []string {
 	return regions
 }
 
-func getRegion(project, regionName string) *compute.Region {
+func getRegion(project, regionName string) (*compute.Region, error) {
 	if regionName == "global" {
-		return &compute.Region{}
+		return &compute.Region{}, nil
 	}
 	computeService, err := compute.NewService(context.Background())
 	if err != nil {
-		log.Println(err)
-		return &compute.Region{}
+		return nil, fmt.Errorf("initialize GCP compute service: %w", err)
 	}
 	regionsGetCall := computeService.Regions.Get(project, regionName).Fields("name", "zones")
 	region, err := regionsGetCall.Do()
 	if err != nil {
-		log.Println(err)
-		return &compute.Region{}
+		return nil, fmt.Errorf("get GCP region %q for project %q: %w", regionName, project, err)
 	}
-	return region
+	return region, nil
 }
 
 // check projectName in env params
@@ -63,7 +61,11 @@ func (p *GCPProvider) Init(args []string) error {
 		return errors.New("google cloud project name must be set")
 	}
 	p.projectName = projectName
-	p.region = *getRegion(projectName, args[0])
+	region, err := getRegion(projectName, args[0])
+	if err != nil {
+		return err
+	}
+	p.region = *region
 	p.providerType = args[2]
 	return nil
 }

--- a/providers/gcp/gcp_provider.go
+++ b/providers/gcp/gcp_provider.go
@@ -76,6 +76,8 @@ func (p *GCPProvider) Init(args []string) error {
 	p.region = *region
 	if len(args) > 2 {
 		p.providerType = args[2]
+	} else {
+		p.providerType = ""
 	}
 	return nil
 }

--- a/providers/gcp/gcp_provider.go
+++ b/providers/gcp/gcp_provider.go
@@ -53,6 +53,10 @@ func getRegion(project, regionName string) (*compute.Region, error) {
 
 // check projectName in env params
 func (p *GCPProvider) Init(args []string) error {
+	if len(args) == 0 {
+		return errors.New("gcp region must be provided")
+	}
+
 	projectName := os.Getenv("GOOGLE_CLOUD_PROJECT")
 	if len(args) > 1 {
 		projectName = args[1]
@@ -66,7 +70,9 @@ func (p *GCPProvider) Init(args []string) error {
 		return err
 	}
 	p.region = *region
-	p.providerType = args[2]
+	if len(args) > 2 {
+		p.providerType = args[2]
+	}
 	return nil
 }
 

--- a/providers/gcp/gcp_provider_test.go
+++ b/providers/gcp/gcp_provider_test.go
@@ -37,6 +37,25 @@ func TestGCPProviderInitAllowsDefaultProviderType(t *testing.T) {
 	}
 }
 
+func TestGCPProviderInitClearsProviderTypeWhenOmitted(t *testing.T) {
+	t.Setenv("GOOGLE_CLOUD_PROJECT", "test-project")
+
+	provider := GCPProvider{}
+	if err := provider.Init([]string{"global", "test-project", "beta"}); err != nil {
+		t.Fatalf("Init with beta provider returned error: %v", err)
+	}
+	if provider.GetName() != "google-beta" {
+		t.Fatalf("GetName() = %q, want %q", provider.GetName(), "google-beta")
+	}
+
+	if err := provider.Init([]string{"global"}); err != nil {
+		t.Fatalf("Init without provider type returned error: %v", err)
+	}
+	if provider.GetName() != "google" {
+		t.Fatalf("GetName() = %q, want %q", provider.GetName(), "google")
+	}
+}
+
 func TestGCPProviderInitReturnsNonGlobalRegionLookupError(t *testing.T) {
 	t.Setenv("GOOGLE_CLOUD_PROJECT", "test-project")
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {

--- a/providers/gcp/gcp_provider_test.go
+++ b/providers/gcp/gcp_provider_test.go
@@ -3,8 +3,13 @@
 package gcp
 
 import (
+	"context"
+	"net/http"
+	"net/http/httptest"
 	"strings"
 	"testing"
+
+	"google.golang.org/api/compute/v1"
 )
 
 func TestGCPProviderInitRequiresRegion(t *testing.T) {
@@ -29,5 +34,31 @@ func TestGCPProviderInitAllowsDefaultProviderType(t *testing.T) {
 	}
 	if provider.GetName() != "google" {
 		t.Fatalf("GetName() = %q, want %q", provider.GetName(), "google")
+	}
+}
+
+func TestGCPProviderInitReturnsNonGlobalRegionLookupError(t *testing.T) {
+	t.Setenv("GOOGLE_CLOUD_PROJECT", "test-project")
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		http.Error(w, "{\"error\":{\"message\":\"region lookup failed\"}}", http.StatusServiceUnavailable)
+	}))
+	t.Cleanup(server.Close)
+
+	originalNewComputeService := newComputeService
+	t.Cleanup(func() {
+		newComputeService = originalNewComputeService
+	})
+	newComputeService = func(ctx context.Context) (*compute.Service, error) {
+		return newTestComputeService(ctx, t, server.URL+"/"), nil
+	}
+
+	provider := GCPProvider{}
+	err := provider.Init([]string{"us-west1"})
+	if err == nil {
+		t.Fatal("expected region lookup error")
+	}
+	want := `get GCP region "us-west1" for project "test-project"`
+	if !strings.Contains(err.Error(), want) {
+		t.Fatalf("Init error = %q, want it to contain %q", err, want)
 	}
 }

--- a/providers/gcp/gcp_provider_test.go
+++ b/providers/gcp/gcp_provider_test.go
@@ -1,0 +1,33 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package gcp
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestGCPProviderInitRequiresRegion(t *testing.T) {
+	t.Setenv("GOOGLE_CLOUD_PROJECT", "test-project")
+
+	provider := GCPProvider{}
+	err := provider.Init(nil)
+	if err == nil {
+		t.Fatal("expected missing region error")
+	}
+	if !strings.Contains(err.Error(), "gcp region must be provided") {
+		t.Fatalf("Init error = %q, want missing region", err)
+	}
+}
+
+func TestGCPProviderInitAllowsDefaultProviderType(t *testing.T) {
+	t.Setenv("GOOGLE_CLOUD_PROJECT", "test-project")
+
+	provider := GCPProvider{}
+	if err := provider.Init([]string{"global"}); err != nil {
+		t.Fatalf("Init returned error: %v", err)
+	}
+	if provider.GetName() != "google" {
+		t.Fatalf("GetName() = %q, want %q", provider.GetName(), "google")
+	}
+}


### PR DESCRIPTION
## Summary

- Return GCP compute service initialization errors during provider region setup.
- Return non-global region lookup failures instead of logging and using an empty region.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Return GCP region lookup errors during provider initialization and require a region. Stop using an empty region; default or reset provider type to `google` when omitted.

- **Bug Fixes**
  - Return errors from `compute.NewService` and `Regions.Get(...)` with context; `global` still succeeds.
  - Update `GCPProvider.Init` to require a region and treat provider type as optional, resetting to default when omitted.

- **Tests**
  - Add unit tests for missing region, default and reset of provider type, and non-global region lookup errors.

<sup>Written for commit 2b660f4d3ac9021162a43c7828a9881011d3594b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * GCP provider initialization now surfaces configuration and region lookup errors, correctly sets the provider region on success, and only applies a provider type when explicitly provided (clears it when omitted).

* **Tests**
  * Added unit tests for required-region validation, successful default-provider initialization, clearing provider type when omitted, and reporting region lookup failures as errors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->