### PR TITLE
fix(providers): validate required init args

### DIFF
--- a/providers/commercetools/commercetools_provider.go
+++ b/providers/commercetools/commercetools_provider.go
@@ -27,6 +27,10 @@ func (p CommercetoolsProvider) GetProviderData(_ ...string) map[string]interface
 
 // Init CommerectoolsProvider
 func (p *CommercetoolsProvider) Init(args []string) error {
+	if len(args) < 6 {
+		return errors.New("commercetools: client id, client scope, client secret, project key, base URL, and token URL are required")
+	}
+
 	p.clientID = args[0]
 	p.clientScope = args[1]
 	p.clientSecret = args[2]

--- a/providers/commercetools/commercetools_provider_test.go
+++ b/providers/commercetools/commercetools_provider_test.go
@@ -1,0 +1,54 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package commercetools
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestCommercetoolsProviderInitRequiresArgs(t *testing.T) {
+	var provider CommercetoolsProvider
+
+	err := provider.Init([]string{"client-id", "scope", "secret", "project", "https://api.example.com"})
+	if err == nil {
+		t.Fatal("expected missing args error")
+	}
+	if !strings.Contains(err.Error(), "client id, client scope, client secret, project key, base URL, and token URL are required") {
+		t.Fatalf("Init error = %q, want missing Commercetools args", err)
+	}
+}
+
+func TestCommercetoolsProviderInitStoresArgs(t *testing.T) {
+	var provider CommercetoolsProvider
+
+	err := provider.Init([]string{
+		"client-id",
+		"scope",
+		"secret",
+		"project",
+		"https://api.example.com",
+		"https://auth.example.com",
+	})
+	if err != nil {
+		t.Fatalf("expected Init to succeed: %v", err)
+	}
+	if provider.clientID != "client-id" {
+		t.Fatalf("clientID = %q, want client-id", provider.clientID)
+	}
+	if provider.clientScope != "scope" {
+		t.Fatalf("clientScope = %q, want scope", provider.clientScope)
+	}
+	if provider.clientSecret != "secret" {
+		t.Fatalf("clientSecret = %q, want secret", provider.clientSecret)
+	}
+	if provider.projectKey != "project" {
+		t.Fatalf("projectKey = %q, want project", provider.projectKey)
+	}
+	if provider.baseURL != "https://api.example.com" {
+		t.Fatalf("baseURL = %q, want https://api.example.com", provider.baseURL)
+	}
+	if provider.tokenURL != "https://auth.example.com" {
+		t.Fatalf("tokenURL = %q, want https://auth.example.com", provider.tokenURL)
+	}
+}

--- a/providers/panos/panos_provider.go
+++ b/providers/panos/panos_provider.go
@@ -15,6 +15,10 @@ type PanosProvider struct { //nolint
 }
 
 func (p *PanosProvider) Init(args []string) error {
+	if len(args) < 1 {
+		return errors.New("panos: vsys is required")
+	}
+
 	p.vsys = args[0]
 
 	return nil

--- a/providers/panos/panos_provider_test.go
+++ b/providers/panos/panos_provider_test.go
@@ -1,0 +1,31 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package panos
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestPanosProviderInitRequiresArgs(t *testing.T) {
+	var provider PanosProvider
+
+	err := provider.Init(nil)
+	if err == nil {
+		t.Fatal("expected missing args error")
+	}
+	if !strings.Contains(err.Error(), "vsys is required") {
+		t.Fatalf("Init error = %q, want missing PAN-OS args", err)
+	}
+}
+
+func TestPanosProviderInitStoresArgs(t *testing.T) {
+	var provider PanosProvider
+
+	if err := provider.Init([]string{"vsys1"}); err != nil {
+		t.Fatalf("expected Init to succeed: %v", err)
+	}
+	if provider.vsys != "vsys1" {
+		t.Fatalf("vsys = %q, want vsys1", provider.vsys)
+	}
+}

--- a/providers/rabbitmq/rabbitmq_provider.go
+++ b/providers/rabbitmq/rabbitmq_provider.go
@@ -17,6 +17,10 @@ type RBTProvider struct {
 }
 
 func (p *RBTProvider) Init(args []string) error {
+	if len(args) < 3 {
+		return errors.New("rabbitmq: endpoint, username, and password are required")
+	}
+
 	p.endpoint = args[0]
 	p.username = args[1]
 	p.password = args[2]

--- a/providers/rabbitmq/rabbitmq_provider_test.go
+++ b/providers/rabbitmq/rabbitmq_provider_test.go
@@ -1,0 +1,37 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package rabbitmq
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestRBTProviderInitRequiresArgs(t *testing.T) {
+	var provider RBTProvider
+
+	err := provider.Init([]string{"https://rabbitmq.example.com", "guest"})
+	if err == nil {
+		t.Fatal("expected missing args error")
+	}
+	if !strings.Contains(err.Error(), "endpoint, username, and password are required") {
+		t.Fatalf("Init error = %q, want missing RabbitMQ args", err)
+	}
+}
+
+func TestRBTProviderInitStoresArgs(t *testing.T) {
+	var provider RBTProvider
+
+	if err := provider.Init([]string{"https://rabbitmq.example.com", "guest", "secret"}); err != nil {
+		t.Fatalf("expected Init to succeed: %v", err)
+	}
+	if provider.endpoint != "https://rabbitmq.example.com" {
+		t.Fatalf("endpoint = %q, want https://rabbitmq.example.com", provider.endpoint)
+	}
+	if provider.username != "guest" {
+		t.Fatalf("username = %q, want guest", provider.username)
+	}
+	if provider.password != "secret" {
+		t.Fatalf("password = %q, want secret", provider.password)
+	}
+}


### PR DESCRIPTION
## Summary

- Validate required provider init args for RabbitMQ, Commercetools, and PAN-OS before indexing.
- Return normal missing-argument errors instead of panicking on short plan args.
- Add focused provider init coverage for missing and valid args.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Validate required init args for `rabbitmq`, `commercetools`, and `panos` providers to return clear missing-argument errors instead of panicking. Adds focused tests and makes indexing safer.

- **Bug Fixes**
  - `commercetools`: require client id, client scope, client secret, project key, base URL, token URL.
  - `rabbitmq`: require endpoint, username, password.
  - `panos`: require vsys.
  - Added init tests for missing and valid args for all three providers.

<sup>Written for commit 46c0cf19f8f9b5b9c9bf038621d61d4575a0c542. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added input validation for Commercetools, Panos, and RabbitMQ provider initialization to ensure required configuration parameters are supplied before proceeding, preventing misconfiguration errors.

* **Tests**
  * Added comprehensive test coverage for provider initialization validation across all three providers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->