### PR TITLE
feat(kubernetes): import metadata patches

### DIFF
--- a/docs/kubernetes.md
+++ b/docs/kubernetes.md
@@ -10,12 +10,15 @@ Example:
 Terraformer discovers Kubernetes API resources from the active cluster and imports resources that are available through either the typed Kubernetes client or an explicit dynamic-client import path, and the installed Terraform Kubernetes provider schema.
 Discovered CRDs and other untyped API extensions without a first-class Terraform Kubernetes provider type can be imported through `kubernetes_manifest` when the API resource is manageable and the installed provider supports that resource.
 Manifest-backed custom resources use a group/version-qualified resource selector such as `example.com/v1/widgets` to avoid collisions between CRDs that share the same plural name.
+When `labels` or `annotations` are selected with full resource imports, Terraformer keeps the full resource import and skips overlapping metadata-only resources to avoid duplicate Terraform ownership of the same object metadata.
 When `configmaps` and `configmapdata` are selected together, Terraformer keeps the full `configmaps` import and skips overlapping data-only resources to avoid duplicate Terraform ownership of the same ConfigMap data.
 When `secrets` and `secretdata` are selected together, Terraformer keeps the full `secrets` import and skips overlapping data-only resources to avoid duplicate Terraform ownership of the same Secret data.
 Because `kubernetes_secret_v1_data` only accepts string data, `secretdata` skips Secrets containing non-UTF-8 payloads instead of emitting lossy configuration.
 
 Common supported resources include:
 
+*   `annotations`
+    * `kubernetes_annotations`
 *   `apiservices`
     * `kubernetes_api_service_v1`
 *   `certificatesigningrequests`
@@ -53,6 +56,8 @@ Common supported resources include:
     * `kubernetes_ingress_v1`
 *   `jobs`
     * `kubernetes_job_v1`
+*   `labels`
+    * `kubernetes_labels`
 *   `limitranges`
     * `kubernetes_limit_range_v1`
 *   `mutatingwebhookconfigurations`

--- a/providers/kubernetes/kubernetes_provider.go
+++ b/providers/kubernetes/kubernetes_provider.go
@@ -143,6 +143,10 @@ func (p *KubernetesProvider) GetSupportedService() map[string]terraformutils.Ser
 		_, exists := resp.ResourceTypes[name]
 		return exists
 	})
+	addMetadataPatchServices(resources, func(name string) bool {
+		_, exists := resp.ResourceTypes[name]
+		return exists
+	})
 	return resources
 }
 
@@ -261,10 +265,31 @@ func addSecretDataService(
 	}
 }
 
+func addMetadataPatchServices(
+	resources map[string]terraformutils.ServiceGenerator,
+	hasResourceType func(string) bool,
+) {
+	if hasResourceType(labelsTerraformType) {
+		resources[labelsServiceName] = &MetadataPatch{
+			TerraformType:     labelsTerraformType,
+			AttributeName:     "labels",
+			AllowEmptyPattern: labelsAllowEmptyPattern,
+		}
+	}
+	if hasResourceType(annotationsTerraformType) {
+		resources[annotationsServiceName] = &MetadataPatch{
+			TerraformType:     annotationsTerraformType,
+			AttributeName:     "annotations",
+			AllowEmptyPattern: annotationsAllowEmptyPattern,
+		}
+	}
+}
+
 func (p KubernetesProvider) PostProcessImportResources(resourcesByService map[string][]terraformutils.Resource) map[string][]terraformutils.Resource {
 	resourcesByService = removeDefaultServiceAccountDuplicates(resourcesByService)
 	resourcesByService = removeConfigMapDataDuplicates(resourcesByService)
 	resourcesByService = removeSecretDataDuplicates(resourcesByService)
+	resourcesByService = removeMetadataPatchDuplicates(resourcesByService)
 	return resourcesByService
 }
 
@@ -368,6 +393,47 @@ func removeSecretDataDuplicates(resourcesByService map[string][]terraformutils.R
 		return resourcesByService
 	}
 	resourcesByService[secretDataServiceName] = filtered
+	return resourcesByService
+}
+
+func removeMetadataPatchDuplicates(resourcesByService map[string][]terraformutils.Resource) map[string][]terraformutils.Resource {
+	targetIDs := map[string]struct{}{}
+	for serviceName, resources := range resourcesByService {
+		if serviceName == labelsServiceName || serviceName == annotationsServiceName {
+			continue
+		}
+		for _, resource := range resources {
+			for _, targetID := range metadataPatchTargetIDs(resource) {
+				targetIDs[targetID] = struct{}{}
+			}
+		}
+	}
+	if len(targetIDs) == 0 {
+		return resourcesByService
+	}
+
+	for _, serviceName := range []string{labelsServiceName, annotationsServiceName} {
+		resources, ok := resourcesByService[serviceName]
+		if !ok {
+			continue
+		}
+		filtered := resources[:0]
+		for _, resource := range resources {
+			if resource.InstanceState == nil {
+				filtered = append(filtered, resource)
+				continue
+			}
+			if _, duplicate := targetIDs[resource.InstanceState.ID]; duplicate {
+				continue
+			}
+			filtered = append(filtered, resource)
+		}
+		if len(filtered) == 0 {
+			delete(resourcesByService, serviceName)
+			continue
+		}
+		resourcesByService[serviceName] = filtered
+	}
 	return resourcesByService
 }
 

--- a/providers/kubernetes/kubernetes_provider.go
+++ b/providers/kubernetes/kubernetes_provider.go
@@ -77,7 +77,7 @@ func (p *KubernetesProvider) GetSupportedService() map[string]terraformutils.Ser
 		return resources
 	}
 
