### PR TITLE
feat(datadog): add APM retention filter import

### DIFF
--- a/docs/datadog.md
+++ b/docs/datadog.md
@@ -87,7 +87,7 @@ Tag filters are order specific. For example, if your monitor has tags (in the or
     * `datadog_apm_retention_filter`
 *   `apm_retention_filter_order`
     * `datadog_apm_retention_filter_order`
-        * **_NOTE:_** Importing a single retention filter order by ID accepts any value because the Datadog provider stores it as `filtersOrderID`
+        * **_NOTE:_** Importing a single retention filter order by ID accepts any value because the Datadog provider stores it as `filtersOrderID`, for example `--filter=apm_retention_filter_order=any-value`
 *   `dashboard`
     * `datadog_dashboard`
 *   `dashboard_json`

--- a/docs/datadog.md
+++ b/docs/datadog.md
@@ -83,6 +83,11 @@ Tag filters are order specific. For example, if your monitor has tags (in the or
 
 ## Supported Datadog resources
 
+*   `apm_retention_filter`
+    * `datadog_apm_retention_filter`
+*   `apm_retention_filter_order`
+    * `datadog_apm_retention_filter_order`
+        * **_NOTE:_** Importing a single retention filter order by ID accepts any value because the Datadog provider stores it as `filtersOrderID`
 *   `dashboard`
     * `datadog_dashboard`
 *   `dashboard_json`

--- a/providers/datadog/apm_retention_filter.go
+++ b/providers/datadog/apm_retention_filter.go
@@ -1,0 +1,98 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package datadog
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/DataDog/datadog-api-client-go/v2/api/datadog"
+	"github.com/DataDog/datadog-api-client-go/v2/api/datadogV2"
+
+	"github.com/chenrui333/terraformer/terraformutils"
+)
+
+var (
+	// APMRetentionFilterAllowEmptyValues ...
+	APMRetentionFilterAllowEmptyValues = []string{}
+)
+
+// APMRetentionFilterGenerator ...
+type APMRetentionFilterGenerator struct {
+	DatadogService
+}
+
+func (g *APMRetentionFilterGenerator) createResources(filters []datadogV2.RetentionFilterAll) []terraformutils.Resource {
+	resources := []terraformutils.Resource{}
+	for _, filter := range filters {
+		if !isImportableAPMRetentionFilter(filter) {
+			continue
+		}
+		resourceName := filter.GetId()
+		resources = append(resources, g.createResource(resourceName))
+	}
+
+	return resources
+}
+
+func (g *APMRetentionFilterGenerator) createResource(filterID string) terraformutils.Resource {
+	return terraformutils.NewSimpleResource(
+		filterID,
+		fmt.Sprintf("apm_retention_filter_%s", filterID),
+		"datadog_apm_retention_filter",
+		"datadog",
+		APMRetentionFilterAllowEmptyValues,
+	)
+}
+
+// InitResources Generate TerraformResources from Datadog API,
+// from each APM retention filter create 1 TerraformResource.
+// Need retention filter ID as ID for terraform resource.
+func (g *APMRetentionFilterGenerator) InitResources() error {
+	datadogClient := g.Args["datadogClient"].(*datadog.APIClient)
+	auth := g.Args["auth"].(context.Context)
+	api := datadogV2.NewAPMRetentionFiltersApi(datadogClient)
+
+	resources := []terraformutils.Resource{}
+	hasIDFilter := false
+	for _, filter := range g.Filter {
+		if filter.FieldPath == "id" && filter.IsApplicable("apm_retention_filter") {
+			hasIDFilter = true
+			for _, value := range filter.AcceptableValues {
+				retentionFilter, httpResp, err := api.GetApmRetentionFilter(auth, value)
+				if httpResp != nil && httpResp.Body != nil {
+					_ = httpResp.Body.Close()
+				}
+				if err != nil {
+					return err
+				}
+
+				filterData := retentionFilter.GetData()
+				if !isImportableAPMRetentionFilter(filterData) {
+					continue
+				}
+				resources = append(resources, g.createResource(filterData.GetId()))
+			}
+		}
+	}
+
+	if hasIDFilter || len(resources) > 0 {
+		g.Resources = resources
+		return nil
+	}
+
+	retentionFilters, httpResp, err := api.ListApmRetentionFilters(auth)
+	if httpResp != nil && httpResp.Body != nil {
+		_ = httpResp.Body.Close()
+	}
+	if err != nil {
+		return err
+	}
+	g.Resources = g.createResources(retentionFilters.GetData())
+	return nil
+}
+
+func isImportableAPMRetentionFilter(filter datadogV2.RetentionFilterAll) bool {
+	attributes := filter.GetAttributes()
+	return attributes.GetFilterType() == datadogV2.RETENTIONFILTERALLTYPE_SPANS_SAMPLING_PROCESSOR
+}

--- a/providers/datadog/apm_retention_filter_order.go
+++ b/providers/datadog/apm_retention_filter_order.go
@@ -1,0 +1,40 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package datadog
+
+import "github.com/chenrui333/terraformer/terraformutils"
+
+const apmRetentionFilterOrderID = "filtersOrderID"
+
+var (
+	// APMRetentionFilterOrderAllowEmptyValues ...
+	APMRetentionFilterOrderAllowEmptyValues = []string{"filter_ids"}
+)
+
+// APMRetentionFilterOrderGenerator ...
+type APMRetentionFilterOrderGenerator struct {
+	DatadogService
+}
+
+func (g *APMRetentionFilterOrderGenerator) createResource() terraformutils.Resource {
+	return terraformutils.NewSimpleResource(
+		apmRetentionFilterOrderID,
+		"apm_retention_filter_order",
+		"datadog_apm_retention_filter_order",
+		"datadog",
+		APMRetentionFilterOrderAllowEmptyValues,
+	)
+}
+
+// InitResources Generate TerraformResources for the singleton APM retention filter order.
+// The Datadog provider read path ignores the import ID and stores filtersOrderID.
+func (g *APMRetentionFilterOrderGenerator) InitResources() error {
+	for i, filter := range g.Filter {
+		if filter.FieldPath == "id" && filter.IsApplicable("apm_retention_filter_order") {
+			g.Filter[i].AcceptableValues = []string{apmRetentionFilterOrderID}
+		}
+	}
+
+	g.Resources = []terraformutils.Resource{g.createResource()}
+	return nil
+}

--- a/providers/datadog/apm_retention_filter_order.go
+++ b/providers/datadog/apm_retention_filter_order.go
@@ -26,6 +26,30 @@ func (g *APMRetentionFilterOrderGenerator) createResource() terraformutils.Resou
 	)
 }
 
