### PR TITLE
fix(providers): handle short init args

### DIFF
--- a/providers/alicloud/alicloud_provider.go
+++ b/providers/alicloud/alicloud_provider.go
@@ -77,6 +77,10 @@ func (p AliCloudProvider) GetProviderData(_ ...string) map[string]interface{} {
 
 // Init Loads up command line arguments in the provider
 func (p *AliCloudProvider) Init(args []string) error {
+	if len(args) < 2 {
+		return errors.New("alicloud: expected 2 init args (region, profile)")
+	}
+
 	p.region = args[0]
 	p.profile = args[1]
 	return nil

--- a/providers/alicloud/alicloud_provider_test.go
+++ b/providers/alicloud/alicloud_provider_test.go
@@ -1,0 +1,20 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package alicloud
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestAliCloudProviderInitRequiresArgs(t *testing.T) {
+	var provider AliCloudProvider
+
+	err := provider.Init([]string{"cn-hangzhou"})
+	if err == nil {
+		t.Fatal("expected missing args error")
+	}
+	if !strings.Contains(err.Error(), "expected 2 init args") {
+		t.Fatalf("Init error = %q, want missing AliCloud args", err)
+	}
+}

--- a/providers/aws/aws_provider.go
+++ b/providers/aws/aws_provider.go
@@ -172,6 +172,10 @@ func (p *AWSProvider) GetBasicConfig() cty.Value {
 
 // check projectName in env params
 func (p *AWSProvider) Init(args []string) error {
+	if len(args) < 2 {
+		return errors.New("aws: expected 2 init args (region, profile)")
+	}
+
 	p.region = args[0]
 	p.profile = args[1]
 

--- a/providers/aws/aws_provider_init_test.go
+++ b/providers/aws/aws_provider_init_test.go
@@ -1,0 +1,20 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package aws
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestAWSProviderInitRequiresArgs(t *testing.T) {
+	var provider AWSProvider
+
+	err := provider.Init([]string{MainRegionPublicPartition})
+	if err == nil {
+		t.Fatal("expected missing args error")
+	}
+	if !strings.Contains(err.Error(), "expected 2 init args") {
+		t.Fatalf("Init error = %q, want missing AWS args", err)
+	}
+}

--- a/providers/azure/azure_provider.go
+++ b/providers/azure/azure_provider.go
@@ -530,6 +530,10 @@ func discoverCloudConfig(metadataHost, environment string) (cloud.Configuration,
 }
 
 func (p *AzureProvider) Init(args []string) error {
+	if len(args) < 1 {
+		return errors.New("azure: expected 1 init arg (resource group)")
+	}
+
 	err := p.setEnvConfig()
 	if err != nil {
 		return err

--- a/providers/azure/azure_provider_test.go
+++ b/providers/azure/azure_provider_test.go
@@ -1,0 +1,20 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package azure
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestAzureProviderInitRequiresResourceGroupArg(t *testing.T) {
+	var provider AzureProvider
+
+	err := provider.Init(nil)
+	if err == nil {
+		t.Fatal("expected missing resource group arg error")
+	}
+	if !strings.Contains(err.Error(), "expected 1 init arg") {
+		t.Fatalf("Init error = %q, want missing resource group arg", err)
+	}
+}

--- a/providers/datadog/datadog_provider.go
+++ b/providers/datadog/datadog_provider.go
@@ -28,9 +28,14 @@ type DatadogProvider struct { //nolint
 
 // Init check env params and initialize API Client
 func (p *DatadogProvider) Init(args []string) error {
+	apiKeyArg := optionalInitArg(args, 0)
+	appKeyArg := optionalInitArg(args, 1)
+	apiURLArg := optionalInitArg(args, 2)
+	validateArg := optionalInitArg(args, 3)
+
 	switch {
-	case args[3] != "":
-		validate, validateErr := strconv.ParseBool(args[3])
+	case validateArg != "":
+		validate, validateErr := strconv.ParseBool(validateArg)
 		if validateErr != nil {
 			return fmt.Errorf(`invalid validate arg : %w`, validateErr)
 		}
@@ -45,8 +50,8 @@ func (p *DatadogProvider) Init(args []string) error {
 		p.validate = true
 	}
 
-	if args[0] != "" {
-		p.apiKey = args[0]
+	if apiKeyArg != "" {
+		p.apiKey = apiKeyArg
 	} else {
 		if apiKey := os.Getenv("DATADOG_API_KEY"); apiKey != "" {
 			p.apiKey = apiKey
@@ -55,8 +60,8 @@ func (p *DatadogProvider) Init(args []string) error {
 		}
 	}
 
-	if args[1] != "" {
-		p.appKey = args[1]
+	if appKeyArg != "" {
+		p.appKey = appKeyArg
 	} else {
 		if appKey := os.Getenv("DATADOG_APP_KEY"); appKey != "" {
 			p.appKey = appKey
@@ -65,8 +70,8 @@ func (p *DatadogProvider) Init(args []string) error {
 		}
 	}
 
-	if args[2] != "" {
-		p.apiURL = args[2]
+	if apiURLArg != "" {
+		p.apiURL = apiURLArg
 	} else if v := os.Getenv("DATADOG_HOST"); v != "" {
 		p.apiURL = v
 	}
@@ -106,6 +111,13 @@ func (p *DatadogProvider) Init(args []string) error {
 	p.datadogClient = datadogClient
 
 	return nil
+}
+
+func optionalInitArg(args []string, index int) string {
+	if len(args) > index {
+		return args[index]
+	}
+	return ""
 }
 
 // GetName return string of provider name for Datadog

--- a/providers/datadog/datadog_provider_test.go
+++ b/providers/datadog/datadog_provider_test.go
@@ -2,7 +2,41 @@
 
 package datadog
 
-import "testing"
+import (
+	"strings"
+	"testing"
+)
+
+func TestDatadogProviderInitHandlesShortArgs(t *testing.T) {
+	t.Setenv("DATADOG_API_KEY", "")
+	t.Setenv("DATADOG_APP_KEY", "")
+	t.Setenv("DATADOG_HOST", "")
+	t.Setenv("DATADOG_VALIDATE", "false")
+
+	var provider DatadogProvider
+	if err := provider.Init(nil); err != nil {
+		t.Fatalf("expected Init to accept missing optional args with validation disabled: %v", err)
+	}
+	if provider.validate {
+		t.Fatal("validate = true, want false")
+	}
+}
+
+func TestDatadogProviderInitReturnsCredentialErrorForShortArgs(t *testing.T) {
+	t.Setenv("DATADOG_API_KEY", "")
+	t.Setenv("DATADOG_APP_KEY", "")
+	t.Setenv("DATADOG_HOST", "")
+	t.Setenv("DATADOG_VALIDATE", "")
+
+	var provider DatadogProvider
+	err := provider.Init(nil)
+	if err == nil {
+		t.Fatal("expected missing API key error")
+	}
+	if !strings.Contains(err.Error(), "api-key requirement") {
+		t.Fatalf("Init error = %q, want missing API key", err)
+	}
+}
 
 func TestDatadogProviderSensitiveDataScannerConnections(t *testing.T) {
 	connections := DatadogProvider{}.GetResourceConnections()

--- a/providers/github/github_errors_test.go
+++ b/providers/github/github_errors_test.go
@@ -27,6 +27,18 @@ func TestCreateMembershipsResourcesReturnsListError(t *testing.T) {
 	}
 }
 
+func TestGithubProviderInitRequiresOwner(t *testing.T) {
+	var provider GithubProvider
+
+	err := provider.Init(nil)
+	if err == nil {
+		t.Fatal("expected missing owner error")
+	}
+	if !strings.Contains(err.Error(), "owner is required") {
+		t.Fatalf("Init error = %q, want missing owner", err)
+	}
+}
+
 func TestCreateRepositoryWebhookResourcesReturnsListError(t *testing.T) {
 	ctx := context.Background()
 	server := newErrorGitHubServer(t)

--- a/providers/github/github_provider.go
+++ b/providers/github/github_provider.go
@@ -60,6 +60,10 @@ func (p *GithubProvider) GetConfig() cty.Value {
 
 // Init GithubProvider with owner
 func (p *GithubProvider) Init(args []string) error {
+	if len(args) < 1 || args[0] == "" {
+		return errors.New("github: owner is required")
+	}
+
 	if appIDValue, ok := os.LookupEnv("GITHUB_APP_ID"); ok {
 		appID, err := strconv.ParseInt(appIDValue, 10, 64)
 		if err != nil {

--- a/providers/gitlab/gitlab_errors_test.go
+++ b/providers/gitlab/gitlab_errors_test.go
@@ -25,6 +25,18 @@ func TestCreateGroupsReturnsGroupGetError(t *testing.T) {
 	}
 }
 
+func TestGitLabProviderInitRequiresGroup(t *testing.T) {
+	var provider GitLabProvider
+
+	err := provider.Init(nil)
+	if err == nil {
+		t.Fatal("expected missing group error")
+	}
+	if !strings.Contains(err.Error(), "group is required") {
+		t.Fatalf("Init error = %q, want missing group", err)
+	}
+}
+
 func TestCreateProjectsReturnsProjectListError(t *testing.T) {
 	ctx := context.Background()
 	client := newErrorGitLabClient(t)

--- a/providers/gitlab/gitlab_provider.go
+++ b/providers/gitlab/gitlab_provider.go
@@ -43,6 +43,10 @@ func (p *GitLabProvider) GetConfig() cty.Value {
 
 // Init GitLabProvider with group
 func (p *GitLabProvider) Init(args []string) error {
+	if len(args) < 1 || args[0] == "" {
+		return errors.New("gitlab: group is required")
+	}
+
 	p.group = args[0]
 	p.baseURL = gitLabDefaultURL
 	if len(args) < 2 {

--- a/providers/ibm/ibm_provider.go
+++ b/providers/ibm/ibm_provider.go
@@ -30,6 +30,10 @@ type IBMProvider struct { //nolint
 }
 
 func (p *IBMProvider) Init(args []string) error {
+	if len(args) < 3 {
+		return errors.New("ibm: expected 3 init args (resource group, region, vpc)")
+	}
+
 	p.ResourceGroup = args[0]
 	p.Region = args[1]
 	p.VPC = args[2]

--- a/providers/ibm/ibm_provider_test.go
+++ b/providers/ibm/ibm_provider_test.go
@@ -22,6 +22,17 @@ func TestProviderInitDoesNotRequireAPIKey(t *testing.T) {
 	}
 }
 
+func TestProviderInitRequiresArgs(t *testing.T) {
+	provider := &IBMProvider{}
+	err := provider.Init([]string{"", ""})
+	if err == nil {
+		t.Fatal("expected missing args error")
+	}
+	if err.Error() != "ibm: expected 3 init args (resource group, region, vpc)" {
+		t.Fatalf("Init error = %q, want missing IBM args", err)
+	}
+}
+
 func TestProviderValidateImportRequiresAPIKey(t *testing.T) {
 	t.Setenv("IC_API_KEY", "")
 

--- a/providers/kubernetes/kubernetes_provider.go
+++ b/providers/kubernetes/kubernetes_provider.go
@@ -42,7 +42,10 @@ func (p KubernetesProvider) GetProviderData(_ ...string) map[string]interface{} 
 }
 
 func (p *KubernetesProvider) Init(args []string) error {
-	p.verbose = args[0]
+	p.verbose = ""
+	if len(args) > 0 {
+		p.verbose = args[0]
+	}
 	return nil
 }
 

--- a/providers/kubernetes/kubernetes_provider_test.go
+++ b/providers/kubernetes/kubernetes_provider_test.go
@@ -10,6 +10,28 @@ import (
 	"k8s.io/client-go/kubernetes/fake"
 )
 
+func TestKubernetesProviderInitHandlesMissingVerboseArg(t *testing.T) {
+	provider := KubernetesProvider{verbose: "true"}
+
+	if err := provider.Init(nil); err != nil {
+		t.Fatalf("expected Init to succeed: %v", err)
+	}
+	if provider.verbose != "" {
+		t.Fatalf("verbose = %q, want empty", provider.verbose)
+	}
+}
+
+func TestKubernetesProviderInitStoresVerboseArg(t *testing.T) {
+	var provider KubernetesProvider
+
+	if err := provider.Init([]string{"true"}); err != nil {
+		t.Fatalf("expected Init to succeed: %v", err)
+	}
+	if provider.verbose != "true" {
+		t.Fatalf("verbose = %q, want true", provider.verbose)
+	}
+}
+
 func TestAddDefaultServiceAccountService(t *testing.T) {
 	resources := map[string]terraformutils.ServiceGenerator{}
 	clientset := fake.NewSimpleClientset()

--- a/providers/newrelic/newrelic_provider.go
+++ b/providers/newrelic/newrelic_provider.go
@@ -39,7 +39,7 @@ func (p *NewRelicProvider) Init(args []string) error {
 		}
 		p.accountID = accountID
 	}
-	if len(args) > 1 {
+	if len(args) > 2 {
 		p.Region = args[2]
 	}
 	if p.Region == "" {

--- a/providers/newrelic/newrelic_provider_test.go
+++ b/providers/newrelic/newrelic_provider_test.go
@@ -1,0 +1,18 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package newrelic
+
+import "testing"
+
+func TestNewRelicProviderInitHandlesMissingRegionArg(t *testing.T) {
+	t.Setenv("NEW_RELIC_API_KEY", "")
+	t.Setenv("NEW_RELIC_ACCOUNT_ID", "")
+
+	var provider NewRelicProvider
+	if err := provider.Init([]string{"api-key", "123"}); err != nil {
+		t.Fatalf("expected Init to succeed without region arg: %v", err)
+	}
+	if provider.Region != "US" {
+		t.Fatalf("Region = %q, want US", provider.Region)
+	}
+}

--- a/providers/openstack/openstack_provider.go
+++ b/providers/openstack/openstack_provider.go
@@ -30,6 +30,10 @@ func (p OpenStackProvider) GetProviderData(_ ...string) map[string]interface{} {
 
 // check projectName in env params
 func (p *OpenStackProvider) Init(args []string) error {
+	if len(args) < 1 {
+		return errors.New("openstack: expected 1 init arg (region)")
+	}
+
 	p.region = args[0]
 	// terraform work with env param OS_REGION_NAME
 	err := os.Setenv("OS_REGION_NAME", p.region)

--- a/providers/openstack/openstack_provider_test.go
+++ b/providers/openstack/openstack_provider_test.go
@@ -1,0 +1,20 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package openstack
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestOpenStackProviderInitRequiresRegion(t *testing.T) {
+	var provider OpenStackProvider
+
+	err := provider.Init(nil)
+	if err == nil {
+		t.Fatal("expected missing region error")
+	}
+	if !strings.Contains(err.Error(), "expected 1 init arg") {
+		t.Fatalf("Init error = %q, want missing region", err)
+	}
+}

--- a/providers/tencentcloud/tencentcloud_provider.go
+++ b/providers/tencentcloud/tencentcloud_provider.go
@@ -52,6 +52,10 @@ func (p *TencentCloudProvider) GetSource() string {
 }
 
 func (p *TencentCloudProvider) Init(args []string) error {
+	if len(args) < 1 {
+		return errors.New("tencentcloud: expected 1 init arg (region)")
+	}
+
 	err := p.getCredential()
 	if err != nil {
 		return err

--- a/providers/tencentcloud/tencentcloud_provider_test.go
+++ b/providers/tencentcloud/tencentcloud_provider_test.go
@@ -1,0 +1,20 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package tencentcloud
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestTencentCloudProviderInitRequiresRegion(t *testing.T) {
+	var provider TencentCloudProvider
+
+	err := provider.Init(nil)
+	if err == nil {
+		t.Fatal("expected missing region error")
+	}
+	if !strings.Contains(err.Error(), "expected 1 init arg") {
+		t.Fatalf("Init error = %q, want missing region", err)
+	}
+}


### PR DESCRIPTION
## Summary

- Guard short provider init args across AliCloud, AWS, Azure, Datadog, GitHub, GitLab, IBM, Kubernetes, OpenStack, New Relic, and Tencent Cloud.
- Treat absent optional Datadog and Kubernetes init args as missing values instead of indexing past the slice.
- Add focused init coverage for missing and short arg paths.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Handle short or missing init args across providers to prevent out-of-range panics and return clear, consistent errors. Optional args are handled correctly for Datadog and Kubernetes, and New Relic region parsing is fixed.

- **Bug Fixes**
  - Added init arg validation for AliCloud, AWS, Azure, IBM, OpenStack, Tencent Cloud, GitHub, and GitLab; return specific errors when required args are missing.
  - Datadog: treat apiKey/appKey/apiURL/validate as optional, parse validate safely, and prefer env vars when args are absent.
  - Kubernetes: make the verbose arg optional and default to empty.
  - New Relic: fix region arg indexing and default to US when missing.
  - Added focused tests to cover missing/short arg paths across providers.

<sup>Written for commit 718bac218c34dc701b4a6559fe2fb00adf4b74c6. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

