### PR TITLE
aws(appsync): add additional resources

### DIFF
--- a/docs/aws.md
+++ b/docs/aws.md
@@ -73,7 +73,16 @@ terraformer import aws --resources=sg --regions=us-east-1
     * `aws_apigatewayv2_stage`
     * `aws_apigatewayv2_vpc_link`
 *   `appsync`
+    * `aws_appsync_api_cache`
+    * `aws_appsync_api_key`
+    * `aws_appsync_datasource`
+    * `aws_appsync_domain_name`
+    * `aws_appsync_domain_name_api_association`
+    * `aws_appsync_function`
     * `aws_appsync_graphql_api`
+    * `aws_appsync_resolver`
+    * `aws_appsync_source_api_association`
+    * `aws_appsync_type`
 *   `auto_scaling`
     * `aws_autoscaling_group`
     * `aws_launch_configuration`

--- a/providers/aws/appsync.go
+++ b/providers/aws/appsync.go
@@ -1,14 +1,63 @@
+// SPDX-License-Identifier: Apache-2.0
+
 package aws
 
 import (
 	"context"
+	"errors"
+	"fmt"
+	"log"
+	"strings"
 
+	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/appsync"
+	appsynctypes "github.com/aws/aws-sdk-go-v2/service/appsync/types"
 	"github.com/chenrui333/terraformer/terraformutils"
+)
+
+const (
+	appSyncGraphQLAPIResourceType = "appsync_graphql_api"
+	appSyncAPICacheResourceType   = "appsync_api_cache"
+	//nolint:gosec // Terraform resource type name, not a credential.
+	appSyncAPIKeyResourceType                    = "appsync_api_key"
+	appSyncDataSourceResourceType                = "appsync_datasource"
+	appSyncDomainNameResourceType                = "appsync_domain_name"
+	appSyncDomainNameAPIAssociationResourceType  = "appsync_domain_name_api_association"
+	appSyncFunctionResourceType                  = "appsync_function"
+	appSyncResolverResourceType                  = "appsync_resolver"
+	appSyncSourceAPIAssociationResourceType      = "appsync_source_api_association"
+	appSyncTypeResourceType                      = "appsync_type"
+	appSyncAPIKeyResourceIDSeparator             = ":"
+	appSyncDataSourceResourceIDSeparator         = "-"
+	appSyncFunctionResourceIDSeparator           = "-"
+	appSyncResolverResourceIDSeparator           = "-"
+	appSyncSourceAPIAssociationResourceSeparator = ","
+	appSyncTypeResourceIDSeparator               = ":"
+)
+
+var (
+	appSyncAllowEmptyValues      = []string{"tags."}
+	appSyncAPIChildResourceTypes = []string{
+		appSyncAPICacheResourceType,
+		appSyncAPIKeyResourceType,
+		appSyncDataSourceResourceType,
+		appSyncFunctionResourceType,
+		appSyncResolverResourceType,
+		appSyncSourceAPIAssociationResourceType,
+		appSyncTypeResourceType,
+	}
+	appSyncChildResourceTypes = append([]string{
+		appSyncDomainNameAPIAssociationResourceType,
+	}, appSyncAPIChildResourceTypes...)
 )
 
 type AppSyncGenerator struct {
 	AWSService
+}
+
+type appSyncOptionalResourceLoader struct {
+	name string
+	load func() error
 }
 
 func (g *AppSyncGenerator) InitResources() error {
@@ -16,33 +65,640 @@ func (g *AppSyncGenerator) InitResources() error {
 	if e != nil {
 		return e
 	}
-
 	svc := appsync.NewFromConfig(config)
 
-	var nextToken *string
-	for {
-		apis, err := svc.ListGraphqlApis(context.TODO(), &appsync.ListGraphqlApisInput{
-			NextToken: nextToken,
+	if err := g.loadGraphQLAPIs(svc); err != nil {
+		return err
+	}
+	if g.shouldLoadDomainNames() {
+		g.loadOptionalResources([]appSyncOptionalResourceLoader{
+			{name: "domain names", load: func() error { return g.loadDomainNames(svc) }},
 		})
+	}
+	return nil
+}
+
+func (g *AppSyncGenerator) loadGraphQLAPIs(svc *appsync.Client) error {
+	p := appsync.NewListGraphqlApisPaginator(svc, &appsync.ListGraphqlApisInput{})
+	for p.HasMorePages() {
+		page, err := p.NextPage(context.TODO())
 		if err != nil {
 			return err
 		}
-
-		for _, api := range apis.GraphqlApis {
-			var id = *api.ApiId
-			var name = *api.Name
-			g.Resources = append(g.Resources, terraformutils.NewSimpleResource(
-				id,
-				name,
-				"aws_appsync_graphql_api",
-				"aws",
-				[]string{}))
+		for _, api := range page.GraphqlApis {
+			apiID := StringValue(api.ApiId)
+			apiName := StringValue(api.Name)
+			if apiID == "" || apiName == "" {
+				continue
+			}
+			apiResource := newAppSyncGraphQLAPIResource(apiID, apiName)
+			if g.shouldAppendGraphQLAPIResource(apiResource) {
+				g.Resources = append(g.Resources, apiResource)
+			}
+			if !g.shouldLoadGraphQLAPIChildren(apiResource) {
+				continue
+			}
+			g.loadOptionalResources(g.graphQLAPIChildLoaders(svc, apiID))
 		}
-		nextToken = apis.NextToken
-		if nextToken == nil {
-			break
+	}
+	return nil
+}
+
+func (g *AppSyncGenerator) graphQLAPIChildLoaders(svc *appsync.Client, apiID string) []appSyncOptionalResourceLoader {
+	loaders := []appSyncOptionalResourceLoader{}
+	if g.shouldLoadAPIChildResourceType(appSyncAPICacheResourceType, apiID) {
+		loaders = append(loaders, appSyncOptionalResourceLoader{name: fmt.Sprintf("API cache for %s", apiID), load: func() error {
+			return g.addAPICache(svc, apiID)
+		}})
+	}
+	if g.shouldLoadAPIChildResourceType(appSyncAPIKeyResourceType, apiID) {
+		loaders = append(loaders, appSyncOptionalResourceLoader{name: fmt.Sprintf("API keys for %s", apiID), load: func() error {
+			return g.addAPIKeys(svc, apiID)
+		}})
+	}
+	if g.shouldLoadAPIChildResourceType(appSyncDataSourceResourceType, apiID) {
+		loaders = append(loaders, appSyncOptionalResourceLoader{name: fmt.Sprintf("data sources for %s", apiID), load: func() error {
+			return g.addDataSources(svc, apiID)
+		}})
+	}
+	if g.shouldLoadAPIChildResourceType(appSyncFunctionResourceType, apiID) {
+		loaders = append(loaders, appSyncOptionalResourceLoader{name: fmt.Sprintf("functions for %s", apiID), load: func() error {
+			return g.addFunctions(svc, apiID)
+		}})
+	}
+	if g.shouldLoadAPIChildResourceType(appSyncTypeResourceType, apiID) || g.shouldLoadAPIChildResourceType(appSyncResolverResourceType, apiID) {
+		loaders = append(loaders, appSyncOptionalResourceLoader{name: fmt.Sprintf("types and resolvers for %s", apiID), load: func() error {
+			return g.addTypesAndResolvers(svc, apiID)
+		}})
+	}
+	if g.shouldLoadAPIChildResourceType(appSyncSourceAPIAssociationResourceType, apiID) {
+		loaders = append(loaders, appSyncOptionalResourceLoader{name: fmt.Sprintf("source API associations for %s", apiID), load: func() error {
+			return g.addSourceAPIAssociations(svc, apiID)
+		}})
+	}
+	return loaders
+}
+
+func (g *AppSyncGenerator) loadOptionalResources(loaders []appSyncOptionalResourceLoader) {
+	for _, loader := range loaders {
+		if err := loader.load(); err != nil {
+			if appSyncResourceMissing(err) {
+				continue
+			}
+			log.Printf("Skipping AppSync %s: %v", loader.name, err)
+		}
+	}
+}
+
+func (g *AppSyncGenerator) addAPICache(svc *appsync.Client, apiID string) error {
+	output, err := svc.GetApiCache(context.TODO(), &appsync.GetApiCacheInput{
+		ApiId: aws.String(apiID),
+	})
+	if err != nil {
+		return err
+	}
+	if output == nil || output.ApiCache == nil {
+		return nil
+	}
+	resource := newAppSyncAPICacheResource(apiID)
+	if g.shouldAppendAppSyncChildResource(appSyncAPICacheResourceType, resource) {
+		g.Resources = append(g.Resources, resource)
+	}
+	return nil
+}
+
+func (g *AppSyncGenerator) addAPIKeys(svc *appsync.Client, apiID string) error {
+	p := appsync.NewListApiKeysPaginator(svc, &appsync.ListApiKeysInput{ApiId: aws.String(apiID)})
+	for p.HasMorePages() {
+		page, err := p.NextPage(context.TODO())
+		if err != nil {
+			return err
+		}
+		for _, key := range page.ApiKeys {
+			keyID := StringValue(key.Id)
+			if keyID == "" {
+				continue
+			}
+			resource := newAppSyncAPIKeyResource(apiID, keyID)
+			if g.shouldAppendAppSyncChildResource(appSyncAPIKeyResourceType, resource) {
+				g.Resources = append(g.Resources, resource)
+			}
+		}
+	}
+	return nil
+}
+
+func (g *AppSyncGenerator) addDataSources(svc *appsync.Client, apiID string) error {
+	p := appsync.NewListDataSourcesPaginator(svc, &appsync.ListDataSourcesInput{ApiId: aws.String(apiID)})
+	for p.HasMorePages() {
+		page, err := p.NextPage(context.TODO())
+		if err != nil {
+			return err
+		}
+		for _, dataSource := range page.DataSources {
+			name := StringValue(dataSource.Name)
+			if name == "" {
+				continue
+			}
+			resource := newAppSyncDataSourceResource(apiID, name)
+			if g.shouldAppendAppSyncChildResource(appSyncDataSourceResourceType, resource) {
+				g.Resources = append(g.Resources, resource)
+			}
+		}
+	}
+	return nil
+}
+
+func (g *AppSyncGenerator) addFunctions(svc *appsync.Client, apiID string) error {
+	p := appsync.NewListFunctionsPaginator(svc, &appsync.ListFunctionsInput{ApiId: aws.String(apiID)})
+	for p.HasMorePages() {
+		page, err := p.NextPage(context.TODO())
+		if err != nil {
+			return err
+		}
+		for _, function := range page.Functions {
+			functionID := StringValue(function.FunctionId)
+			if functionID == "" {
+				continue
+			}
+			resource := newAppSyncFunctionResource(apiID, functionID)
+			if g.shouldAppendAppSyncChildResource(appSyncFunctionResourceType, resource) {
+				g.Resources = append(g.Resources, resource)
+			}
+		}
+	}
+	return nil
+}
+
+func (g *AppSyncGenerator) addTypesAndResolvers(svc *appsync.Client, apiID string) error {
+	p := appsync.NewListTypesPaginator(svc, &appsync.ListTypesInput{
+		ApiId:  aws.String(apiID),
+		Format: appsynctypes.TypeDefinitionFormatSdl,
+	})
+	for p.HasMorePages() {
+		page, err := p.NextPage(context.TODO())
+		if err != nil {
+			return err
+		}
+		for _, graphqlType := range page.Types {
+			typeName := StringValue(graphqlType.Name)
+			if typeName == "" {
+				continue
+			}
+			if g.shouldLoadAPIChildResourceType(appSyncTypeResourceType, apiID) {
+				resource := newAppSyncTypeResource(apiID, typeName)
+				if g.shouldAppendAppSyncChildResource(appSyncTypeResourceType, resource) {
+					g.Resources = append(g.Resources, resource)
+				}
+			}
+			if g.shouldLoadAPIChildResourceType(appSyncResolverResourceType, apiID) {
+				if err := g.addResolvers(svc, apiID, typeName); err != nil {
+					if appSyncResourceMissing(err) {
+						continue
+					}
+					return err
+				}
+			}
+		}
+	}
+	return nil
+}
+
+func (g *AppSyncGenerator) addResolvers(svc *appsync.Client, apiID, typeName string) error {
+	p := appsync.NewListResolversPaginator(svc, &appsync.ListResolversInput{
+		ApiId:    aws.String(apiID),
+		TypeName: aws.String(typeName),
+	})
+	for p.HasMorePages() {
+		page, err := p.NextPage(context.TODO())
+		if err != nil {
+			return err
+		}
+		for _, resolver := range page.Resolvers {
+			fieldName := StringValue(resolver.FieldName)
+			if fieldName == "" {
+				continue
+			}
+			resource := newAppSyncResolverResource(apiID, typeName, fieldName)
+			if g.shouldAppendAppSyncChildResource(appSyncResolverResourceType, resource) {
+				g.Resources = append(g.Resources, resource)
+			}
+		}
+	}
+	return nil
+}
+
+func (g *AppSyncGenerator) addSourceAPIAssociations(svc *appsync.Client, mergedAPIID string) error {
+	p := appsync.NewListSourceApiAssociationsPaginator(svc, &appsync.ListSourceApiAssociationsInput{ApiId: aws.String(mergedAPIID)})
+	for p.HasMorePages() {
+		page, err := p.NextPage(context.TODO())
+		if err != nil {
+			return err
+		}
+		for _, association := range page.SourceApiAssociationSummaries {
+			associationID := StringValue(association.AssociationId)
+			if associationID == "" {
+				continue
+			}
+			resource := newAppSyncSourceAPIAssociationResource(mergedAPIID, associationID)
+			if g.shouldAppendAppSyncChildResource(appSyncSourceAPIAssociationResourceType, resource) {
+				g.Resources = append(g.Resources, resource)
+			}
+		}
+	}
+	return nil
+}
+
+func (g *AppSyncGenerator) loadDomainNames(svc *appsync.Client) error {
+	p := appsync.NewListDomainNamesPaginator(svc, &appsync.ListDomainNamesInput{})
+	for p.HasMorePages() {
+		page, err := p.NextPage(context.TODO())
+		if err != nil {
+			return err
+		}
+		for _, domain := range page.DomainNameConfigs {
+			domainName := StringValue(domain.DomainName)
+			if domainName == "" {
+				continue
+			}
+			domainResource := newAppSyncDomainNameResource(domainName)
+			if g.shouldAppendDomainNameResource(domainResource) {
+				g.Resources = append(g.Resources, domainResource)
+			}
+			if !g.shouldLoadDomainNameAPIAssociation(domainName) {
+				continue
+			}
+			if err := g.addDomainNameAPIAssociation(svc, domainName); err != nil {
+				if appSyncResourceMissing(err) {
+					continue
+				}
+				log.Printf("Skipping AppSync domain name API association for %s: %v", domainName, err)
+			}
+		}
+	}
+	return nil
+}
+
+func (g *AppSyncGenerator) addDomainNameAPIAssociation(svc *appsync.Client, domainName string) error {
+	output, err := svc.GetApiAssociation(context.TODO(), &appsync.GetApiAssociationInput{
+		DomainName: aws.String(domainName),
+	})
+	if err != nil {
+		return err
+	}
+	if output == nil || output.ApiAssociation == nil {
+		return nil
+	}
+	apiID := StringValue(output.ApiAssociation.ApiId)
+	if apiID == "" {
+		return nil
+	}
+	resource := newAppSyncDomainNameAPIAssociationResource(domainName, apiID)
+	if g.shouldAppendAppSyncChildResource(appSyncDomainNameAPIAssociationResourceType, resource) {
+		g.Resources = append(g.Resources, resource)
+	}
+	return nil
+}
+
+func newAppSyncGraphQLAPIResource(apiID, apiName string) terraformutils.Resource {
+	return terraformutils.NewSimpleResource(apiID, apiName, "aws_appsync_graphql_api", "aws", appSyncAllowEmptyValues)
+}
+
+func newAppSyncAPICacheResource(apiID string) terraformutils.Resource {
+	return terraformutils.NewResource(
+		apiID,
+		appSyncResourceName(apiID, "api-cache"),
+		"aws_appsync_api_cache",
+		"aws",
+		map[string]string{"api_id": apiID},
+		appSyncAllowEmptyValues,
+		map[string]interface{}{},
+	)
+}
+
+func newAppSyncAPIKeyResource(apiID, keyID string) terraformutils.Resource {
+	return terraformutils.NewResource(
+		appSyncAPIKeyResourceID(apiID, keyID),
+		appSyncResourceName(apiID, "api-key", keyID),
+		"aws_appsync_api_key",
+		"aws",
+		map[string]string{"api_id": apiID},
+		appSyncAllowEmptyValues,
+		map[string]interface{}{},
+	)
+}
+
+func newAppSyncDataSourceResource(apiID, name string) terraformutils.Resource {
+	return terraformutils.NewResource(
+		appSyncDataSourceResourceID(apiID, name),
+		appSyncResourceName(apiID, "datasource", name),
+		"aws_appsync_datasource",
+		"aws",
+		map[string]string{
+			"api_id": apiID,
+			"name":   name,
+		},
+		appSyncAllowEmptyValues,
+		map[string]interface{}{},
+	)
+}
+
+func newAppSyncDomainNameResource(domainName string) terraformutils.Resource {
+	return terraformutils.NewSimpleResource(domainName, domainName, "aws_appsync_domain_name", "aws", appSyncAllowEmptyValues)
+}
+
+func newAppSyncDomainNameAPIAssociationResource(domainName, apiID string) terraformutils.Resource {
+	return terraformutils.NewResource(
+		domainName,
+		appSyncResourceName(domainName, "api-association"),
+		"aws_appsync_domain_name_api_association",
+		"aws",
+		map[string]string{
+			"api_id":      apiID,
+			"domain_name": domainName,
+		},
+		appSyncAllowEmptyValues,
+		map[string]interface{}{},
+	)
+}
+
+func newAppSyncFunctionResource(apiID, functionID string) terraformutils.Resource {
+	return terraformutils.NewResource(
+		appSyncFunctionResourceID(apiID, functionID),
+		appSyncResourceName(apiID, "function", functionID),
+		"aws_appsync_function",
+		"aws",
+		map[string]string{
+			"api_id":      apiID,
+			"function_id": functionID,
+		},
+		appSyncAllowEmptyValues,
+		map[string]interface{}{},
+	)
+}
+
+func newAppSyncResolverResource(apiID, typeName, fieldName string) terraformutils.Resource {
+	return terraformutils.NewResource(
+		appSyncResolverResourceID(apiID, typeName, fieldName),
+		appSyncResourceName(apiID, "resolver", typeName, fieldName),
+		"aws_appsync_resolver",
+		"aws",
+		map[string]string{
+			"api_id": apiID,
+			"field":  fieldName,
+			"type":   typeName,
+		},
+		appSyncAllowEmptyValues,
+		map[string]interface{}{},
+	)
+}
+
+func newAppSyncSourceAPIAssociationResource(mergedAPIID, associationID string) terraformutils.Resource {
+	return terraformutils.NewResource(
+		appSyncSourceAPIAssociationResourceID(mergedAPIID, associationID),
+		appSyncResourceName(mergedAPIID, "source-api-association", associationID),
+		"aws_appsync_source_api_association",
+		"aws",
+		map[string]string{
+			"association_id": associationID,
+			"merged_api_id":  mergedAPIID,
+		},
+		appSyncAllowEmptyValues,
+		map[string]interface{}{},
+	)
+}
+
+func newAppSyncTypeResource(apiID, typeName string) terraformutils.Resource {
+	format := string(appsynctypes.TypeDefinitionFormatSdl)
+	return terraformutils.NewResource(
+		appSyncTypeResourceID(apiID, format, typeName),
+		appSyncResourceName(apiID, "type", format, typeName),
+		"aws_appsync_type",
+		"aws",
+		map[string]string{
+			"api_id": apiID,
+			"format": format,
+			"name":   typeName,
+		},
+		appSyncAllowEmptyValues,
+		map[string]interface{}{},
+	)
+}
+
+func appSyncAPIKeyResourceID(apiID, keyID string) string {
+	return strings.Join([]string{apiID, keyID}, appSyncAPIKeyResourceIDSeparator)
+}
+
+func appSyncDataSourceResourceID(apiID, name string) string {
+	return strings.Join([]string{apiID, name}, appSyncDataSourceResourceIDSeparator)
+}
+
+func appSyncFunctionResourceID(apiID, functionID string) string {
+	return strings.Join([]string{apiID, functionID}, appSyncFunctionResourceIDSeparator)
+}
+
+func appSyncResolverResourceID(apiID, typeName, fieldName string) string {
+	return strings.Join([]string{apiID, typeName, fieldName}, appSyncResolverResourceIDSeparator)
+}
+
+func appSyncSourceAPIAssociationResourceID(mergedAPIID, associationID string) string {
+	return strings.Join([]string{mergedAPIID, associationID}, appSyncSourceAPIAssociationResourceSeparator)
+}
+
+func appSyncTypeResourceID(apiID, format, typeName string) string {
+	return strings.Join([]string{apiID, format, typeName}, appSyncTypeResourceIDSeparator)
+}
+
+func appSyncResourceName(parts ...string) string {
+	nonEmptyParts := []string{}
+	for _, part := range parts {
+		if part != "" {
+			nonEmptyParts = append(nonEmptyParts, part)
+		}
+	}
+	return strings.Join(nonEmptyParts, ":")
+}
+
+func appSyncResourceMissing(err error) bool {
+	var notFound *appsynctypes.NotFoundException
+	return errors.As(err, &notFound)
+}
+
+func (g *AppSyncGenerator) shouldAppendGraphQLAPIResource(resource terraformutils.Resource) bool {
+	if !g.resourceMatchesInitialIDFilters(appSyncGraphQLAPIResourceType, resource) {
+		return false
+	}
+	if g.hasTypedAppSyncChildFilter() && !g.hasTypedFilterFor(appSyncGraphQLAPIResourceType) && !g.hasUntypedIDFilter() {
+		return false
+	}
+	return true
+}
+
+func (g *AppSyncGenerator) shouldAppendDomainNameResource(resource terraformutils.Resource) bool {
+	if !g.resourceMatchesInitialIDFilters(appSyncDomainNameResourceType, resource) {
+		return false
+	}
+	if g.hasTypedAppSyncChildFilter() && !g.hasTypedFilterFor(appSyncDomainNameResourceType) && !g.hasUntypedIDFilter() {
+		return false
+	}
+	return true
+}
+
+func (g *AppSyncGenerator) shouldAppendAppSyncChildResource(serviceName string, resource terraformutils.Resource) bool {
+	if g.hasTypedAppSyncChildFilter() && !g.hasTypedFilterFor(serviceName) {
+		return false
+	}
+	return g.resourceMatchesInitialIDFilters(serviceName, resource)
+}
+
+func (g *AppSyncGenerator) shouldLoadGraphQLAPIChildren(apiResource terraformutils.Resource) bool {
+	if !g.hasTypedAppSyncChildFilter() && !g.hasUntypedIDFilter() {
+		if !g.resourceMatchesInitialIDFilters(appSyncGraphQLAPIResourceType, apiResource) {
+			return false
+		}
+		if g.hasTypedNonIDFilterFor(appSyncGraphQLAPIResourceType) {
+			return false
 		}
 	}
 
-	return nil
+	apiID := apiResource.InstanceState.ID
+	for _, childServiceName := range appSyncAPIChildResourceTypes {
+		if g.shouldLoadAPIChildResourceType(childServiceName, apiID) {
+			return true
+		}
+	}
+	return false
+}
+
+func (g *AppSyncGenerator) shouldLoadAPIChildResourceType(serviceName, apiID string) bool {
+	if !g.hasTypedAppSyncChildFilter() && !g.hasUntypedIDFilter() {
+		apiResource := newAppSyncGraphQLAPIResource(apiID, apiID)
+		if !g.resourceMatchesInitialIDFilters(appSyncGraphQLAPIResourceType, apiResource) {
+			return false
+		}
+		if g.hasTypedNonIDFilterFor(appSyncGraphQLAPIResourceType) {
+			return false
+		}
+	}
+	if g.hasTypedAppSyncChildFilter() && !g.hasTypedFilterFor(serviceName) {
+		return false
+	}
+	return g.initialIDFiltersCanMatchAPIChild(serviceName, apiID)
+}
+
+func (g *AppSyncGenerator) shouldLoadDomainNames() bool {
+	if g.hasTypedAppSyncChildFilter() {
+		return g.hasTypedFilterFor(appSyncDomainNameResourceType) || g.hasTypedFilterFor(appSyncDomainNameAPIAssociationResourceType)
+	}
+	return true
+}
+
+func (g *AppSyncGenerator) shouldLoadDomainNameAPIAssociation(domainName string) bool {
+	if g.hasTypedAppSyncChildFilter() && !g.hasTypedFilterFor(appSyncDomainNameAPIAssociationResourceType) {
+		return false
+	}
+	return g.initialIDFiltersCanMatchDomainName(appSyncDomainNameAPIAssociationResourceType, domainName)
+}
+
+func (g *AppSyncGenerator) resourceMatchesInitialIDFilters(serviceName string, resource terraformutils.Resource) bool {
+	for _, filter := range g.Filter {
+		if filter.FieldPath != "id" || !filter.IsApplicable(serviceName) {
+			continue
+		}
+		if !filter.Filter(resource) {
+			return false
+		}
+	}
+	return true
+}
+
+func (g *AppSyncGenerator) initialIDFiltersCanMatchAPIChild(serviceName, apiID string) bool {
+	for _, filter := range g.Filter {
+		if filter.FieldPath != "id" || !filter.IsApplicable(serviceName) {
+			continue
+		}
+		if !appSyncAnyAcceptableIDMatches(filter.AcceptableValues, func(value string) bool {
+			return appSyncChildIDMayBelongToAPI(serviceName, apiID, value)
+		}) {
+			return false
+		}
+	}
+	return true
+}
+
+func (g *AppSyncGenerator) initialIDFiltersCanMatchDomainName(serviceName, domainName string) bool {
+	for _, filter := range g.Filter {
+		if filter.FieldPath != "id" || !filter.IsApplicable(serviceName) {
+			continue
+		}
+		if !appSyncAnyAcceptableIDMatches(filter.AcceptableValues, func(value string) bool {
+			return value == domainName
+		}) {
+			return false
+		}
+	}
+	return true
+}
+
+func appSyncAnyAcceptableIDMatches(values []string, match func(string) bool) bool {
+	if len(values) == 0 {
+		return true
+	}
+	for _, value := range values {
+		if match(value) {
+			return true
+		}
+	}
+	return false
+}
+
+func appSyncChildIDMayBelongToAPI(serviceName, apiID, value string) bool {
+	switch serviceName {
+	case appSyncAPICacheResourceType:
+		return value == apiID
+	case appSyncAPIKeyResourceType, appSyncTypeResourceType:
+		return strings.HasPrefix(value, apiID+appSyncAPIKeyResourceIDSeparator)
+	case appSyncDataSourceResourceType, appSyncFunctionResourceType, appSyncResolverResourceType:
+		return strings.HasPrefix(value, apiID+appSyncDataSourceResourceIDSeparator)
+	case appSyncSourceAPIAssociationResourceType:
+		return strings.HasPrefix(value, apiID+appSyncSourceAPIAssociationResourceSeparator)
+	default:
+		return true
+	}
+}
+
+func (g *AppSyncGenerator) hasTypedAppSyncChildFilter() bool {
+	for _, serviceName := range appSyncChildResourceTypes {
+		if g.hasTypedFilterFor(serviceName) {
+			return true
+		}
+	}
+	return false
+}
+
+func (g *AppSyncGenerator) hasTypedFilterFor(serviceName string) bool {
+	for _, filter := range g.Filter {
+		if filter.ServiceName == serviceName {
+			return true
+		}
+	}
+	return false
+}
+
+func (g *AppSyncGenerator) hasTypedNonIDFilterFor(serviceName string) bool {
+	for _, filter := range g.Filter {
+		if filter.ServiceName == serviceName && filter.FieldPath != "id" {
+			return true
+		}
+	}
+	return false
+}
+
+func (g *AppSyncGenerator) hasUntypedIDFilter() bool {
+	for _, filter := range g.Filter {
+		if filter.ServiceName == "" && filter.FieldPath == "id" {
+			return true
+		}
+	}
+	return false
 }

--- a/providers/aws/appsync.go
+++ b/providers/aws/appsync.go
@@ -82,8 +82,14 @@ func (g *AppSyncGenerator) InitResources() error {
 		}
 	}
 	if g.shouldLoadDomainNames() {
-		if err := g.loadDomainNames(svc); err != nil {
-			return err
+		if g.shouldRequireDomainNameLoad() {
+			if err := g.loadDomainNames(svc); err != nil {
+				return err
+			}
+		} else {
+			g.loadOptionalResources([]appSyncOptionalResourceLoader{
+				{name: "domain names", load: func() error { return g.loadDomainNames(svc) }},
+			})
 		}
 	}
 	return nil
@@ -619,22 +625,31 @@ func (g *AppSyncGenerator) shouldLoadGraphQLAPIs() bool {
 }
 
 func (g *AppSyncGenerator) shouldLoadAPIChildResourceType(serviceName, apiID string) bool {
-	if !g.hasTypedAppSyncAPIChildFilter() && !g.hasUntypedIDFilter() {
-		apiResource := newAppSyncGraphQLAPIResource(apiID, apiID)
-		if !g.resourceMatchesInitialIDFilters(appSyncGraphQLAPIResourceType, apiResource) {
-			return false
-		}
-		if g.hasTypedNonIDFilterFor(appSyncGraphQLAPIResourceType) {
-			return false
-		}
-	}
+	hasTypedChildFilter := g.hasTypedFilterFor(serviceName)
 	if g.hasTypedAppSyncAPIChildFilter() && !g.hasTypedFilterFor(serviceName) {
 		return false
 	}
-	if g.hasTypedAppSyncFilter() && !g.hasTypedFilterFor(serviceName) && !g.hasTypedFilterFor(appSyncGraphQLAPIResourceType) && !g.hasUntypedIDFilter() {
+	if g.hasTypedAppSyncFilter() && !hasTypedChildFilter && !g.hasTypedFilterFor(appSyncGraphQLAPIResourceType) && !g.hasUntypedIDFilter() {
 		return false
 	}
-	return g.initialIDFiltersCanMatchAPIChild(serviceName, apiID)
+	if !g.initialIDFiltersCanMatchAPIChild(serviceName, apiID) {
+		return false
+	}
+	if !hasTypedChildFilter && !g.hasUntypedIDFilter() {
+		return g.graphQLAPIMatchesPreDiscoveryFilters(apiID)
+	}
+	if hasTypedChildFilter && !g.hasIDFilterFor(serviceName) && !g.hasUntypedIDFilter() && g.hasTypedFilterFor(appSyncGraphQLAPIResourceType) {
+		return g.graphQLAPIMatchesPreDiscoveryFilters(apiID)
+	}
+	return true
+}
+
+func (g *AppSyncGenerator) graphQLAPIMatchesPreDiscoveryFilters(apiID string) bool {
+	apiResource := newAppSyncGraphQLAPIResource(apiID, apiID)
+	if !g.resourceMatchesInitialIDFilters(appSyncGraphQLAPIResourceType, apiResource) {
+		return false
+	}
+	return !g.hasTypedNonIDFilterFor(appSyncGraphQLAPIResourceType)
 }
 
 func (g *AppSyncGenerator) shouldLoadDomainNames() bool {
@@ -647,13 +662,23 @@ func (g *AppSyncGenerator) shouldLoadDomainNames() bool {
 	return true
 }
 
+func (g *AppSyncGenerator) shouldRequireDomainNameLoad() bool {
+	return g.hasTypedFilterFor(appSyncDomainNameResourceType) || g.hasTypedFilterFor(appSyncDomainNameAPIAssociationResourceType)
+}
+
 func (g *AppSyncGenerator) shouldLoadDomainNameAPIAssociation(domainName string) bool {
+	hasTypedDomainFilter := g.hasTypedFilterFor(appSyncDomainNameResourceType)
+	if g.hasTypedFilterFor(appSyncDomainNameResourceType) {
+		domainResource := newAppSyncDomainNameResource(domainName)
+		if !g.resourceMatchesInitialIDFilters(appSyncDomainNameResourceType, domainResource) || g.hasTypedNonIDFilterFor(appSyncDomainNameResourceType) {
+			return false
+		}
+	}
 	if g.hasTypedFilterFor(appSyncDomainNameAPIAssociationResourceType) {
 		return g.initialIDFiltersCanMatchDomainName(appSyncDomainNameAPIAssociationResourceType, domainName)
 	}
-	if g.hasTypedFilterFor(appSyncDomainNameResourceType) {
-		domainResource := newAppSyncDomainNameResource(domainName)
-		return g.resourceMatchesInitialIDFilters(appSyncDomainNameResourceType, domainResource) && !g.hasTypedNonIDFilterFor(appSyncDomainNameResourceType)
+	if hasTypedDomainFilter {
+		return true
 	}
 	if g.hasTypedAppSyncFilter() && !g.hasUntypedIDFilter() {
 		return false
@@ -767,6 +792,15 @@ func (g *AppSyncGenerator) hasTypedFilterFor(serviceName string) bool {
 func (g *AppSyncGenerator) hasTypedNonIDFilterFor(serviceName string) bool {
 	for _, filter := range g.Filter {
 		if filter.ServiceName == serviceName && filter.FieldPath != "id" {
+			return true
+		}
+	}
+	return false
+}
+
+func (g *AppSyncGenerator) hasIDFilterFor(serviceName string) bool {
+	for _, filter := range g.Filter {
+		if filter.FieldPath == "id" && filter.IsApplicable(serviceName) {
 			return true
 		}
 	}

--- a/providers/aws/appsync.go
+++ b/providers/aws/appsync.go
@@ -37,6 +37,10 @@ const (
 
 var (
 	appSyncAllowEmptyValues      = []string{"tags."}
+	appSyncTopLevelResourceTypes = []string{
+		appSyncGraphQLAPIResourceType,
+		appSyncDomainNameResourceType,
+	}
 	appSyncAPIChildResourceTypes = []string{
 		appSyncAPICacheResourceType,
 		appSyncAPIKeyResourceType,
@@ -49,6 +53,11 @@ var (
 	appSyncChildResourceTypes = append([]string{
 		appSyncDomainNameAPIAssociationResourceType,
 	}, appSyncAPIChildResourceTypes...)
+	appSyncResourceTypes         = append(appSyncTopLevelResourceTypes, appSyncChildResourceTypes...)
+	appSyncTypeDefinitionFormats = []appsynctypes.TypeDefinitionFormat{
+		appsynctypes.TypeDefinitionFormatSdl,
+		appsynctypes.TypeDefinitionFormatJson,
+	}
 )
 
 type AppSyncGenerator struct {
@@ -231,27 +240,35 @@ func (g *AppSyncGenerator) addFunctions(svc *appsync.Client, apiID string) error
 }
 
 func (g *AppSyncGenerator) addTypesAndResolvers(svc *appsync.Client, apiID string) error {
-	p := appsync.NewListTypesPaginator(svc, &appsync.ListTypesInput{
-		ApiId:  aws.String(apiID),
-		Format: appsynctypes.TypeDefinitionFormatSdl,
-	})
-	for p.HasMorePages() {
-		page, err := p.NextPage(context.TODO())
-		if err != nil {
-			return err
-		}
-		for _, graphqlType := range page.Types {
-			typeName := StringValue(graphqlType.Name)
-			if typeName == "" {
-				continue
+	seenResolverTypes := map[string]struct{}{}
+	for _, format := range appSyncTypeDefinitionFormats {
+		p := appsync.NewListTypesPaginator(svc, &appsync.ListTypesInput{
+			ApiId:  aws.String(apiID),
+			Format: format,
+		})
+		for p.HasMorePages() {
+			page, err := p.NextPage(context.TODO())
+			if err != nil {
+				return err
 			}
-			if g.shouldLoadAPIChildResourceType(appSyncTypeResourceType, apiID) {
-				resource := newAppSyncTypeResource(apiID, typeName)
-				if g.shouldAppendAppSyncChildResource(appSyncTypeResourceType, resource) {
-					g.Resources = append(g.Resources, resource)
+			for _, graphqlType := range page.Types {
+				typeName := StringValue(graphqlType.Name)
+				if typeName == "" {
+					continue
 				}
-			}
-			if g.shouldLoadAPIChildResourceType(appSyncResolverResourceType, apiID) {
+				if g.shouldLoadAPIChildResourceType(appSyncTypeResourceType, apiID) {
+					resource := newAppSyncTypeResource(apiID, string(format), typeName)
+					if g.shouldAppendAppSyncChildResource(appSyncTypeResourceType, resource) {
+						g.Resources = append(g.Resources, resource)
+					}
+				}
+				if !g.shouldLoadAPIChildResourceType(appSyncResolverResourceType, apiID) {
+					continue
+				}
+				if _, seen := seenResolverTypes[typeName]; seen {
+					continue
+				}
+				seenResolverTypes[typeName] = struct{}{}
 				if err := g.addResolvers(svc, apiID, typeName); err != nil {
 					if appSyncResourceMissing(err) {
 						continue
@@ -468,8 +485,7 @@ func newAppSyncSourceAPIAssociationResource(mergedAPIID, associationID string) t
 	)
 }
 
-func newAppSyncTypeResource(apiID, typeName string) terraformutils.Resource {
-	format := string(appsynctypes.TypeDefinitionFormatSdl)
+func newAppSyncTypeResource(apiID, format, typeName string) terraformutils.Resource {
 	return terraformutils.NewResource(
 		appSyncTypeResourceID(apiID, format, typeName),
 		appSyncResourceName(apiID, "type", format, typeName),
@@ -528,7 +544,7 @@ func (g *AppSyncGenerator) shouldAppendGraphQLAPIResource(resource terraformutil
 	if !g.resourceMatchesInitialIDFilters(appSyncGraphQLAPIResourceType, resource) {
 		return false
 	}
-	if g.hasTypedAppSyncChildFilter() && !g.hasTypedFilterFor(appSyncGraphQLAPIResourceType) && !g.hasUntypedIDFilter() {
+	if g.hasTypedAppSyncFilter() && !g.hasTypedFilterFor(appSyncGraphQLAPIResourceType) && !g.hasUntypedIDFilter() {
 		return false
 	}
 	return true
@@ -538,7 +554,7 @@ func (g *AppSyncGenerator) shouldAppendDomainNameResource(resource terraformutil
 	if !g.resourceMatchesInitialIDFilters(appSyncDomainNameResourceType, resource) {
 		return false
 	}
-	if g.hasTypedAppSyncChildFilter() && !g.hasTypedFilterFor(appSyncDomainNameResourceType) && !g.hasUntypedIDFilter() {
+	if g.hasTypedAppSyncFilter() && !g.hasTypedFilterFor(appSyncDomainNameResourceType) && !g.hasUntypedIDFilter() {
 		return false
 	}
 	return true
@@ -548,11 +564,26 @@ func (g *AppSyncGenerator) shouldAppendAppSyncChildResource(serviceName string, 
 	if g.hasTypedAppSyncChildFilter() && !g.hasTypedFilterFor(serviceName) {
 		return false
 	}
+	if g.hasTypedAppSyncFilter() && !g.hasTypedAppSyncChildFilter() && !g.hasUntypedIDFilter() {
+		switch serviceName {
+		case appSyncDomainNameAPIAssociationResourceType:
+			if !g.hasTypedFilterFor(appSyncDomainNameResourceType) {
+				return false
+			}
+		default:
+			if !g.hasTypedFilterFor(appSyncGraphQLAPIResourceType) {
+				return false
+			}
+		}
+	}
 	return g.resourceMatchesInitialIDFilters(serviceName, resource)
 }
 
 func (g *AppSyncGenerator) shouldLoadGraphQLAPIChildren(apiResource terraformutils.Resource) bool {
-	if !g.hasTypedAppSyncChildFilter() && !g.hasUntypedIDFilter() {
+	if g.hasTypedAppSyncFilter() && !g.hasTypedFilterFor(appSyncGraphQLAPIResourceType) && !g.hasTypedAppSyncAPIChildFilter() && !g.hasUntypedIDFilter() {
+		return false
+	}
+	if !g.hasTypedAppSyncAPIChildFilter() && !g.hasUntypedIDFilter() {
 		if !g.resourceMatchesInitialIDFilters(appSyncGraphQLAPIResourceType, apiResource) {
 			return false
 		}
@@ -571,7 +602,7 @@ func (g *AppSyncGenerator) shouldLoadGraphQLAPIChildren(apiResource terraformuti
 }
 
 func (g *AppSyncGenerator) shouldLoadAPIChildResourceType(serviceName, apiID string) bool {
-	if !g.hasTypedAppSyncChildFilter() && !g.hasUntypedIDFilter() {
+	if !g.hasTypedAppSyncAPIChildFilter() && !g.hasUntypedIDFilter() {
 		apiResource := newAppSyncGraphQLAPIResource(apiID, apiID)
 		if !g.resourceMatchesInitialIDFilters(appSyncGraphQLAPIResourceType, apiResource) {
 			return false
@@ -580,21 +611,31 @@ func (g *AppSyncGenerator) shouldLoadAPIChildResourceType(serviceName, apiID str
 			return false
 		}
 	}
-	if g.hasTypedAppSyncChildFilter() && !g.hasTypedFilterFor(serviceName) {
+	if g.hasTypedAppSyncAPIChildFilter() && !g.hasTypedFilterFor(serviceName) {
+		return false
+	}
+	if g.hasTypedAppSyncFilter() && !g.hasTypedFilterFor(serviceName) && !g.hasTypedFilterFor(appSyncGraphQLAPIResourceType) && !g.hasUntypedIDFilter() {
 		return false
 	}
 	return g.initialIDFiltersCanMatchAPIChild(serviceName, apiID)
 }
 
 func (g *AppSyncGenerator) shouldLoadDomainNames() bool {
-	if g.hasTypedAppSyncChildFilter() {
+	if g.hasTypedAppSyncFilter() {
 		return g.hasTypedFilterFor(appSyncDomainNameResourceType) || g.hasTypedFilterFor(appSyncDomainNameAPIAssociationResourceType)
 	}
 	return true
 }
 
 func (g *AppSyncGenerator) shouldLoadDomainNameAPIAssociation(domainName string) bool {
-	if g.hasTypedAppSyncChildFilter() && !g.hasTypedFilterFor(appSyncDomainNameAPIAssociationResourceType) {
+	if g.hasTypedFilterFor(appSyncDomainNameAPIAssociationResourceType) {
+		return g.initialIDFiltersCanMatchDomainName(appSyncDomainNameAPIAssociationResourceType, domainName)
+	}
+	if g.hasTypedFilterFor(appSyncDomainNameResourceType) {
+		domainResource := newAppSyncDomainNameResource(domainName)
+		return g.resourceMatchesInitialIDFilters(appSyncDomainNameResourceType, domainResource) && !g.hasTypedNonIDFilterFor(appSyncDomainNameResourceType)
+	}
+	if g.hasTypedAppSyncFilter() && !g.hasUntypedIDFilter() {
 		return false
 	}
 	return g.initialIDFiltersCanMatchDomainName(appSyncDomainNameAPIAssociationResourceType, domainName)
@@ -669,6 +710,24 @@ func appSyncChildIDMayBelongToAPI(serviceName, apiID, value string) bool {
 
 func (g *AppSyncGenerator) hasTypedAppSyncChildFilter() bool {
 	for _, serviceName := range appSyncChildResourceTypes {
+		if g.hasTypedFilterFor(serviceName) {
+			return true
+		}
+	}
+	return false
+}
+
+func (g *AppSyncGenerator) hasTypedAppSyncAPIChildFilter() bool {
+	for _, serviceName := range appSyncAPIChildResourceTypes {
+		if g.hasTypedFilterFor(serviceName) {
+			return true
+		}
+	}
+	return false
+}
+
+func (g *AppSyncGenerator) hasTypedAppSyncFilter() bool {
+	for _, serviceName := range appSyncResourceTypes {
 		if g.hasTypedFilterFor(serviceName) {
 			return true
 		}

--- a/providers/aws/appsync.go
+++ b/providers/aws/appsync.go
@@ -76,13 +76,15 @@ func (g *AppSyncGenerator) InitResources() error {
 	}
 	svc := appsync.NewFromConfig(config)
 
-	if err := g.loadGraphQLAPIs(svc); err != nil {
-		return err
+	if g.shouldLoadGraphQLAPIs() {
+		if err := g.loadGraphQLAPIs(svc); err != nil {
+			return err
+		}
 	}
 	if g.shouldLoadDomainNames() {
-		g.loadOptionalResources([]appSyncOptionalResourceLoader{
-			{name: "domain names", load: func() error { return g.loadDomainNames(svc) }},
-		})
+		if err := g.loadDomainNames(svc); err != nil {
+			return err
+		}
 	}
 	return nil
 }
@@ -606,6 +608,16 @@ func (g *AppSyncGenerator) shouldLoadGraphQLAPIChildren(apiResource terraformuti
 	return false
 }
 
+func (g *AppSyncGenerator) shouldLoadGraphQLAPIs() bool {
+	if g.hasUntypedIDFilter() {
+		return true
+	}
+	if g.hasTypedAppSyncFilter() {
+		return g.hasTypedFilterFor(appSyncGraphQLAPIResourceType) || g.hasTypedAppSyncAPIChildFilter()
+	}
+	return true
+}
+
 func (g *AppSyncGenerator) shouldLoadAPIChildResourceType(serviceName, apiID string) bool {
 	if !g.hasTypedAppSyncAPIChildFilter() && !g.hasUntypedIDFilter() {
 		apiResource := newAppSyncGraphQLAPIResource(apiID, apiID)
@@ -626,6 +638,9 @@ func (g *AppSyncGenerator) shouldLoadAPIChildResourceType(serviceName, apiID str
 }
 
 func (g *AppSyncGenerator) shouldLoadDomainNames() bool {
+	if g.hasUntypedIDFilter() {
+		return true
+	}
 	if g.hasTypedAppSyncFilter() {
 		return g.hasTypedFilterFor(appSyncDomainNameResourceType) || g.hasTypedFilterFor(appSyncDomainNameAPIAssociationResourceType)
 	}

--- a/providers/aws/appsync.go
+++ b/providers/aws/appsync.go
@@ -484,7 +484,7 @@ func newAppSyncResolverResource(apiID, typeName, fieldName string) terraformutil
 }
 
 func newAppSyncSourceAPIAssociationResource(mergedAPIID, associationID string) terraformutils.Resource {
-	return terraformutils.NewResource(
+	resource := terraformutils.NewResource(
 		appSyncSourceAPIAssociationResourceID(mergedAPIID, associationID),
 		appSyncResourceName(mergedAPIID, "source-api-association", associationID),
 		"aws_appsync_source_api_association",
@@ -496,6 +496,8 @@ func newAppSyncSourceAPIAssociationResource(mergedAPIID, associationID string) t
 		appSyncAllowEmptyValues,
 		map[string]interface{}{},
 	)
+	resource.IgnoreKeys = append(resource.IgnoreKeys, "^merged_api_arn$", "^source_api_arn$")
+	return resource
 }
 
 func newAppSyncTypeResource(apiID, format, typeName string) terraformutils.Resource {
@@ -668,7 +670,8 @@ func (g *AppSyncGenerator) shouldRequireDomainNameLoad() bool {
 
 func (g *AppSyncGenerator) shouldLoadDomainNameAPIAssociation(domainName string) bool {
 	hasTypedDomainFilter := g.hasTypedFilterFor(appSyncDomainNameResourceType)
-	if g.hasTypedFilterFor(appSyncDomainNameResourceType) {
+	hasTypedAssociationIDFilter := g.hasTypedFilterFor(appSyncDomainNameAPIAssociationResourceType) && g.hasIDFilterFor(appSyncDomainNameAPIAssociationResourceType)
+	if hasTypedDomainFilter && !hasTypedAssociationIDFilter {
 		domainResource := newAppSyncDomainNameResource(domainName)
 		if !g.resourceMatchesInitialIDFilters(appSyncDomainNameResourceType, domainResource) || g.hasTypedNonIDFilterFor(appSyncDomainNameResourceType) {
 			return false

--- a/providers/aws/appsync.go
+++ b/providers/aws/appsync.go
@@ -240,6 +240,7 @@ func (g *AppSyncGenerator) addFunctions(svc *appsync.Client, apiID string) error
 }
 
 func (g *AppSyncGenerator) addTypesAndResolvers(svc *appsync.Client, apiID string) error {
+	seenTypes := map[string]struct{}{}
 	seenResolverTypes := map[string]struct{}{}
 	for _, format := range appSyncTypeDefinitionFormats {
 		p := appsync.NewListTypesPaginator(svc, &appsync.ListTypesInput{
@@ -257,9 +258,13 @@ func (g *AppSyncGenerator) addTypesAndResolvers(svc *appsync.Client, apiID strin
 					continue
 				}
 				if g.shouldLoadAPIChildResourceType(appSyncTypeResourceType, apiID) {
+					if _, seen := seenTypes[typeName]; seen {
+						continue
+					}
 					resource := newAppSyncTypeResource(apiID, string(format), typeName)
 					if g.shouldAppendAppSyncChildResource(appSyncTypeResourceType, resource) {
 						g.Resources = append(g.Resources, resource)
+						seenTypes[typeName] = struct{}{}
 					}
 				}
 				if !g.shouldLoadAPIChildResourceType(appSyncResolverResourceType, apiID) {

--- a/providers/aws/appsync_test.go
+++ b/providers/aws/appsync_test.go
@@ -67,6 +67,7 @@ func TestAppSyncFilterGatesGraphQLAPIAndChildDiscovery(t *testing.T) {
 	tests := []struct {
 		name              string
 		filters           []terraformutils.ResourceFilter
+		loadAPIs          bool
 		appendAPI         bool
 		appendOtherAPI    bool
 		loadChildren      bool
@@ -78,6 +79,7 @@ func TestAppSyncFilterGatesGraphQLAPIAndChildDiscovery(t *testing.T) {
 	}{
 		{
 			name:              "no filters imports APIs and children",
+			loadAPIs:          true,
 			appendAPI:         true,
 			appendOtherAPI:    true,
 			loadChildren:      true,
@@ -92,6 +94,7 @@ func TestAppSyncFilterGatesGraphQLAPIAndChildDiscovery(t *testing.T) {
 			filters: []terraformutils.ResourceFilter{
 				{ServiceName: appSyncGraphQLAPIResourceType, FieldPath: "id", AcceptableValues: []string{apiID}},
 			},
+			loadAPIs:       true,
 			appendAPI:      true,
 			loadChildren:   true,
 			loadAPIKeys:    true,
@@ -103,6 +106,7 @@ func TestAppSyncFilterGatesGraphQLAPIAndChildDiscovery(t *testing.T) {
 			filters: []terraformutils.ResourceFilter{
 				{ServiceName: appSyncAPIKeyResourceType, FieldPath: "id", AcceptableValues: []string{appSyncAPIKeyResourceID(apiID, "key123")}},
 			},
+			loadAPIs:     true,
 			loadChildren: true,
 			loadAPIKeys:  true,
 			appendAPIKey: true,
@@ -113,6 +117,7 @@ func TestAppSyncFilterGatesGraphQLAPIAndChildDiscovery(t *testing.T) {
 				{ServiceName: appSyncGraphQLAPIResourceType, FieldPath: "id", AcceptableValues: []string{otherAPIID}},
 				{ServiceName: appSyncAPIKeyResourceType, FieldPath: "id", AcceptableValues: []string{appSyncAPIKeyResourceID(apiID, "key123")}},
 			},
+			loadAPIs:       true,
 			appendOtherAPI: true,
 			loadChildren:   true,
 			loadAPIKeys:    true,
@@ -130,6 +135,7 @@ func TestAppSyncFilterGatesGraphQLAPIAndChildDiscovery(t *testing.T) {
 				{FieldPath: "id", AcceptableValues: []string{otherAPIID}},
 				{ServiceName: appSyncAPIKeyResourceType, FieldPath: "id", AcceptableValues: []string{appSyncAPIKeyResourceID(apiID, "key123")}},
 			},
+			loadAPIs:       true,
 			appendOtherAPI: true,
 		},
 		{
@@ -137,6 +143,7 @@ func TestAppSyncFilterGatesGraphQLAPIAndChildDiscovery(t *testing.T) {
 			filters: []terraformutils.ResourceFilter{
 				{FieldPath: "id", AcceptableValues: []string{appSyncAPIKeyResourceID(apiID, "key123")}},
 			},
+			loadAPIs:     true,
 			loadChildren: true,
 			loadAPIKeys:  true,
 			appendAPIKey: true,
@@ -146,6 +153,7 @@ func TestAppSyncFilterGatesGraphQLAPIAndChildDiscovery(t *testing.T) {
 			filters: []terraformutils.ResourceFilter{
 				{ServiceName: appSyncGraphQLAPIResourceType, FieldPath: "tags.env", AcceptableValues: []string{"prod"}},
 			},
+			loadAPIs:       true,
 			appendAPI:      true,
 			appendOtherAPI: true,
 			appendAPIKey:   true,
@@ -157,6 +165,9 @@ func TestAppSyncFilterGatesGraphQLAPIAndChildDiscovery(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			g := AppSyncGenerator{}
 			g.Filter = tt.filters
+			if got := g.shouldLoadGraphQLAPIs(); got != tt.loadAPIs {
+				t.Fatalf("shouldLoadGraphQLAPIs() = %t, want %t", got, tt.loadAPIs)
+			}
 			if got := g.shouldAppendGraphQLAPIResource(api); got != tt.appendAPI {
 				t.Fatalf("shouldAppendGraphQLAPIResource(api) = %t, want %t", got, tt.appendAPI)
 			}
@@ -214,6 +225,17 @@ func TestAppSyncFilterGatesDomainNamesAndAssociations(t *testing.T) {
 			filters: []terraformutils.ResourceFilter{
 				{ServiceName: appSyncGraphQLAPIResourceType, FieldPath: "id", AcceptableValues: []string{"api123"}},
 			},
+		},
+		{
+			name: "untyped domain id filter keeps domain scan with typed API filter",
+			filters: []terraformutils.ResourceFilter{
+				{ServiceName: appSyncGraphQLAPIResourceType, FieldPath: "id", AcceptableValues: []string{"api123"}},
+				{FieldPath: "id", AcceptableValues: []string{domainName}},
+			},
+			loadDomains:       true,
+			appendDomain:      true,
+			loadAssociation:   true,
+			appendAssociation: true,
 		},
 		{
 			name: "typed API child filter skips domain scan",

--- a/providers/aws/appsync_test.go
+++ b/providers/aws/appsync_test.go
@@ -1,0 +1,252 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package aws
+
+import (
+	"errors"
+	"testing"
+
+	appsynctypes "github.com/aws/aws-sdk-go-v2/service/appsync/types"
+	"github.com/chenrui333/terraformer/terraformutils"
+)
+
+func TestAppSyncResourceIDs(t *testing.T) {
+	tests := []struct {
+		name string
+		got  string
+		want string
+	}{
+		{name: "api key", got: appSyncAPIKeyResourceID("api123", "key123"), want: "api123:key123"},
+		{name: "data source", got: appSyncDataSourceResourceID("api123", "orders"), want: "api123-orders"},
+		{name: "function", got: appSyncFunctionResourceID("api123", "func123"), want: "api123-func123"},
+		{name: "resolver", got: appSyncResolverResourceID("api123", "Query", "getOrder"), want: "api123-Query-getOrder"},
+		{name: "source api association", got: appSyncSourceAPIAssociationResourceID("api123", "assoc123"), want: "api123,assoc123"},
+		{name: "type", got: appSyncTypeResourceID("api123", "SDL", "Order"), want: "api123:SDL:Order"},
+		{name: "resource name skips empty parts", got: appSyncResourceName("api123", "", "resolver", "Query"), want: "api123:resolver:Query"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.got != tt.want {
+				t.Fatalf("got %q, want %q", tt.got, tt.want)
+			}
+		})
+	}
+}
+
+func TestAppSyncResourceMissing(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{name: "nil", err: nil, want: false},
+		{name: "not found", err: &appsynctypes.NotFoundException{}, want: true},
+		{name: "wrapped not found", err: errors.Join(errors.New("wrapper"), &appsynctypes.NotFoundException{}), want: true},
+		{name: "generic", err: errors.New("boom"), want: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := appSyncResourceMissing(tt.err); got != tt.want {
+				t.Fatalf("appSyncResourceMissing(%v) = %t, want %t", tt.err, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestAppSyncFilterGatesGraphQLAPIAndChildDiscovery(t *testing.T) {
+	apiID := "api123"
+	otherAPIID := "api456"
+	api := newAppSyncGraphQLAPIResource(apiID, "orders")
+	otherAPI := newAppSyncGraphQLAPIResource(otherAPIID, "other")
+	apiKey := newAppSyncAPIKeyResource(apiID, "key123")
+	resolver := newAppSyncResolverResource(apiID, "Query", "getOrder")
+
+	tests := []struct {
+		name              string
+		filters           []terraformutils.ResourceFilter
+		appendAPI         bool
+		appendOtherAPI    bool
+		loadChildren      bool
+		loadOtherChildren bool
+		loadAPIKeys       bool
+		loadOtherAPIKeys  bool
+		appendAPIKey      bool
+		appendResolver    bool
+	}{
+		{
+			name:              "no filters imports APIs and children",
+			appendAPI:         true,
+			appendOtherAPI:    true,
+			loadChildren:      true,
+			loadOtherChildren: true,
+			loadAPIKeys:       true,
+			loadOtherAPIKeys:  true,
+			appendAPIKey:      true,
+			appendResolver:    true,
+		},
+		{
+			name: "typed API id filter limits APIs and children",
+			filters: []terraformutils.ResourceFilter{
+				{ServiceName: appSyncGraphQLAPIResourceType, FieldPath: "id", AcceptableValues: []string{apiID}},
+			},
+			appendAPI:      true,
+			loadChildren:   true,
+			loadAPIKeys:    true,
+			appendAPIKey:   true,
+			appendResolver: true,
+		},
+		{
+			name: "typed child id filter does not import parent APIs",
+			filters: []terraformutils.ResourceFilter{
+				{ServiceName: appSyncAPIKeyResourceType, FieldPath: "id", AcceptableValues: []string{appSyncAPIKeyResourceID(apiID, "key123")}},
+			},
+			loadChildren: true,
+			loadAPIKeys:  true,
+			appendAPIKey: true,
+		},
+		{
+			name: "typed parent and child id filters load matching child outside parent filter",
+			filters: []terraformutils.ResourceFilter{
+				{ServiceName: appSyncGraphQLAPIResourceType, FieldPath: "id", AcceptableValues: []string{otherAPIID}},
+				{ServiceName: appSyncAPIKeyResourceType, FieldPath: "id", AcceptableValues: []string{appSyncAPIKeyResourceID(apiID, "key123")}},
+			},
+			appendOtherAPI: true,
+			loadChildren:   true,
+			loadAPIKeys:    true,
+			appendAPIKey:   true,
+		},
+		{
+			name: "global id filter constrains typed child discovery",
+			filters: []terraformutils.ResourceFilter{
+				{FieldPath: "id", AcceptableValues: []string{otherAPIID}},
+				{ServiceName: appSyncAPIKeyResourceType, FieldPath: "id", AcceptableValues: []string{appSyncAPIKeyResourceID(apiID, "key123")}},
+			},
+			appendOtherAPI: true,
+		},
+		{
+			name: "untyped child id filter reaches matching child without parent API",
+			filters: []terraformutils.ResourceFilter{
+				{FieldPath: "id", AcceptableValues: []string{appSyncAPIKeyResourceID(apiID, "key123")}},
+			},
+			loadChildren: true,
+			loadAPIKeys:  true,
+			appendAPIKey: true,
+		},
+		{
+			name: "typed non-id API filter does not pre-load children",
+			filters: []terraformutils.ResourceFilter{
+				{ServiceName: appSyncGraphQLAPIResourceType, FieldPath: "tags.env", AcceptableValues: []string{"prod"}},
+			},
+			appendAPI:      true,
+			appendOtherAPI: true,
+			appendAPIKey:   true,
+			appendResolver: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := AppSyncGenerator{}
+			g.Filter = tt.filters
+			if got := g.shouldAppendGraphQLAPIResource(api); got != tt.appendAPI {
+				t.Fatalf("shouldAppendGraphQLAPIResource(api) = %t, want %t", got, tt.appendAPI)
+			}
+			if got := g.shouldAppendGraphQLAPIResource(otherAPI); got != tt.appendOtherAPI {
+				t.Fatalf("shouldAppendGraphQLAPIResource(otherAPI) = %t, want %t", got, tt.appendOtherAPI)
+			}
+			if got := g.shouldLoadGraphQLAPIChildren(api); got != tt.loadChildren {
+				t.Fatalf("shouldLoadGraphQLAPIChildren(api) = %t, want %t", got, tt.loadChildren)
+			}
+			if got := g.shouldLoadGraphQLAPIChildren(otherAPI); got != tt.loadOtherChildren {
+				t.Fatalf("shouldLoadGraphQLAPIChildren(otherAPI) = %t, want %t", got, tt.loadOtherChildren)
+			}
+			if got := g.shouldLoadAPIChildResourceType(appSyncAPIKeyResourceType, apiID); got != tt.loadAPIKeys {
+				t.Fatalf("shouldLoadAPIChildResourceType(api key, api) = %t, want %t", got, tt.loadAPIKeys)
+			}
+			if got := g.shouldLoadAPIChildResourceType(appSyncAPIKeyResourceType, otherAPIID); got != tt.loadOtherAPIKeys {
+				t.Fatalf("shouldLoadAPIChildResourceType(api key, other api) = %t, want %t", got, tt.loadOtherAPIKeys)
+			}
+			if got := g.shouldAppendAppSyncChildResource(appSyncAPIKeyResourceType, apiKey); got != tt.appendAPIKey {
+				t.Fatalf("shouldAppendAppSyncChildResource(api key) = %t, want %t", got, tt.appendAPIKey)
+			}
+			if got := g.shouldAppendAppSyncChildResource(appSyncResolverResourceType, resolver); got != tt.appendResolver {
+				t.Fatalf("shouldAppendAppSyncChildResource(resolver) = %t, want %t", got, tt.appendResolver)
+			}
+		})
+	}
+}
+
+func TestAppSyncFilterGatesDomainNamesAndAssociations(t *testing.T) {
+	domainName := "api.example.com"
+	otherDomainName := "other.example.com"
+	domain := newAppSyncDomainNameResource(domainName)
+	otherDomain := newAppSyncDomainNameResource(otherDomainName)
+	association := newAppSyncDomainNameAPIAssociationResource(domainName, "api123")
+
+	tests := []struct {
+		name              string
+		filters           []terraformutils.ResourceFilter
+		loadDomains       bool
+		appendDomain      bool
+		appendOther       bool
+		loadAssociation   bool
+		appendAssociation bool
+	}{
+		{
+			name:              "no filters imports domain names and associations",
+			loadDomains:       true,
+			appendDomain:      true,
+			appendOther:       true,
+			loadAssociation:   true,
+			appendAssociation: true,
+		},
+		{
+			name: "typed API child filter skips domain scan",
+			filters: []terraformutils.ResourceFilter{
+				{ServiceName: appSyncAPIKeyResourceType, FieldPath: "id", AcceptableValues: []string{"api123:key123"}},
+			},
+		},
+		{
+			name: "typed association filter skips parent domain resource",
+			filters: []terraformutils.ResourceFilter{
+				{ServiceName: appSyncDomainNameAPIAssociationResourceType, FieldPath: "id", AcceptableValues: []string{domainName}},
+			},
+			loadDomains:       true,
+			loadAssociation:   true,
+			appendAssociation: true,
+		},
+		{
+			name: "global id filter constrains typed association",
+			filters: []terraformutils.ResourceFilter{
+				{FieldPath: "id", AcceptableValues: []string{otherDomainName}},
+				{ServiceName: appSyncDomainNameAPIAssociationResourceType, FieldPath: "id", AcceptableValues: []string{domainName}},
+			},
+			loadDomains: true,
+			appendOther: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := AppSyncGenerator{}
+			g.Filter = tt.filters
+			if got := g.shouldLoadDomainNames(); got != tt.loadDomains {
+				t.Fatalf("shouldLoadDomainNames() = %t, want %t", got, tt.loadDomains)
+			}
+			if got := g.shouldAppendDomainNameResource(domain); got != tt.appendDomain {
+				t.Fatalf("shouldAppendDomainNameResource(domain) = %t, want %t", got, tt.appendDomain)
+			}
+			if got := g.shouldAppendDomainNameResource(otherDomain); got != tt.appendOther {
+				t.Fatalf("shouldAppendDomainNameResource(otherDomain) = %t, want %t", got, tt.appendOther)
+			}
+			if got := g.shouldLoadDomainNameAPIAssociation(domainName); got != tt.loadAssociation {
+				t.Fatalf("shouldLoadDomainNameAPIAssociation() = %t, want %t", got, tt.loadAssociation)
+			}
+			if got := g.shouldAppendAppSyncChildResource(appSyncDomainNameAPIAssociationResourceType, association); got != tt.appendAssociation {
+				t.Fatalf("shouldAppendAppSyncChildResource(association) = %t, want %t", got, tt.appendAssociation)
+			}
+		})
+	}
+}

--- a/providers/aws/appsync_test.go
+++ b/providers/aws/appsync_test.go
@@ -35,6 +35,19 @@ func TestAppSyncResourceIDs(t *testing.T) {
 	}
 }
 
+func TestAppSyncSourceAPIAssociationIgnoresARNIdentifiers(t *testing.T) {
+	resource := newAppSyncSourceAPIAssociationResource("api123", "assoc123")
+	want := []string{"^merged_api_arn$", "^source_api_arn$"}
+	if len(resource.IgnoreKeys) != len(want) {
+		t.Fatalf("IgnoreKeys = %v, want %v", resource.IgnoreKeys, want)
+	}
+	for i, key := range want {
+		if resource.IgnoreKeys[i] != key {
+			t.Fatalf("IgnoreKeys[%d] = %q, want %q", i, resource.IgnoreKeys[i], key)
+		}
+	}
+}
+
 func TestAppSyncResourceMissing(t *testing.T) {
 	tests := []struct {
 		name string
@@ -278,6 +291,18 @@ func TestAppSyncFilterGatesDomainNamesAndAssociations(t *testing.T) {
 			loadDomains:       true,
 			requireDomains:    true,
 			appendDomain:      true,
+			loadAssociation:   true,
+			appendAssociation: true,
+		},
+		{
+			name: "typed association id filter can load outside parent domain filter",
+			filters: []terraformutils.ResourceFilter{
+				{ServiceName: appSyncDomainNameResourceType, FieldPath: "id", AcceptableValues: []string{otherDomainName}},
+				{ServiceName: appSyncDomainNameAPIAssociationResourceType, FieldPath: "id", AcceptableValues: []string{domainName}},
+			},
+			loadDomains:       true,
+			requireDomains:    true,
+			appendOther:       true,
 			loadAssociation:   true,
 			appendAssociation: true,
 		},

--- a/providers/aws/appsync_test.go
+++ b/providers/aws/appsync_test.go
@@ -124,6 +124,18 @@ func TestAppSyncFilterGatesGraphQLAPIAndChildDiscovery(t *testing.T) {
 			appendAPIKey:   true,
 		},
 		{
+			name: "typed parent id filter scopes typed child non-id discovery",
+			filters: []terraformutils.ResourceFilter{
+				{ServiceName: appSyncGraphQLAPIResourceType, FieldPath: "id", AcceptableValues: []string{apiID}},
+				{ServiceName: appSyncAPIKeyResourceType, FieldPath: "description", AcceptableValues: []string{"orders"}},
+			},
+			loadAPIs:     true,
+			appendAPI:    true,
+			loadChildren: true,
+			loadAPIKeys:  true,
+			appendAPIKey: true,
+		},
+		{
 			name: "typed domain id filter skips APIs and API children",
 			filters: []terraformutils.ResourceFilter{
 				{ServiceName: appSyncDomainNameResourceType, FieldPath: "id", AcceptableValues: []string{"api.example.com"}},
@@ -204,21 +216,24 @@ func TestAppSyncFilterGatesDomainNamesAndAssociations(t *testing.T) {
 	association := newAppSyncDomainNameAPIAssociationResource(domainName, "api123")
 
 	tests := []struct {
-		name              string
-		filters           []terraformutils.ResourceFilter
-		loadDomains       bool
-		appendDomain      bool
-		appendOther       bool
-		loadAssociation   bool
-		appendAssociation bool
+		name                 string
+		filters              []terraformutils.ResourceFilter
+		loadDomains          bool
+		requireDomains       bool
+		appendDomain         bool
+		appendOther          bool
+		loadAssociation      bool
+		loadOtherAssociation bool
+		appendAssociation    bool
 	}{
 		{
-			name:              "no filters imports domain names and associations",
-			loadDomains:       true,
-			appendDomain:      true,
-			appendOther:       true,
-			loadAssociation:   true,
-			appendAssociation: true,
+			name:                 "no filters imports domain names and associations",
+			loadDomains:          true,
+			appendDomain:         true,
+			appendOther:          true,
+			loadAssociation:      true,
+			loadOtherAssociation: true,
+			appendAssociation:    true,
 		},
 		{
 			name: "typed GraphQL API filter skips domain scan",
@@ -249,6 +264,19 @@ func TestAppSyncFilterGatesDomainNamesAndAssociations(t *testing.T) {
 				{ServiceName: appSyncDomainNameResourceType, FieldPath: "id", AcceptableValues: []string{domainName}},
 			},
 			loadDomains:       true,
+			requireDomains:    true,
+			appendDomain:      true,
+			loadAssociation:   true,
+			appendAssociation: true,
+		},
+		{
+			name: "typed domain id filter scopes typed association non-id discovery",
+			filters: []terraformutils.ResourceFilter{
+				{ServiceName: appSyncDomainNameResourceType, FieldPath: "id", AcceptableValues: []string{domainName}},
+				{ServiceName: appSyncDomainNameAPIAssociationResourceType, FieldPath: "api_id", AcceptableValues: []string{"api123"}},
+			},
+			loadDomains:       true,
+			requireDomains:    true,
 			appendDomain:      true,
 			loadAssociation:   true,
 			appendAssociation: true,
@@ -259,6 +287,7 @@ func TestAppSyncFilterGatesDomainNamesAndAssociations(t *testing.T) {
 				{ServiceName: appSyncDomainNameResourceType, FieldPath: "tags.env", AcceptableValues: []string{"prod"}},
 			},
 			loadDomains:       true,
+			requireDomains:    true,
 			appendDomain:      true,
 			appendOther:       true,
 			appendAssociation: true,
@@ -269,6 +298,7 @@ func TestAppSyncFilterGatesDomainNamesAndAssociations(t *testing.T) {
 				{ServiceName: appSyncDomainNameAPIAssociationResourceType, FieldPath: "id", AcceptableValues: []string{domainName}},
 			},
 			loadDomains:       true,
+			requireDomains:    true,
 			loadAssociation:   true,
 			appendAssociation: true,
 		},
@@ -278,8 +308,9 @@ func TestAppSyncFilterGatesDomainNamesAndAssociations(t *testing.T) {
 				{FieldPath: "id", AcceptableValues: []string{otherDomainName}},
 				{ServiceName: appSyncDomainNameAPIAssociationResourceType, FieldPath: "id", AcceptableValues: []string{domainName}},
 			},
-			loadDomains: true,
-			appendOther: true,
+			loadDomains:    true,
+			requireDomains: true,
+			appendOther:    true,
 		},
 	}
 
@@ -290,6 +321,9 @@ func TestAppSyncFilterGatesDomainNamesAndAssociations(t *testing.T) {
 			if got := g.shouldLoadDomainNames(); got != tt.loadDomains {
 				t.Fatalf("shouldLoadDomainNames() = %t, want %t", got, tt.loadDomains)
 			}
+			if got := g.shouldRequireDomainNameLoad(); got != tt.requireDomains {
+				t.Fatalf("shouldRequireDomainNameLoad() = %t, want %t", got, tt.requireDomains)
+			}
 			if got := g.shouldAppendDomainNameResource(domain); got != tt.appendDomain {
 				t.Fatalf("shouldAppendDomainNameResource(domain) = %t, want %t", got, tt.appendDomain)
 			}
@@ -298,6 +332,9 @@ func TestAppSyncFilterGatesDomainNamesAndAssociations(t *testing.T) {
 			}
 			if got := g.shouldLoadDomainNameAPIAssociation(domainName); got != tt.loadAssociation {
 				t.Fatalf("shouldLoadDomainNameAPIAssociation() = %t, want %t", got, tt.loadAssociation)
+			}
+			if got := g.shouldLoadDomainNameAPIAssociation(otherDomainName); got != tt.loadOtherAssociation {
+				t.Fatalf("shouldLoadDomainNameAPIAssociation(other) = %t, want %t", got, tt.loadOtherAssociation)
 			}
 			if got := g.shouldAppendAppSyncChildResource(appSyncDomainNameAPIAssociationResourceType, association); got != tt.appendAssociation {
 				t.Fatalf("shouldAppendAppSyncChildResource(association) = %t, want %t", got, tt.appendAssociation)

--- a/providers/aws/appsync_test.go
+++ b/providers/aws/appsync_test.go
@@ -21,7 +21,8 @@ func TestAppSyncResourceIDs(t *testing.T) {
 		{name: "function", got: appSyncFunctionResourceID("api123", "func123"), want: "api123-func123"},
 		{name: "resolver", got: appSyncResolverResourceID("api123", "Query", "getOrder"), want: "api123-Query-getOrder"},
 		{name: "source api association", got: appSyncSourceAPIAssociationResourceID("api123", "assoc123"), want: "api123,assoc123"},
-		{name: "type", got: appSyncTypeResourceID("api123", "SDL", "Order"), want: "api123:SDL:Order"},
+		{name: "SDL type", got: appSyncTypeResourceID("api123", "SDL", "Order"), want: "api123:SDL:Order"},
+		{name: "JSON type", got: appSyncTypeResourceID("api123", "JSON", "Order"), want: "api123:JSON:Order"},
 		{name: "resource name skips empty parts", got: appSyncResourceName("api123", "", "resolver", "Query"), want: "api123:resolver:Query"},
 	}
 
@@ -118,6 +119,12 @@ func TestAppSyncFilterGatesGraphQLAPIAndChildDiscovery(t *testing.T) {
 			appendAPIKey:   true,
 		},
 		{
+			name: "typed domain id filter skips APIs and API children",
+			filters: []terraformutils.ResourceFilter{
+				{ServiceName: appSyncDomainNameResourceType, FieldPath: "id", AcceptableValues: []string{"api.example.com"}},
+			},
+		},
+		{
 			name: "global id filter constrains typed child discovery",
 			filters: []terraformutils.ResourceFilter{
 				{FieldPath: "id", AcceptableValues: []string{otherAPIID}},
@@ -203,10 +210,36 @@ func TestAppSyncFilterGatesDomainNamesAndAssociations(t *testing.T) {
 			appendAssociation: true,
 		},
 		{
+			name: "typed GraphQL API filter skips domain scan",
+			filters: []terraformutils.ResourceFilter{
+				{ServiceName: appSyncGraphQLAPIResourceType, FieldPath: "id", AcceptableValues: []string{"api123"}},
+			},
+		},
+		{
 			name: "typed API child filter skips domain scan",
 			filters: []terraformutils.ResourceFilter{
 				{ServiceName: appSyncAPIKeyResourceType, FieldPath: "id", AcceptableValues: []string{"api123:key123"}},
 			},
+		},
+		{
+			name: "typed domain id filter loads matching domain and association",
+			filters: []terraformutils.ResourceFilter{
+				{ServiceName: appSyncDomainNameResourceType, FieldPath: "id", AcceptableValues: []string{domainName}},
+			},
+			loadDomains:       true,
+			appendDomain:      true,
+			loadAssociation:   true,
+			appendAssociation: true,
+		},
+		{
+			name: "typed domain non-id filter avoids association pre-load",
+			filters: []terraformutils.ResourceFilter{
+				{ServiceName: appSyncDomainNameResourceType, FieldPath: "tags.env", AcceptableValues: []string{"prod"}},
+			},
+			loadDomains:       true,
+			appendDomain:      true,
+			appendOther:       true,
+			appendAssociation: true,
 		},
 		{
 			name: "typed association filter skips parent domain resource",


### PR DESCRIPTION
Summary:
- add AppSync discovery for API caches, API keys, data sources, functions, resolvers, types, domain names, domain API associations, and source API associations
- make AppSync child discovery best-effort and filter-aware so targeted imports do not leak parent or sibling resources
- update AWS docs and add focused helper tests for import IDs, missing-resource handling, and filter gating

Notes:
- source API associations use the AWS provider import ID shape `merged_api_id,association_id`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Expand AWS AppSync discovery to include caches, keys, data sources, functions, resolvers, types, domain names, and associations. Tighten filter gating so targeted imports don’t pull unrelated APIs or domain resources, and dedupe types across formats.

- **New Features**
  - Discover `aws_appsync_api_cache`, `aws_appsync_api_key`, `aws_appsync_datasource`, `aws_appsync_function`, `aws_appsync_resolver`, `aws_appsync_type`, `aws_appsync_domain_name`, `aws_appsync_domain_name_api_association`, `aws_appsync_graphql_api`, and `aws_appsync_source_api_association`.
  - Respect typed and global ID filters when loading children; targeted imports no longer pull extra resources.
  - Support `aws` provider import ID `merged_api_id,association_id` for `aws_appsync_source_api_association`. Updated `docs/aws.md`. Added tests for import IDs, NotFound handling, and filter gating.

- **Bug Fixes**
  - Scoped top‑level scans for GraphQL APIs and domain names; only run when typed filters match those resources or their children.
  - Enforced stricter typed/untyped filter rules for APIs and children and skipped child pre-loading when non‑ID filters are used.
  - Refined domain and association gating so domain scans and API associations load only when filters or IDs can match.
  - Deduplicated `aws_appsync_type` resources across SDL/JSON scans.
  - Ignored read-only `merged_api_arn` and `source_api_arn` in `aws_appsync_source_api_association` to avoid noisy diffs.

<sup>Written for commit 0be19c72abdf144e4c978089b33663a1b7f91f50. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Expanded AWS AppSync discovery and import: caches, API keys, data sources, functions, resolvers, types and source associations, plus domain names and domain–API associations; improved pagination, optional child loading, and more deterministic resource IDs.

* **Documentation**
  * Updated AWS AppSync docs to list all newly supported resource types.

* **Tests**
  * Added unit tests for ID/name construction, missing-resource handling, and filter-driven discovery behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->