### PR TITLE
feat(kubernetes): import secret data

### DIFF
--- a/docs/kubernetes.md
+++ b/docs/kubernetes.md
@@ -11,6 +11,8 @@ Terraformer discovers Kubernetes API resources from the active cluster and impor
 Discovered CRDs and other untyped API extensions without a first-class Terraform Kubernetes provider type can be imported through `kubernetes_manifest` when the API resource is manageable and the installed provider supports that resource.
 Manifest-backed custom resources use a group/version-qualified resource selector such as `example.com/v1/widgets` to avoid collisions between CRDs that share the same plural name.
 When `configmaps` and `configmapdata` are selected together, Terraformer keeps the full `configmaps` import and skips overlapping data-only resources to avoid duplicate Terraform ownership of the same ConfigMap data.
+When `secrets` and `secretdata` are selected together, Terraformer keeps the full `secrets` import and skips overlapping data-only resources to avoid duplicate Terraform ownership of the same Secret data.
+Because `kubernetes_secret_v1_data` only accepts string data, `secretdata` skips Secrets containing non-UTF-8 payloads instead of emitting lossy configuration.
 
 Common supported resources include:
 
@@ -85,6 +87,8 @@ Common supported resources include:
     * `kubernetes_runtime_class_v1`
 *   `secrets`
     * `kubernetes_secret_v1`
+*   `secretdata`
+    * `kubernetes_secret_v1_data`
 *   `services`
     * `kubernetes_service_v1`
 *   `serviceaccounts`

--- a/providers/kubernetes/kubernetes_provider.go
+++ b/providers/kubernetes/kubernetes_provider.go
@@ -139,6 +139,10 @@ func (p *KubernetesProvider) GetSupportedService() map[string]terraformutils.Ser
 		_, exists := resp.ResourceTypes[name]
 		return exists
 	})
+	addSecretDataService(resources, clientset, listableResources, func(name string) bool {
+		_, exists := resp.ResourceTypes[name]
+		return exists
+	})
 	return resources
 }
 
@@ -236,9 +240,31 @@ func addConfigMapDataService(
 	}
 }
 
+func addSecretDataService(
+	resources map[string]terraformutils.ServiceGenerator,
+	clientset k8sclient.Interface,
+	listableResources map[kubernetesResourceID]struct{},
+	hasResourceType func(string) bool,
+) {
+	if _, ok := listableResources[kubernetesResourceID{version: "v1", kind: "Secret"}]; !ok {
+		return
+	}
+	if !supportsTypedClientResource(clientset, "", "v1", "Secret") {
+		return
+	}
+	if !hasResourceType(secretDataTerraformType) {
+		return
+	}
+
+	resources[secretDataServiceName] = &SecretData{
+		TerraformType: secretDataTerraformType,
+	}
+}
+
 func (p KubernetesProvider) PostProcessImportResources(resourcesByService map[string][]terraformutils.Resource) map[string][]terraformutils.Resource {
 	resourcesByService = removeDefaultServiceAccountDuplicates(resourcesByService)
 	resourcesByService = removeConfigMapDataDuplicates(resourcesByService)
+	resourcesByService = removeSecretDataDuplicates(resourcesByService)
 	return resourcesByService
 }
 
@@ -304,6 +330,44 @@ func removeConfigMapDataDuplicates(resourcesByService map[string][]terraformutil
 		return resourcesByService
 	}
 	resourcesByService[configMapDataServiceName] = filtered
