### PR TITLE
fix(aws): return efs child lookup errors

### DIFF
--- a/providers/aws/efs.go
+++ b/providers/aws/efs.go
@@ -4,11 +4,14 @@ package aws
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
 	"github.com/chenrui333/terraformer/terraformutils"
 
 	"github.com/aws/aws-sdk-go-v2/service/efs"
+	efstypes "github.com/aws/aws-sdk-go-v2/service/efs/types"
+	"github.com/aws/smithy-go"
 )
 
 var efsAllowEmptyValues = []string{"tags."}
@@ -40,9 +43,10 @@ func (g *EfsGenerator) loadFileSystem(svc *efs.Client) error {
 			return err
 		}
 		for _, fileSystem := range page.FileSystems {
+			fileSystemID := StringValue(fileSystem.FileSystemId)
 			g.Resources = append(g.Resources, terraformutils.NewSimpleResource(
-				StringValue(fileSystem.FileSystemId),
-				StringValue(fileSystem.FileSystemId),
+				fileSystemID,
+				fileSystemID,
 				"aws_efs_file_system",
 				"aws",
 				efsAllowEmptyValues))
@@ -51,8 +55,7 @@ func (g *EfsGenerator) loadFileSystem(svc *efs.Client) error {
 				FileSystemId: fileSystem.FileSystemId,
 			})
 			if err != nil {
-				fmt.Println(err.Error())
-				continue
+				return fmt.Errorf("describe efs mount targets for %s: %w", fileSystemID, err)
 			}
 			for _, mountTarget := range targetsResponse.MountTargets {
 				g.Resources = append(g.Resources, terraformutils.NewSimpleResource(
@@ -66,17 +69,22 @@ func (g *EfsGenerator) loadFileSystem(svc *efs.Client) error {
 			policyResponse, err := svc.DescribeFileSystemPolicy(context.TODO(), &efs.DescribeFileSystemPolicyInput{
 				FileSystemId: fileSystem.FileSystemId,
 			})
+			if efsFileSystemPolicyMissing(err) {
+				continue
+			}
 			if err != nil {
-				fmt.Println(err.Error())
+				return fmt.Errorf("describe efs file system policy for %s: %w", fileSystemID, err)
+			}
+			if policyResponse == nil || StringValue(policyResponse.Policy) == "" {
 				continue
 			}
 			g.Resources = append(g.Resources, terraformutils.NewResource(
-				StringValue(fileSystem.FileSystemId),
-				StringValue(fileSystem.FileSystemId),
+				fileSystemID,
+				fileSystemID,
 				"aws_efs_file_system_policy",
 				"aws",
 				map[string]string{
-					"file_system_id": StringValue(fileSystem.FileSystemId),
+					"file_system_id": fileSystemID,
 					"policy":         StringValue(policyResponse.Policy),
 				},
 				efsAllowEmptyValues,
@@ -84,6 +92,16 @@ func (g *EfsGenerator) loadFileSystem(svc *efs.Client) error {
 		}
 	}
 	return nil
+}
+
+func efsFileSystemPolicyMissing(err error) bool {
+	var notFound *efstypes.PolicyNotFound
+	if errors.As(err, &notFound) {
+		return true
+	}
+
+	var apiErr smithy.APIError
+	return errors.As(err, &apiErr) && apiErr.ErrorCode() == "PolicyNotFound"
 }
 
 func (g *EfsGenerator) loadAccessPoint(svc *efs.Client) error {

--- a/providers/aws/efs_test.go
+++ b/providers/aws/efs_test.go
@@ -1,0 +1,117 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package aws
+
+import (
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/credentials"
+	"github.com/aws/aws-sdk-go-v2/service/efs"
+	efstypes "github.com/aws/aws-sdk-go-v2/service/efs/types"
+	"github.com/aws/smithy-go"
+)
+
+func TestEfsLoadFileSystemReturnsMountTargetErrors(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/2015-02-01/file-systems":
+			writeEfsJSON(w, http.StatusOK, "{\"FileSystems\":[{\"FileSystemId\":\"fs-123\"}]}")
+		case "/2015-02-01/mount-targets":
+			if got := r.URL.Query().Get("FileSystemId"); got != "fs-123" {
+				t.Errorf("FileSystemId query = %q, want %q", got, "fs-123")
+			}
+			writeEfsJSON(w, http.StatusInternalServerError, "{\"message\":\"temporary failure\"}")
+		default:
+			t.Errorf("unexpected path %s", r.URL.Path)
+			http.NotFound(w, r)
+		}
+	}))
+	t.Cleanup(server.Close)
+
+	generator := &EfsGenerator{}
+	err := generator.loadFileSystem(newTestEfsClient(server))
+	if err == nil {
+		t.Fatal("expected mount target lookup error")
+	}
+	if !strings.Contains(err.Error(), "describe efs mount targets for fs-123") {
+		t.Fatalf("loadFileSystem error = %q, want mount target context", err)
+	}
+}
+
+func TestEfsLoadFileSystemSkipsMissingPolicy(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/2015-02-01/file-systems":
+			writeEfsJSON(w, http.StatusOK, "{\"FileSystems\":[{\"FileSystemId\":\"fs-123\"}]}")
+		case "/2015-02-01/mount-targets":
+			if got := r.URL.Query().Get("FileSystemId"); got != "fs-123" {
+				t.Errorf("FileSystemId query = %q, want %q", got, "fs-123")
+			}
+			writeEfsJSON(w, http.StatusOK, "{\"MountTargets\":[]}")
+		case "/2015-02-01/file-systems/fs-123/policy":
+			w.Header().Set("x-amzn-ErrorType", "PolicyNotFound")
+			writeEfsJSON(w, http.StatusNotFound, "{\"__type\":\"PolicyNotFound\",\"message\":\"policy not found\"}")
+		default:
+			t.Errorf("unexpected path %s", r.URL.Path)
+			http.NotFound(w, r)
+		}
+	}))
+	t.Cleanup(server.Close)
+
+	generator := &EfsGenerator{}
+	if err := generator.loadFileSystem(newTestEfsClient(server)); err != nil {
+		t.Fatalf("loadFileSystem returned error for missing policy: %v", err)
+	}
+	if len(generator.Resources) != 1 {
+		t.Fatalf("len(Resources) = %d, want 1", len(generator.Resources))
+	}
+	if got := generator.Resources[0].InstanceInfo.Type; got != "aws_efs_file_system" {
+		t.Fatalf("resource type = %q, want aws_efs_file_system", got)
+	}
+}
+
+func TestEfsFileSystemPolicyMissing(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{name: "typed policy not found", err: &efstypes.PolicyNotFound{}, want: true},
+		{name: "wrapped policy not found", err: errors.Join(errors.New("lookup failed"), &efstypes.PolicyNotFound{}), want: true},
+		{name: "api error code", err: &smithy.GenericAPIError{Code: "PolicyNotFound"}, want: true},
+		{name: "access denied", err: &smithy.GenericAPIError{Code: "AccessDeniedException"}, want: false},
+		{name: "generic error", err: errors.New("boom"), want: false},
+		{name: "nil error", want: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := efsFileSystemPolicyMissing(tt.err); got != tt.want {
+				t.Fatalf("efsFileSystemPolicyMissing() = %t, want %t", got, tt.want)
+			}
+		})
+	}
+}
+
+func newTestEfsClient(server *httptest.Server) *efs.Client {
+	config := aws.Config{
+		Region:           "us-east-1",
+		Credentials:      credentials.NewStaticCredentialsProvider("test", "test", ""),
+		HTTPClient:       server.Client(),
+		RetryMaxAttempts: 1,
+	}
+	return efs.NewFromConfig(config, func(options *efs.Options) {
+		options.BaseEndpoint = aws.String(server.URL)
+	})
+}
+
+func writeEfsJSON(w http.ResponseWriter, status int, body string) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	_, _ = w.Write([]byte(body))
+}


### PR DESCRIPTION
## Summary

- Return EFS mount target and file system policy lookup errors instead of printing and skipping them.
- Preserve the expected no-policy path by skipping EFS PolicyNotFound responses.
- Add focused AWS EFS coverage for propagated child lookup failures and missing-policy skips.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Return EFS child lookup errors with clear context instead of printing and skipping, and treat missing file system policies as expected. This improves error visibility while preserving the no-policy path.

- **Bug Fixes**
  - Propagate errors from `DescribeMountTargets` and `DescribeFileSystemPolicy` with the file system ID.
  - Skip missing policy (`PolicyNotFound` via typed `efs` error or `smithy` API code) without failing generation.
  - Added focused tests covering error propagation and missing-policy behavior.

<sup>Written for commit dce040d4f5bdad1ab10b39730731f29cd21625a4. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling for EFS file system and mount-target operations with proper error propagation.
  * Enhanced handling of missing EFS file system policies to gracefully skip them.

* **Tests**
  * Added comprehensive test coverage for EFS file system operations and error scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->