### PR TITLE
feat(datadog): add monitor JSON import

### DIFF
--- a/docs/datadog.md
+++ b/docs/datadog.md
@@ -137,6 +137,8 @@ Tag filters are order specific. For example, if your monitor has tags (in the or
     * `datadog_monitor`
 *   `monitor_config_policy`
     * `datadog_monitor_config_policy`
+*   `monitor_json`
+    * `datadog_monitor_json`
 *   `monitor_notification_rule`
     * `datadog_monitor_notification_rule`
         * **_NOTE:_** Requires DataDog/datadog provider 3.83.0 or newer.

--- a/providers/datadog/datadog_provider.go
+++ b/providers/datadog/datadog_provider.go
@@ -206,6 +206,12 @@ func (p DatadogProvider) GetResourceConnections() map[string]map[string][]string
 				"widget.alert_value_definition.alert_id", "id",
 				"widget.group_definition.widget.alert_value_definition.alert_id", "id",
 			},
+			"monitor_json": {
+				"widget.alert_graph_definition.alert_id", "id",
+				"widget.group_definition.widget.alert_graph_definition.alert_id", "id",
+				"widget.alert_value_definition.alert_id", "id",
+				"widget.group_definition.widget.alert_value_definition.alert_id", "id",
+			},
 			"service_level_objective": {
 				"widget.service_level_objective_definition.slo_id", "id",
 				"widget.group_definition.widget.service_level_objective_definition.slo_id", "id",
@@ -218,6 +224,9 @@ func (p DatadogProvider) GetResourceConnections() map[string]map[string][]string
 		},
 		"downtime": {
 			"monitor": {
+				"monitor_id", "id",
+			},
+			"monitor_json": {
 				"monitor_id", "id",
 			},
 		},
@@ -276,6 +285,9 @@ func (p DatadogProvider) GetResourceConnections() map[string]map[string][]string
 		},
 		"service_level_objective": {
 			"monitor": {
+				"monitor_ids", "id",
+			},
+			"monitor_json": {
 				"monitor_ids", "id",
 			},
 		},

--- a/providers/datadog/datadog_provider.go
+++ b/providers/datadog/datadog_provider.go
@@ -172,6 +172,7 @@ func (p *DatadogProvider) GetSupportedService() map[string]terraformutils.Servic
 		"metric_tag_configuration":             &MetricTagConfigurationGenerator{},
 		"monitor":                              &MonitorGenerator{},
 		"monitor_config_policy":                &MonitorConfigPolicyGenerator{},
+		"monitor_json":                         &MonitorJSONGenerator{},
 		"monitor_notification_rule":            &MonitorNotificationRuleGenerator{},
 		"security_monitoring_default_rule":     &SecurityMonitoringDefaultRuleGenerator{},
 		"security_monitoring_filter":           &SecurityMonitoringFilterGenerator{},

--- a/providers/datadog/datadog_provider_test.go
+++ b/providers/datadog/datadog_provider_test.go
@@ -25,7 +25,46 @@ func TestDatadogProviderSensitiveDataScannerConnections(t *testing.T) {
 	)
 }
 