+	return resourcesByService
+}
+
+func removeSecretDataDuplicates(resourcesByService map[string][]terraformutils.Resource) map[string][]terraformutils.Resource {
+	secrets, ok := resourcesByService["secrets"]
+	if !ok {
+		return resourcesByService
+	}
+	secretIDs := map[string]struct{}{}
+	for _, resource := range secrets {
+		if resource.InstanceState != nil {
+			secretIDs[resource.InstanceState.ID] = struct{}{}
+		}
+	}
+	if len(secretIDs) == 0 {
+		return resourcesByService
+	}
+
+	secretData, ok := resourcesByService[secretDataServiceName]
+	if !ok {
+		return resourcesByService
+	}
+	filtered := secretData[:0]
+	for _, resource := range secretData {
+		if resource.InstanceState == nil {
+			filtered = append(filtered, resource)
+			continue
+		}
+		if _, duplicate := secretIDs[resource.InstanceState.ID]; duplicate {
+			continue
+		}
+		filtered = append(filtered, resource)
+	}
+	if len(filtered) == 0 {
+		delete(resourcesByService, secretDataServiceName)
+		return resourcesByService
+	}
+	resourcesByService[secretDataServiceName] = filtered
 	return resourcesByService
 }
 

--- a/providers/kubernetes/kubernetes_provider_test.go
+++ b/providers/kubernetes/kubernetes_provider_test.go
@@ -169,6 +169,59 @@ func TestAddConfigMapDataServiceRequiresConfigMapAPI(t *testing.T) {
 	}
 }
 
