### PR TITLE
fix(providers): guard optional init args

### DIFF
--- a/providers/mackerel/mackerel_provider.go
+++ b/providers/mackerel/mackerel_provider.go
@@ -19,7 +19,7 @@ type MackerelProvider struct { //nolint
 
 // Init check env params and initialize API Client
 func (p *MackerelProvider) Init(args []string) error {
-	if args[0] != "" {
+	if len(args) > 0 && args[0] != "" {
 		p.apiKey = args[0]
 	} else {
 		if apiKey := os.Getenv("MACKEREL_API_KEY"); apiKey != "" {

--- a/providers/mackerel/mackerel_provider_test.go
+++ b/providers/mackerel/mackerel_provider_test.go
@@ -1,0 +1,48 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package mackerel
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestMackerelProviderInitReturnsMissingAPIKeyWithNoArgs(t *testing.T) {
+	t.Setenv("MACKEREL_API_KEY", "")
+	var provider MackerelProvider
+
+	err := provider.Init(nil)
+	if err == nil {
+		t.Fatal("expected missing API key error")
+	}
+	if !strings.Contains(err.Error(), "api-key requirement") {
+		t.Fatalf("expected missing API key error, got %q", err)
+	}
+}
+
+func TestMackerelProviderInitUsesEnvAPIKey(t *testing.T) {
+	t.Setenv("MACKEREL_API_KEY", "env-key")
+	var provider MackerelProvider
+
+	if err := provider.Init(nil); err != nil {
+		t.Fatalf("expected Init to succeed: %v", err)
+	}
+	if provider.apiKey != "env-key" {
+		t.Fatalf("apiKey = %q, want env-key", provider.apiKey)
+	}
+	if provider.mackerelClient == nil {
+		t.Fatal("expected mackerel client to be initialized")
+	}
+}
+
+func TestMackerelProviderInitPrefersArgAPIKey(t *testing.T) {
+	t.Setenv("MACKEREL_API_KEY", "env-key")
+	var provider MackerelProvider
+
+	if err := provider.Init([]string{"arg-key"}); err != nil {
+		t.Fatalf("expected Init to succeed: %v", err)
+	}
+	if provider.apiKey != "arg-key" {
+		t.Fatalf("apiKey = %q, want arg-key", provider.apiKey)
+	}
+}

--- a/providers/octopusdeploy/octopusdeploy_provider.go
+++ b/providers/octopusdeploy/octopusdeploy_provider.go
@@ -15,7 +15,7 @@ type OctopusDeployProvider struct { //nolint
 }
 
 func (p *OctopusDeployProvider) Init(args []string) error {
-	if args[0] != "" {
+	if len(args) > 0 && args[0] != "" {
 		p.address = args[0]
 	} else {
 		if address := os.Getenv("OCTOPUS_CLI_SERVER"); address != "" {
@@ -25,7 +25,7 @@ func (p *OctopusDeployProvider) Init(args []string) error {
 		}
 	}
 
-	if args[1] != "" {
+	if len(args) > 1 && args[1] != "" {
 		p.apiKey = args[1]
 	} else {
 		if apiKey := os.Getenv("OCTOPUS_CLI_API_KEY"); apiKey != "" {

--- a/providers/octopusdeploy/octopusdeploy_provider_test.go
+++ b/providers/octopusdeploy/octopusdeploy_provider_test.go
@@ -1,0 +1,70 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package octopusdeploy
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestOctopusDeployProviderInitReturnsMissingServerWithNoArgs(t *testing.T) {
+	t.Setenv("OCTOPUS_CLI_SERVER", "")
+	t.Setenv("OCTOPUS_CLI_API_KEY", "")
+	var provider OctopusDeployProvider
+
+	err := provider.Init(nil)
+	if err == nil {
+		t.Fatal("expected missing server error")
+	}
+	if !strings.Contains(err.Error(), "server requirement") {
+		t.Fatalf("expected server requirement error, got %q", err)
+	}
+}
+
+func TestOctopusDeployProviderInitUsesEnvCredentials(t *testing.T) {
+	t.Setenv("OCTOPUS_CLI_SERVER", "https://octopus.example.com")
+	t.Setenv("OCTOPUS_CLI_API_KEY", "env-key")
+	var provider OctopusDeployProvider
+
+	if err := provider.Init(nil); err != nil {
+		t.Fatalf("expected Init to succeed: %v", err)
+	}
+	if provider.address != "https://octopus.example.com" {
+		t.Fatalf("address = %q, want https://octopus.example.com", provider.address)
+	}
+	if provider.apiKey != "env-key" {
+		t.Fatalf("apiKey = %q, want env-key", provider.apiKey)
+	}
+}
+
+func TestOctopusDeployProviderInitPrefersArgs(t *testing.T) {
+	t.Setenv("OCTOPUS_CLI_SERVER", "https://octopus.example.com")
+	t.Setenv("OCTOPUS_CLI_API_KEY", "env-key")
+	var provider OctopusDeployProvider
+
+	if err := provider.Init([]string{"https://arg.example.com", "arg-key"}); err != nil {
+		t.Fatalf("expected Init to succeed: %v", err)
+	}
+	if provider.address != "https://arg.example.com" {
+		t.Fatalf("address = %q, want https://arg.example.com", provider.address)
+	}
+	if provider.apiKey != "arg-key" {
+		t.Fatalf("apiKey = %q, want arg-key", provider.apiKey)
+	}
+}
+
+func TestOctopusDeployProviderInitUsesEnvAPIKeyWithArgServer(t *testing.T) {
+	t.Setenv("OCTOPUS_CLI_SERVER", "")
+	t.Setenv("OCTOPUS_CLI_API_KEY", "env-key")
+	var provider OctopusDeployProvider
+
+	if err := provider.Init([]string{"https://arg.example.com"}); err != nil {
+		t.Fatalf("expected Init to succeed: %v", err)
+	}
+	if provider.address != "https://arg.example.com" {
+		t.Fatalf("address = %q, want https://arg.example.com", provider.address)
+	}
+	if provider.apiKey != "env-key" {
+		t.Fatalf("apiKey = %q, want env-key", provider.apiKey)
+	}
+}

--- a/providers/opsgenie/opsgenie_provider.go
+++ b/providers/opsgenie/opsgenie_provider.go
@@ -17,9 +17,9 @@ type OpsgenieProvider struct { //nolint
 
 func (p *OpsgenieProvider) Init(args []string) error {
 	if apiKey := os.Getenv("OPSGENIE_API_KEY"); apiKey != "" {
-		p.APIKey = os.Getenv("OPSGENIE_API_KEY")
+		p.APIKey = apiKey
 	}
-	if args[0] != "" {
+	if len(args) > 0 && args[0] != "" {
 		p.APIKey = args[0]
 	}
 	if p.APIKey == "" {

--- a/providers/opsgenie/opsgenie_provider_test.go
+++ b/providers/opsgenie/opsgenie_provider_test.go
@@ -1,0 +1,45 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package opsgenie
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestOpsgenieProviderInitReturnsMissingAPIKeyWithNoArgs(t *testing.T) {
+	t.Setenv("OPSGENIE_API_KEY", "")
+	var provider OpsgenieProvider
+
+	err := provider.Init(nil)
+	if err == nil {
+		t.Fatal("expected missing API key error")
+	}
+	if !strings.Contains(err.Error(), "required API Key missing") {
+		t.Fatalf("expected missing API key error, got %q", err)
+	}
+}
+
+func TestOpsgenieProviderInitUsesEnvAPIKey(t *testing.T) {
+	t.Setenv("OPSGENIE_API_KEY", "env-key")
+	var provider OpsgenieProvider
+
+	if err := provider.Init(nil); err != nil {
+		t.Fatalf("expected Init to succeed: %v", err)
+	}
+	if provider.APIKey != "env-key" {
+		t.Fatalf("APIKey = %q, want env-key", provider.APIKey)
+	}
+}
+
+func TestOpsgenieProviderInitPrefersArgAPIKey(t *testing.T) {
+	t.Setenv("OPSGENIE_API_KEY", "env-key")
+	var provider OpsgenieProvider
+
+	if err := provider.Init([]string{"arg-key"}); err != nil {
+		t.Fatalf("expected Init to succeed: %v", err)
+	}
+	if provider.APIKey != "arg-key" {
+		t.Fatalf("APIKey = %q, want arg-key", provider.APIKey)
+	}
+}


### PR DESCRIPTION
## Summary

- Guard optional provider init args for Opsgenie, Mackerel, and OctopusDeploy before indexing.
- Preserve env fallback behavior for missing CLI args.
- Add focused coverage for nil args, env fallback, and CLI arg overrides.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Guard optional CLI init args in `opsgenie`, `mackerel`, and `octopusdeploy` to prevent slice out-of-bounds when no args are passed. Keeps env var fallback and CLI arg precedence, with tests for nil args, env fallback, and overrides.

- **Bug Fixes**
  - `mackerel`: Check len before args[0]; tests for missing key, env key, CLI override.
  - `octopusdeploy`: Check len for address (args[0]) and API key (args[1]); tests for missing server, env creds, CLI precedence, mixed input.
  - `opsgenie`: Check len before args[0]; prefer CLI over env; tests for missing key, env key, CLI override.

<sup>Written for commit e9c4dfca4c6b811f68f9871142066af7f35ab5f9. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