+func TestDatadogProviderMonitorJSONConnections(t *testing.T) {
+	connections := DatadogProvider{}.GetResourceConnections()
+
+	assertDatadogConnectionPairs(
+		t,
+		connections,
+		"dashboard",
+		"monitor_json",
+		[]string{
+			"widget.alert_graph_definition.alert_id", "id",
+			"widget.group_definition.widget.alert_graph_definition.alert_id", "id",
+			"widget.alert_value_definition.alert_id", "id",
+			"widget.group_definition.widget.alert_value_definition.alert_id", "id",
+		},
+	)
+	assertDatadogConnection(
+		t,
+		connections,
+		"downtime",
+		"monitor_json",
+		"monitor_id",
+		"id",
+	)
+	assertDatadogConnection(
+		t,
+		connections,
+		"service_level_objective",
+		"monitor_json",
+		"monitor_ids",
+		"id",
+	)
+}
+
 func assertDatadogConnection(t *testing.T, connections map[string]map[string][]string, source, target, sourceField, targetField string) {
+	t.Helper()
+
+	assertDatadogConnectionPairs(t, connections, source, target, []string{sourceField, targetField})
+}
+
+func assertDatadogConnectionPairs(t *testing.T, connections map[string]map[string][]string, source, target string, expected []string) {
 	t.Helper()
 
 	targets, ok := connections[source]
@@ -36,10 +75,12 @@ func assertDatadogConnection(t *testing.T, connections map[string]map[string][]s
 	if !ok {
 		t.Fatalf("connections[%q][%q] missing", source, target)
 	}
-	if len(fields) != 2 {
-		t.Fatalf("connections[%q][%q] = %v, want two fields", source, target, fields)
+	if len(fields) != len(expected) {
+		t.Fatalf("connections[%q][%q] = %v, want %v", source, target, fields, expected)
 	}
-	if fields[0] != sourceField || fields[1] != targetField {
-		t.Fatalf("connections[%q][%q] = %v, want [%q %q]", source, target, fields, sourceField, targetField)
+	for i := range expected {
+		if fields[i] != expected[i] {
+			t.Fatalf("connections[%q][%q] = %v, want %v", source, target, fields, expected)
+		}
 	}
 }

--- a/providers/datadog/monitor_json.go
+++ b/providers/datadog/monitor_json.go
@@ -5,6 +5,7 @@ package datadog
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"strconv"
 	"strings"
@@ -117,4 +118,78 @@ func (g *MonitorJSONGenerator) InitResources() error {
 
 	g.Resources = g.createResources(monitors)
 	return nil
+}
+
+// PostRefreshCleanup filters datadog_monitor_json resources after provider refresh.
+// The provider stores monitor fields inside the top-level monitor JSON string, so
+// Terraformer's generic tag filter cannot see monitor tags without parsing it.
+func (g *MonitorJSONGenerator) PostRefreshCleanup() {
+	if len(g.Filter) == 0 {
+		return
+	}
+
+	resources := []terraformutils.Resource{}
+	for _, resource := range g.Resources {
+		if g.postRefreshFiltersMatch(resource) && !terraformutils.ContainsResource(resources, resource) {
+			resources = append(resources, resource)
+		}
+	}
+	g.Resources = resources
+}
+
+func (g *MonitorJSONGenerator) postRefreshFiltersMatch(resource terraformutils.Resource) bool {
+	for _, filter := range g.Filter {
+		if filter.FieldPath == "id" {
+			continue
+		}
+		if filter.FieldPath == "tags" && filter.IsApplicable("monitor_json") {
+			if !monitorJSONTagsFilter(resource, filter) {
+				return false
+			}
+			continue
+		}
+		if !filter.Filter(resource) {
+			return false
+		}
+	}
+	return true
+}
+
+func monitorJSONTagsFilter(resource terraformutils.Resource, filter terraformutils.ResourceFilter) bool {
+	monitor, ok := monitorJSONAttributes(resource)
+	if !ok {
+		return false
+	}
+	if filter.AcceptableValues == nil {
+		return terraformutils.WalkAndCheckField("tags", monitor)
+	}
+
+	values := terraformutils.WalkAndGet("tags", monitor)
+	for _, value := range values {
+		for _, acceptableValue := range filter.AcceptableValues {
+			if value == acceptableValue {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func monitorJSONAttributes(resource terraformutils.Resource) (map[string]interface{}, bool) {
+	monitorJSON := resource.InstanceState.Attributes["monitor"]
+	if monitorJSON == "" && resource.Item != nil {
+		monitor, ok := resource.Item["monitor"].(string)
+		if ok {
+			monitorJSON = monitor
+		}
+	}
+	if monitorJSON == "" {
+		return nil, false
+	}
+
+	monitor := map[string]interface{}{}
+	if err := json.Unmarshal([]byte(monitorJSON), &monitor); err != nil {
+		return nil, false
+	}
+	return monitor, true
 }

--- a/providers/datadog/monitor_json.go
+++ b/providers/datadog/monitor_json.go
@@ -1,0 +1,118 @@
+// SPDX-License-Identifier: Apache-2.0
+
+//nolint:gosec // lint triage: legacy provider/API/security baseline is tracked in #175.
+package datadog
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+	"strings"
+
+	"github.com/DataDog/datadog-api-client-go/v2/api/datadog"
+	"github.com/DataDog/datadog-api-client-go/v2/api/datadogV1"
+
+	"github.com/chenrui333/terraformer/terraformutils"
+)
+
+var (
+	// MonitorJSONAllowEmptyValues ...
+	MonitorJSONAllowEmptyValues = []string{}
+)
+
+// MonitorJSONGenerator ...
+type MonitorJSONGenerator struct {
+	DatadogService
+}
+
+func (g *MonitorJSONGenerator) createResources(monitors []datadogV1.Monitor) []terraformutils.Resource {
+	resources := []terraformutils.Resource{}
+	for _, monitor := range monitors {
+		if monitor.GetType() == datadogV1.MONITORTYPE_SYNTHETICS_ALERT {
+			continue
+		}
+		resourceName := strconv.FormatInt(monitor.GetId(), 10)
+		resources = append(resources, g.createResource(resourceName))
+	}
+
+	return resources
+}
+
+func (g *MonitorJSONGenerator) createResource(monitorID string) terraformutils.Resource {
+	return terraformutils.NewSimpleResource(
+		monitorID,
+		fmt.Sprintf("monitor_json_%s", monitorID),
+		"datadog_monitor_json",
+		"datadog",
+		MonitorJSONAllowEmptyValues,
+	)
+}
+
+// InitResources Generate TerraformResources from Datadog API,
+// from each monitor create 1 TerraformResource using datadog_monitor_json.
+// Need Monitor ID as ID for terraform resource.
+func (g *MonitorJSONGenerator) InitResources() error {
+	datadogClient := g.Args["datadogClient"].(*datadog.APIClient)
+	auth := g.Args["auth"].(context.Context)
+	api := datadogV1.NewMonitorsApi(datadogClient)
+
+	optionalParams := datadogV1.NewListMonitorsOptionalParameters()
+	resources := []terraformutils.Resource{}
+	for _, filter := range g.Filter {
+		if filter.FieldPath == "id" && filter.IsApplicable("monitor_json") {
+			for _, value := range filter.AcceptableValues {
+				i, err := strconv.ParseInt(value, 10, 64)
+				if err != nil {
+					return err
+				}
+
+				monitor, httpResp, err := api.GetMonitor(auth, i)
+				if httpResp != nil && httpResp.Body != nil {
+					_ = httpResp.Body.Close()
+				}
+				if err != nil {
+					return err
+				}
+				if monitor.GetType() == datadogV1.MONITORTYPE_SYNTHETICS_ALERT {
+					continue
+				}
+
+				resources = append(resources, g.createResource(strconv.FormatInt(monitor.GetId(), 10)))
+			}
+		}
+		if filter.FieldPath == "tags" && filter.IsApplicable("monitor_json") {
+			optionalParams.WithMonitorTags(strings.Join(filter.AcceptableValues, ","))
+		}
+	}
+
+	if len(resources) > 0 {
+		g.Resources = resources
+		return nil
+	}
+
+	var monitors []datadogV1.Monitor
+	pageSize := int32(1000)
+	pageNumber := int64(0)
+	for {
+		resp, httpResp, err := api.ListMonitors(auth, *optionalParams.
+			WithPageSize(pageSize).
+			WithPage(pageNumber))
+		if httpResp != nil && httpResp.Body != nil {
+			_ = httpResp.Body.Close()
+		}
+		if err != nil {
+			return err
+		}
+
+		if len(resp) == 0 || int32(len(resp)) < pageSize {
+			monitors = append(monitors, resp...)
+			break
+		}
+
+		monitors = append(monitors, resp...)
+		pageNumber++
+	}
+
+	g.Resources = g.createResources(monitors)
+	return nil
+}

--- a/providers/datadog/monitor_json.go
+++ b/providers/datadog/monitor_json.go
@@ -58,8 +58,10 @@ func (g *MonitorJSONGenerator) InitResources() error {
 
 	optionalParams := datadogV1.NewListMonitorsOptionalParameters()
 	resources := []terraformutils.Resource{}
+	hasIDFilter := false
 	for _, filter := range g.Filter {
 		if filter.FieldPath == "id" && filter.IsApplicable("monitor_json") {
+			hasIDFilter = true
 			for _, value := range filter.AcceptableValues {
 				i, err := strconv.ParseInt(value, 10, 64)
 				if err != nil {
@@ -85,7 +87,7 @@ func (g *MonitorJSONGenerator) InitResources() error {
 		}
 	}
 
-	if len(resources) > 0 {
+	if hasIDFilter || len(resources) > 0 {
 		g.Resources = resources
 		return nil
 	}

--- a/providers/datadog/monitor_json_test.go
+++ b/providers/datadog/monitor_json_test.go
@@ -100,3 +100,34 @@ func TestMonitorJSONInitResourcesKeepsIDFilterTerminalWhenAllMatchesAreSkipped(t
 		}
 	}
 }
+
+func TestMonitorJSONPostRefreshCleanupMatchesTagsInsideMonitorJSON(t *testing.T) {
+	matching := (&MonitorJSONGenerator{}).createResource("1001")
+	matching.InstanceState.Attributes["monitor"] = "{\"tags\":[\"env:prod\",\"team:core\"],\"query\":\"avg:system.cpu.user{*} > 10\",\"type\":\"metric alert\"}"
+
+	nonMatching := (&MonitorJSONGenerator{}).createResource("1002")
+	nonMatching.InstanceState.Attributes["monitor"] = "{\"tags\":[\"env:stage\"],\"query\":\"avg:system.cpu.user{*} > 10\",\"type\":\"metric alert\"}"
+
+	generator := &MonitorJSONGenerator{
+		DatadogService: DatadogService{
+			Service: terraformutils.Service{
+				Resources: []terraformutils.Resource{matching, nonMatching},
+				Filter: []terraformutils.ResourceFilter{
+					{
+						FieldPath:        "tags",
+						AcceptableValues: []string{"env:prod"},
+					},
+				},
+			},
+		},
+	}
+
+	generator.PostRefreshCleanup()
+
+	if len(generator.Resources) != 1 {
+		t.Fatalf("expected 1 resource, got %d", len(generator.Resources))
+	}
+	if generator.Resources[0].InstanceState.ID != "1001" {
+		t.Fatalf("expected resource ID 1001, got %s", generator.Resources[0].InstanceState.ID)
+	}
+}

--- a/providers/datadog/monitor_json_test.go
+++ b/providers/datadog/monitor_json_test.go
@@ -1,0 +1,44 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package datadog
+
+import (
+	"testing"
+
+	"github.com/DataDog/datadog-api-client-go/v2/api/datadogV1"
+)
+
+func TestMonitorJSONCreateResource(t *testing.T) {
+	generator := &MonitorJSONGenerator{}
+	resource := generator.createResource("12345")
+
+	if resource.InstanceState.ID != "12345" {
+		t.Fatalf("expected resource ID 12345, got %s", resource.InstanceState.ID)
+	}
+	if resource.ResourceName != "tfer--monitor_json_12345" {
+		t.Fatalf("expected resource name tfer--monitor_json_12345, got %s", resource.ResourceName)
+	}
+	if resource.InstanceInfo.Type != "datadog_monitor_json" {
+		t.Fatalf("expected resource type datadog_monitor_json, got %s", resource.InstanceInfo.Type)
+	}
+}
+
+func TestMonitorJSONCreateResourcesSkipsSyntheticsAlerts(t *testing.T) {
+	metricMonitor := datadogV1.NewMonitorWithDefaults()
+	metricMonitor.SetId(1001)
+	metricMonitor.SetType(datadogV1.MONITORTYPE_METRIC_ALERT)
+
+	syntheticsMonitor := datadogV1.NewMonitorWithDefaults()
+	syntheticsMonitor.SetId(1002)
+	syntheticsMonitor.SetType(datadogV1.MONITORTYPE_SYNTHETICS_ALERT)
+
+	generator := &MonitorJSONGenerator{}
+	resources := generator.createResources([]datadogV1.Monitor{*metricMonitor, *syntheticsMonitor})
+
+	if len(resources) != 1 {
+		t.Fatalf("expected 1 resource, got %d", len(resources))
+	}
+	if resources[0].InstanceState.ID != "1001" {
+		t.Fatalf("expected resource ID 1001, got %s", resources[0].InstanceState.ID)
+	}
+}

--- a/providers/datadog/monitor_json_test.go
+++ b/providers/datadog/monitor_json_test.go
@@ -3,9 +3,15 @@
 package datadog
 
 import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
 	"testing"
 
+	"github.com/DataDog/datadog-api-client-go/v2/api/datadog"
 	"github.com/DataDog/datadog-api-client-go/v2/api/datadogV1"
+	"github.com/chenrui333/terraformer/terraformutils"
 )
 
 func TestMonitorJSONCreateResource(t *testing.T) {
@@ -40,5 +46,57 @@ func TestMonitorJSONCreateResourcesSkipsSyntheticsAlerts(t *testing.T) {
 	}
 	if resources[0].InstanceState.ID != "1001" {
 		t.Fatalf("expected resource ID 1001, got %s", resources[0].InstanceState.ID)
+	}
+}
+
+func TestMonitorJSONInitResourcesKeepsIDFilterTerminalWhenAllMatchesAreSkipped(t *testing.T) {
+	requestedPaths := []string{}
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestedPaths = append(requestedPaths, r.URL.Path)
+		w.Header().Set("Content-Type", "application/json")
+
+		switch r.URL.Path {
+		case "/api/v1/monitor/1002":
+			_, _ = fmt.Fprint(w, "{\"id\":1002,\"type\":\"synthetics alert\",\"query\":\"synthetics query\"}")
+		case "/api/v1/monitor":
+			_, _ = fmt.Fprint(w, "[]")
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+
+	config := datadog.NewConfiguration()
+	config.Servers = datadog.ServerConfigurations{{URL: server.URL}}
+	config.HTTPClient = server.Client()
+
+	generator := &MonitorJSONGenerator{
+		DatadogService: DatadogService{
+			Service: terraformutils.Service{
+				Args: map[string]interface{}{
+					"auth":          context.Background(),
+					"datadogClient": datadog.NewAPIClient(config),
+				},
+				Filter: []terraformutils.ResourceFilter{
+					{
+						ServiceName:      "monitor_json",
+						FieldPath:        "id",
+						AcceptableValues: []string{"1002"},
+					},
+				},
+			},
+		},
+	}
+
+	if err := generator.InitResources(); err != nil {
+		t.Fatalf("InitResources returned error: %v", err)
+	}
+	if len(generator.Resources) != 0 {
+		t.Fatalf("expected no resources, got %d", len(generator.Resources))
+	}
+	for _, path := range requestedPaths {
+		if path == "/api/v1/monitor" {
+			t.Fatalf("expected id filter to avoid full monitor list, got requests %v", requestedPaths)
+		}
 	}
 }


### PR DESCRIPTION
Summary
- Add Datadog monitor_json import support using the existing monitor list API.
- Mirror monitor ID and tag filters while skipping synthetics alert monitors.
- Document the new Datadog resource.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add Datadog monitor JSON import to generate `datadog_monitor_json` resources with `id` and `tags` filters, skipping synthetics alert monitors. Connect dashboard, downtime, and SLO references to these monitors and preserve `tags` filtering after provider refresh.

- **New Features**
  - Register `monitor_json` service and generator; update docs.
  - Support `id` and `tags` filters; use Get/List with 1000-per-page pagination.
  - Skip `SYNTHETICS_ALERT` monitors.

- **Bug Fixes**
  - Honor `id` filters for `monitor_json`: call Get for specified IDs; do not fall back to List if matches are skipped.
  - Preserve `tags` filters after refresh by parsing the monitor JSON during cleanup.
  - Connect `monitor_json` references in `dashboard` alert widgets, `downtime.monitor_id`, and `service_level_objective.monitor_ids`.

<sup>Written for commit b35890af56ef7ed61c040cb6b69b5d459b4f6d71. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Import Datadog monitors as datadog_monitor_json resources
  * Support filtering imports by monitor IDs or tags with automatic pagination
  * Wire monitor_json resources into dashboard and dashboard_list connections and monitor_ids links for SLOs
  * Post-refresh cleanup removes resources that don’t match configured filters (including tags)

* **Documentation**
  * Added datadog_monitor_json to supported resources list

* **Tests**
  * Added tests for monitor JSON generation, ID/tag filtering, skipped Synthetics alerts, and provider connection mappings
<!-- end of auto-generated comment: release notes by coderabbit.ai -->