+func TestAddSecretDataService(t *testing.T) {
+	resources := map[string]terraformutils.ServiceGenerator{}
+	clientset := fake.NewSimpleClientset()
+	listableResources := map[kubernetesResourceID]struct{}{
+		{version: "v1", kind: "Secret"}: {},
+	}
+
+	addSecretDataService(resources, clientset, listableResources, func(name string) bool {
+		return name == secretDataTerraformType
+	})
+
+	service, ok := resources[secretDataServiceName]
+	if !ok {
+		t.Fatalf("resources[%q] was not registered", secretDataServiceName)
+	}
+	secretData, ok := service.(*SecretData)
+	if !ok {
+		t.Fatalf("service type = %T, want *SecretData", service)
+	}
+	if secretData.TerraformType != secretDataTerraformType {
+		t.Fatalf("TerraformType = %q, want %q", secretData.TerraformType, secretDataTerraformType)
+	}
+}
+
+func TestAddSecretDataServiceRequiresProviderType(t *testing.T) {
+	resources := map[string]terraformutils.ServiceGenerator{}
+	clientset := fake.NewSimpleClientset()
+	listableResources := map[kubernetesResourceID]struct{}{
+		{version: "v1", kind: "Secret"}: {},
+	}
+
+	addSecretDataService(resources, clientset, listableResources, func(string) bool {
+		return false
+	})
+
+	if _, ok := resources[secretDataServiceName]; ok {
+		t.Fatalf("resources[%q] was registered without provider type support", secretDataServiceName)
+	}
+}
+
+func TestAddSecretDataServiceRequiresSecretAPI(t *testing.T) {
+	resources := map[string]terraformutils.ServiceGenerator{}
+	clientset := fake.NewSimpleClientset()
+
+	addSecretDataService(resources, clientset, map[kubernetesResourceID]struct{}{}, func(name string) bool {
+		return name == secretDataTerraformType
+	})
+
+	if _, ok := resources[secretDataServiceName]; ok {
+		t.Fatalf("resources[%q] was registered without secrets API support", secretDataServiceName)
+	}
+}
+
 func TestAddKubernetesResourceServiceDisambiguatesManifestPluralCollisions(t *testing.T) {
 	resources := map[string]terraformutils.ServiceGenerator{}
 	resource := metav1.APIResource{
@@ -309,6 +362,55 @@ func TestPostProcessImportResourcesRemovesConfigMapDataServiceWhenAllOverlap(t *
 
 	if _, ok := got[configMapDataServiceName]; ok {
 		t.Fatalf("resources[%q] was not removed after all entries overlapped configmaps", configMapDataServiceName)
+	}
+}
+
+func TestPostProcessImportResourcesRemovesOverlappingSecretData(t *testing.T) {
+	provider := KubernetesProvider{}
+	resourcesByService := map[string][]terraformutils.Resource{
+		"secrets": {
+			terraformutils.NewSimpleResource("default/app-secret", "default/app-secret", "kubernetes_secret_v1", "kubernetes", nil),
+		},
+		secretDataServiceName: {
+			terraformutils.NewSimpleResource("default/app-secret", "default/app-secret", secretDataTerraformType, "kubernetes", nil),
+			terraformutils.NewSimpleResource("default/other-secret", "default/other-secret", secretDataTerraformType, "kubernetes", nil),
+		},
+	}
+
+	got := provider.PostProcessImportResources(resourcesByService)
+
+	assertResourceIDs(t, got["secrets"], []string{"default/app-secret"})
+	assertResourceIDs(t, got[secretDataServiceName], []string{"default/other-secret"})
+}
+
+func TestPostProcessImportResourcesKeepsSecretDataWithoutSecretsImport(t *testing.T) {
+	provider := KubernetesProvider{}
+	resourcesByService := map[string][]terraformutils.Resource{
+		secretDataServiceName: {
+			terraformutils.NewSimpleResource("default/app-secret", "default/app-secret", secretDataTerraformType, "kubernetes", nil),
+		},
+	}
+
+	got := provider.PostProcessImportResources(resourcesByService)
+
+	assertResourceIDs(t, got[secretDataServiceName], []string{"default/app-secret"})
+}
+
+func TestPostProcessImportResourcesRemovesSecretDataServiceWhenAllOverlap(t *testing.T) {
+	provider := KubernetesProvider{}
+	resourcesByService := map[string][]terraformutils.Resource{
+		"secrets": {
+			terraformutils.NewSimpleResource("default/app-secret", "default/app-secret", "kubernetes_secret_v1", "kubernetes", nil),
+		},
+		secretDataServiceName: {
+			terraformutils.NewSimpleResource("default/app-secret", "default/app-secret", secretDataTerraformType, "kubernetes", nil),
+		},
+	}
+
+	got := provider.PostProcessImportResources(resourcesByService)
+
+	if _, ok := got[secretDataServiceName]; ok {
+		t.Fatalf("resources[%q] was not removed after all entries overlapped secrets", secretDataServiceName)
 	}
 }
 

--- a/providers/kubernetes/secret_data.go
+++ b/providers/kubernetes/secret_data.go
@@ -1,0 +1,104 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package kubernetes
+
+import (
+	"context"
+	"strconv"
+	"time"
+	"unicode/utf8"
+
+	"github.com/chenrui333/terraformer/terraformutils"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+)
+
+const (
+	secretDataServiceName       = "secretdata"
+	secretDataTerraformType     = "kubernetes_secret_v1_data"
+	secretDataAllowEmptyPattern = `^data\.`
+	secretDataListTimeout       = 30 * time.Second
+)
+
+type SecretData struct {
+	KubernetesService
+	TerraformType string
+}
+
+func (s *SecretData) InitResources() error {
+	config, _, err := initClientAndConfig()
+	if err != nil {
+		return err
+	}
+
+	clientset, err := kubernetes.NewForConfig(config)
+	if err != nil {
+		return err
+	}
+
+	return s.initResources(clientset)
+}
+
+func (s *SecretData) initResources(clientset kubernetes.Interface) error {
+	ctx, cancel := context.WithTimeout(context.Background(), secretDataListTimeout)
+	defer cancel()
+
+	secrets, err := clientset.CoreV1().Secrets(metav1.NamespaceAll).List(ctx, metav1.ListOptions{})
+	if err != nil {
+		return err
+	}
+
+	terraformType := s.TerraformType
+	if terraformType == "" {
+		terraformType = secretDataTerraformType
+	}
+
+	for i := range secrets.Items {
+		secret := secrets.Items[i]
+		if len(secret.Data) == 0 || len(secret.OwnerReferences) > 0 {
+			continue
+		}
+
+		attributes, ok := secretDataAttributes(secret)
+		if !ok {
+			continue
+		}
+
+		name := secret.Namespace + "/" + secret.Name
+		s.Resources = append(s.Resources, terraformutils.NewResource(
+			name,
+			name,
+			terraformType,
+			"kubernetes",
+			attributes,
+			[]string{secretDataAllowEmptyPattern},
+			map[string]interface{}{},
+		))
+	}
+	return nil
+}
+
+func secretDataAttributes(secret corev1.Secret) (map[string]string, bool) {
+	data := make(map[string]string, len(secret.Data))
+	for key, value := range secret.Data {
+		// kubernetes_secret_v1_data accepts string data only.
+		if !utf8.Valid(value) {
+			return nil, false
+		}
+		data[key] = string(value)
+	}
+
+	attributes := map[string]string{
+		"id":                   secret.Namespace + "/" + secret.Name,
+		"metadata.#":           "1",
+		"metadata.0.name":      secret.Name,
+		"metadata.0.namespace": secret.Namespace,
+		"data.%":               strconv.Itoa(len(data)),
+	}
+	for key, value := range data {
+		attributes["data."+key] = value
+	}
+	return attributes, true
+}

--- a/providers/kubernetes/secret_data_test.go
+++ b/providers/kubernetes/secret_data_test.go
@@ -1,0 +1,161 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package kubernetes
+
+import (
+	"testing"
+
+	"github.com/chenrui333/terraformer/terraformutils/tfcompat"
+	"github.com/chenrui333/terraformer/terraformutils/tfcompat/configschema"
+	"github.com/zclconf/go-cty/cty"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/fake"
+)
+
+func TestSecretDataInitResources(t *testing.T) {
+	clientset := fake.NewSimpleClientset(
+		&corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: "default",
+				Name:      "app-secret",
+			},
+			Data: map[string][]byte{
+				"empty":   {},
+				"setting": []byte("example-value"),
+			},
+		},
+		&corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: "default",
+				Name:      "no-data",
+			},
+		},
+		&corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: "default",
+				Name:      "owned-secret",
+				OwnerReferences: []metav1.OwnerReference{{
+					APIVersion: "v1",
+					Kind:       "Pod",
+					Name:       "owner",
+					UID:        "owner-uid",
+				}},
+			},
+			Data: map[string][]byte{"setting": []byte("example-value")},
+		},
+		&corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: "default",
+				Name:      "binary-secret",
+			},
+			Data: map[string][]byte{"payload": {0xff, 0xfe}},
+		},
+	)
+
+	service := &SecretData{}
+	if err := service.initResources(clientset); err != nil {
+		t.Fatalf("initResources() error = %v", err)
+	}
+
+	if len(service.Resources) != 1 {
+		t.Fatalf("Resources len = %d, want 1", len(service.Resources))
+	}
+	resource := service.Resources[0]
+	if resource.InstanceInfo.Type != secretDataTerraformType {
+		t.Fatalf("resource type = %q, want %q", resource.InstanceInfo.Type, secretDataTerraformType)
+	}
+	if resource.InstanceState.ID != "default/app-secret" {
+		t.Fatalf("resource ID = %q, want %q", resource.InstanceState.ID, "default/app-secret")
+	}
+	if resource.ResourceName != "tfer--default-002F-app-secret" {
+		t.Fatalf("resource name = %q, want %q", resource.ResourceName, "tfer--default-002F-app-secret")
+	}
+
+	attributes := resource.InstanceState.Attributes
+	for key, want := range map[string]string{
+		"id":                   "default/app-secret",
+		"metadata.#":           "1",
+		"metadata.0.name":      "app-secret",
+		"metadata.0.namespace": "default",
+		"data.%":               "2",
+		"data.empty":           "",
+		"data.setting":         "example-value",
+	} {
+		if got := attributes[key]; got != want {
+			t.Fatalf("attribute %q = %q, want %q", key, got, want)
+		}
+	}
+	if len(resource.AllowEmptyValues) != 1 || resource.AllowEmptyValues[0] != secretDataAllowEmptyPattern {
+		t.Fatalf("AllowEmptyValues = %#v, want %#v", resource.AllowEmptyValues, []string{secretDataAllowEmptyPattern})
+	}
+	if _, err := tfcompat.HCL2ValueFromFlatmap(attributes, secretDataTestBlock().ImpliedType()); err != nil {
+		t.Fatalf("secret data flatmap does not decode into provider schema: %v", err)
+	}
+}
+
+func TestSecretDataInitResourcesUsesConfiguredTerraformType(t *testing.T) {
+	clientset := fake.NewSimpleClientset(&corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "default",
+			Name:      "app-secret",
+		},
+		Data: map[string][]byte{"setting": []byte("example-value")},
+	})
+	service := &SecretData{TerraformType: "custom_secret_data"}
+
+	if err := service.initResources(clientset); err != nil {
+		t.Fatalf("initResources() error = %v", err)
+	}
+
+	if len(service.Resources) != 1 {
+		t.Fatalf("Resources len = %d, want 1", len(service.Resources))
+	}
+	if service.Resources[0].InstanceInfo.Type != "custom_secret_data" {
+		t.Fatalf("resource type = %q, want %q", service.Resources[0].InstanceInfo.Type, "custom_secret_data")
+	}
+}
+
+func secretDataTestBlock() *configschema.Block {
+	return &configschema.Block{
+		Attributes: map[string]*configschema.Attribute{
+			"id": {
+				Type:     cty.String,
+				Computed: true,
+			},
+			"data": {
+				Type:      cty.Map(cty.String),
+				Required:  true,
+				Sensitive: true,
+			},
+			"field_manager": {
+				Type:     cty.String,
+				Optional: true,
+			},
+			"force": {
+				Type:     cty.Bool,
+				Optional: true,
+			},
+		},
+		BlockTypes: map[string]*configschema.NestedBlock{
+			"metadata": {
+				Nesting:  configschema.NestingList,
+				MinItems: 1,
+				MaxItems: 1,
+				Block: configschema.Block{
+					Attributes: map[string]*configschema.Attribute{
+						"name": {
+							Type:     cty.String,
+							Required: true,
+						},
+						"namespace": {
+							Type:     cty.String,
+							Optional: true,
+						},
+					},
+				},
+			},
+		},
+	}
+}