+func (g *APMRetentionFilterOrderGenerator) PostConvertHook() error {
+	for i := range g.Resources {
+		resource := &g.Resources[i]
+		if resource.Item == nil {
+			resource.Item = map[string]interface{}{}
+		}
+		if _, ok := resource.Item["filter_ids"]; ok {
+			continue
+		}
+		if !apmRetentionFilterOrderStateHasEmptyFilterIDs(resource) {
+			continue
+		}
+		resource.Item["filter_ids"] = []interface{}{}
+	}
+	return nil
+}
+
+func apmRetentionFilterOrderStateHasEmptyFilterIDs(resource *terraformutils.Resource) bool {
+	if resource == nil || resource.InstanceState == nil || resource.InstanceState.Attributes == nil {
+		return false
+	}
+	return resource.InstanceState.Attributes["filter_ids.#"] == "0"
+}
+
 // InitResources Generate TerraformResources for the singleton APM retention filter order.
 // The Datadog provider read path ignores the import ID and stores filtersOrderID.
 func (g *APMRetentionFilterOrderGenerator) InitResources() error {

--- a/providers/datadog/apm_retention_filter_order_test.go
+++ b/providers/datadog/apm_retention_filter_order_test.go
@@ -1,0 +1,53 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package datadog
+
+import (
+	"testing"
+
+	"github.com/chenrui333/terraformer/terraformutils"
+)
+
+func TestAPMRetentionFilterOrderCreateResource(t *testing.T) {
+	generator := &APMRetentionFilterOrderGenerator{}
+	resource := generator.createResource()
+
+	if resource.InstanceState.ID != apmRetentionFilterOrderID {
+		t.Fatalf("expected resource ID %s, got %s", apmRetentionFilterOrderID, resource.InstanceState.ID)
+	}
+	if resource.ResourceName != "tfer--apm_retention_filter_order" {
+		t.Fatalf("expected resource name tfer--apm_retention_filter_order, got %s", resource.ResourceName)
+	}
+	if resource.InstanceInfo.Type != "datadog_apm_retention_filter_order" {
+		t.Fatalf("expected resource type datadog_apm_retention_filter_order, got %s", resource.InstanceInfo.Type)
+	}
+}
+
+func TestAPMRetentionFilterOrderNormalizesIDFilter(t *testing.T) {
+	generator := &APMRetentionFilterOrderGenerator{
+		DatadogService: DatadogService{
+			Service: terraformutils.Service{
+				Filter: []terraformutils.ResourceFilter{
+					{
+						ServiceName:      "apm_retention_filter_order",
+						FieldPath:        "id",
+						AcceptableValues: []string{"anything"},
+					},
+				},
+			},
+		},
+	}
+
+	if err := generator.InitResources(); err != nil {
+		t.Fatalf("InitResources returned error: %v", err)
+	}
+	if len(generator.Resources) != 1 {
+		t.Fatalf("expected 1 resource, got %d", len(generator.Resources))
+	}
+	if got := generator.Filter[0].AcceptableValues; len(got) != 1 || got[0] != apmRetentionFilterOrderID {
+		t.Fatalf("expected normalized filter ID %s, got %v", apmRetentionFilterOrderID, got)
+	}
+	if !generator.Filter[0].Filter(generator.Resources[0]) {
+		t.Fatal("expected normalized ID filter to keep singleton order resource")
+	}
+}

--- a/providers/datadog/apm_retention_filter_order_test.go
+++ b/providers/datadog/apm_retention_filter_order_test.go
@@ -51,3 +51,53 @@ func TestAPMRetentionFilterOrderNormalizesIDFilter(t *testing.T) {
 		t.Fatal("expected normalized ID filter to keep singleton order resource")
 	}
 }
