### PR TITLE
fix(datadog): return synthetics variable errors

### DIFF
--- a/providers/datadog/synthetics_global_variable.go
+++ b/providers/datadog/synthetics_global_variable.go
@@ -60,8 +60,7 @@ func (g *SyntheticsGlobalVariableGenerator) InitResources() error {
 					_ = httpResp.Body.Close()
 				}
 				if err != nil {
-					log.Printf("error retrieving synthetics gloval variable with id:%s - %s", v, err)
-					continue
+					return fmt.Errorf("get datadog synthetics global variable %s: %w", v, err)
 				}
 				globalVariableIDs = append(globalVariableIDs, resp)
 			}

--- a/providers/datadog/synthetics_global_variable_test.go
+++ b/providers/datadog/synthetics_global_variable_test.go
@@ -16,7 +16,9 @@ import (
 func TestSyntheticsGlobalVariableInitResourcesReturnsFilteredIDError(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path != "/api/v1/synthetics/variables/global-1" {
-			t.Fatalf("unexpected path %s", r.URL.Path)
+			t.Errorf("unexpected path %s", r.URL.Path)
+			http.NotFound(w, r)
+			return
 		}
 		http.Error(w, "{\"errors\":[\"service unavailable\"]}", http.StatusServiceUnavailable)
 	}))
@@ -50,5 +52,42 @@ func TestSyntheticsGlobalVariableInitResourcesReturnsFilteredIDError(t *testing.
 	}
 	if !strings.Contains(err.Error(), "get datadog synthetics global variable global-1") {
 		t.Fatalf("InitResources error = %q, want wrapped global variable error", err)
+	}
+}
+
+func TestSyntheticsGlobalVariableInitResourcesOmitsFilteredIDSucceeds(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		t.Errorf("unexpected request for omitted synthetics global variable: %s", r.URL.Path)
+		http.NotFound(w, r)
+	}))
+	t.Cleanup(server.Close)
+
+	config := datadog.NewConfiguration()
+	config.Servers = datadog.ServerConfigurations{{URL: server.URL}}
+	config.HTTPClient = server.Client()
+
+	generator := &SyntheticsGlobalVariableGenerator{
+		DatadogService: DatadogService{
+			Service: terraformutils.Service{
+				Args: map[string]interface{}{
+					"auth":          context.Background(),
+					"datadogClient": datadog.NewAPIClient(config),
+				},
+				Filter: []terraformutils.ResourceFilter{
+					{
+						ServiceName:      "synthetics_global_variable",
+						FieldPath:        "id",
+						AcceptableValues: nil,
+					},
+				},
+			},
+		},
+	}
+
+	if err := generator.InitResources(); err != nil {
+		t.Fatalf("InitResources returned error for omitted synthetics global variable ID: %v", err)
+	}
+	if len(generator.Resources) != 0 {
+		t.Fatalf("Resources length = %d, want 0", len(generator.Resources))
 	}
 }

--- a/providers/datadog/synthetics_global_variable_test.go
+++ b/providers/datadog/synthetics_global_variable_test.go
@@ -1,0 +1,54 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package datadog
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/DataDog/datadog-api-client-go/v2/api/datadog"
+	"github.com/chenrui333/terraformer/terraformutils"
+)
+
+func TestSyntheticsGlobalVariableInitResourcesReturnsFilteredIDError(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/v1/synthetics/variables/global-1" {
+			t.Fatalf("unexpected path %s", r.URL.Path)
+		}
+		http.Error(w, "{\"errors\":[\"service unavailable\"]}", http.StatusServiceUnavailable)
+	}))
+	t.Cleanup(server.Close)
+
+	config := datadog.NewConfiguration()
+	config.Servers = datadog.ServerConfigurations{{URL: server.URL}}
+	config.HTTPClient = server.Client()
+
+	generator := &SyntheticsGlobalVariableGenerator{
+		DatadogService: DatadogService{
+			Service: terraformutils.Service{
+				Args: map[string]interface{}{
+					"auth":          context.Background(),
+					"datadogClient": datadog.NewAPIClient(config),
+				},
+				Filter: []terraformutils.ResourceFilter{
+					{
+						ServiceName:      "synthetics_global_variable",
+						FieldPath:        "id",
+						AcceptableValues: []string{"global-1"},
+					},
+				},
+			},
+		},
+	}
+
+	err := generator.InitResources()
+	if err == nil {
+		t.Fatal("expected filtered synthetics global variable error")
+	}
+	if !strings.Contains(err.Error(), "get datadog synthetics global variable global-1") {
+		t.Fatalf("InitResources error = %q, want wrapped global variable error", err)
+	}
+}


### PR DESCRIPTION
## Summary

- Return explicit Datadog synthetics global variable lookup errors instead of logging and skipping filtered IDs.
- Keep filtered-ID imports from succeeding after omitting requested synthetics global variables.
- Add focused coverage for the filtered lookup failure path.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Return explicit errors when fetching Datadog synthetics global variables, instead of logging and skipping, so filtered-ID imports fail fast and surface the API error.

- **Bug Fixes**
  - Return wrapped error from `InitResources` when a global variable fetch fails.
  - Add unit tests for the filtered lookup failure and omitted-ID paths.

<sup>Written for commit 51915ae5af8ae21f85489262cf00a7bbd398df23. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fail-fast error handling added for Datadog synthetics global variable retrieval so initialization stops on retrieval errors rather than continuing.

* **Tests**
  * New unit tests covering initialization error scenarios and filtered-ID behavior for synthetics global variables.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->