### PR DESCRIPTION
Summary
- add a `secretdata` Kubernetes service for `kubernetes_secret_v1_data`
- seed data-only resources from listable core/v1 Secrets, skipping owned or non-UTF-8 payloads
- de-dupe `secretdata` when full `secrets` imports the same object

Notes
- Builds on the `configmapdata` virtual service pattern from #285.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `secretdata` service to import string-only Secret data as `kubernetes_secret_v1_data`. Skips owned or non‑UTF‑8 Secrets and de-dupes with `secrets`.

- **New Features**
  - Registers only when the Secret API and `kubernetes_secret_v1_data` are supported.
  - Imports from listable Secrets across namespaces. Allows empty `data.*` values.
  - Post-processing drops overlapping `secretdata` when the same Secret is imported via `secrets`; keeps non-overlapping entries.
  - Docs updated; tests cover registration, import filtering, and de-duplication.

<sup>Written for commit bb494abb492417385ae0d7aea2bff31b00e4b4d3. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for importing Kubernetes secret data as Terraform resources, with automatic filtering for UTF-8 string payloads.
  * Implemented automatic de-duplication when importing both secrets and secret data to prevent overlapping resource ownership.

* **Documentation**
  * Updated documentation with guidance on combined secrets and secretdata import behavior and supported resources.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->