+
+func TestAPMRetentionFilterOrderPostConvertHookPreservesEmptyFilterIDs(t *testing.T) {
+	resource := terraformutils.NewSimpleResource(
+		apmRetentionFilterOrderID,
+		"apm_retention_filter_order",
+		"datadog_apm_retention_filter_order",
+		"datadog",
+		APMRetentionFilterOrderAllowEmptyValues,
+	)
+	resource.InstanceState.Attributes = map[string]string{
+		"filter_ids.#": "0",
+	}
+	resource.Item = map[string]interface{}{}
+
+	generator := &APMRetentionFilterOrderGenerator{}
+	generator.Resources = []terraformutils.Resource{resource}
+
+	if err := generator.PostConvertHook(); err != nil {
+		t.Fatalf("PostConvertHook returned error: %v", err)
+	}
+
+	filterIDs, ok := generator.Resources[0].Item["filter_ids"].([]interface{})
+	if !ok {
+		t.Fatalf("filter_ids = %T, want []interface{}", generator.Resources[0].Item["filter_ids"])
+	}
+	if len(filterIDs) != 0 {
+		t.Fatalf("filter_ids length = %d, want %d", len(filterIDs), 0)
+	}
+}
+
+func TestAPMRetentionFilterOrderPostConvertHookDoesNotInventUnknownFilterIDs(t *testing.T) {
+	resource := terraformutils.NewSimpleResource(
+		apmRetentionFilterOrderID,
+		"apm_retention_filter_order",
+		"datadog_apm_retention_filter_order",
+		"datadog",
+		APMRetentionFilterOrderAllowEmptyValues,
+	)
+	resource.Item = map[string]interface{}{}
+
+	generator := &APMRetentionFilterOrderGenerator{}
+	generator.Resources = []terraformutils.Resource{resource}
+
+	if err := generator.PostConvertHook(); err != nil {
+		t.Fatalf("PostConvertHook returned error: %v", err)
+	}
+	if _, ok := generator.Resources[0].Item["filter_ids"]; ok {
+		t.Fatal("PostConvertHook added filter_ids without empty filter_ids state")
+	}
+}

