### PR TITLE
fix(providers): propagate discovery errors

### DIFF
--- a/providers/github/github_errors_test.go
+++ b/providers/github/github_errors_test.go
@@ -39,6 +39,25 @@ func TestGithubProviderInitRequiresOwner(t *testing.T) {
 	}
 }
 
+func TestGithubServiceCreateClientReturnsAppAuthError(t *testing.T) {
+	service := &GithubService{}
+	service.SetArgs(map[string]interface{}{
+		"base_url":        githubDefaultURL,
+		"app_id":          int64(123),
+		"installation_id": int64(456),
+		"pem":             "not a pem",
+		"token":           "",
+	})
+
+	client, err := service.createClient()
+	if err == nil {
+		t.Fatal("expected GitHub app auth setup error")
+	}
+	if client != nil {
+		t.Fatalf("client = %v, want nil", client)
+	}
+}
+
 func TestCreateRepositoryWebhookResourcesReturnsListError(t *testing.T) {
 	ctx := context.Background()
 	server := newErrorGitHubServer(t)

--- a/providers/github/github_service.go
+++ b/providers/github/github_service.go
@@ -20,25 +20,25 @@ type GithubService struct { //nolint
 
 func (g *GithubService) createClient() (*github.Client, error) {
 	if g.GetArgs()["base_url"].(string) == githubDefaultURL {
-		return g.createRegularClient(), nil
+		return g.createRegularClient()
 	}
 	return g.createEnterpriseClient()
 }
 
-func (g *GithubService) createRegularClient() *github.Client {
+func (g *GithubService) createRegularClient() (*github.Client, error) {
 	ctx := context.Background()
 	if g.Args["app_id"].(int64) != 0 && g.Args["installation_id"].(int64) != 0 && g.Args["pem"].(string) != "" {
 		itr, err := ghinstallation.New(http.DefaultTransport, g.Args["app_id"].(int64), g.Args["installation_id"].(int64), []byte(g.Args["pem"].(string)))
 		if err != nil {
-			return nil
+			return nil, err
 		}
-		return github.NewClient(&http.Client{Transport: itr})
+		return github.NewClient(&http.Client{Transport: itr}), nil
 	}
 	ts := oauth2.StaticTokenSource(
 		&oauth2.Token{AccessToken: g.Args["token"].(string)},
 	)
 	tc := oauth2.NewClient(ctx, ts)
-	return github.NewClient(tc)
+	return github.NewClient(tc), nil
 }
 
 func (g *GithubService) createEnterpriseClient() (*github.Client, error) {

--- a/providers/vault/vault_service_generator.go
+++ b/providers/vault/vault_service_generator.go
@@ -82,8 +82,7 @@ func (g *ServiceGenerator) createSecretBackendRoleResources() error {
 		path := fmt.Sprintf("%s/roles", mount)
 		s, err := g.client.Logical().List(path)
 		if err != nil {
-			log.Printf("error calling path %s: %s", path, err)
-			continue
+			return fmt.Errorf("list vault secret backend roles at %s: %w", path, err)
 		}
 		if s == nil {
 			log.Printf("call to %s returned nil result", path)
@@ -148,8 +147,7 @@ func (g *ServiceGenerator) createAuthBackendEntityResources(apiEntity, tfEntity 
 		path := fmt.Sprintf("/auth/%s/%s", backend, apiEntity)
 		s, err := g.client.Logical().List(path)
 		if err != nil {
-			log.Printf("error calling path %s: %s", path, err)
-			continue
+			return fmt.Errorf("list vault auth backend %s at %s: %w", apiEntity, path, err)
 		}
 		if s == nil {
 			log.Printf("call to %s returned nil result", path)
@@ -218,8 +216,7 @@ func (g *ServiceGenerator) createGenericSecretResources() error {
 		path := fmt.Sprintf("%s/", mount)
 		s, err := g.client.Logical().List(path)
 		if err != nil {
-			log.Printf("error calling path %s: %s", path, err)
-			continue
+			return fmt.Errorf("list vault generic secrets at %s: %w", path, err)
 		}
 		if s == nil {
 			log.Printf("call to %s returned nil result", path)

--- a/providers/vault/vault_service_generator_test.go
+++ b/providers/vault/vault_service_generator_test.go
@@ -1,0 +1,101 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package vault
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	vaultapi "github.com/hashicorp/vault/api"
+)
+
+func TestCreateSecretBackendRoleResourcesReturnsListError(t *testing.T) {
+	generator := newVaultTestGenerator(t, func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/v1/sys/mounts":
+			writeVaultMounts(t, w, "aws/", "aws")
+		default:
+			http.Error(w, "list failed", http.StatusServiceUnavailable)
+		}
+	})
+	generator.mountType = "aws"
+
+	err := generator.createSecretBackendRoleResources()
+	if err == nil {
+		t.Fatal("expected secret backend role list error")
+	}
+	if !strings.Contains(err.Error(), "list vault secret backend roles at aws/roles") {
+		t.Fatalf("error = %q, want wrapped secret backend role list error", err)
+	}
+}
+
+func TestCreateAuthBackendEntityResourcesReturnsListError(t *testing.T) {
+	generator := newVaultTestGenerator(t, func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/v1/sys/auth":
+			writeVaultMounts(t, w, "approle/", "approle")
+		default:
+			http.Error(w, "list failed", http.StatusServiceUnavailable)
+		}
+	})
+	generator.mountType = "approle"
+
+	err := generator.createAuthBackendEntityResources("role", "role")
+	if err == nil {
+		t.Fatal("expected auth backend entity list error")
+	}
+	if !strings.Contains(err.Error(), "list vault auth backend role at /auth/approle/role") {
+		t.Fatalf("error = %q, want wrapped auth backend entity list error", err)
+	}
+}
+
+func TestCreateGenericSecretResourcesReturnsListError(t *testing.T) {
+	generator := newVaultTestGenerator(t, func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/v1/sys/mounts":
+			writeVaultMounts(t, w, "secret/", "kv")
+		default:
+			http.Error(w, "list failed", http.StatusServiceUnavailable)
+		}
+	})
+	generator.mountType = "kv"
+
+	err := generator.createGenericSecretResources()
+	if err == nil {
+		t.Fatal("expected generic secret list error")
+	}
+	if !strings.Contains(err.Error(), "list vault generic secrets at secret/") {
+		t.Fatalf("error = %q, want wrapped generic secret list error", err)
+	}
+}
+
+func newVaultTestGenerator(t *testing.T, handler http.HandlerFunc) *ServiceGenerator {
+	t.Helper()
+
+	server := httptest.NewServer(handler)
+	t.Cleanup(server.Close)
+
+	client, err := vaultapi.NewClient(&vaultapi.Config{Address: server.URL})
+	if err != nil {
+		t.Fatal(err)
+	}
+	return &ServiceGenerator{client: client}
+}
+
+func writeVaultMounts(t *testing.T, w http.ResponseWriter, mountPath, mountType string) {
+	t.Helper()
+
+	w.Header().Set("Content-Type", "application/json")
+	if err := json.NewEncoder(w).Encode(map[string]interface{}{
+		"data": map[string]interface{}{
+			mountPath: map[string]interface{}{
+				"type": mountType,
+			},
+		},
+	}); err != nil {
+		t.Fatal(err)
+	}
+}


### PR DESCRIPTION
## Summary

- Return GitHub app-auth client construction errors instead of handing back a nil client.
- Propagate Vault nested list errors for secret backend roles, auth backend entities, and generic secrets.
- Add focused tests for GitHub app-auth setup failure and Vault list failure propagation.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Surfaced provider discovery/setup errors so failures are explicit and actionable. Prevents nil GitHub clients and avoids silent skips during Vault resource generation.

- **Bug Fixes**
  - GitHub: `createClient`/`createRegularClient` now return errors; propagate GitHub App auth failures from `ghinstallation` (e.g., bad PEM) instead of returning a nil client.
  - Vault: return wrapped errors when `List` calls fail for secret backend roles, auth backend entities, and generic secrets, including the failing path.
  - Tests: added focused tests for GitHub app-auth setup failure and Vault list error propagation.

<sup>Written for commit 3d45f898f0daa15b20d7ef2a7c4e78bebd279640. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling for GitHub service authentication failures
  * Enhanced error reporting for Vault list operations to prevent silent failures

<!-- end of auto-generated comment: release notes by coderabbit.ai -->