### PR TITLE
fix(keycloak): validate provider init args

### DIFF
--- a/providers/keycloak/keycloak_provider.go
+++ b/providers/keycloak/keycloak_provider.go
@@ -4,11 +4,14 @@ package keycloak
 
 import (
 	"errors"
+	"fmt"
 	"strconv"
 
 	"github.com/chenrui333/terraformer/terraformutils"
 	"github.com/zclconf/go-cty/cty"
 )
+
+const keycloakInitArgCount = 10
 
 type KeycloakProvider struct { //nolint
 	terraformutils.Provider
@@ -32,15 +35,32 @@ func getArg(arg string) string {
 }
 
 func (p *KeycloakProvider) Init(args []string) error {
+	if len(args) < keycloakInitArgCount {
+		return fmt.Errorf("keycloak: expected %d init args, got %d", keycloakInitArgCount, len(args))
+	}
+
+	clientTimeout, err := strconv.Atoi(args[5])
+	if err != nil {
+		return fmt.Errorf("keycloak: invalid client timeout %q: %w", args[5], err)
+	}
+	tlsInsecureSkipVerify, err := strconv.ParseBool(args[7])
+	if err != nil {
+		return fmt.Errorf("keycloak: invalid tls insecure skip verify %q: %w", args[7], err)
+	}
+	redHatSSO, err := strconv.ParseBool(args[8])
+	if err != nil {
+		return fmt.Errorf("keycloak: invalid red hat sso %q: %w", args[8], err)
+	}
+
 	p.url = args[0]
 	p.basePath = args[1]
 	p.clientID = args[2]
 	p.clientSecret = args[3]
 	p.realm = args[4]
-	p.clientTimeout, _ = strconv.Atoi(args[5])
+	p.clientTimeout = clientTimeout
 	p.caCert = getArg(args[6])
-	p.tlsInsecureSkipVerify, _ = strconv.ParseBool(args[7])
-	p.redHatSSO, _ = strconv.ParseBool(args[8])
+	p.tlsInsecureSkipVerify = tlsInsecureSkipVerify
+	p.redHatSSO = redHatSSO
 	p.target = getArg(args[9])
 	return nil
 }

--- a/providers/keycloak/keycloak_provider_test.go
+++ b/providers/keycloak/keycloak_provider_test.go
@@ -1,0 +1,103 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package keycloak
+
+import (
+	"strings"
+	"testing"
+)
+
+func validKeycloakInitArgs() []string {
+	return []string{
+		"https://keycloak.example.com",
+		"/auth",
+		"terraformer",
+		"secret",
+		"master",
+		"30",
+		"-",
+		"true",
+		"false",
+		"-",
+	}
+}
+
+func TestKeycloakProviderInitRequiresArgs(t *testing.T) {
+	var provider KeycloakProvider
+
+	err := provider.Init(validKeycloakInitArgs()[:9])
+	if err == nil {
+		t.Fatal("expected missing args error")
+	}
+	if !strings.Contains(err.Error(), "expected 10 init args") {
+		t.Fatalf("expected init arg count error, got %q", err)
+	}
+}
+
+func TestKeycloakProviderInitReturnsClientTimeoutError(t *testing.T) {
+	var provider KeycloakProvider
+	args := validKeycloakInitArgs()
+	args[5] = "slow"
+
+	err := provider.Init(args)
+	if err == nil {
+		t.Fatal("expected client timeout parse error")
+	}
+	if !strings.Contains(err.Error(), "invalid client timeout") {
+		t.Fatalf("expected client timeout error, got %q", err)
+	}
+}
+
+func TestKeycloakProviderInitReturnsTLSBoolError(t *testing.T) {
+	var provider KeycloakProvider
+	args := validKeycloakInitArgs()
+	args[7] = "sometimes"
+
+	err := provider.Init(args)
+	if err == nil {
+		t.Fatal("expected TLS bool parse error")
+	}
+	if !strings.Contains(err.Error(), "invalid tls insecure skip verify") {
+		t.Fatalf("expected TLS bool error, got %q", err)
+	}
+}
+
+func TestKeycloakProviderInitReturnsRedHatSSOBoolError(t *testing.T) {
+	var provider KeycloakProvider
+	args := validKeycloakInitArgs()
+	args[8] = "maybe"
+
+	err := provider.Init(args)
+	if err == nil {
+		t.Fatal("expected Red Hat SSO bool parse error")
+	}
+	if !strings.Contains(err.Error(), "invalid red hat sso") {
+		t.Fatalf("expected Red Hat SSO bool error, got %q", err)
+	}
+}
+
+func TestKeycloakProviderInitStoresArgs(t *testing.T) {
+	var provider KeycloakProvider
+
+	if err := provider.Init(validKeycloakInitArgs()); err != nil {
+		t.Fatalf("expected Init to succeed: %v", err)
+	}
+	if provider.url != "https://keycloak.example.com" {
+		t.Fatalf("url = %q, want https://keycloak.example.com", provider.url)
+	}
+	if provider.clientTimeout != 30 {
+		t.Fatalf("clientTimeout = %d, want 30", provider.clientTimeout)
+	}
+	if provider.caCert != "" {
+		t.Fatalf("caCert = %q, want empty", provider.caCert)
+	}
+	if !provider.tlsInsecureSkipVerify {
+		t.Fatal("tlsInsecureSkipVerify = false, want true")
+	}
+	if provider.redHatSSO {
+		t.Fatal("redHatSSO = true, want false")
+	}
+	if provider.target != "" {
+		t.Fatalf("target = %q, want empty", provider.target)
+	}
+}


### PR DESCRIPTION
## Summary

- Validate Keycloak provider init arg count before indexing positional args.
- Return client timeout and boolean parse errors instead of silently using zero values.
- Add focused provider init coverage for short args, parse failures, and normal CLI args.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Validate init args for the `keycloak` provider to prevent panics and surface invalid input. Errors are now returned for missing args and bad client timeout or boolean flags.

- **Bug Fixes**
  - Require exactly 10 init args before indexing.
  - Parse and validate client timeout and TLS/Red Hat SSO booleans; return specific errors instead of using zero values.
  - Added tests for missing args, parse failures, and the normal path.

<sup>Written for commit 9b11ca3a105de9bb9d828faed361595a6dde7b73. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Keycloak provider now validates initialization arguments and returns clear error messages for missing or invalid configuration values (timeout, TLS settings, SSO settings) instead of silently ignoring conversion errors.

* **Tests**
  * Added comprehensive test coverage for Keycloak provider initialization, including validation of required arguments and error handling for invalid configuration values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->