--- a/providers/datadog/apm_retention_filter_test.go
+++ b/providers/datadog/apm_retention_filter_test.go
@@ -1,0 +1,75 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package datadog
+
+import (
+	"testing"
+
+	"github.com/DataDog/datadog-api-client-go/v2/api/datadogV2"
+)
+
+func TestAPMRetentionFilterCreateResource(t *testing.T) {
+	generator := &APMRetentionFilterGenerator{}
+	resource := generator.createResource("rf-123")
+
+	if resource.InstanceState.ID != "rf-123" {
+		t.Fatalf("expected resource ID rf-123, got %s", resource.InstanceState.ID)
+	}
+	if resource.ResourceName != "tfer--apm_retention_filter_rf-123" {
+		t.Fatalf("expected resource name tfer--apm_retention_filter_rf-123, got %s", resource.ResourceName)
+	}
+	if resource.InstanceInfo.Type != "datadog_apm_retention_filter" {
+		t.Fatalf("expected resource type datadog_apm_retention_filter, got %s", resource.InstanceInfo.Type)
+	}
+}
+
+func TestAPMRetentionFilterCreateResources(t *testing.T) {
+	firstFilter := datadogV2.NewRetentionFilterAllWithDefaults()
+	firstFilter.SetId("rf-123")
+	firstFilter.SetAttributes(importableAPMRetentionFilterAttributes())
+
+	secondFilter := datadogV2.NewRetentionFilterAllWithDefaults()
+	secondFilter.SetId("rf-456")
+	secondFilter.SetAttributes(importableAPMRetentionFilterAttributes())
+
+	generator := &APMRetentionFilterGenerator{}
+	resources := generator.createResources([]datadogV2.RetentionFilterAll{*firstFilter, *secondFilter})
+
+	if len(resources) != 2 {
+		t.Fatalf("expected 2 resources, got %d", len(resources))
+	}
+	if resources[0].InstanceState.ID != "rf-123" {
+		t.Fatalf("expected first resource ID rf-123, got %s", resources[0].InstanceState.ID)
+	}
+	if resources[1].InstanceState.ID != "rf-456" {
+		t.Fatalf("expected second resource ID rf-456, got %s", resources[1].InstanceState.ID)
+	}
+}
+
+func TestAPMRetentionFilterCreateResourcesSkipsUnsupportedFilterTypes(t *testing.T) {
+	userFilter := datadogV2.NewRetentionFilterAllWithDefaults()
+	userFilter.SetId("rf-user")
+	userFilter.SetAttributes(importableAPMRetentionFilterAttributes())
+
+	defaultFilter := datadogV2.NewRetentionFilterAllWithDefaults()
+	defaultFilter.SetId("rf-default")
+	attributes := importableAPMRetentionFilterAttributes()
+	attributes.SetFilterType(datadogV2.RETENTIONFILTERALLTYPE_SPANS_ERRORS_SAMPLING_PROCESSOR)
+	defaultFilter.SetAttributes(attributes)
+
+	generator := &APMRetentionFilterGenerator{}
+	resources := generator.createResources([]datadogV2.RetentionFilterAll{*userFilter, *defaultFilter})
+
+	if len(resources) != 1 {
+		t.Fatalf("expected 1 resource, got %d", len(resources))
+	}
+	if resources[0].InstanceState.ID != "rf-user" {
+		t.Fatalf("expected resource ID rf-user, got %s", resources[0].InstanceState.ID)
+	}
+}
+
+func importableAPMRetentionFilterAttributes() datadogV2.RetentionFilterAllAttributes {
+	attributes := datadogV2.NewRetentionFilterAllAttributesWithDefaults()
+	attributes.SetFilterType(datadogV2.RETENTIONFILTERALLTYPE_SPANS_SAMPLING_PROCESSOR)
+	return *attributes
+}

--- a/providers/datadog/apm_retention_filter_test.go
+++ b/providers/datadog/apm_retention_filter_test.go
@@ -146,7 +146,7 @@ func TestAPMRetentionFilterInitResourcesListsWithoutIDFilter(t *testing.T) {
 }
 
 func TestAPMRetentionFilterInitResourcesPropagatesIDFilterError(t *testing.T) {
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		http.Error(w, "fetch failed", http.StatusInternalServerError)
 	}))
 	defer server.Close()
@@ -165,7 +165,7 @@ func TestAPMRetentionFilterInitResourcesPropagatesIDFilterError(t *testing.T) {
 }
 
 func TestAPMRetentionFilterInitResourcesPropagatesListError(t *testing.T) {
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		http.Error(w, "list failed", http.StatusInternalServerError)
 	}))
 	defer server.Close()

--- a/providers/datadog/apm_retention_filter_test.go
+++ b/providers/datadog/apm_retention_filter_test.go
@@ -3,9 +3,16 @@
 package datadog
 
 import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
 	"testing"
 
+	"github.com/DataDog/datadog-api-client-go/v2/api/datadog"
 	"github.com/DataDog/datadog-api-client-go/v2/api/datadogV2"
+	"github.com/chenrui333/terraformer/terraformutils"
 )
 
 func TestAPMRetentionFilterCreateResource(t *testing.T) {
@@ -68,8 +75,147 @@ func TestAPMRetentionFilterCreateResourcesSkipsUnsupportedFilterTypes(t *testing
 	}
 }
 
