### PR TITLE
fix(gcp): return gcs iam policy errors

### DIFF
--- a/providers/gcp/gcs.go
+++ b/providers/gcp/gcs.go
@@ -74,38 +74,11 @@ func (g *GcsGenerator) createBucketsResources(ctx context.Context, gcsService *s
 				GcsAdditionalFields,
 			))
 
-			if iam, err := gcsService.Buckets.GetIamPolicy(bucket.Name).Do(); err == nil {
-				for _, binding := range iam.Bindings {
-					resources = append(resources, terraformutils.NewResource(
-						bucket.Name,
-						bucket.Name,
-						"google_storage_bucket_iam_binding",
-						g.ProviderName,
-						map[string]string{
-							"bucket": bucket.Name,
-							"role":   binding.Role,
-						},
-						GcsAllowEmptyValues,
-						GcsAdditionalFields,
-					))
-
-					for _, member := range binding.Members {
-						resources = append(resources, terraformutils.NewResource(
-							bucket.Name,
-							bucket.Name,
-							"google_storage_bucket_iam_member",
-							g.ProviderName,
-							map[string]string{
-								"bucket": bucket.Name,
-								"role":   binding.Role,
-								"member": member,
-							},
-							GcsAllowEmptyValues,
-							GcsAdditionalFields,
-						))
-					}
-				}
+			iamResources, err := g.createBucketIAMResources(gcsService, bucket)
+			if err != nil {
+				return err
 			}
+			resources = append(resources, iamResources...)
 
 			notificationResources, err := g.createNotificationResources(gcsService, bucket)
 			if err != nil {
@@ -116,6 +89,45 @@ func (g *GcsGenerator) createBucketsResources(ctx context.Context, gcsService *s
 		return nil
 	}); err != nil {
 		return nil, fmt.Errorf("list gcs buckets: %w", err)
+	}
+	return resources, nil
+}
+
+func (g *GcsGenerator) createBucketIAMResources(gcsService *storage.Service, bucket *storage.Bucket) ([]terraformutils.Resource, error) {
+	resources := []terraformutils.Resource{}
+	iam, err := gcsService.Buckets.GetIamPolicy(bucket.Name).Do()
+	if err != nil {
+		return nil, fmt.Errorf("get gcs bucket IAM policy for %s: %w", bucket.Name, err)
+	}
+	for _, binding := range iam.Bindings {
+		resources = append(resources, terraformutils.NewResource(
+			bucket.Name,
+			bucket.Name,
+			"google_storage_bucket_iam_binding",
+			g.ProviderName,
+			map[string]string{
+				"bucket": bucket.Name,
+				"role":   binding.Role,
+			},
+			GcsAllowEmptyValues,
+			GcsAdditionalFields,
+		))
+
+		for _, member := range binding.Members {
+			resources = append(resources, terraformutils.NewResource(
+				bucket.Name,
+				bucket.Name,
+				"google_storage_bucket_iam_member",
+				g.ProviderName,
+				map[string]string{
+					"bucket": bucket.Name,
+					"role":   binding.Role,
+					"member": member,
+				},
+				GcsAllowEmptyValues,
+				GcsAdditionalFields,
+			))
+		}
 	}
 	return resources, nil
 }

--- a/providers/gcp/gcs_test.go
+++ b/providers/gcp/gcs_test.go
@@ -4,6 +4,7 @@ package gcp
 
 import (
 	"context"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -34,6 +35,37 @@ func TestCreateBucketsResourcesReturnsBucketListError(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "list gcs buckets") {
 		t.Fatalf("expected wrapped gcs bucket list error, got %q", err)
+	}
+}
+
+func TestCreateBucketsResourcesReturnsIAMPolicyError(t *testing.T) {
+	ctx := context.Background()
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/b":
+			fmt.Fprint(w, "{\"items\":[{\"name\":\"test-bucket\"}]}")
+		case "/b/test-bucket/iam":
+			http.Error(w, "{\"error\":{\"message\":\"service unavailable\"}}", http.StatusServiceUnavailable)
+		default:
+			t.Fatalf("unexpected path %s", r.URL.Path)
+		}
+	}))
+	t.Cleanup(server.Close)
+
+	gcsService, err := storage.NewService(ctx, option.WithEndpoint(server.URL+"/"), option.WithoutAuthentication())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	g := GcsGenerator{}
+	g.SetArgs(map[string]interface{}{"project": "test-project"})
+
+	_, err = g.createBucketsResources(ctx, gcsService)
+	if err == nil {
+		t.Fatal("expected gcs bucket IAM policy error")
+	}
+	if !strings.Contains(err.Error(), "get gcs bucket IAM policy for test-bucket") {
+		t.Fatalf("expected wrapped gcs bucket IAM policy error, got %q", err)
 	}
 }
 


### PR DESCRIPTION
## Summary

- Return GCS bucket IAM policy lookup errors instead of silently omitting IAM binding/member resources.
- Move bucket IAM resource construction into a helper that returns wrapped API errors.
- Add focused coverage for the GCS IAM policy failure path.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Return GCS bucket IAM policy errors during bucket resource generation to avoid silently skipping IAM bindings and members. This improves error visibility and troubleshooting when `Buckets.GetIamPolicy` fails.

- **Bug Fixes**
  - Return wrapped errors from IAM policy lookup and halt generation on failure.
  - Add a focused test for the IAM policy failure path.

- **Refactors**
  - Extract IAM resource creation into `createBucketIAMResources`, which builds `google_storage_bucket_iam_binding` and `google_storage_bucket_iam_member` resources and wraps API errors.

<sup>Written for commit d3f493cee5f2d728db7c67353283b3d3289e437f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * GCS bucket IAM policy fetch errors are now properly reported and handled, preventing incomplete resource configurations.

* **Refactoring**
  * Refactored IAM resource generation logic into a dedicated helper function for improved code organization.

* **Tests**
  * Added test coverage for IAM policy fetch failure scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->