### PR TITLE
feat(datadog): add RUM metric import

### DIFF
--- a/docs/datadog.md
+++ b/docs/datadog.md
@@ -142,6 +142,8 @@ Tag filters are order specific. For example, if your monitor has tags (in the or
 *   `monitor_notification_rule`
     * `datadog_monitor_notification_rule`
         * **_NOTE:_** Requires DataDog/datadog provider 3.83.0 or newer.
+*   `rum_metric`
+    * `datadog_rum_metric`
 *   `role`
     * `datadog_role`
 *   `security_monitoring_default_rule`

--- a/providers/datadog/datadog_provider.go
+++ b/providers/datadog/datadog_provider.go
@@ -174,6 +174,7 @@ func (p *DatadogProvider) GetSupportedService() map[string]terraformutils.Servic
 		"monitor_config_policy":                &MonitorConfigPolicyGenerator{},
 		"monitor_json":                         &MonitorJSONGenerator{},
 		"monitor_notification_rule":            &MonitorNotificationRuleGenerator{},
+		"rum_metric":                           &RumMetricGenerator{},
 		"security_monitoring_default_rule":     &SecurityMonitoringDefaultRuleGenerator{},
 		"security_monitoring_filter":           &SecurityMonitoringFilterGenerator{},
 		"security_monitoring_rule":             &SecurityMonitoringRuleGenerator{},

--- a/providers/datadog/rum_metric.go
+++ b/providers/datadog/rum_metric.go
@@ -1,0 +1,86 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package datadog
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/DataDog/datadog-api-client-go/v2/api/datadog"
+	"github.com/DataDog/datadog-api-client-go/v2/api/datadogV2"
+
+	"github.com/chenrui333/terraformer/terraformutils"
+)
+
+var (
+	// RumMetricAllowEmptyValues ...
+	RumMetricAllowEmptyValues = []string{}
+)
+
+// RumMetricGenerator ...
+type RumMetricGenerator struct {
+	DatadogService
+}
+
+func (g *RumMetricGenerator) createResources(rumMetrics []datadogV2.RumMetricResponseData) []terraformutils.Resource {
+	resources := []terraformutils.Resource{}
+	for _, rumMetric := range rumMetrics {
+		resourceName := rumMetric.GetId()
+		resources = append(resources, g.createResource(resourceName))
+	}
+
+	return resources
+}
+
+func (g *RumMetricGenerator) createResource(rumMetricName string) terraformutils.Resource {
+	return terraformutils.NewSimpleResource(
+		rumMetricName,
+		fmt.Sprintf("rum_metric_%s", rumMetricName),
+		"datadog_rum_metric",
+		"datadog",
+		RumMetricAllowEmptyValues,
+	)
+}
+
+// InitResources Generate TerraformResources from Datadog API,
+// from each RUM-based metric create 1 TerraformResource.
+// Need RumMetric Name as ID for terraform resource.
+func (g *RumMetricGenerator) InitResources() error {
+	datadogClient := g.Args["datadogClient"].(*datadog.APIClient)
+	auth := g.Args["auth"].(context.Context)
+	api := datadogV2.NewRumMetricsApi(datadogClient)
+
+	resources := []terraformutils.Resource{}
+	hasIDFilter := false
+	for _, filter := range g.Filter {
+		if filter.FieldPath == "id" && filter.IsApplicable("rum_metric") {
+			hasIDFilter = true
+			for _, value := range filter.AcceptableValues {
+				rumMetric, httpResp, err := api.GetRumMetric(auth, value)
+				if httpResp != nil && httpResp.Body != nil {
+					_ = httpResp.Body.Close()
+				}
+				if err != nil {
+					return err
+				}
+
+				resources = append(resources, g.createResource(rumMetric.Data.GetId()))
+			}
+		}
+	}
+
+	if hasIDFilter || len(resources) > 0 {
+		g.Resources = resources
+		return nil
+	}
+
+	rumMetrics, httpResp, err := api.ListRumMetrics(auth)
+	if httpResp != nil && httpResp.Body != nil {
+		_ = httpResp.Body.Close()
+	}
+	if err != nil {
+		return err
+	}
+	g.Resources = g.createResources(rumMetrics.GetData())
+	return nil
+}

--- a/providers/datadog/rum_metric_test.go
+++ b/providers/datadog/rum_metric_test.go
@@ -1,0 +1,45 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package datadog
+
+import (
+	"testing"
+
+	"github.com/DataDog/datadog-api-client-go/v2/api/datadogV2"
+)
+
+func TestRumMetricCreateResource(t *testing.T) {
+	generator := &RumMetricGenerator{}
+	resource := generator.createResource("rum.sessions")
+
+	if resource.InstanceState.ID != "rum.sessions" {
+		t.Fatalf("expected resource ID rum.sessions, got %s", resource.InstanceState.ID)
+	}
+	if resource.ResourceName != "tfer--rum_metric_rum-002E-sessions" {
+		t.Fatalf("expected resource name tfer--rum_metric_rum-002E-sessions, got %s", resource.ResourceName)
+	}
+	if resource.InstanceInfo.Type != "datadog_rum_metric" {
+		t.Fatalf("expected resource type datadog_rum_metric, got %s", resource.InstanceInfo.Type)
+	}
+}
+
+func TestRumMetricCreateResources(t *testing.T) {
+	firstMetric := datadogV2.NewRumMetricResponseDataWithDefaults()
+	firstMetric.SetId("rum.sessions")
+
+	secondMetric := datadogV2.NewRumMetricResponseDataWithDefaults()
+	secondMetric.SetId("rum.errors")
+
+	generator := &RumMetricGenerator{}
+	resources := generator.createResources([]datadogV2.RumMetricResponseData{*firstMetric, *secondMetric})
+
+	if len(resources) != 2 {
+		t.Fatalf("expected 2 resources, got %d", len(resources))
+	}
+	if resources[0].InstanceState.ID != "rum.sessions" {
+		t.Fatalf("expected first resource ID rum.sessions, got %s", resources[0].InstanceState.ID)
+	}
+	if resources[1].InstanceState.ID != "rum.errors" {
+		t.Fatalf("expected second resource ID rum.errors, got %s", resources[1].InstanceState.ID)
+	}
+}


### PR DESCRIPTION
Summary
- Add Datadog rum_metric import support using the V2 RUM metrics API.
- Support all-resource and ID-filtered imports for datadog_rum_metric.
- Document the new Datadog resource.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds Datadog RUM metric import using the V2 RUM Metrics API, enabling Terraformer to generate `datadog_rum_metric` resources. Supports importing all metrics or specific IDs via filters.

- New Features
  - Import `datadog_rum_metric` via Datadog V2 RUM Metrics API.
  - Supports all-resource imports and ID-filtered imports (`id` filter on `rum_metric`).
  - Updates docs to include `rum_metric`; adds generator and tests.

<sup>Written for commit af7fc9254b077b431095957c55b1a6a967fde5be. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