+func TestAPMRetentionFilterInitResourcesFetchesIDFilter(t *testing.T) {
+	requestedPaths := []string{}
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestedPaths = append(requestedPaths, r.URL.Path)
+		w.Header().Set("Content-Type", "application/json")
+
+		switch r.URL.Path {
+		case "/api/v2/apm/config/retention-filters/rf-123":
+			_, _ = fmt.Fprint(w, apmRetentionFilterResponseJSON("rf-123"))
+		case "/api/v2/apm/config/retention-filters":
+			http.Error(w, "unexpected list request", http.StatusInternalServerError)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+
+	generator := newAPMRetentionFilterTestGenerator(server, []terraformutils.ResourceFilter{
+		{
+			ServiceName:      "apm_retention_filter",
+			FieldPath:        "id",
+			AcceptableValues: []string{"rf-123"},
+		},
+	})
+
+	if err := generator.InitResources(); err != nil {
+		t.Fatalf("InitResources returned error: %v", err)
+	}
+	if len(generator.Resources) != 1 {
+		t.Fatalf("expected 1 resource, got %d", len(generator.Resources))
+	}
+	if generator.Resources[0].InstanceState.ID != "rf-123" {
+		t.Fatalf("expected resource ID rf-123, got %s", generator.Resources[0].InstanceState.ID)
+	}
+	for _, path := range requestedPaths {
+		if path == "/api/v2/apm/config/retention-filters" {
+			t.Fatalf("expected id filter to avoid list request, got requests %v", requestedPaths)
+		}
+	}
+}
+
+func TestAPMRetentionFilterInitResourcesListsWithoutIDFilter(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+
+		switch r.URL.Path {
+		case "/api/v2/apm/config/retention-filters":
+			_, _ = fmt.Fprint(w, apmRetentionFilterListResponseJSON("rf-123", "rf-456"))
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+
+	generator := newAPMRetentionFilterTestGenerator(server, nil)
+
+	if err := generator.InitResources(); err != nil {
+		t.Fatalf("InitResources returned error: %v", err)
+	}
+	if len(generator.Resources) != 2 {
+		t.Fatalf("expected 2 resources, got %d", len(generator.Resources))
+	}
+	if generator.Resources[0].InstanceState.ID != "rf-123" {
+		t.Fatalf("expected first resource ID rf-123, got %s", generator.Resources[0].InstanceState.ID)
+	}
+	if generator.Resources[1].InstanceState.ID != "rf-456" {
+		t.Fatalf("expected second resource ID rf-456, got %s", generator.Resources[1].InstanceState.ID)
+	}
+}
+
+func TestAPMRetentionFilterInitResourcesPropagatesIDFilterError(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "fetch failed", http.StatusInternalServerError)
+	}))
+	defer server.Close()
+
+	generator := newAPMRetentionFilterTestGenerator(server, []terraformutils.ResourceFilter{
+		{
+			ServiceName:      "apm_retention_filter",
+			FieldPath:        "id",
+			AcceptableValues: []string{"rf-error"},
+		},
+	})
+
+	if err := generator.InitResources(); err == nil {
+		t.Fatal("InitResources returned nil error, want ID fetch error")
+	}
+}
+
+func TestAPMRetentionFilterInitResourcesPropagatesListError(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "list failed", http.StatusInternalServerError)
+	}))
+	defer server.Close()
+
+	generator := newAPMRetentionFilterTestGenerator(server, nil)
+
+	if err := generator.InitResources(); err == nil {
+		t.Fatal("InitResources returned nil error, want list error")
+	}
+}
+
 func importableAPMRetentionFilterAttributes() datadogV2.RetentionFilterAllAttributes {
 	attributes := datadogV2.NewRetentionFilterAllAttributesWithDefaults()
 	attributes.SetFilterType(datadogV2.RETENTIONFILTERALLTYPE_SPANS_SAMPLING_PROCESSOR)
 	return *attributes
+}
+
+func newAPMRetentionFilterTestGenerator(server *httptest.Server, filter []terraformutils.ResourceFilter) *APMRetentionFilterGenerator {
+	config := datadog.NewConfiguration()
+	config.Servers = datadog.ServerConfigurations{{URL: server.URL}}
+	config.HTTPClient = server.Client()
+
+	return &APMRetentionFilterGenerator{
+		DatadogService: DatadogService{
+			Service: terraformutils.Service{
+				Args: map[string]interface{}{
+					"auth":          context.Background(),
+					"datadogClient": datadog.NewAPIClient(config),
+				},
+				Filter: filter,
+			},
+		},
+	}
+}
+
+func apmRetentionFilterResponseJSON(id string) string {
+	return fmt.Sprintf("{\"data\":%s}", apmRetentionFilterJSON(id))
+}
+
+func apmRetentionFilterListResponseJSON(ids ...string) string {
+	filters := []string{}
+	for _, id := range ids {
+		filters = append(filters, apmRetentionFilterJSON(id))
+	}
+	return fmt.Sprintf("{\"data\":[%s]}", strings.Join(filters, ","))
+}
+
+func apmRetentionFilterJSON(id string) string {
+	return fmt.Sprintf(
+		"{\"id\":%q,\"type\":\"apm_retention_filter\",\"attributes\":{\"filter_type\":\"spans-sampling-processor\"}}",
+		id,
+	)
 }