-	lists, err := dc.ServerPreferredResources()
+	lists, err := kubernetesPreferredResources(dc)
 	if err != nil {
 		log.Println(err)
 		return resources

--- a/providers/kubernetes/kubernetes_provider.go
+++ b/providers/kubernetes/kubernetes_provider.go
@@ -398,6 +398,7 @@ func removeSecretDataDuplicates(resourcesByService map[string][]terraformutils.R
 
 func removeMetadataPatchDuplicates(resourcesByService map[string][]terraformutils.Resource) map[string][]terraformutils.Resource {
 	targetIDs := map[string]struct{}{}
+	targetObjectKeys := map[string]struct{}{}
 	for serviceName, resources := range resourcesByService {
 		if serviceName == labelsServiceName || serviceName == annotationsServiceName {
 			continue
@@ -406,9 +407,12 @@ func removeMetadataPatchDuplicates(resourcesByService map[string][]terraformutil
 			for _, targetID := range metadataPatchTargetIDs(resource) {
 				targetIDs[targetID] = struct{}{}
 			}
+			for _, targetKey := range metadataPatchFallbackTargetKeys(resource) {
+				targetObjectKeys[targetKey] = struct{}{}
+			}
 		}
 	}
-	if len(targetIDs) == 0 {
+	if len(targetIDs) == 0 && len(targetObjectKeys) == 0 {
 		return resourcesByService
 	}
 
@@ -425,6 +429,11 @@ func removeMetadataPatchDuplicates(resourcesByService map[string][]terraformutil
 			}
 			if _, duplicate := targetIDs[resource.InstanceState.ID]; duplicate {
 				continue
+			}
+			if targetKey, ok := metadataPatchObjectKeyFromID(resource.InstanceState.ID); ok {
+				if _, duplicate := targetObjectKeys[targetKey]; duplicate {
+					continue
+				}
 			}
 			filtered = append(filtered, resource)
 		}

--- a/providers/kubernetes/kubernetes_provider.go
+++ b/providers/kubernetes/kubernetes_provider.go
@@ -415,6 +415,7 @@ func removeMetadataPatchDuplicates(resourcesByService map[string][]terraformutil
 	if len(targetIDs) == 0 && len(targetObjectKeys) == 0 {
 		return resourcesByService
 	}
+	ambiguousObjectKeys := metadataPatchAmbiguousObjectKeys(resourcesByService)
 
 	for _, serviceName := range []string{labelsServiceName, annotationsServiceName} {
 		resources, ok := resourcesByService[serviceName]
@@ -430,7 +431,11 @@ func removeMetadataPatchDuplicates(resourcesByService map[string][]terraformutil
 			if _, duplicate := targetIDs[resource.InstanceState.ID]; duplicate {
 				continue
 			}
-			if targetKey, ok := metadataPatchObjectKeyFromID(resource.InstanceState.ID); ok {
+			if targetKey, _, ok := metadataPatchObjectKeyAndAPIVersionFromID(resource.InstanceState.ID); ok {
+				if _, ambiguous := ambiguousObjectKeys[targetKey]; ambiguous {
+					filtered = append(filtered, resource)
+					continue
+				}
 				if _, duplicate := targetObjectKeys[targetKey]; duplicate {
 					continue
 				}
@@ -444,6 +449,33 @@ func removeMetadataPatchDuplicates(resourcesByService map[string][]terraformutil
 		resourcesByService[serviceName] = filtered
 	}
 	return resourcesByService
+}
+
+func metadataPatchAmbiguousObjectKeys(resourcesByService map[string][]terraformutils.Resource) map[string]struct{} {
+	apiVersionsByObjectKey := map[string]map[string]struct{}{}
+	for _, serviceName := range []string{labelsServiceName, annotationsServiceName} {
+		for _, resource := range resourcesByService[serviceName] {
+			if resource.InstanceState == nil {
+				continue
+			}
+			objectKey, apiVersion, ok := metadataPatchObjectKeyAndAPIVersionFromID(resource.InstanceState.ID)
+			if !ok {
+				continue
+			}
+			if _, ok := apiVersionsByObjectKey[objectKey]; !ok {
+				apiVersionsByObjectKey[objectKey] = map[string]struct{}{}
+			}
+			apiVersionsByObjectKey[objectKey][apiVersion] = struct{}{}
+		}
+	}
+
+	ambiguousObjectKeys := map[string]struct{}{}
+	for objectKey, apiVersions := range apiVersionsByObjectKey {
+		if len(apiVersions) > 1 {
+			ambiguousObjectKeys[objectKey] = struct{}{}
+		}
+	}
+	return ambiguousObjectKeys
 }
 
 func isDefaultServiceAccountDuplicate(resource terraformutils.Resource, defaultServiceAccountIDs map[string]struct{}) bool {

--- a/providers/kubernetes/metadata_patch.go
+++ b/providers/kubernetes/metadata_patch.go
@@ -1,0 +1,259 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package kubernetes
+
+import (
+	"context"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/chenrui333/terraformer/terraformutils"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/discovery"
+	"k8s.io/client-go/dynamic"
+)
+
+const (
+	labelsServiceName       = "labels"
+	labelsTerraformType     = "kubernetes_labels"
+	labelsAllowEmptyPattern = `^labels\.`
+
+	annotationsServiceName       = "annotations"
+	annotationsTerraformType     = "kubernetes_annotations"
+	annotationsAllowEmptyPattern = `^annotations\.`
+
+	metadataPatchListTimeout = 30 * time.Second
+)
+
+type MetadataPatch struct {
+	KubernetesService
+	TerraformType     string
+	AttributeName     string
+	AllowEmptyPattern string
+}
+
+func (m *MetadataPatch) InitResources() error {
+	config, _, err := initClientAndConfig()
+	if err != nil {
+		return err
+	}
+
+	dc, err := discovery.NewDiscoveryClientForConfig(config)
+	if err != nil {
+		return err
+	}
+	lists, err := dc.ServerPreferredResources()
+	if err != nil {
+		return err
+	}
+
+	client, err := dynamic.NewForConfig(config)
+	if err != nil {
+		return err
+	}
+
+	return m.initResources(client, lists)
+}
+
+func (m *MetadataPatch) initResources(client dynamic.Interface, lists []*metav1.APIResourceList) error {
+	for _, list := range lists {
+		if len(list.APIResources) == 0 {
+			continue
+		}
+
+		gv, err := schema.ParseGroupVersion(list.GroupVersion)
+		if err != nil {
+			continue
+		}
+		for _, resource := range list.APIResources {
+			if !metadataPatchSupportsResource(resource) {
+				continue
+			}
+			if err := m.initResourceList(client, gv, resource); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+func (m *MetadataPatch) initResourceList(client dynamic.Interface, gv schema.GroupVersion, resource metav1.APIResource) error {
+	resourceClient := client.Resource(schema.GroupVersionResource{
+		Group:    gv.Group,
+		Version:  gv.Version,
+		Resource: resource.Name,
+	})
+	listClient := dynamic.ResourceInterface(resourceClient)
+	if resource.Namespaced {
+		listClient = resourceClient.Namespace(metav1.NamespaceAll)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), metadataPatchListTimeout)
+	defer cancel()
+
+	results, err := listClient.List(ctx, metav1.ListOptions{})
+	if err != nil {
+		return err
+	}
+
+	apiVersion := metadataPatchAPIVersion(gv)
+	terraformType := m.terraformType()
+	for i := range results.Items {
+		item := results.Items[i]
+		if len(item.GetOwnerReferences()) > 0 {
+			continue
+		}
+		values := metadataPatchValues(item, m.AttributeName)
+		if len(values) == 0 {
+			continue
+		}
+
+		importID := metadataPatchID(apiVersion, resource.Kind, item.GetNamespace(), item.GetName(), resource.Namespaced)
+		resourceName := metadataPatchResourceName(m.AttributeName, apiVersion, resource.Kind, item.GetNamespace(), item.GetName(), resource.Namespaced)
+		m.Resources = append(m.Resources, terraformutils.NewResource(
+			importID,
+			resourceName,
+			terraformType,
+			"kubernetes",
+			metadataPatchAttributes(item, apiVersion, resource.Kind, m.AttributeName, values, resource.Namespaced),
+			[]string{m.AllowEmptyPattern},
+			map[string]interface{}{},
+		))
+	}
+	return nil
+}
+
+func metadataPatchSupportsResource(resource metav1.APIResource) bool {
+	if resource.Kind == "" || strings.Contains(resource.Name, "/") {
+		return false
+	}
+	for _, verb := range resource.Verbs {
+		if verb == "list" {
+			return true
+		}
+	}
+	return false
+}
+
+func (m *MetadataPatch) terraformType() string {
+	if m.TerraformType != "" {
+		return m.TerraformType
+	}
+	switch m.AttributeName {
+	case "labels":
+		return labelsTerraformType
+	case "annotations":
+		return annotationsTerraformType
+	default:
+		return ""
+	}
+}
+
+func metadataPatchValues(item unstructured.Unstructured, attributeName string) map[string]string {
+	switch attributeName {
+	case "labels":
+		return item.GetLabels()
+	case "annotations":
+		return item.GetAnnotations()
+	default:
+		return nil
+	}
+}
+
+func metadataPatchAttributes(item unstructured.Unstructured, apiVersion, kind, attributeName string, values map[string]string, namespaced bool) map[string]string {
+	attributes := map[string]string{
+		"id":                 metadataPatchID(apiVersion, kind, item.GetNamespace(), item.GetName(), namespaced),
+		"api_version":        apiVersion,
+		"kind":               kind,
+		"metadata.#":         "1",
+		"metadata.0.name":    item.GetName(),
+		attributeName + ".%": strconv.Itoa(len(values)),
+	}
+	if namespaced {
+		attributes["metadata.0.namespace"] = item.GetNamespace()
+	}
+	for key, value := range values {
+		attributes[attributeName+"."+key] = value
+	}
+	return attributes
+}
+
+func metadataPatchID(apiVersion, kind, namespace, name string, namespaced bool) string {
+	parts := []string{
+		"apiVersion=" + apiVersion,
+		"kind=" + kind,
+	}
+	if namespaced {
+		parts = append(parts, "namespace="+namespace)
+	}
+	parts = append(parts, "name="+name)
+	return strings.Join(parts, ",")
+}
+
+func metadataPatchResourceName(attributeName, apiVersion, kind, namespace, name string, namespaced bool) string {
+	parts := []string{attributeName, apiVersion, kind}
+	if namespaced {
+		parts = append(parts, namespace)
+	}
+	parts = append(parts, name)
+	return strings.Join(parts, "/")
+}
+
+func metadataPatchAPIVersion(gv schema.GroupVersion) string {
+	if gv.Group == "" {
+		return gv.Version
+	}
+	return gv.Group + "/" + gv.Version
+}
+
+func metadataPatchTargetIDs(resource terraformutils.Resource) []string {
+	if resource.InstanceInfo == nil || resource.InstanceState == nil {
+		return nil
+	}
+	if resource.InstanceInfo.Type == manifestTerraformResourceName && strings.HasPrefix(resource.InstanceState.ID, "apiVersion=") {
+		return []string{resource.InstanceState.ID}
+	}
+
+	name := resource.InstanceState.Attributes["metadata.0.name"]
+	if name == "" {
+		return nil
+	}
+	namespace, namespaced := resource.InstanceState.Attributes["metadata.0.namespace"]
+
+	ids := []string{}
+	for _, resourceID := range metadataPatchResourceKindsForTerraformType(resource.InstanceInfo.Type) {
+		apiVersion := metadataPatchAPIVersion(schema.GroupVersion{Group: resourceID.group, Version: resourceID.version})
+		ids = append(ids, metadataPatchID(apiVersion, resourceID.kind, namespace, name, namespaced))
+	}
+	return ids
+}
+
+func metadataPatchResourceKindsForTerraformType(terraformType string) []kubernetesResourceID {
+	seen := map[kubernetesResourceID]struct{}{}
+	resourceIDs := []kubernetesResourceID{}
+	for resourceID := range preferredTerraformResourceNames {
+		for _, candidate := range terraformResourceNameCandidates(resourceID.group, resourceID.version, resourceID.kind) {
+			if candidate != terraformType {
+				continue
+			}
+			if _, ok := seen[resourceID]; ok {
+				continue
+			}
+			seen[resourceID] = struct{}{}
+			resourceIDs = append(resourceIDs, resourceID)
+		}
+	}
+
+	switch terraformType {
+	case "kubernetes_default_service_account", "kubernetes_default_service_account_v1":
+		serviceAccount := kubernetesResourceID{version: "v1", kind: "ServiceAccount"}
+		if _, ok := seen[serviceAccount]; !ok {
+			resourceIDs = append(resourceIDs, serviceAccount)
+		}
+	}
+	return resourceIDs
+}

--- a/providers/kubernetes/metadata_patch.go
+++ b/providers/kubernetes/metadata_patch.go
@@ -269,11 +269,10 @@ func metadataPatchTargetIDs(resource terraformutils.Resource) []string {
 		return []string{resource.InstanceState.ID}
 	}
 
-	name := resource.InstanceState.Attributes["metadata.0.name"]
-	if name == "" {
+	name, namespace, namespaced, ok := metadataPatchResourceObject(resource)
+	if !ok {
 		return nil
 	}
-	namespace, namespaced := resource.InstanceState.Attributes["metadata.0.namespace"]
 
 	ids := []string{}
 	for _, resourceID := range metadataPatchResourceKindsForTerraformType(resource.InstanceInfo.Type) {
@@ -298,12 +297,41 @@ func metadataPatchFallbackTargetKeys(resource terraformutils.Resource) []string 
 	if !ok {
 		return nil
 	}
-	name := resource.InstanceState.Attributes["metadata.0.name"]
-	if name == "" {
+	name, namespace, namespaced, ok := metadataPatchResourceObject(resource)
+	if !ok {
 		return nil
 	}
-	namespace, namespaced := resource.InstanceState.Attributes["metadata.0.namespace"]
 	return []string{metadataPatchObjectKey(kind, namespace, name, namespaced)}
+}
+
+func metadataPatchResourceObject(resource terraformutils.Resource) (string, string, bool, bool) {
+	name := resource.InstanceState.Attributes["metadata.0.name"]
+	if name != "" {
+		namespace, namespaced := resource.InstanceState.Attributes["metadata.0.namespace"]
+		return name, namespace, namespaced, true
+	}
+	return metadataPatchResourceObjectFromImportID(resource.InstanceState.ID)
+}
+
+func metadataPatchResourceObjectFromImportID(id string) (string, string, bool, bool) {
+	if id == "" || strings.HasPrefix(id, "apiVersion=") {
+		return "", "", false, false
+	}
+	parts := strings.Split(id, "/")
+	switch len(parts) {
+	case 1:
+		if parts[0] == "" {
+			return "", "", false, false
+		}
+		return parts[0], "", false, true
+	case 2:
+		if parts[0] == "" || parts[1] == "" {
+			return "", "", false, false
+		}
+		return parts[1], parts[0], true, true
+	default:
+		return "", "", false, false
+	}
 }
 
 func metadataPatchResourceKindsForTerraformType(terraformType string) []kubernetesResourceID {

--- a/providers/kubernetes/metadata_patch.go
+++ b/providers/kubernetes/metadata_patch.go
@@ -225,23 +225,24 @@ func metadataPatchObjectKey(kind, namespace, name string, namespaced bool) strin
 	return strings.Join(parts, ",")
 }
 
-func metadataPatchObjectKeyFromID(id string) (string, bool) {
+func metadataPatchObjectKeyAndAPIVersionFromID(id string) (string, string, bool) {
 	values := map[string]string{}
 	for _, part := range strings.Split(id, ",") {
 		key, value, ok := strings.Cut(part, "=")
 		if !ok {
-			return "", false
+			return "", "", false
 		}
 		values[key] = value
 	}
 
+	apiVersion := values["apiVersion"]
 	kind := values["kind"]
 	name := values["name"]
-	if kind == "" || name == "" {
-		return "", false
+	if apiVersion == "" || kind == "" || name == "" {
+		return "", "", false
 	}
 	namespace, namespaced := values["namespace"]
-	return metadataPatchObjectKey(kind, namespace, name, namespaced), true
+	return metadataPatchObjectKey(kind, namespace, name, namespaced), apiVersion, true
 }
 
 func metadataPatchResourceName(attributeName, apiVersion, kind, namespace, name string, namespaced bool) string {

--- a/providers/kubernetes/metadata_patch.go
+++ b/providers/kubernetes/metadata_patch.go
@@ -47,7 +47,7 @@ func (m *MetadataPatch) InitResources() error {
 	if err != nil {
 		return err
 	}
-	lists, err := metadataPatchPreferredResources(dc)
+	lists, err := kubernetesPreferredResources(dc)
 	if err != nil {
 		return err
 	}
@@ -60,13 +60,13 @@ func (m *MetadataPatch) InitResources() error {
 	return m.initResources(client, lists)
 }
 
-func metadataPatchPreferredResources(dc discovery.DiscoveryInterface) ([]*metav1.APIResourceList, error) {
+func kubernetesPreferredResources(dc discovery.DiscoveryInterface) ([]*metav1.APIResourceList, error) {
 	lists, err := dc.ServerPreferredResources()
 	if err != nil {
 		if !discovery.IsGroupDiscoveryFailedError(err) {
 			return nil, err
 		}
-		log.Printf("kubernetes: metadata patch discovery skipped unavailable API groups: %v", err)
+		log.Printf("kubernetes: discovery skipped unavailable API groups: %v", err)
 	}
 	return lists, nil
 }

--- a/providers/kubernetes/metadata_patch.go
+++ b/providers/kubernetes/metadata_patch.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/chenrui333/terraformer/terraformutils"
+	"github.com/iancoleman/strcase"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -215,6 +216,34 @@ func metadataPatchID(apiVersion, kind, namespace, name string, namespaced bool) 
 	return strings.Join(parts, ",")
 }
 
+func metadataPatchObjectKey(kind, namespace, name string, namespaced bool) string {
+	parts := []string{"kind=" + kind}
+	if namespaced {
+		parts = append(parts, "namespace="+namespace)
+	}
+	parts = append(parts, "name="+name)
+	return strings.Join(parts, ",")
+}
+
+func metadataPatchObjectKeyFromID(id string) (string, bool) {
+	values := map[string]string{}
+	for _, part := range strings.Split(id, ",") {
+		key, value, ok := strings.Cut(part, "=")
+		if !ok {
+			return "", false
+		}
+		values[key] = value
+	}
+
+	kind := values["kind"]
+	name := values["name"]
+	if kind == "" || name == "" {
+		return "", false
+	}
+	namespace, namespaced := values["namespace"]
+	return metadataPatchObjectKey(kind, namespace, name, namespaced), true
+}
+
 func metadataPatchResourceName(attributeName, apiVersion, kind, namespace, name string, namespaced bool) string {
 	parts := []string{attributeName, apiVersion, kind}
 	if namespaced {
@@ -253,6 +282,29 @@ func metadataPatchTargetIDs(resource terraformutils.Resource) []string {
 	return ids
 }
 
+func metadataPatchFallbackTargetKeys(resource terraformutils.Resource) []string {
+	if resource.InstanceInfo == nil || resource.InstanceState == nil {
+		return nil
+	}
+	if len(metadataPatchResourceKindsForTerraformType(resource.InstanceInfo.Type)) != 0 {
+		return nil
+	}
+
+	// selectTerraformResourceName can choose extractTfResourceName(kind) for
+	// typed resources that have no explicit preferred mapping; by this point the
+	// discovered group/version is no longer available, so match on object shape.
+	kind, ok := metadataPatchFallbackKindForTerraformType(resource.InstanceInfo.Type)
+	if !ok {
+		return nil
+	}
+	name := resource.InstanceState.Attributes["metadata.0.name"]
+	if name == "" {
+		return nil
+	}
+	namespace, namespaced := resource.InstanceState.Attributes["metadata.0.namespace"]
+	return []string{metadataPatchObjectKey(kind, namespace, name, namespaced)}
+}
+
 func metadataPatchResourceKindsForTerraformType(terraformType string) []kubernetesResourceID {
 	seen := map[kubernetesResourceID]struct{}{}
 	resourceIDs := []kubernetesResourceID{}
@@ -277,4 +329,21 @@ func metadataPatchResourceKindsForTerraformType(terraformType string) []kubernet
 		}
 	}
 	return resourceIDs
+}
+
+func metadataPatchFallbackKindForTerraformType(terraformType string) (string, bool) {
+	const prefix = "kubernetes_"
+	if !strings.HasPrefix(terraformType, prefix) {
+		return "", false
+	}
+	switch terraformType {
+	case labelsTerraformType, annotationsTerraformType, manifestTerraformResourceName:
+		return "", false
+	}
+
+	kind := strcase.ToCamel(strings.TrimPrefix(terraformType, prefix))
+	if kind == "" || extractTfResourceName(kind) != terraformType {
+		return "", false
+	}
+	return kind, true
 }

--- a/providers/kubernetes/metadata_patch.go
+++ b/providers/kubernetes/metadata_patch.go
@@ -4,6 +4,7 @@ package kubernetes
 
 import (
 	"context"
+	"log"
 	"strconv"
 	"strings"
 	"time"
@@ -46,7 +47,7 @@ func (m *MetadataPatch) InitResources() error {
 	if err != nil {
 		return err
 	}
-	lists, err := dc.ServerPreferredResources()
+	lists, err := metadataPatchPreferredResources(dc)
 	if err != nil {
 		return err
 	}
@@ -57,6 +58,17 @@ func (m *MetadataPatch) InitResources() error {
 	}
 
 	return m.initResources(client, lists)
+}
+
+func metadataPatchPreferredResources(dc discovery.DiscoveryInterface) ([]*metav1.APIResourceList, error) {
+	lists, err := dc.ServerPreferredResources()
+	if err != nil {
+		if !discovery.IsGroupDiscoveryFailedError(err) {
+			return nil, err
+		}
+		log.Printf("kubernetes: metadata patch discovery skipped unavailable API groups: %v", err)
+	}
+	return lists, nil
 }
 
 func (m *MetadataPatch) initResources(client dynamic.Interface, lists []*metav1.APIResourceList) error {
@@ -74,7 +86,8 @@ func (m *MetadataPatch) initResources(client dynamic.Interface, lists []*metav1.
 				continue
 			}
 			if err := m.initResourceList(client, gv, resource); err != nil {
-				return err
+				log.Printf("kubernetes: metadata patch skipped %s/%s: %v", list.GroupVersion, resource.Name, err)
+				continue
 			}
 		}
 	}
@@ -131,12 +144,20 @@ func metadataPatchSupportsResource(resource metav1.APIResource) bool {
 	if resource.Kind == "" || strings.Contains(resource.Name, "/") {
 		return false
 	}
+	return metadataPatchHasVerbs(resource, "get", "list", "patch")
+}
+
+func metadataPatchHasVerbs(resource metav1.APIResource, required ...string) bool {
+	verbs := map[string]struct{}{}
 	for _, verb := range resource.Verbs {
-		if verb == "list" {
-			return true
+		verbs[verb] = struct{}{}
+	}
+	for _, verb := range required {
+		if _, ok := verbs[verb]; !ok {
+			return false
 		}
 	}
-	return false
+	return true
 }
 
 func (m *MetadataPatch) terraformType() string {

--- a/providers/kubernetes/metadata_patch_test.go
+++ b/providers/kubernetes/metadata_patch_test.go
@@ -3,6 +3,7 @@
 package kubernetes
 
 import (
+	"errors"
 	"testing"
 
 	"github.com/chenrui333/terraformer/terraformutils"
@@ -13,7 +14,9 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/discovery"
 	dynamicfake "k8s.io/client-go/dynamic/fake"
+	k8stesting "k8s.io/client-go/testing"
 )
 
 func TestMetadataPatchInitResourcesLabels(t *testing.T) {
@@ -140,6 +143,98 @@ func TestMetadataPatchInitResourcesAnnotations(t *testing.T) {
 	}
 }
 
+func TestMetadataPatchPreferredResourcesKeepsPartialDiscoveryResults(t *testing.T) {
+	lists := metadataPatchTestAPIResources()
+	got, err := metadataPatchPreferredResources(metadataPatchDiscoveryClient{
+		lists: lists,
+		err: &discovery.ErrGroupDiscoveryFailed{Groups: map[schema.GroupVersion]error{
+			{Group: "broken.example.com", Version: "v1"}: errors.New("unavailable"),
+		}},
+	})
+	if err != nil {
+		t.Fatalf("metadataPatchPreferredResources() error = %v", err)
+	}
+	if len(got) != len(lists) {
+		t.Fatalf("lists len = %d, want %d", len(got), len(lists))
+	}
+}
+
+func TestMetadataPatchPreferredResourcesReturnsNonPartialDiscoveryErrors(t *testing.T) {
+	if _, err := metadataPatchPreferredResources(metadataPatchDiscoveryClient{err: errors.New("boom")}); err == nil {
+		t.Fatal("metadataPatchPreferredResources() error = nil, want error")
+	}
+}
+
+func TestMetadataPatchInitResourcesSkipsListFailures(t *testing.T) {
+	configMap := newUnstructured("v1", "ConfigMap", "app-config", "default")
+	configMap.SetLabels(map[string]string{"app": "demo"})
+	client := dynamicfake.NewSimpleDynamicClientWithCustomListKinds(
+		runtime.NewScheme(),
+		map[schema.GroupVersionResource]string{
+			{Version: "v1", Resource: "configmaps"}: "ConfigMapList",
+			{Version: "v1", Resource: "secrets"}:    "SecretList",
+		},
+		configMap,
+	)
+	client.PrependReactor("list", "secrets", func(k8stesting.Action) (bool, runtime.Object, error) {
+		return true, nil, errors.New("forbidden")
+	})
+	service := &MetadataPatch{
+		TerraformType:     labelsTerraformType,
+		AttributeName:     "labels",
+		AllowEmptyPattern: labelsAllowEmptyPattern,
+	}
+
+	if err := service.initResources(client, []*metav1.APIResourceList{{
+		GroupVersion: "v1",
+		APIResources: []metav1.APIResource{
+			{Name: "configmaps", Kind: "ConfigMap", Namespaced: true, Verbs: []string{"get", "list", "patch"}},
+			{Name: "secrets", Kind: "Secret", Namespaced: true, Verbs: []string{"get", "list", "patch"}},
+		},
+	}}); err != nil {
+		t.Fatalf("initResources() error = %v", err)
+	}
+
+	assertResourceIDs(t, service.Resources, []string{"apiVersion=v1,kind=ConfigMap,namespace=default,name=app-config"})
+}
+
+func TestMetadataPatchSupportsResourceRequiresReadAndPatchVerbs(t *testing.T) {
+	tests := []struct {
+		name     string
+		resource metav1.APIResource
+		want     bool
+	}{
+		{
+			name:     "manageable resource",
+			resource: metav1.APIResource{Name: "configmaps", Kind: "ConfigMap", Verbs: []string{"get", "list", "patch"}},
+			want:     true,
+		},
+		{
+			name:     "list only",
+			resource: metav1.APIResource{Name: "widgets", Kind: "Widget", Verbs: []string{"list"}},
+		},
+		{
+			name:     "missing patch",
+			resource: metav1.APIResource{Name: "widgets", Kind: "Widget", Verbs: []string{"get", "list"}},
+		},
+		{
+			name:     "missing get",
+			resource: metav1.APIResource{Name: "widgets", Kind: "Widget", Verbs: []string{"list", "patch"}},
+		},
+		{
+			name:     "subresource",
+			resource: metav1.APIResource{Name: "configmaps/status", Kind: "ConfigMap", Verbs: []string{"get", "list", "patch"}},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := metadataPatchSupportsResource(tt.resource); got != tt.want {
+				t.Fatalf("metadataPatchSupportsResource() = %t, want %t", got, tt.want)
+			}
+		})
+	}
+}
+
 func TestAddMetadataPatchServices(t *testing.T) {
 	resources := map[string]terraformutils.ServiceGenerator{}
 
@@ -227,12 +322,22 @@ func metadataPatchTestAPIResources() []*metav1.APIResourceList {
 	return []*metav1.APIResourceList{{
 		GroupVersion: "v1",
 		APIResources: []metav1.APIResource{
-			{Name: "configmaps", Kind: "ConfigMap", Namespaced: true, Verbs: []string{"get", "list"}},
+			{Name: "configmaps", Kind: "ConfigMap", Namespaced: true, Verbs: []string{"get", "list", "patch"}},
 			{Name: "configmaps/status", Kind: "ConfigMap", Namespaced: true, Verbs: []string{"get", "list"}},
 			{Name: "secrets", Kind: "Secret", Namespaced: true, Verbs: []string{"get"}},
-			{Name: "namespaces", Kind: "Namespace", Verbs: []string{"get", "list"}},
+			{Name: "namespaces", Kind: "Namespace", Verbs: []string{"get", "list", "patch"}},
 		},
 	}}
+}
+
+type metadataPatchDiscoveryClient struct {
+	discovery.DiscoveryInterface
+	lists []*metav1.APIResourceList
+	err   error
+}
+
+func (m metadataPatchDiscoveryClient) ServerPreferredResources() ([]*metav1.APIResourceList, error) {
+	return m.lists, m.err
 }
 
 func metadataPatchTestBlock(attributeName string, required bool) *configschema.Block {

--- a/providers/kubernetes/metadata_patch_test.go
+++ b/providers/kubernetes/metadata_patch_test.go
@@ -264,17 +264,11 @@ func TestAddMetadataPatchServicesRequiresProviderTypes(t *testing.T) {
 
 func TestPostProcessImportResourcesRemovesOverlappingMetadataPatches(t *testing.T) {
 	provider := KubernetesProvider{}
-	fullConfigMap := terraformutils.NewResource(
+	fullConfigMap := terraformutils.NewSimpleResource(
 		"default/app-config",
 		"default/app-config",
 		"kubernetes_config_map_v1",
 		"kubernetes",
-		map[string]string{
-			"metadata.#":           "1",
-			"metadata.0.name":      "app-config",
-			"metadata.0.namespace": "default",
-		},
-		nil,
 		nil,
 	)
 	resourcesByService := map[string][]terraformutils.Resource{
@@ -297,17 +291,11 @@ func TestPostProcessImportResourcesRemovesOverlappingMetadataPatches(t *testing.
 
 func TestPostProcessImportResourcesRemovesFallbackNativeMetadataPatchOverlap(t *testing.T) {
 	provider := KubernetesProvider{}
-	fullWidget := terraformutils.NewResource(
+	fullWidget := terraformutils.NewSimpleResource(
 		"default/sample",
 		"default/sample",
 		"kubernetes_widget",
 		"kubernetes",
-		map[string]string{
-			"metadata.#":           "1",
-			"metadata.0.name":      "sample",
-			"metadata.0.namespace": "default",
-		},
-		nil,
 		nil,
 	)
 	resourcesByService := map[string][]terraformutils.Resource{
@@ -329,17 +317,11 @@ func TestPostProcessImportResourcesRemovesFallbackNativeMetadataPatchOverlap(t *
 
 func TestPostProcessImportResourcesKeepsAmbiguousFallbackNativeMetadataPatchOverlap(t *testing.T) {
 	provider := KubernetesProvider{}
-	fullWidget := terraformutils.NewResource(
+	fullWidget := terraformutils.NewSimpleResource(
 		"default/sample",
 		"default/sample",
 		"kubernetes_widget",
 		"kubernetes",
-		map[string]string{
-			"metadata.#":           "1",
-			"metadata.0.name":      "sample",
-			"metadata.0.namespace": "default",
-		},
-		nil,
 		nil,
 	)
 	resourcesByService := map[string][]terraformutils.Resource{
@@ -383,16 +365,11 @@ func TestPostProcessImportResourcesRemovesManifestMetadataPatchOverlap(t *testin
 
 func TestPostProcessImportResourcesRemovesClusterScopedNativeMetadataPatchOverlap(t *testing.T) {
 	provider := KubernetesProvider{}
-	namespace := terraformutils.NewResource(
+	namespace := terraformutils.NewSimpleResource(
 		"team-a",
 		"team-a",
 		"kubernetes_namespace_v1",
 		"kubernetes",
-		map[string]string{
-			"metadata.#":      "1",
-			"metadata.0.name": "team-a",
-		},
-		nil,
 		nil,
 	)
 	resourcesByService := map[string][]terraformutils.Resource{

--- a/providers/kubernetes/metadata_patch_test.go
+++ b/providers/kubernetes/metadata_patch_test.go
@@ -143,25 +143,25 @@ func TestMetadataPatchInitResourcesAnnotations(t *testing.T) {
 	}
 }
 
-func TestMetadataPatchPreferredResourcesKeepsPartialDiscoveryResults(t *testing.T) {
+func TestKubernetesPreferredResourcesKeepsPartialDiscoveryResults(t *testing.T) {
 	lists := metadataPatchTestAPIResources()
-	got, err := metadataPatchPreferredResources(metadataPatchDiscoveryClient{
+	got, err := kubernetesPreferredResources(metadataPatchDiscoveryClient{
 		lists: lists,
 		err: &discovery.ErrGroupDiscoveryFailed{Groups: map[schema.GroupVersion]error{
 			{Group: "broken.example.com", Version: "v1"}: errors.New("unavailable"),
 		}},
 	})
 	if err != nil {
-		t.Fatalf("metadataPatchPreferredResources() error = %v", err)
+		t.Fatalf("kubernetesPreferredResources() error = %v", err)
 	}
 	if len(got) != len(lists) {
 		t.Fatalf("lists len = %d, want %d", len(got), len(lists))
 	}
 }
 
-func TestMetadataPatchPreferredResourcesReturnsNonPartialDiscoveryErrors(t *testing.T) {
-	if _, err := metadataPatchPreferredResources(metadataPatchDiscoveryClient{err: errors.New("boom")}); err == nil {
-		t.Fatal("metadataPatchPreferredResources() error = nil, want error")
+func TestKubernetesPreferredResourcesReturnsNonPartialDiscoveryErrors(t *testing.T) {
+	if _, err := kubernetesPreferredResources(metadataPatchDiscoveryClient{err: errors.New("boom")}); err == nil {
+		t.Fatal("kubernetesPreferredResources() error = nil, want error")
 	}
 }
 
@@ -315,6 +315,57 @@ func TestPostProcessImportResourcesRemovesManifestMetadataPatchOverlap(t *testin
 
 	if _, ok := got[labelsServiceName]; ok {
 		t.Fatalf("resources[%q] was not removed after manifest overlap", labelsServiceName)
+	}
+}
+
+func TestPostProcessImportResourcesRemovesClusterScopedNativeMetadataPatchOverlap(t *testing.T) {
+	provider := KubernetesProvider{}
+	namespace := terraformutils.NewResource(
+		"team-a",
+		"team-a",
+		"kubernetes_namespace_v1",
+		"kubernetes",
+		map[string]string{
+			"metadata.#":      "1",
+			"metadata.0.name": "team-a",
+		},
+		nil,
+		nil,
+	)
+	resourcesByService := map[string][]terraformutils.Resource{
+		"namespaces": {namespace},
+		labelsServiceName: {
+			metadataPatchTestResource(labelsTerraformType, "apiVersion=v1,kind=Namespace,name=team-a"),
+		},
+	}
+
+	got := provider.PostProcessImportResources(resourcesByService)
+
+	if _, ok := got[labelsServiceName]; ok {
+		t.Fatalf("resources[%q] was not removed after cluster-scoped native overlap", labelsServiceName)
+	}
+}
+
+func TestPostProcessImportResourcesRemovesClusterScopedManifestMetadataPatchOverlap(t *testing.T) {
+	provider := KubernetesProvider{}
+	manifest := terraformutils.NewSimpleResource(
+		"apiVersion=example.com/v1,kind=Widget,name=sample",
+		"example.com/v1/Widget/sample",
+		manifestTerraformResourceName,
+		"kubernetes",
+		nil,
+	)
+	resourcesByService := map[string][]terraformutils.Resource{
+		"example.com/v1/widgets": {manifest},
+		labelsServiceName: {
+			metadataPatchTestResource(labelsTerraformType, "apiVersion=example.com/v1,kind=Widget,name=sample"),
+		},
+	}
+
+	got := provider.PostProcessImportResources(resourcesByService)
+
+	if _, ok := got[labelsServiceName]; ok {
+		t.Fatalf("resources[%q] was not removed after cluster-scoped manifest overlap", labelsServiceName)
 	}
 }
 

--- a/providers/kubernetes/metadata_patch_test.go
+++ b/providers/kubernetes/metadata_patch_test.go
@@ -1,0 +1,312 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package kubernetes
+
+import (
+	"testing"
+
+	"github.com/chenrui333/terraformer/terraformutils"
+	"github.com/chenrui333/terraformer/terraformutils/tfcompat"
+	"github.com/chenrui333/terraformer/terraformutils/tfcompat/configschema"
+	"github.com/zclconf/go-cty/cty"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	dynamicfake "k8s.io/client-go/dynamic/fake"
+)
+
+func TestMetadataPatchInitResourcesLabels(t *testing.T) {
+	configMap := newUnstructured("v1", "ConfigMap", "app-config", "default")
+	configMap.SetLabels(map[string]string{
+		"app":   "demo",
+		"empty": "",
+	})
+	noLabels := newUnstructured("v1", "ConfigMap", "no-labels", "default")
+	ownedConfigMap := newUnstructured("v1", "ConfigMap", "owned-config", "default")
+	ownedConfigMap.SetLabels(map[string]string{"app": "owned"})
+	ownedConfigMap.SetOwnerReferences([]metav1.OwnerReference{{
+		APIVersion: "v1",
+		Kind:       "Pod",
+		Name:       "owner",
+		UID:        "owner-uid",
+	}})
+	namespace := newUnstructured("v1", "Namespace", "team-a", "")
+	namespace.SetLabels(map[string]string{"team": "a"})
+
+	client := dynamicfake.NewSimpleDynamicClientWithCustomListKinds(
+		runtime.NewScheme(),
+		map[schema.GroupVersionResource]string{
+			{Version: "v1", Resource: "configmaps"}: "ConfigMapList",
+			{Version: "v1", Resource: "namespaces"}: "NamespaceList",
+		},
+		configMap,
+		noLabels,
+		ownedConfigMap,
+		namespace,
+	)
+	service := &MetadataPatch{
+		TerraformType:     labelsTerraformType,
+		AttributeName:     "labels",
+		AllowEmptyPattern: labelsAllowEmptyPattern,
+	}
+
+	if err := service.initResources(client, metadataPatchTestAPIResources()); err != nil {
+		t.Fatalf("initResources() error = %v", err)
+	}
+
+	if len(service.Resources) != 2 {
+		t.Fatalf("Resources len = %d, want 2", len(service.Resources))
+	}
+	resources := resourcesByID(service.Resources)
+	resource := resources["apiVersion=v1,kind=ConfigMap,namespace=default,name=app-config"]
+	if resource.InstanceInfo.Type != labelsTerraformType {
+		t.Fatalf("resource type = %q, want %q", resource.InstanceInfo.Type, labelsTerraformType)
+	}
+	if resource.ResourceName != "tfer--labels-002F-v1-002F-ConfigMap-002F-default-002F-app-config" {
+		t.Fatalf("resource name = %q, want ConfigMap labels resource name", resource.ResourceName)
+	}
+	for key, want := range map[string]string{
+		"id":                   "apiVersion=v1,kind=ConfigMap,namespace=default,name=app-config",
+		"api_version":          "v1",
+		"kind":                 "ConfigMap",
+		"metadata.#":           "1",
+		"metadata.0.name":      "app-config",
+		"metadata.0.namespace": "default",
+		"labels.%":             "2",
+		"labels.app":           "demo",
+		"labels.empty":         "",
+	} {
+		if got := resource.InstanceState.Attributes[key]; got != want {
+			t.Fatalf("attribute %q = %q, want %q", key, got, want)
+		}
+	}
+	if len(resource.AllowEmptyValues) != 1 || resource.AllowEmptyValues[0] != labelsAllowEmptyPattern {
+		t.Fatalf("AllowEmptyValues = %#v, want %#v", resource.AllowEmptyValues, []string{labelsAllowEmptyPattern})
+	}
+	if _, err := tfcompat.HCL2ValueFromFlatmap(resource.InstanceState.Attributes, metadataPatchTestBlock("labels", true).ImpliedType()); err != nil {
+		t.Fatalf("labels flatmap does not decode into provider schema: %v", err)
+	}
+
+	namespaceResource := resources["apiVersion=v1,kind=Namespace,name=team-a"]
+	if _, ok := namespaceResource.InstanceState.Attributes["metadata.0.namespace"]; ok {
+		t.Fatal("cluster-scoped metadata resource included namespace attribute")
+	}
+}
+
+func TestMetadataPatchInitResourcesAnnotations(t *testing.T) {
+	configMap := newUnstructured("v1", "ConfigMap", "app-config", "default")
+	configMap.SetAnnotations(map[string]string{
+		"example.com/owner": "platform",
+	})
+	client := dynamicfake.NewSimpleDynamicClientWithCustomListKinds(
+		runtime.NewScheme(),
+		map[schema.GroupVersionResource]string{
+			{Version: "v1", Resource: "configmaps"}: "ConfigMapList",
+			{Version: "v1", Resource: "namespaces"}: "NamespaceList",
+		},
+		configMap,
+	)
+	service := &MetadataPatch{
+		TerraformType:     annotationsTerraformType,
+		AttributeName:     "annotations",
+		AllowEmptyPattern: annotationsAllowEmptyPattern,
+	}
+
+	if err := service.initResources(client, metadataPatchTestAPIResources()); err != nil {
+		t.Fatalf("initResources() error = %v", err)
+	}
+
+	if len(service.Resources) != 1 {
+		t.Fatalf("Resources len = %d, want 1", len(service.Resources))
+	}
+	resource := service.Resources[0]
+	for key, want := range map[string]string{
+		"id":                            "apiVersion=v1,kind=ConfigMap,namespace=default,name=app-config",
+		"api_version":                   "v1",
+		"kind":                          "ConfigMap",
+		"metadata.#":                    "1",
+		"metadata.0.name":               "app-config",
+		"metadata.0.namespace":          "default",
+		"annotations.%":                 "1",
+		"annotations.example.com/owner": "platform",
+	} {
+		if got := resource.InstanceState.Attributes[key]; got != want {
+			t.Fatalf("attribute %q = %q, want %q", key, got, want)
+		}
+	}
+	if _, err := tfcompat.HCL2ValueFromFlatmap(resource.InstanceState.Attributes, metadataPatchTestBlock("annotations", false).ImpliedType()); err != nil {
+		t.Fatalf("annotations flatmap does not decode into provider schema: %v", err)
+	}
+}
+
+func TestAddMetadataPatchServices(t *testing.T) {
+	resources := map[string]terraformutils.ServiceGenerator{}
+
+	addMetadataPatchServices(resources, func(name string) bool {
+		return name == labelsTerraformType || name == annotationsTerraformType
+	})
+
+	if service, ok := resources[labelsServiceName].(*MetadataPatch); !ok || service.TerraformType != labelsTerraformType {
+		t.Fatalf("labels service = %#v, want MetadataPatch with %q", resources[labelsServiceName], labelsTerraformType)
+	}
+	if service, ok := resources[annotationsServiceName].(*MetadataPatch); !ok || service.TerraformType != annotationsTerraformType {
+		t.Fatalf("annotations service = %#v, want MetadataPatch with %q", resources[annotationsServiceName], annotationsTerraformType)
+	}
+}
+
+func TestAddMetadataPatchServicesRequiresProviderTypes(t *testing.T) {
+	resources := map[string]terraformutils.ServiceGenerator{}
+
+	addMetadataPatchServices(resources, func(string) bool {
+		return false
+	})
+
+	if len(resources) != 0 {
+		t.Fatalf("resources len = %d, want 0", len(resources))
+	}
+}
+
+func TestPostProcessImportResourcesRemovesOverlappingMetadataPatches(t *testing.T) {
+	provider := KubernetesProvider{}
+	fullConfigMap := terraformutils.NewResource(
+		"default/app-config",
+		"default/app-config",
+		"kubernetes_config_map_v1",
+		"kubernetes",
+		map[string]string{
+			"metadata.#":           "1",
+			"metadata.0.name":      "app-config",
+			"metadata.0.namespace": "default",
+		},
+		nil,
+		nil,
+	)
+	resourcesByService := map[string][]terraformutils.Resource{
+		"configmaps": {fullConfigMap},
+		labelsServiceName: {
+			metadataPatchTestResource(labelsTerraformType, "apiVersion=v1,kind=ConfigMap,namespace=default,name=app-config"),
+			metadataPatchTestResource(labelsTerraformType, "apiVersion=v1,kind=ConfigMap,namespace=default,name=other-config"),
+		},
+		annotationsServiceName: {
+			metadataPatchTestResource(annotationsTerraformType, "apiVersion=v1,kind=ConfigMap,namespace=default,name=app-config"),
+			metadataPatchTestResource(annotationsTerraformType, "apiVersion=v1,kind=ConfigMap,namespace=default,name=other-config"),
+		},
+	}
+
+	got := provider.PostProcessImportResources(resourcesByService)
+
+	assertResourceIDs(t, got[labelsServiceName], []string{"apiVersion=v1,kind=ConfigMap,namespace=default,name=other-config"})
+	assertResourceIDs(t, got[annotationsServiceName], []string{"apiVersion=v1,kind=ConfigMap,namespace=default,name=other-config"})
+}
+
+func TestPostProcessImportResourcesRemovesManifestMetadataPatchOverlap(t *testing.T) {
+	provider := KubernetesProvider{}
+	manifest := terraformutils.NewSimpleResource(
+		"apiVersion=example.com/v1,kind=Widget,namespace=default,name=sample",
+		"example.com/v1/Widget/default/sample",
+		manifestTerraformResourceName,
+		"kubernetes",
+		nil,
+	)
+	resourcesByService := map[string][]terraformutils.Resource{
+		"example.com/v1/widgets": {manifest},
+		labelsServiceName: {
+			metadataPatchTestResource(labelsTerraformType, "apiVersion=example.com/v1,kind=Widget,namespace=default,name=sample"),
+		},
+	}
+
+	got := provider.PostProcessImportResources(resourcesByService)
+
+	if _, ok := got[labelsServiceName]; ok {
+		t.Fatalf("resources[%q] was not removed after manifest overlap", labelsServiceName)
+	}
+}
+
+func metadataPatchTestAPIResources() []*metav1.APIResourceList {
+	return []*metav1.APIResourceList{{
+		GroupVersion: "v1",
+		APIResources: []metav1.APIResource{
+			{Name: "configmaps", Kind: "ConfigMap", Namespaced: true, Verbs: []string{"get", "list"}},
+			{Name: "configmaps/status", Kind: "ConfigMap", Namespaced: true, Verbs: []string{"get", "list"}},
+			{Name: "secrets", Kind: "Secret", Namespaced: true, Verbs: []string{"get"}},
+			{Name: "namespaces", Kind: "Namespace", Verbs: []string{"get", "list"}},
+		},
+	}}
+}
+
+func metadataPatchTestBlock(attributeName string, required bool) *configschema.Block {
+	metadataAttribute := &configschema.Attribute{
+		Type: cty.Map(cty.String),
+	}
+	if required {
+		metadataAttribute.Required = true
+	} else {
+		metadataAttribute.Optional = true
+	}
+
+	return &configschema.Block{
+		Attributes: map[string]*configschema.Attribute{
+			"id": {
+				Type:     cty.String,
+				Computed: true,
+			},
+			"api_version": {
+				Type:     cty.String,
+				Required: true,
+			},
+			"kind": {
+				Type:     cty.String,
+				Required: true,
+			},
+			attributeName: metadataAttribute,
+			"field_manager": {
+				Type:     cty.String,
+				Optional: true,
+			},
+			"force": {
+				Type:     cty.Bool,
+				Optional: true,
+			},
+		},
+		BlockTypes: map[string]*configschema.NestedBlock{
+			"metadata": {
+				Nesting:  configschema.NestingList,
+				MinItems: 1,
+				MaxItems: 1,
+				Block: configschema.Block{
+					Attributes: map[string]*configschema.Attribute{
+						"name": {
+							Type:     cty.String,
+							Required: true,
+						},
+						"namespace": {
+							Type:     cty.String,
+							Optional: true,
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func resourcesByID(resources []terraformutils.Resource) map[string]terraformutils.Resource {
+	byID := map[string]terraformutils.Resource{}
+	for _, resource := range resources {
+		byID[resource.InstanceState.ID] = resource
+	}
+	return byID
+}
+
+func metadataPatchTestResource(resourceType, id string) terraformutils.Resource {
+	return terraformutils.NewResource(
+		id,
+		id,
+		resourceType,
+		"kubernetes",
+		map[string]string{"id": id},
+		nil,
+		nil,
+	)
+}

--- a/providers/kubernetes/metadata_patch_test.go
+++ b/providers/kubernetes/metadata_patch_test.go
@@ -295,6 +295,38 @@ func TestPostProcessImportResourcesRemovesOverlappingMetadataPatches(t *testing.
 	assertResourceIDs(t, got[annotationsServiceName], []string{"apiVersion=v1,kind=ConfigMap,namespace=default,name=other-config"})
 }
 
+func TestPostProcessImportResourcesRemovesFallbackNativeMetadataPatchOverlap(t *testing.T) {
+	provider := KubernetesProvider{}
+	fullWidget := terraformutils.NewResource(
+		"default/sample",
+		"default/sample",
+		"kubernetes_widget",
+		"kubernetes",
+		map[string]string{
+			"metadata.#":           "1",
+			"metadata.0.name":      "sample",
+			"metadata.0.namespace": "default",
+		},
+		nil,
+		nil,
+	)
+	resourcesByService := map[string][]terraformutils.Resource{
+		"widgets": {fullWidget},
+		labelsServiceName: {
+			metadataPatchTestResource(labelsTerraformType, "apiVersion=example.com/v1,kind=Widget,namespace=default,name=sample"),
+			metadataPatchTestResource(labelsTerraformType, "apiVersion=example.com/v1,kind=Widget,namespace=default,name=other"),
+			metadataPatchTestResource(labelsTerraformType, "apiVersion=example.com/v1,kind=Gadget,namespace=default,name=sample"),
+		},
+	}
+
+	got := provider.PostProcessImportResources(resourcesByService)
+
+	assertResourceIDs(t, got[labelsServiceName], []string{
+		"apiVersion=example.com/v1,kind=Widget,namespace=default,name=other",
+		"apiVersion=example.com/v1,kind=Gadget,namespace=default,name=sample",
+	})
+}
+
 func TestPostProcessImportResourcesRemovesManifestMetadataPatchOverlap(t *testing.T) {
 	provider := KubernetesProvider{}
 	manifest := terraformutils.NewSimpleResource(

--- a/providers/kubernetes/metadata_patch_test.go
+++ b/providers/kubernetes/metadata_patch_test.go
@@ -327,6 +327,37 @@ func TestPostProcessImportResourcesRemovesFallbackNativeMetadataPatchOverlap(t *
 	})
 }
 
+func TestPostProcessImportResourcesKeepsAmbiguousFallbackNativeMetadataPatchOverlap(t *testing.T) {
+	provider := KubernetesProvider{}
+	fullWidget := terraformutils.NewResource(
+		"default/sample",
+		"default/sample",
+		"kubernetes_widget",
+		"kubernetes",
+		map[string]string{
+			"metadata.#":           "1",
+			"metadata.0.name":      "sample",
+			"metadata.0.namespace": "default",
+		},
+		nil,
+		nil,
+	)
+	resourcesByService := map[string][]terraformutils.Resource{
+		"widgets": {fullWidget},
+		labelsServiceName: {
+			metadataPatchTestResource(labelsTerraformType, "apiVersion=example.com/v1,kind=Widget,namespace=default,name=sample"),
+			metadataPatchTestResource(labelsTerraformType, "apiVersion=other.example.com/v1,kind=Widget,namespace=default,name=sample"),
+		},
+	}
+
+	got := provider.PostProcessImportResources(resourcesByService)
+
+	assertResourceIDs(t, got[labelsServiceName], []string{
+		"apiVersion=example.com/v1,kind=Widget,namespace=default,name=sample",
+		"apiVersion=other.example.com/v1,kind=Widget,namespace=default,name=sample",
+	})
+}
+
 func TestPostProcessImportResourcesRemovesManifestMetadataPatchOverlap(t *testing.T) {
 	provider := KubernetesProvider{}
 	manifest := terraformutils.NewSimpleResource(


### PR DESCRIPTION
Summary
- add Kubernetes `labels` and `annotations` services for metadata-only provider resources
- seed metadata patch resources from discovered listable API resources
- skip owned objects and de-dupe metadata-only resources when a full native or manifest import covers the same object

Notes
- Leaves `env` and `token_request_v1` out of scope because they are not safe broad import targets.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add metadata-only imports for Kubernetes labels and annotations to manage object metadata without owning full resources. Imports are resilient to partial discovery and avoid duplicate ownership by deduping against native, `kubernetes_manifest`, and fallback kind-based mappings.

- **New Features**
  - Added `labels` and `annotations` services using `kubernetes_labels` and `kubernetes_annotations` when the provider supports these types.
  - Discovers manageable resources (namespaced and cluster-scoped), requires `get/list/patch`, skips subresources and owned objects, and allows empty metadata values.
  - Post-processing de-dupes metadata-only resources when a full native import or `kubernetes_manifest` exists, including fallback kind-based native mappings.
  - Excludes `env` and `token_request_v1` from broad imports for safety.

- **Bug Fixes**
  - Deduplicate metadata-only imports before the refresh step to avoid refresh conflicts and provider errors.
  - Avoid ambiguous metadata patch dedupe: keep patches when multiple API versions share the same object key to prevent accidental removals.

<sup>Written for commit 93289729db2018112100e99b47052abd986952ce. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Import Kubernetes labels and annotations as standalone Terraform resources for namespaced and cluster-scoped objects
  * Automatic removal of duplicate metadata imports when native or manifest resources already cover the same targets
  * Resilient discovery and import generation that tolerates partial API availability and skips unreachable resources

* **Documentation**
  * Kubernetes docs updated to describe label/annotation import support and corresponding Terraform resource types

* **Tests**
  * Comprehensive unit tests covering discovery, import generation, duplicate removal, and failure resilience
<!-- end of auto-generated comment: release notes by coderabbit.ai -->