### PR TITLE
feat(datadog): add spans metric import

### DIFF
--- a/docs/datadog.md
+++ b/docs/datadog.md
@@ -166,6 +166,8 @@ Tag filters are order specific. For example, if your monitor has tags (in the or
     * `datadog_service_level_objective`
 *   `slo_correction`
     * `datadog_slo_correction`
+*   `spans_metric`
+    * `datadog_spans_metric`
 *   `synthetics_global_variable`
     * `datadog_synthetics_global_variable`
         * **_NOTE:_** Importing resource requires resource ID's to be passed via [Filter][1] option

--- a/providers/datadog/datadog_provider.go
+++ b/providers/datadog/datadog_provider.go
@@ -183,6 +183,7 @@ func (p *DatadogProvider) GetSupportedService() map[string]terraformutils.Servic
 		"sensitive_data_scanner_rule":          &SensitiveDataScannerRuleGenerator{},
 		"service_level_objective":              &ServiceLevelObjectiveGenerator{},
 		"slo_correction":                       &SLOCorrectionGenerator{},
+		"spans_metric":                         &SpansMetricGenerator{},
 		"synthetics_test":                      &SyntheticsTestGenerator{},
 		"synthetics_global_variable":           &SyntheticsGlobalVariableGenerator{},
 		"synthetics_private_location":          &SyntheticsPrivateLocationGenerator{},

--- a/providers/datadog/spans_metric.go
+++ b/providers/datadog/spans_metric.go
@@ -1,0 +1,86 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package datadog
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/DataDog/datadog-api-client-go/v2/api/datadog"
+	"github.com/DataDog/datadog-api-client-go/v2/api/datadogV2"
+
+	"github.com/chenrui333/terraformer/terraformutils"
+)
+
+var (
+	// SpansMetricAllowEmptyValues ...
+	SpansMetricAllowEmptyValues = []string{}
+)
+
+// SpansMetricGenerator ...
+type SpansMetricGenerator struct {
+	DatadogService
+}
+
+func (g *SpansMetricGenerator) createResources(spansMetrics []datadogV2.SpansMetricResponseData) []terraformutils.Resource {
+	resources := []terraformutils.Resource{}
+	for _, spansMetric := range spansMetrics {
+		resourceName := spansMetric.GetId()
+		resources = append(resources, g.createResource(resourceName))
+	}
+
+	return resources
+}
+
+func (g *SpansMetricGenerator) createResource(spansMetricName string) terraformutils.Resource {
+	return terraformutils.NewSimpleResource(
+		spansMetricName,
+		fmt.Sprintf("spans_metric_%s", spansMetricName),
+		"datadog_spans_metric",
+		"datadog",
+		SpansMetricAllowEmptyValues,
+	)
+}
+
+// InitResources Generate TerraformResources from Datadog API,
+// from each span-based metric create 1 TerraformResource.
+// Need SpansMetric Name as ID for terraform resource.
+func (g *SpansMetricGenerator) InitResources() error {
+	datadogClient := g.Args["datadogClient"].(*datadog.APIClient)
+	auth := g.Args["auth"].(context.Context)
+	api := datadogV2.NewSpansMetricsApi(datadogClient)
+
+	resources := []terraformutils.Resource{}
+	hasIDFilter := false
+	for _, filter := range g.Filter {
+		if filter.FieldPath == "id" && filter.IsApplicable("spans_metric") {
+			hasIDFilter = true
+			for _, value := range filter.AcceptableValues {
+				spansMetric, httpResp, err := api.GetSpansMetric(auth, value)
+				if httpResp != nil && httpResp.Body != nil {
+					_ = httpResp.Body.Close()
+				}
+				if err != nil {
+					return err
+				}
+
+				resources = append(resources, g.createResource(spansMetric.Data.GetId()))
+			}
+		}
+	}
+
+	if hasIDFilter || len(resources) > 0 {
+		g.Resources = resources
+		return nil
+	}
+
+	spansMetrics, httpResp, err := api.ListSpansMetrics(auth)
+	if httpResp != nil && httpResp.Body != nil {
+		_ = httpResp.Body.Close()
+	}
+	if err != nil {
+		return err
+	}
+	g.Resources = g.createResources(spansMetrics.GetData())
+	return nil
+}

--- a/providers/datadog/spans_metric_test.go
+++ b/providers/datadog/spans_metric_test.go
@@ -1,0 +1,45 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package datadog
+
+import (
+	"testing"
+
+	"github.com/DataDog/datadog-api-client-go/v2/api/datadogV2"
+)
+
+func TestSpansMetricCreateResource(t *testing.T) {
+	generator := &SpansMetricGenerator{}
+	resource := generator.createResource("trace.duration")
+
+	if resource.InstanceState.ID != "trace.duration" {
+		t.Fatalf("expected resource ID trace.duration, got %s", resource.InstanceState.ID)
+	}
+	if resource.ResourceName != "tfer--spans_metric_trace-002E-duration" {
+		t.Fatalf("expected resource name tfer--spans_metric_trace-002E-duration, got %s", resource.ResourceName)
+	}
+	if resource.InstanceInfo.Type != "datadog_spans_metric" {
+		t.Fatalf("expected resource type datadog_spans_metric, got %s", resource.InstanceInfo.Type)
+	}
+}
+
+func TestSpansMetricCreateResources(t *testing.T) {
+	firstMetric := datadogV2.NewSpansMetricResponseDataWithDefaults()
+	firstMetric.SetId("trace.duration")
+
+	secondMetric := datadogV2.NewSpansMetricResponseDataWithDefaults()
+	secondMetric.SetId("trace.errors")
+
+	generator := &SpansMetricGenerator{}
+	resources := generator.createResources([]datadogV2.SpansMetricResponseData{*firstMetric, *secondMetric})
+
+	if len(resources) != 2 {
+		t.Fatalf("expected 2 resources, got %d", len(resources))
+	}
+	if resources[0].InstanceState.ID != "trace.duration" {
+		t.Fatalf("expected first resource ID trace.duration, got %s", resources[0].InstanceState.ID)
+	}
+	if resources[1].InstanceState.ID != "trace.errors" {
+		t.Fatalf("expected second resource ID trace.errors, got %s", resources[1].InstanceState.ID)
+	}
+}


### PR DESCRIPTION
Summary
- Add Datadog spans_metric import support using the V2 span-based metrics API.
- Support all-resource and ID-filtered imports for datadog_spans_metric.
- Document the new Datadog resource.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add import support for Datadog span-based metrics using the V2 Spans Metrics API. You can now import all metrics or specific IDs as `datadog_spans_metric`.

- **New Features**
  - Added `SpansMetricGenerator` wired into the provider map to handle `spans_metric` via `datadogV2` Spans Metrics API (list/get).
  - Supports all-resource and ID-filtered imports via `Filter`; docs updated to include `spans_metric`; unit tests added for resource creation.

<sup>Written for commit c62e8352d365064a3a7825acf4be82500ab304a3. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

