### PR TITLE
fix(okta): return list and pagination errors

### DIFF
--- a/providers/okta/authorization_server.go
+++ b/providers/okta/authorization_server.go
@@ -39,7 +39,7 @@ func (g *AuthorizationServerGenerator) InitResources() error {
 
 	output, err := getAuthorizationServers(ctx, client)
 	if err != nil {
-		return e
+		return err
 	}
 
 	g.Resources = g.createResources(output)
@@ -54,7 +54,10 @@ func getAuthorizationServers(ctx context.Context, client *okta.Client) ([]*okta.
 
 	for resp.HasNextPage() {
 		var nextAuthorizationServerSet []*okta.AuthorizationServer
-		resp, _ = resp.Next(ctx, &nextAuthorizationServerSet)
+		resp, err = resp.Next(ctx, &nextAuthorizationServerSet)
+		if err != nil {
+			return nil, err
+		}
 		output = append(output, nextAuthorizationServerSet...)
 	}
 

--- a/providers/okta/event_hook.go
+++ b/providers/okta/event_hook.go
@@ -32,12 +32,15 @@ func (g *EventHookGenerator) InitResources() error {
 
 	output, resp, err := client.EventHook.ListEventHooks(ctx)
 	if err != nil {
-		return e
+		return err
 	}
 
 	for resp.HasNextPage() {
 		var nextEventHookSet []*okta.EventHook
-		resp, _ = resp.Next(ctx, &nextEventHookSet)
+		resp, err = resp.Next(ctx, &nextEventHookSet)
+		if err != nil {
+			return err
+		}
 		output = append(output, nextEventHookSet...)
 	}
 

--- a/providers/okta/group.go
+++ b/providers/okta/group.go
@@ -34,12 +34,15 @@ func (g *GroupGenerator) InitResources() error {
 	filter := query.NewQueryParams(query.WithFilter("type eq \"OKTA_GROUP\""))
 	output, resp, err := client.Group.ListGroups(ctx, filter)
 	if err != nil {
-		return e
+		return err
 	}
 
 	for resp.HasNextPage() {
 		var nextGroupSet []*okta.Group
-		resp, _ = resp.Next(ctx, &nextGroupSet)
+		resp, err = resp.Next(ctx, &nextGroupSet)
+		if err != nil {
+			return err
+		}
 		output = append(output, nextGroupSet...)
 	}
 

--- a/providers/okta/group_rule.go
+++ b/providers/okta/group_rule.go
@@ -32,12 +32,15 @@ func (g *GroupRuleGenerator) InitResources() error {
 
 	output, resp, err := client.Group.ListGroupRules(ctx, nil)
 	if err != nil {
-		return e
+		return err
 	}
 
 	for resp.HasNextPage() {
 		var nextGroupRuleSet []*okta.GroupRule
-		resp, _ = resp.Next(ctx, &nextGroupRuleSet)
+		resp, err = resp.Next(ctx, &nextGroupRuleSet)
+		if err != nil {
+			return err
+		}
 		output = append(output, nextGroupRuleSet...)
 	}
 

--- a/providers/okta/idp_oidc.go
+++ b/providers/okta/idp_oidc.go
@@ -51,7 +51,10 @@ func getIdpOIDC(ctx context.Context, client *okta.Client) ([]*okta.IdentityProvi
 
 	for resp.HasNextPage() {
 		var nextIdpOIDCSet []*okta.IdentityProvider
-		resp, _ = resp.Next(ctx, &nextIdpOIDCSet)
+		resp, err = resp.Next(ctx, &nextIdpOIDCSet)
+		if err != nil {
+			return nil, err
+		}
 		output = append(output, nextIdpOIDCSet...)
 	}
 

--- a/providers/okta/idp_social.go
+++ b/providers/okta/idp_social.go
@@ -56,7 +56,10 @@ func getIdpSocials(ctx context.Context, client *okta.Client) ([]*okta.IdentityPr
 
 		for resp.HasNextPage() {
 			var nextIdpSocialSet []*okta.IdentityProvider
-			resp, _ = resp.Next(ctx, &nextIdpSocialSet)
+			resp, err = resp.Next(ctx, &nextIdpSocialSet)
+			if err != nil {
+				return nil, err
+			}
 			output = append(output, nextIdpSocialSet...)
 		}
 

--- a/providers/okta/inline_hook.go
+++ b/providers/okta/inline_hook.go
@@ -32,12 +32,15 @@ func (g *InlineHookGenerator) InitResources() error {
 
 	output, resp, err := client.InlineHook.ListInlineHooks(ctx, nil)
 	if err != nil {
-		return e
+		return err
 	}
 
 	for resp.HasNextPage() {
 		var nextInlineHookSet []*okta.InlineHook
-		resp, _ = resp.Next(ctx, &nextInlineHookSet)
+		resp, err = resp.Next(ctx, &nextInlineHookSet)
+		if err != nil {
+			return err
+		}
 		output = append(output, nextInlineHookSet...)
 	}
 

--- a/providers/okta/policy_mfa.go
+++ b/providers/okta/policy_mfa.go
@@ -33,13 +33,15 @@ func (g MFAPolicyGenerator) createResources(mfaPolicyList []*okta.Policy) []terr
 }
 
 func (g *MFAPolicyGenerator) InitResources() error {
-	var output []*okta.Policy
 	ctx, client, e := g.Client()
 	if e != nil {
 		return e
 	}
 
-	output, _ = getMFAPolicies(ctx, client)
+	output, err := getMFAPolicies(ctx, client)
+	if err != nil {
+		return err
+	}
 	g.Resources = g.createResources(output)
 	return nil
 }
@@ -54,7 +56,10 @@ func getMFAPolicies(ctx context.Context, client *okta.Client) ([]*okta.Policy, e
 
 	for resp.HasNextPage() {
 		var nextPolicies []*okta.Policy
-		resp, _ = resp.Next(ctx, &nextPolicies)
+		resp, err = resp.Next(ctx, &nextPolicies)
+		if err != nil {
+			return nil, err
+		}
 		policies = append(policies, nextPolicies...)
 	}
 	for _, p := range data {

--- a/providers/okta/policy_password.go
+++ b/providers/okta/policy_password.go
@@ -33,13 +33,15 @@ func (g PasswordPolicyGenerator) createResources(passwordPolicyList []*okta.Poli
 }
 
 func (g *PasswordPolicyGenerator) InitResources() error {
-	var output []*okta.Policy
 	ctx, client, e := g.Client()
 	if e != nil {
 		return e
 	}
 
-	output, _ = getPasswordPolicies(ctx, client)
+	output, err := getPasswordPolicies(ctx, client)
+	if err != nil {
+		return err
+	}
 	g.Resources = g.createResources(output)
 	return nil
 }
@@ -54,7 +56,10 @@ func getPasswordPolicies(ctx context.Context, client *okta.Client) ([]*okta.Poli
 
 	for resp.HasNextPage() {
 		var nextPolicies []*okta.Policy
-		resp, _ = resp.Next(ctx, &nextPolicies)
+		resp, err = resp.Next(ctx, &nextPolicies)
+		if err != nil {
+			return nil, err
+		}
 		policies = append(policies, nextPolicies...)
 	}
 	for _, p := range data {

--- a/providers/okta/policy_rule_mfa.go
+++ b/providers/okta/policy_rule_mfa.go
@@ -70,7 +70,10 @@ func getMFAPolicyRules(g *MFAPolicyRuleGenerator, policyID string) ([]sdk.SdkPol
 
 	for resp.HasNextPage() {
 		var nextPolicySet []sdk.SdkPolicyRule
-		resp, _ = resp.Next(ctx, &nextPolicySet)
+		resp, err = resp.Next(ctx, &nextPolicySet)
+		if err != nil {
+			return nil, err
+		}
 		output = append(output, nextPolicySet...)
 	}
 

--- a/providers/okta/policy_rule_password.go
+++ b/providers/okta/policy_rule_password.go
@@ -70,7 +70,10 @@ func getPasswordPolicyRules(g *PasswordPolicyRuleGenerator, policyID string) ([]
 
 	for resp.HasNextPage() {
 		var nextPolicySet []sdk.SdkPolicyRule
-		resp, _ = resp.Next(ctx, &nextPolicySet)
+		resp, err = resp.Next(ctx, &nextPolicySet)
+		if err != nil {
+			return nil, err
+		}
 		output = append(output, nextPolicySet...)
 	}
 

--- a/providers/okta/policy_rule_signon.go
+++ b/providers/okta/policy_rule_signon.go
@@ -70,7 +70,10 @@ func getSignOnPolicyRules(g *SignOnPolicyRuleGenerator, policyID string) ([]sdk.
 
 	for resp.HasNextPage() {
 		var nextPolicySet []sdk.SdkPolicyRule
-		resp, _ = resp.Next(ctx, &nextPolicySet)
+		resp, err = resp.Next(ctx, &nextPolicySet)
+		if err != nil {
+			return nil, err
+		}
 		output = append(output, nextPolicySet...)
 	}
 

--- a/providers/okta/policy_signon.go
+++ b/providers/okta/policy_signon.go
@@ -31,13 +31,15 @@ func (g SignOnPolicyGenerator) createResources(signOnPolicyList []*okta.Policy) 
 }
 
 func (g *SignOnPolicyGenerator) InitResources() error {
-	var output []*okta.Policy
 	ctx, client, e := g.Client()
 	if e != nil {
 		return e
 	}
 
-	output, _ = getSignOnPolicies(ctx, client)
+	output, err := getSignOnPolicies(ctx, client)
+	if err != nil {
+		return err
+	}
 	g.Resources = g.createResources(output)
 	return nil
 }
@@ -52,7 +54,10 @@ func getSignOnPolicies(ctx context.Context, client *okta.Client) ([]*okta.Policy
 
 	for resp.HasNextPage() {
 		var nextPolicies []*okta.Policy
-		resp, _ = resp.Next(ctx, &nextPolicies)
+		resp, err = resp.Next(ctx, &nextPolicies)
+		if err != nil {
+			return nil, err
+		}
 		policies = append(policies, nextPolicies...)
 	}
 	for _, p := range data {

--- a/providers/okta/template_sms.go
+++ b/providers/okta/template_sms.go
@@ -32,12 +32,15 @@ func (g *SMSTemplateGenerator) InitResources() error {
 
 	output, resp, err := client.SmsTemplate.ListSmsTemplates(ctx, nil)
 	if err != nil {
-		return e
+		return err
 	}
 
 	for resp.HasNextPage() {
 		var nextSmsTemplateSet []*okta.SmsTemplate
-		resp, _ = resp.Next(ctx, &nextSmsTemplateSet)
+		resp, err = resp.Next(ctx, &nextSmsTemplateSet)
+		if err != nil {
+			return err
+		}
 		output = append(output, nextSmsTemplateSet...)
 	}
 

--- a/providers/okta/trusted_origin.go
+++ b/providers/okta/trusted_origin.go
@@ -32,12 +32,15 @@ func (g *TrustedOriginGenerator) InitResources() error {
 
 	output, resp, err := client.TrustedOrigin.ListOrigins(ctx, nil)
 	if err != nil {
-		return e
+		return err
 	}
 
 	for resp.HasNextPage() {
 		var nextTrustedOriginSet []*okta.TrustedOrigin
-		resp, _ = resp.Next(ctx, &nextTrustedOriginSet)
+		resp, err = resp.Next(ctx, &nextTrustedOriginSet)
+		if err != nil {
+			return err
+		}
 		output = append(output, nextTrustedOriginSet...)
 	}
 

--- a/providers/okta/user.go
+++ b/providers/okta/user.go
@@ -37,7 +37,10 @@ func (g *UserGenerator) InitResources() error {
 
 	for resp.HasNextPage() {
 		var nextUserSet []okta.User
-		resp, _ = resp.Next(&nextUserSet)
+		resp, err = resp.Next(&nextUserSet)
+		if err != nil {
+			return err
+		}
 		output = append(output, nextUserSet...)
 	}
 

--- a/providers/okta/user_schema.go
+++ b/providers/okta/user_schema.go
@@ -90,7 +90,10 @@ func getUserTypes(ctx context.Context, client *okta.Client) ([]*okta.UserType, e
 
 	for resp.HasNextPage() {
 		var nextUserTypeSet []*okta.UserType
-		resp, _ = resp.Next(ctx, &nextUserTypeSet)
+		resp, err = resp.Next(ctx, &nextUserTypeSet)
+		if err != nil {
+			return nil, err
+		}
 		output = append(output, nextUserTypeSet...)
 	}
 

--- a/providers/okta/user_type.go
+++ b/providers/okta/user_type.go
@@ -32,12 +32,15 @@ func (g *UserTypeGenerator) InitResources() error {
 
 	output, resp, err := client.UserType.ListUserTypes(ctx)
 	if err != nil {
-		return e
+		return err
 	}
 
 	for resp.HasNextPage() {
 		var nextUserTypeSet []*okta.UserType
-		resp, _ = resp.Next(ctx, &nextUserTypeSet)
+		resp, err = resp.Next(ctx, &nextUserTypeSet)
+		if err != nil {
+			return err
+		}
 		output = append(output, nextUserTypeSet...)
 	}
 


### PR DESCRIPTION
## Summary

- Return Okta first-page list errors from generators that previously returned the earlier nil client error.
- Propagate Okta pagination failures instead of ignoring errors from resp.Next.
- Return MFA, password, and sign-on policy lookup errors before creating resources.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes error handling in the Okta provider by surfacing real list and pagination errors instead of masking them. Also fails fast on MFA, password, and sign-on policy lookups before creating resources.

- **Bug Fixes**
  - Return first-page list errors from `okta` SDK calls instead of previous nil client errors.
  - Propagate and return `resp.Next(...)` pagination errors across all list operations.
  - Fail fast on `getMFAPolicies`, `getPasswordPolicies`, and `getSignOnPolicies` errors before creating resources.

<sup>Written for commit c12b6fa3b0d21836c27a3ee63da84c2bc5688f42. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed error handling in Okta resource retrieval operations to properly capture and report pagination errors. Failed page retrievals during resource enumeration across authorization servers, event hooks, groups, policies, rules, identity providers, inline hooks, SMS templates, trusted origins, and user resources are now properly detected and surfaced instead of being silently ignored.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->