### PR TITLE
feat(datadog): add RUM application import

### DIFF
--- a/docs/datadog.md
+++ b/docs/datadog.md
@@ -147,6 +147,8 @@ Tag filters are order specific. For example, if your monitor has tags (in the or
 *   `monitor_notification_rule`
     * `datadog_monitor_notification_rule`
         * **_NOTE:_** Requires DataDog/datadog provider 3.83.0 or newer.
+*   `rum_application`
+    * `datadog_rum_application`
 *   `rum_metric`
     * `datadog_rum_metric`
 *   `role`

--- a/providers/datadog/datadog_provider.go
+++ b/providers/datadog/datadog_provider.go
@@ -188,6 +188,7 @@ func (p *DatadogProvider) GetSupportedService() map[string]terraformutils.Servic
 		"monitor_config_policy":                &MonitorConfigPolicyGenerator{},
 		"monitor_json":                         &MonitorJSONGenerator{},
 		"monitor_notification_rule":            &MonitorNotificationRuleGenerator{},
+		"rum_application":                      &RumApplicationGenerator{},
 		"rum_metric":                           &RumMetricGenerator{},
 		"security_monitoring_default_rule":     &SecurityMonitoringDefaultRuleGenerator{},
 		"security_monitoring_filter":           &SecurityMonitoringFilterGenerator{},

--- a/providers/datadog/rum_application.go
+++ b/providers/datadog/rum_application.go
@@ -1,0 +1,97 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package datadog
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/DataDog/datadog-api-client-go/v2/api/datadog"
+	"github.com/DataDog/datadog-api-client-go/v2/api/datadogV2"
+
+	"github.com/chenrui333/terraformer/terraformutils"
+)
+
+var (
+	// RumApplicationAllowEmptyValues ...
+	RumApplicationAllowEmptyValues = []string{}
+)
+
+// RumApplicationGenerator ...
+type RumApplicationGenerator struct {
+	DatadogService
+}
+
+func (g *RumApplicationGenerator) createResources(rumApplications []datadogV2.RUMApplicationList) []terraformutils.Resource {
+	resources := []terraformutils.Resource{}
+	for _, rumApplication := range rumApplications {
+		applicationID := rumApplication.GetId()
+		if applicationID == "" {
+			attributes := rumApplication.GetAttributes()
+			applicationID = attributes.GetApplicationId()
+		}
+		if applicationID == "" {
+			continue
+		}
+		resources = append(resources, g.createResource(applicationID))
+	}
+
+	return resources
+}
+
+func (g *RumApplicationGenerator) createResource(applicationID string) terraformutils.Resource {
+	return terraformutils.NewSimpleResource(
+		applicationID,
+		fmt.Sprintf("rum_application_%s", applicationID),
+		"datadog_rum_application",
+		"datadog",
+		RumApplicationAllowEmptyValues,
+	)
+}
+
+// InitResources Generate TerraformResources from Datadog API,
+// from each RUM application create 1 TerraformResource.
+func (g *RumApplicationGenerator) InitResources() error {
+	datadogClient := g.Args["datadogClient"].(*datadog.APIClient)
+	auth := g.Args["auth"].(context.Context)
+	api := datadogV2.NewRUMApi(datadogClient)
+
+	resources := []terraformutils.Resource{}
+	hasIDFilter := false
+	for _, filter := range g.Filter {
+		if filter.FieldPath == "id" && filter.IsApplicable("rum_application") {
+			hasIDFilter = true
+			for _, value := range filter.AcceptableValues {
+				rumApplication, httpResp, err := api.GetRUMApplication(auth, value)
+				if httpResp != nil && httpResp.Body != nil {
+					_ = httpResp.Body.Close()
+				}
+				if err != nil {
+					return err
+				}
+
+				applicationData := rumApplication.GetData()
+				applicationID := applicationData.GetId()
+				if applicationID == "" {
+					applicationID = value
+				}
+				resources = append(resources, g.createResource(applicationID))
+			}
+		}
+	}
+
+	if hasIDFilter || len(resources) > 0 {
+		g.Resources = resources
+		return nil
+	}
+
+	rumApplications, httpResp, err := api.GetRUMApplications(auth)
+	if httpResp != nil && httpResp.Body != nil {
+		_ = httpResp.Body.Close()
+	}
+	if err != nil {
+		return err
+	}
+	g.Resources = g.createResources(rumApplications.GetData())
+	return nil
+}

