### PR TITLE
fix(logzio): return client setup errors

### DIFF
--- a/providers/logzio/alert_notification_endpoints.go
+++ b/providers/logzio/alert_notification_endpoints.go
@@ -16,8 +16,10 @@ type AlertNotificationEndpointsGenerator struct {
 
 // Generate Terraform Resources from Logzio API,
 func (g *AlertNotificationEndpointsGenerator) InitResources() error {
-	var client *endpoints.EndpointsClient
-	client, _ = endpoints.New(g.Args["api_token"].(string), g.Args["base_url"].(string))
+	client, err := endpoints.New(g.Args["api_token"].(string), g.Args["base_url"].(string))
+	if err != nil {
+		return err
+	}
 
 	endpoints, err := client.ListEndpoints()
 	if err != nil {

--- a/providers/logzio/alerts.go
+++ b/providers/logzio/alerts.go
@@ -16,8 +16,10 @@ type AlertsGenerator struct {
 
 // Generate Terraform Resources from Logzio API,
 func (g *AlertsGenerator) InitResources() error {
-	var client *alerts.AlertsV2Client
-	client, _ = alerts.New(g.Args["api_token"].(string), g.Args["base_url"].(string))
+	client, err := alerts.New(g.Args["api_token"].(string), g.Args["base_url"].(string))
+	if err != nil {
+		return err
+	}
 
 	alerts, err := client.ListAlerts()
 	if err != nil {

--- a/providers/logzio/logzio_provider.go
+++ b/providers/logzio/logzio_provider.go
@@ -40,6 +40,9 @@ func (p *LogzioProvider) GetConfig() cty.Value {
 
 // Init LogzioProvider with API apiToken
 func (p *LogzioProvider) Init(args []string) error {
+	if len(args) < 2 {
+		return errors.New("logzio: api token and base URL are required")
+	}
 	p.apiToken = args[0]
 	p.baseURL = args[1]
 	return nil

--- a/providers/logzio/logzio_provider_test.go
+++ b/providers/logzio/logzio_provider_test.go
@@ -1,0 +1,62 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package logzio
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestLogzioProviderInitRequiresArgs(t *testing.T) {
+	var provider LogzioProvider
+
+	if err := provider.Init([]string{"token"}); err == nil {
+		t.Fatal("expected missing base URL error")
+	}
+}
+
+func TestLogzioProviderInitStoresArgs(t *testing.T) {
+	var provider LogzioProvider
+
+	if err := provider.Init([]string{"token", "https://api.logz.io"}); err != nil {
+		t.Fatalf("expected Init to succeed: %v", err)
+	}
+	if provider.apiToken != "token" {
+		t.Fatalf("apiToken = %q, want token", provider.apiToken)
+	}
+	if provider.baseURL != "https://api.logz.io" {
+		t.Fatalf("baseURL = %q, want https://api.logz.io", provider.baseURL)
+	}
+}
+
+func TestAlertsGeneratorReturnsClientError(t *testing.T) {
+	generator := &AlertsGenerator{}
+	generator.SetArgs(map[string]interface{}{
+		"api_token": "",
+		"base_url":  "https://api.logz.io",
+	})
+
+	err := generator.InitResources()
+	if err == nil {
+		t.Fatal("expected client setup error")
+	}
+	if !strings.Contains(err.Error(), "API token not defined") {
+		t.Fatalf("expected API token error, got %q", err)
+	}
+}
+
+func TestAlertNotificationEndpointsGeneratorReturnsClientError(t *testing.T) {
+	generator := &AlertNotificationEndpointsGenerator{}
+	generator.SetArgs(map[string]interface{}{
+		"api_token": "token",
+		"base_url":  "",
+	})
+
+	err := generator.InitResources()
+	if err == nil {
+		t.Fatal("expected client setup error")
+	}
+	if !strings.Contains(err.Error(), "Base URL not defined") {
+		t.Fatalf("expected base URL error, got %q", err)
+	}
+}


### PR DESCRIPTION
## Summary

- Return Logz.io alerts and endpoint client setup errors instead of ignoring them.
- Validate Logz.io provider initialization args before indexing them.
- Add focused coverage for missing args and constructor error propagation.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes silent failures when initializing Logz.io clients by surfacing setup errors and validating provider args. Adds tests to ensure errors are returned for missing token or base URL.

- **Bug Fixes**
  - Return errors from `alerts.New` and `endpoints.New` during client setup.
  - Validate `LogzioProvider.Init` requires both API token and base URL.
  - Add focused tests for missing args and constructor error propagation.

<sup>Written for commit 12ab2d8191e31a6b1ab69962550890a281417c57. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