--- a/providers/datadog/datadog_provider.go
+++ b/providers/datadog/datadog_provider.go
@@ -147,6 +147,8 @@ func (p *DatadogProvider) InitService(serviceName string, verbose bool) error {
 // GetSupportedService return map of support service for Datadog
 func (p *DatadogProvider) GetSupportedService() map[string]terraformutils.ServiceGenerator {
 	return map[string]terraformutils.ServiceGenerator{
+		"apm_retention_filter":                 &APMRetentionFilterGenerator{},
+		"apm_retention_filter_order":           &APMRetentionFilterOrderGenerator{},
 		"cloud_inventory_sync_config":          &CloudInventorySyncConfigGenerator{},
 		"dashboard_list":                       &DashboardListGenerator{},
 		"dashboard":                            &DashboardGenerator{},
@@ -201,6 +203,11 @@ func (p *DatadogProvider) GetSupportedService() map[string]terraformutils.Servic
 // GetResourceConnections return map of resource connections for Datadog
 func (p DatadogProvider) GetResourceConnections() map[string]map[string][]string {
 	return map[string]map[string][]string{
+		"apm_retention_filter_order": {
+			"apm_retention_filter": {
+				"filter_ids", "id",
+			},
+		},
 		"dashboard": {
 			"monitor": {
 				"widget.alert_graph_definition.alert_id", "id",

--- a/providers/datadog/datadog_provider_test.go
+++ b/providers/datadog/datadog_provider_test.go
@@ -4,6 +4,19 @@ package datadog
 
 import "testing"
 
+func TestDatadogProviderAPMRetentionFilterConnections(t *testing.T) {
+	connections := DatadogProvider{}.GetResourceConnections()
+
+	assertDatadogConnection(
+		t,
+		connections,
+		"apm_retention_filter_order",
+		"apm_retention_filter",
+		"filter_ids",
+		"id",
+	)
+}
+
 func TestDatadogProviderSensitiveDataScannerConnections(t *testing.T) {
 	connections := DatadogProvider{}.GetResourceConnections()
 


### PR DESCRIPTION
Summary
- Add Datadog APM retention filter import support using the V2 APM retention filters API.
- Add the singleton APM retention filter order import and connection mapping to imported filters.
- Document the new Datadog resources.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add import support for Datadog APM retention filters and their global order using the V2 APM Retention Filters API. Hardened the import path to support ID-only fetches and preserve empty order state.

- **New Features**
  - New resources: `datadog_apm_retention_filter`, `datadog_apm_retention_filter_order`.
  - Imports only filters with type `SPANS_SAMPLING_PROCESSOR`; others are skipped.
  - Singleton order import accepts any ID and normalizes to `filtersOrderID` (documented).
  - Adds provider connection: `apm_retention_filter_order.filter_ids` → `apm_retention_filter.id`.

- **Bug Fixes**
  - Preserve empty `filter_ids` on order import (set to `[]` when state is empty); do not invent IDs.
  - Use ID-filtered fetch to avoid unnecessary list calls; close response bodies and surface API errors.
  - Satisfy lint in APM retention code; no behavior changes.

<sup>Written for commit 01272f1b61cbc230538e925ca421496513aa63e0. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Support for Datadog APM retention filters and retention filter orders; orders reference filters.

* **Bug Fixes / Behavior**
  * Preserve empty filter ID lists during conversion; do not invent IDs.
  * Importing a single filter-order by ID accepts any value due to provider storage format.

* **Documentation**
  * Added APM retention filters and filter orders to supported Datadog resources.

* **Tests**
  * Added unit tests for resource creation, ID filtering, error handling, and post-conversion behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->