--- a/providers/datadog/rum_application_test.go
+++ b/providers/datadog/rum_application_test.go
@@ -1,0 +1,226 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package datadog
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/DataDog/datadog-api-client-go/v2/api/datadog"
+	"github.com/DataDog/datadog-api-client-go/v2/api/datadogV2"
+	"github.com/chenrui333/terraformer/terraformutils"
+)
+
+func TestRumApplicationCreateResource(t *testing.T) {
+	generator := &RumApplicationGenerator{}
+	resource := generator.createResource("app-123")
+
+	if resource.InstanceState.ID != "app-123" {
+		t.Fatalf("expected resource ID app-123, got %s", resource.InstanceState.ID)
+	}
+	if resource.ResourceName != "tfer--rum_application_app-123" {
+		t.Fatalf("expected resource name tfer--rum_application_app-123, got %s", resource.ResourceName)
+	}
+	if resource.InstanceInfo.Type != "datadog_rum_application" {
+		t.Fatalf("expected resource type datadog_rum_application, got %s", resource.InstanceInfo.Type)
+	}
+}
+
+func TestRumApplicationCreateResources(t *testing.T) {
+	firstApplication := datadogV2.NewRUMApplicationListWithDefaults()
+	firstApplication.SetId("app-123")
+
+	secondApplication := datadogV2.NewRUMApplicationListWithDefaults()
+	secondApplication.SetId("app-456")
+
+	generator := &RumApplicationGenerator{}
+	resources := generator.createResources([]datadogV2.RUMApplicationList{*firstApplication, *secondApplication})
+
+	if len(resources) != 2 {
+		t.Fatalf("expected 2 resources, got %d", len(resources))
+	}
+	if resources[0].InstanceState.ID != "app-123" {
+		t.Fatalf("expected first resource ID app-123, got %s", resources[0].InstanceState.ID)
+	}
+	if resources[1].InstanceState.ID != "app-456" {
+		t.Fatalf("expected second resource ID app-456, got %s", resources[1].InstanceState.ID)
+	}
+}
+
+func TestRumApplicationCreateResourcesSkipsEmptyIDs(t *testing.T) {
+	validApplication := datadogV2.NewRUMApplicationListWithDefaults()
+	validApplication.SetId("app-123")
+
+	missingIDApplication := datadogV2.NewRUMApplicationListWithDefaults()
+
+	generator := &RumApplicationGenerator{}
+	resources := generator.createResources([]datadogV2.RUMApplicationList{*missingIDApplication, *validApplication})
+
+	if len(resources) != 1 {
+		t.Fatalf("expected 1 resource, got %d", len(resources))
+	}
+	if resources[0].InstanceState.ID != "app-123" {
+		t.Fatalf("expected resource ID app-123, got %s", resources[0].InstanceState.ID)
+	}
+}
+
+func TestRumApplicationCreateResourcesFallsBackToAttributeApplicationID(t *testing.T) {
+	application := datadogV2.NewRUMApplicationListWithDefaults()
+	attributes := datadogV2.NewRUMApplicationListAttributesWithDefaults()
+	attributes.SetApplicationId("app-attributes")
+	application.SetAttributes(*attributes)
+
+	generator := &RumApplicationGenerator{}
+	resources := generator.createResources([]datadogV2.RUMApplicationList{*application})
+
+	if len(resources) != 1 {
+		t.Fatalf("expected 1 resource, got %d", len(resources))
+	}
+	if resources[0].InstanceState.ID != "app-attributes" {
+		t.Fatalf("expected resource ID app-attributes, got %s", resources[0].InstanceState.ID)
+	}
+}
+
+func TestRumApplicationInitResourcesFetchesIDFilter(t *testing.T) {
+	requestedPaths := []string{}
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestedPaths = append(requestedPaths, r.URL.Path)
+		w.Header().Set("Content-Type", "application/json")
+
+		switch r.URL.Path {
+		case "/api/v2/rum/applications/app-123":
+			_, _ = fmt.Fprint(w, rumApplicationResponseJSON("app-123"))
+		case "/api/v2/rum/applications":
+			http.Error(w, "unexpected list request", http.StatusInternalServerError)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+
+	generator := newRumApplicationTestGenerator(server, []terraformutils.ResourceFilter{
+		{
+			ServiceName:      "rum_application",
+			FieldPath:        "id",
+			AcceptableValues: []string{"app-123"},
+		},
+	})
+
+	if err := generator.InitResources(); err != nil {
+		t.Fatalf("InitResources returned error: %v", err)
+	}
+	if len(generator.Resources) != 1 {
+		t.Fatalf("expected 1 resource, got %d", len(generator.Resources))
+	}
+	if generator.Resources[0].InstanceState.ID != "app-123" {
+		t.Fatalf("expected resource ID app-123, got %s", generator.Resources[0].InstanceState.ID)
+	}
+	for _, path := range requestedPaths {
+		if path == "/api/v2/rum/applications" {
+			t.Fatalf("expected id filter to avoid list request, got requests %v", requestedPaths)
+		}
+	}
+}
+
+func TestRumApplicationInitResourcesListsWithoutIDFilter(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+
+		switch r.URL.Path {
+		case "/api/v2/rum/applications":
+			_, _ = fmt.Fprint(w, rumApplicationListResponseJSON("app-123", "app-456"))
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+
+	generator := newRumApplicationTestGenerator(server, nil)
+
+	if err := generator.InitResources(); err != nil {
+		t.Fatalf("InitResources returned error: %v", err)
+	}
+	if len(generator.Resources) != 2 {
+		t.Fatalf("expected 2 resources, got %d", len(generator.Resources))
+	}
+	if generator.Resources[0].InstanceState.ID != "app-123" {
+		t.Fatalf("expected first resource ID app-123, got %s", generator.Resources[0].InstanceState.ID)
+	}
+	if generator.Resources[1].InstanceState.ID != "app-456" {
+		t.Fatalf("expected second resource ID app-456, got %s", generator.Resources[1].InstanceState.ID)
+	}
+}
+
+func TestRumApplicationInitResourcesPropagatesIDFilterError(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		http.Error(w, "fetch failed", http.StatusInternalServerError)
+	}))
+	defer server.Close()
+
+	generator := newRumApplicationTestGenerator(server, []terraformutils.ResourceFilter{
+		{
+			ServiceName:      "rum_application",
+			FieldPath:        "id",
+			AcceptableValues: []string{"app-error"},
+		},
+	})
+
+	if err := generator.InitResources(); err == nil {
+		t.Fatal("InitResources returned nil error, want ID fetch error")
+	}
+}
+
+func TestRumApplicationInitResourcesPropagatesListError(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		http.Error(w, "list failed", http.StatusInternalServerError)
+	}))
+	defer server.Close()
+
+	generator := newRumApplicationTestGenerator(server, nil)
+
+	if err := generator.InitResources(); err == nil {
+		t.Fatal("InitResources returned nil error, want list error")
+	}
+}
+
+func newRumApplicationTestGenerator(server *httptest.Server, filter []terraformutils.ResourceFilter) *RumApplicationGenerator {
+	config := datadog.NewConfiguration()
+	config.Servers = datadog.ServerConfigurations{{URL: server.URL}}
+	config.HTTPClient = server.Client()
+
+	return &RumApplicationGenerator{
+		DatadogService: DatadogService{
+			Service: terraformutils.Service{
+				Args: map[string]interface{}{
+					"auth":          context.Background(),
+					"datadogClient": datadog.NewAPIClient(config),
+				},
+				Filter: filter,
+			},
+		},
+	}
+}
+
+func rumApplicationResponseJSON(id string) string {
+	return fmt.Sprintf("{\"data\":%s}", rumApplicationJSON(id))
+}
+
+func rumApplicationListResponseJSON(ids ...string) string {
+	applications := []string{}
+	for _, id := range ids {
+		applications = append(applications, rumApplicationJSON(id))
+	}
+	return fmt.Sprintf("{\"data\":[%s]}", strings.Join(applications, ","))
+}
+
+func rumApplicationJSON(id string) string {
+	return fmt.Sprintf(
+		"{\"id\":%q,\"type\":\"rum_application\",\"attributes\":{\"application_id\":%q,\"created_at\":1700000000000,\"created_by_handle\":\"user@example.com\",\"name\":\"Test application\",\"org_id\":123,\"type\":\"browser\",\"updated_at\":1700000000000,\"updated_by_handle\":\"user@example.com\"}}",
+		id,
+		id,
+	)
+}


### PR DESCRIPTION
Summary
- add Datadog RUM application import support
- support ID-filtered imports and full list imports through the Datadog RUM v2 API
- document the new `rum_application` service

Notes
- RUM application import uses the Terraform provider's ID passthrough read path.
- List imports fall back to `attributes.application_id` when the API omits the optional top-level list item ID.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds support for importing Datadog RUM applications. You can import by ID or import all apps via the RUM v2 API.

- **New Features**
  - Added `rum_application` service mapped to `datadog_rum_application`.
  - Supports ID-filtered imports and full list imports.
  - Uses ID passthrough on read; falls back to `attributes.application_id` when list items omit the top-level ID. Docs updated.

<sup>Written for commit 5c6010e32ed6368643b16643f364c17548f547b7. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for RUM application resources to the Datadog Terraform provider, enabling full Terraform-based management of RUM applications.

* **Documentation**
  * Updated the list of supported Datadog resource types to include the new RUM application resource.

* **Tests**
  * Added comprehensive test coverage for RUM application resource creation, initialization, filtering, and error handling scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->