### PR TITLE
feat(datadog): add RUM retention filter import

### DIFF
--- a/docs/datadog.md
+++ b/docs/datadog.md
@@ -151,6 +151,12 @@ Tag filters are order specific. For example, if your monitor has tags (in the or
     * `datadog_rum_application`
 *   `rum_metric`
     * `datadog_rum_metric`
+*   `rum_retention_filter`
+    * `datadog_rum_retention_filter`
+        * **_NOTE:_** Importing a single RUM retention filter by ID requires `application_id:retention_filter_id`, for example `--filter=rum_retention_filter=app-id:filter-id`
+*   `rum_retention_filters_order`
+    * `datadog_rum_retention_filters_order`
+        * **_NOTE:_** Importing a single RUM retention filters order by ID uses the RUM application ID, for example `--filter=rum_retention_filters_order=app-id`
 *   `role`
     * `datadog_role`
 *   `security_monitoring_default_rule`

--- a/docs/datadog.md
+++ b/docs/datadog.md
@@ -153,7 +153,7 @@ Tag filters are order specific. For example, if your monitor has tags (in the or
     * `datadog_rum_metric`
 *   `rum_retention_filter`
     * `datadog_rum_retention_filter`
-        * **_NOTE:_** Importing a single RUM retention filter by ID requires `application_id:retention_filter_id`, for example `--filter=rum_retention_filter=app-id:filter-id`
+        * **_NOTE:_** Importing a single RUM retention filter by ID requires `application_id:retention_filter_id`, for example `--filter="rum_retention_filter='app-id:filter-id'"`
 *   `rum_retention_filters_order`
     * `datadog_rum_retention_filters_order`
         * **_NOTE:_** Importing a single RUM retention filters order by ID uses the RUM application ID, for example `--filter=rum_retention_filters_order=app-id`

--- a/providers/datadog/datadog_provider.go
+++ b/providers/datadog/datadog_provider.go
@@ -190,6 +190,8 @@ func (p *DatadogProvider) GetSupportedService() map[string]terraformutils.Servic
 		"monitor_notification_rule":            &MonitorNotificationRuleGenerator{},
 		"rum_application":                      &RumApplicationGenerator{},
 		"rum_metric":                           &RumMetricGenerator{},
+		"rum_retention_filter":                 &RumRetentionFilterGenerator{},
+		"rum_retention_filters_order":          &RumRetentionFiltersOrderGenerator{},
 		"security_monitoring_default_rule":     &SecurityMonitoringDefaultRuleGenerator{},
 		"security_monitoring_filter":           &SecurityMonitoringFilterGenerator{},
 		"security_monitoring_rule":             &SecurityMonitoringRuleGenerator{},
@@ -250,6 +252,19 @@ func (p DatadogProvider) GetResourceConnections() map[string]map[string][]string
 			},
 			"monitor_json": {
 				"monitor_id", "id",
+			},
+		},
+		"rum_retention_filter": {
+			"rum_application": {
+				"application_id", "id",
+			},
+		},
+		"rum_retention_filters_order": {
+			"rum_application": {
+				"application_id", "id",
+			},
+			"rum_retention_filter": {
+				"retention_filter_ids", "id",
 			},
 		},
 		"integration_aws_lambda_arn": {

--- a/providers/datadog/datadog_provider.go
+++ b/providers/datadog/datadog_provider.go
@@ -263,9 +263,6 @@ func (p DatadogProvider) GetResourceConnections() map[string]map[string][]string
 			"rum_application": {
 				"application_id", "id",
 			},
-			"rum_retention_filter": {
-				"retention_filter_ids", "id",
-			},
 		},
 		"integration_aws_lambda_arn": {
 			"integration_aws": {

--- a/providers/datadog/datadog_provider_test.go
+++ b/providers/datadog/datadog_provider_test.go
@@ -70,14 +70,6 @@ func TestDatadogProviderRumRetentionFilterConnections(t *testing.T) {
 		"application_id",
 		"id",
 	)
-	assertDatadogConnection(
-		t,
-		connections,
-		"rum_retention_filters_order",
-		"rum_retention_filter",
-		"retention_filter_ids",
-		"id",
-	)
 }
 
 func TestDatadogProviderSensitiveDataScannerConnections(t *testing.T) {

--- a/providers/datadog/datadog_provider_test.go
+++ b/providers/datadog/datadog_provider_test.go
@@ -51,6 +51,35 @@ func TestDatadogProviderAPMRetentionFilterConnections(t *testing.T) {
 	)
 }
 
+func TestDatadogProviderRumRetentionFilterConnections(t *testing.T) {
+	connections := DatadogProvider{}.GetResourceConnections()
+
+	assertDatadogConnection(
+		t,
+		connections,
+		"rum_retention_filter",
+		"rum_application",
+		"application_id",
+		"id",
+	)
+	assertDatadogConnection(
+		t,
+		connections,
+		"rum_retention_filters_order",
+		"rum_application",
+		"application_id",
+		"id",
+	)
+	assertDatadogConnection(
+		t,
+		connections,
+		"rum_retention_filters_order",
+		"rum_retention_filter",
+		"retention_filter_ids",
+		"id",
+	)
+}
+
 func TestDatadogProviderSensitiveDataScannerConnections(t *testing.T) {
 	connections := DatadogProvider{}.GetResourceConnections()
 

--- a/providers/datadog/rum_retention_filter.go
+++ b/providers/datadog/rum_retention_filter.go
@@ -1,0 +1,230 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package datadog
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/DataDog/datadog-api-client-go/v2/api/datadog"
+	"github.com/DataDog/datadog-api-client-go/v2/api/datadogV2"
+
+	"github.com/chenrui333/terraformer/terraformutils"
+)
+
+const rumRetentionFilterImportIDDelimiter = ":"
+
+var (
+	// RumRetentionFilterAllowEmptyValues ...
+	RumRetentionFilterAllowEmptyValues = []string{"query"}
+)
+
+// RumRetentionFilterGenerator ...
+type RumRetentionFilterGenerator struct {
+	DatadogService
+}
+
+func (g *RumRetentionFilterGenerator) createResources(applicationID string, rumRetentionFilters []datadogV2.RumRetentionFilterData) ([]terraformutils.Resource, error) {
+	resources := []terraformutils.Resource{}
+	for _, rumRetentionFilter := range rumRetentionFilters {
+		resource, err := g.createResource(applicationID, rumRetentionFilter)
+		if err != nil {
+			return nil, err
+		}
+		resources = append(resources, resource)
+	}
+
+	return resources, nil
+}
+
+func (g *RumRetentionFilterGenerator) createResource(applicationID string, rumRetentionFilter datadogV2.RumRetentionFilterData) (terraformutils.Resource, error) {
+	retentionFilterID := rumRetentionFilter.GetId()
+	if retentionFilterID == "" {
+		return terraformutils.Resource{}, fmt.Errorf("RUM retention filter missing id")
+	}
+	if applicationID == "" {
+		return terraformutils.Resource{}, fmt.Errorf("RUM retention filter %q missing application id", retentionFilterID)
+	}
+
+	return terraformutils.NewResource(
+		retentionFilterID,
+		fmt.Sprintf("rum_retention_filter_%s_%s", applicationID, retentionFilterID),
+		"datadog_rum_retention_filter",
+		"datadog",
+		map[string]string{
+			"application_id": applicationID,
+		},
+		RumRetentionFilterAllowEmptyValues,
+		map[string]interface{}{},
+	), nil
+}
+
+// InitResources Generate TerraformResources from Datadog API,
+// from each RUM retention filter create 1 TerraformResource.
+// Need RUM retention filter ID formatted as '<application_id>:<retention_filter_id>' for filter lookup.
+func (g *RumRetentionFilterGenerator) InitResources() error {
+	datadogClient := g.Args["datadogClient"].(*datadog.APIClient)
+	auth := g.Args["auth"].(context.Context)
+	rumAPI := datadogV2.NewRUMApi(datadogClient)
+	retentionFilterAPI := datadogV2.NewRumRetentionFiltersApi(datadogClient)
+
+	resources, filtered, err := g.filteredResources(auth, retentionFilterAPI)
+	if err != nil {
+		return err
+	}
+	if filtered {
+		g.Resources = resources
+		return nil
+	}
+
+	applications, err := listRumApplications(auth, rumAPI)
+	if err != nil {
+		return err
+	}
+	for _, application := range applications {
+		applicationID := rumApplicationID(application)
+		if applicationID == "" {
+			continue
+		}
+		rumRetentionFilters, err := listRumRetentionFilters(auth, retentionFilterAPI, applicationID)
+		if err != nil {
+			return err
+		}
+		applicationResources, err := g.createResources(applicationID, rumRetentionFilters)
+		if err != nil {
+			return err
+		}
+		resources = append(resources, applicationResources...)
+	}
+
+	g.Resources = resources
+	return nil
+}
+
+func (g *RumRetentionFilterGenerator) filteredResources(auth context.Context, api *datadogV2.RumRetentionFiltersApi) ([]terraformutils.Resource, bool, error) {
+	resources := []terraformutils.Resource{}
+	filtered := false
+
+	for filterIndex, filter := range g.Filter {
+		if !filter.IsApplicable("rum_retention_filter") {
+			continue
+		}
+
+		switch filter.FieldPath {
+		case "id":
+			filtered = true
+			filterIDs, err := parseRumRetentionFilterImportIDs(filter.AcceptableValues)
+			if err != nil {
+				return nil, true, err
+			}
+			for _, filterID := range filterIDs {
+				rumRetentionFilter, err := getRumRetentionFilter(auth, api, filterID.applicationID, filterID.retentionFilterID)
+				if err != nil {
+					return nil, true, err
+				}
+				resource, err := g.createResource(filterID.applicationID, rumRetentionFilter)
+				if err != nil {
+					return nil, true, err
+				}
+				resources = append(resources, resource)
+			}
+			g.Filter[filterIndex].AcceptableValues = rumRetentionFilterIDs(filterIDs)
+		case "application_id":
+			filtered = true
+			for _, applicationID := range filter.AcceptableValues {
+				rumRetentionFilters, err := listRumRetentionFilters(auth, api, applicationID)
+				if err != nil {
+					return nil, true, err
+				}
+				applicationResources, err := g.createResources(applicationID, rumRetentionFilters)
+				if err != nil {
+					return nil, true, err
+				}
+				resources = append(resources, applicationResources...)
+			}
+		}
+	}
+
+	return resources, filtered, nil
+}
+
+type rumRetentionFilterImportID struct {
+	applicationID     string
+	retentionFilterID string
+}
+
+func parseRumRetentionFilterImportIDs(importIDs []string) ([]rumRetentionFilterImportID, error) {
+	filterIDs := []rumRetentionFilterImportID{}
+	for _, importID := range importIDs {
+		applicationID, retentionFilterID, err := parseRumRetentionFilterImportID(importID)
+		if err != nil {
+			return nil, err
+		}
+		filterIDs = append(filterIDs, rumRetentionFilterImportID{applicationID: applicationID, retentionFilterID: retentionFilterID})
+	}
+	return filterIDs, nil
+}
+
+func rumRetentionFilterIDs(filterIDs []rumRetentionFilterImportID) []string {
+	retentionFilterIDs := []string{}
+	for _, filterID := range filterIDs {
+		retentionFilterIDs = append(retentionFilterIDs, filterID.retentionFilterID)
+	}
+	return retentionFilterIDs
+}
+
+func parseRumRetentionFilterImportID(importID string) (string, string, error) {
+	parts := strings.SplitN(importID, rumRetentionFilterImportIDDelimiter, 2)
+	if len(parts) != 2 || parts[0] == "" || parts[1] == "" {
+		return "", "", fmt.Errorf("RUM retention filter import ID %q must be formatted as application_id:retention_filter_id", importID)
+	}
+	return parts[0], parts[1], nil
+}
+
+func getRumRetentionFilter(auth context.Context, api *datadogV2.RumRetentionFiltersApi, applicationID string, retentionFilterID string) (datadogV2.RumRetentionFilterData, error) {
+	rumRetentionFilterResponse, httpResponse, err := api.GetRetentionFilter(auth, applicationID, retentionFilterID)
+	if httpResponse != nil && httpResponse.Body != nil {
+		defer httpResponse.Body.Close()
+	}
+	if err != nil {
+		return datadogV2.RumRetentionFilterData{}, err
+	}
+
+	rumRetentionFilter := rumRetentionFilterResponse.GetData()
+	if rumRetentionFilter.GetId() == "" {
+		rumRetentionFilter.SetId(retentionFilterID)
+	}
+	return rumRetentionFilter, nil
+}
+
+func listRumRetentionFilters(auth context.Context, api *datadogV2.RumRetentionFiltersApi, applicationID string) ([]datadogV2.RumRetentionFilterData, error) {
+	rumRetentionFiltersResponse, httpResponse, err := api.ListRetentionFilters(auth, applicationID)
+	if httpResponse != nil && httpResponse.Body != nil {
+		defer httpResponse.Body.Close()
+	}
+	if err != nil {
+		return nil, err
+	}
+	return rumRetentionFiltersResponse.GetData(), nil
+}
+
+func listRumApplications(auth context.Context, api *datadogV2.RUMApi) ([]datadogV2.RUMApplicationList, error) {
+	rumApplicationsResponse, httpResponse, err := api.GetRUMApplications(auth)
+	if httpResponse != nil && httpResponse.Body != nil {
+		defer httpResponse.Body.Close()
+	}
+	if err != nil {
+		return nil, err
+	}
+	return rumApplicationsResponse.GetData(), nil
+}
+
+func rumApplicationID(application datadogV2.RUMApplicationList) string {
+	applicationID := application.GetId()
+	if applicationID != "" {
+		return applicationID
+	}
+	attributes := application.GetAttributes()
+	return attributes.GetApplicationId()
+}

--- a/providers/datadog/rum_retention_filter_test.go
+++ b/providers/datadog/rum_retention_filter_test.go
@@ -1,0 +1,209 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package datadog
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/DataDog/datadog-api-client-go/v2/api/datadog"
+	"github.com/DataDog/datadog-api-client-go/v2/api/datadogV2"
+	"github.com/chenrui333/terraformer/terraformutils"
+)
+
+func TestRumRetentionFilterCreateResource(t *testing.T) {
+	filter := datadogV2.NewRumRetentionFilterDataWithDefaults()
+	filter.SetId("rf-123")
+
+	generator := &RumRetentionFilterGenerator{}
+	resource, err := generator.createResource("app-123", *filter)
+	if err != nil {
+		t.Fatalf("createResource returned error: %v", err)
+	}
+
+	if resource.InstanceState.ID != "rf-123" {
+		t.Fatalf("expected resource ID rf-123, got %s", resource.InstanceState.ID)
+	}
+	if resource.ResourceName != "tfer--rum_retention_filter_app-123_rf-123" {
+		t.Fatalf("expected resource name tfer--rum_retention_filter_app-123_rf-123, got %s", resource.ResourceName)
+	}
+	if resource.InstanceInfo.Type != "datadog_rum_retention_filter" {
+		t.Fatalf("expected resource type datadog_rum_retention_filter, got %s", resource.InstanceInfo.Type)
+	}
+	if resource.InstanceState.Attributes["application_id"] != "app-123" {
+		t.Fatalf("application_id = %q, want app-123", resource.InstanceState.Attributes["application_id"])
+	}
+}
+
+func TestRumRetentionFilterCreateResourceRequiresIDs(t *testing.T) {
+	filter := datadogV2.NewRumRetentionFilterDataWithDefaults()
+
+	generator := &RumRetentionFilterGenerator{}
+	if _, err := generator.createResource("app-123", *filter); err == nil {
+		t.Fatal("createResource returned nil error, want missing retention filter ID error")
+	}
+
+	filter.SetId("rf-123")
+	if _, err := generator.createResource("", *filter); err == nil {
+		t.Fatal("createResource returned nil error, want missing application ID error")
+	}
+}
+
+func TestRumRetentionFilterParseImportID(t *testing.T) {
+	applicationID, retentionFilterID, err := parseRumRetentionFilterImportID("app-123:rf-123")
+	if err != nil {
+		t.Fatalf("parseRumRetentionFilterImportID returned error: %v", err)
+	}
+	if applicationID != "app-123" {
+		t.Fatalf("applicationID = %q, want app-123", applicationID)
+	}
+	if retentionFilterID != "rf-123" {
+		t.Fatalf("retentionFilterID = %q, want rf-123", retentionFilterID)
+	}
+}
+
+func TestRumRetentionFilterParseImportIDRejectsInvalid(t *testing.T) {
+	if _, _, err := parseRumRetentionFilterImportID("rf-123"); err == nil {
+		t.Fatal("parseRumRetentionFilterImportID returned nil error, want invalid format error")
+	}
+}
+
+func TestRumRetentionFilterInitResourcesFetchesIDFilter(t *testing.T) {
+	requestedPaths := []string{}
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestedPaths = append(requestedPaths, r.URL.Path)
+		w.Header().Set("Content-Type", "application/json")
+
+		switch r.URL.Path {
+		case "/api/v2/rum/applications/app-123/retention_filters/rf-123":
+			_, _ = fmt.Fprint(w, rumRetentionFilterResponseJSON("rf-123"))
+		case "/api/v2/rum/applications/app-123/retention_filters", "/api/v2/rum/applications":
+			http.Error(w, "unexpected list request", http.StatusInternalServerError)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+
+	generator := newRumRetentionFilterTestGenerator(server, []terraformutils.ResourceFilter{
+		{
+			ServiceName:      "rum_retention_filter",
+			FieldPath:        "id",
+			AcceptableValues: []string{"app-123:rf-123"},
+		},
+	})
+
+	if err := generator.InitResources(); err != nil {
+		t.Fatalf("InitResources returned error: %v", err)
+	}
+	if len(generator.Resources) != 1 {
+		t.Fatalf("expected 1 resource, got %d", len(generator.Resources))
+	}
+	if generator.Resources[0].InstanceState.ID != "rf-123" {
+		t.Fatalf("expected resource ID rf-123, got %s", generator.Resources[0].InstanceState.ID)
+	}
+	if got := generator.Filter[0].AcceptableValues; len(got) != 1 || got[0] != "rf-123" {
+		t.Fatalf("expected normalized filter ID rf-123, got %v", got)
+	}
+	for _, path := range requestedPaths {
+		if path == "/api/v2/rum/applications" || path == "/api/v2/rum/applications/app-123/retention_filters" {
+			t.Fatalf("expected id filter to avoid list requests, got requests %v", requestedPaths)
+		}
+	}
+}
+
+func TestRumRetentionFilterInitResourcesListsApplicationsAndFilters(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+
+		switch r.URL.Path {
+		case "/api/v2/rum/applications":
+			_, _ = fmt.Fprint(w, rumApplicationListResponseJSON("app-123", "app-456"))
+		case "/api/v2/rum/applications/app-123/retention_filters":
+			_, _ = fmt.Fprint(w, rumRetentionFilterListResponseJSON("rf-123"))
+		case "/api/v2/rum/applications/app-456/retention_filters":
+			_, _ = fmt.Fprint(w, rumRetentionFilterListResponseJSON("rf-456"))
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+
+	generator := newRumRetentionFilterTestGenerator(server, nil)
+
+	if err := generator.InitResources(); err != nil {
+		t.Fatalf("InitResources returned error: %v", err)
+	}
+	if len(generator.Resources) != 2 {
+		t.Fatalf("expected 2 resources, got %d", len(generator.Resources))
+	}
+	if generator.Resources[0].InstanceState.ID != "rf-123" {
+		t.Fatalf("expected first resource ID rf-123, got %s", generator.Resources[0].InstanceState.ID)
+	}
+	if generator.Resources[1].InstanceState.ID != "rf-456" {
+		t.Fatalf("expected second resource ID rf-456, got %s", generator.Resources[1].InstanceState.ID)
+	}
+}
+
+func TestRumRetentionFilterInitResourcesPropagatesListError(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+
+		switch r.URL.Path {
+		case "/api/v2/rum/applications":
+			_, _ = fmt.Fprint(w, rumApplicationListResponseJSON("app-123"))
+		case "/api/v2/rum/applications/app-123/retention_filters":
+			http.Error(w, "list failed", http.StatusInternalServerError)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+
+	generator := newRumRetentionFilterTestGenerator(server, nil)
+
+	if err := generator.InitResources(); err == nil {
+		t.Fatal("InitResources returned nil error, want list error")
+	}
+}
+
+func newRumRetentionFilterTestGenerator(server *httptest.Server, filter []terraformutils.ResourceFilter) *RumRetentionFilterGenerator {
+	config := datadog.NewConfiguration()
+	config.Servers = datadog.ServerConfigurations{{URL: server.URL}}
+	config.HTTPClient = server.Client()
+
+	return &RumRetentionFilterGenerator{
+		DatadogService: DatadogService{
+			Service: terraformutils.Service{
+				Args: map[string]interface{}{
+					"auth":          context.Background(),
+					"datadogClient": datadog.NewAPIClient(config),
+				},
+				Filter: filter,
+			},
+		},
+	}
+}
+
+func rumRetentionFilterResponseJSON(id string) string {
+	return fmt.Sprintf("{\"data\":%s}", rumRetentionFilterJSON(id))
+}
+
+func rumRetentionFilterListResponseJSON(ids ...string) string {
+	filters := []string{}
+	for _, id := range ids {
+		filters = append(filters, rumRetentionFilterJSON(id))
+	}
+	return fmt.Sprintf("{\"data\":[%s]}", strings.Join(filters, ","))
+}
+
+func rumRetentionFilterJSON(id string) string {
+	return fmt.Sprintf(
+		"{\"id\":%q,\"type\":\"retention_filters\",\"attributes\":{\"name\":\"Test filter\",\"event_type\":\"session\",\"sample_rate\":100,\"query\":\"\",\"enabled\":true}}",
+		id,
+	)
+}

--- a/providers/datadog/rum_retention_filters_order.go
+++ b/providers/datadog/rum_retention_filters_order.go
@@ -1,0 +1,157 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package datadog
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+
+	"github.com/DataDog/datadog-api-client-go/v2/api/datadog"
+	"github.com/DataDog/datadog-api-client-go/v2/api/datadogV2"
+
+	"github.com/chenrui333/terraformer/terraformutils"
+)
+
+var (
+	// RumRetentionFiltersOrderAllowEmptyValues ...
+	RumRetentionFiltersOrderAllowEmptyValues = []string{"retention_filter_ids"}
+)
+
+// RumRetentionFiltersOrderGenerator ...
+type RumRetentionFiltersOrderGenerator struct {
+	DatadogService
+}
+
+func (g *RumRetentionFiltersOrderGenerator) createResource(applicationID string, rumRetentionFilters []datadogV2.RumRetentionFilterData) (terraformutils.Resource, error) {
+	if applicationID == "" {
+		return terraformutils.Resource{}, fmt.Errorf("RUM retention filters order missing application id")
+	}
+	retentionFilterIDs, err := rumRetentionFilterIDsFromData(applicationID, rumRetentionFilters)
+	if err != nil {
+		return terraformutils.Resource{}, err
+	}
+	attributes := map[string]string{
+		"application_id":         applicationID,
+		"retention_filter_ids.#": strconv.Itoa(len(retentionFilterIDs)),
+	}
+	for index, retentionFilterID := range retentionFilterIDs {
+		attributes[fmt.Sprintf("retention_filter_ids.%d", index)] = retentionFilterID
+	}
+
+	return terraformutils.NewResource(
+		applicationID,
+		fmt.Sprintf("rum_retention_filters_order_%s", applicationID),
+		"datadog_rum_retention_filters_order",
+		"datadog",
+		attributes,
+		RumRetentionFiltersOrderAllowEmptyValues,
+		map[string]interface{}{},
+	), nil
+}
+
+func (g *RumRetentionFiltersOrderGenerator) PostConvertHook() error {
+	for i := range g.Resources {
+		resource := &g.Resources[i]
+		if resource.Item == nil {
+			resource.Item = map[string]interface{}{}
+		}
+		if _, ok := resource.Item["retention_filter_ids"]; ok {
+			continue
+		}
+		if !rumRetentionFiltersOrderStateHasEmptyRetentionFilterIDs(resource) {
+			continue
+		}
+		resource.Item["retention_filter_ids"] = []interface{}{}
+	}
+	return nil
+}
+
+func rumRetentionFiltersOrderStateHasEmptyRetentionFilterIDs(resource *terraformutils.Resource) bool {
+	if resource == nil || resource.InstanceState == nil || resource.InstanceState.Attributes == nil {
+		return false
+	}
+	return resource.InstanceState.Attributes["retention_filter_ids.#"] == "0"
+}
+
+// InitResources Generate TerraformResources from Datadog API,
+// from each RUM application create 1 RUM retention filters order TerraformResource.
+func (g *RumRetentionFiltersOrderGenerator) InitResources() error {
+	datadogClient := g.Args["datadogClient"].(*datadog.APIClient)
+	auth := g.Args["auth"].(context.Context)
+	rumAPI := datadogV2.NewRUMApi(datadogClient)
+	retentionFilterAPI := datadogV2.NewRumRetentionFiltersApi(datadogClient)
+
+	resources, filtered, err := g.filteredResources(auth, retentionFilterAPI)
+	if err != nil {
+		return err
+	}
+	if filtered {
+		g.Resources = resources
+		return nil
+	}
+
+	applications, err := listRumApplications(auth, rumAPI)
+	if err != nil {
+		return err
+	}
+	for _, application := range applications {
+		applicationID := rumApplicationID(application)
+		if applicationID == "" {
+			continue
+		}
+		resource, err := g.resourceForApplication(auth, retentionFilterAPI, applicationID)
+		if err != nil {
+			return err
+		}
+		resources = append(resources, resource)
+	}
+
+	g.Resources = resources
+	return nil
+}
+
+func (g *RumRetentionFiltersOrderGenerator) filteredResources(auth context.Context, api *datadogV2.RumRetentionFiltersApi) ([]terraformutils.Resource, bool, error) {
+	resources := []terraformutils.Resource{}
+	filtered := false
+
+	for _, filter := range g.Filter {
+		if !filter.IsApplicable("rum_retention_filters_order") {
+			continue
+		}
+
+		switch filter.FieldPath {
+		case "id", "application_id":
+			filtered = true
+			for _, applicationID := range filter.AcceptableValues {
+				resource, err := g.resourceForApplication(auth, api, applicationID)
+				if err != nil {
+					return nil, true, err
+				}
+				resources = append(resources, resource)
+			}
+		}
+	}
+
+	return resources, filtered, nil
+}
+
+func (g *RumRetentionFiltersOrderGenerator) resourceForApplication(auth context.Context, api *datadogV2.RumRetentionFiltersApi, applicationID string) (terraformutils.Resource, error) {
+	rumRetentionFilters, err := listRumRetentionFilters(auth, api, applicationID)
+	if err != nil {
+		return terraformutils.Resource{}, err
+	}
+	return g.createResource(applicationID, rumRetentionFilters)
+}
+
+func rumRetentionFilterIDsFromData(applicationID string, rumRetentionFilters []datadogV2.RumRetentionFilterData) ([]string, error) {
+	retentionFilterIDs := []string{}
+	for _, rumRetentionFilter := range rumRetentionFilters {
+		retentionFilterID := rumRetentionFilter.GetId()
+		if retentionFilterID == "" {
+			return nil, fmt.Errorf("RUM retention filter order for application %q has retention filter missing id", applicationID)
+		}
+		retentionFilterIDs = append(retentionFilterIDs, retentionFilterID)
+	}
+	return retentionFilterIDs, nil
+}

--- a/providers/datadog/rum_retention_filters_order_test.go
+++ b/providers/datadog/rum_retention_filters_order_test.go
@@ -1,0 +1,186 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package datadog
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/DataDog/datadog-api-client-go/v2/api/datadog"
+	"github.com/DataDog/datadog-api-client-go/v2/api/datadogV2"
+	"github.com/chenrui333/terraformer/terraformutils"
+)
+
+func TestRumRetentionFiltersOrderCreateResource(t *testing.T) {
+	firstFilter := datadogV2.NewRumRetentionFilterDataWithDefaults()
+	firstFilter.SetId("rf-123")
+	secondFilter := datadogV2.NewRumRetentionFilterDataWithDefaults()
+	secondFilter.SetId("rf-456")
+
+	generator := &RumRetentionFiltersOrderGenerator{}
+	resource, err := generator.createResource("app-123", []datadogV2.RumRetentionFilterData{*firstFilter, *secondFilter})
+	if err != nil {
+		t.Fatalf("createResource returned error: %v", err)
+	}
+
+	if resource.InstanceState.ID != "app-123" {
+		t.Fatalf("expected resource ID app-123, got %s", resource.InstanceState.ID)
+	}
+	if resource.ResourceName != "tfer--rum_retention_filters_order_app-123" {
+		t.Fatalf("expected resource name tfer--rum_retention_filters_order_app-123, got %s", resource.ResourceName)
+	}
+	if resource.InstanceInfo.Type != "datadog_rum_retention_filters_order" {
+		t.Fatalf("expected resource type datadog_rum_retention_filters_order, got %s", resource.InstanceInfo.Type)
+	}
+	if resource.InstanceState.Attributes["application_id"] != "app-123" {
+		t.Fatalf("application_id = %q, want app-123", resource.InstanceState.Attributes["application_id"])
+	}
+	if resource.InstanceState.Attributes["retention_filter_ids.#"] != "2" {
+		t.Fatalf("retention_filter_ids.# = %q, want 2", resource.InstanceState.Attributes["retention_filter_ids.#"])
+	}
+	if resource.InstanceState.Attributes["retention_filter_ids.0"] != "rf-123" {
+		t.Fatalf("retention_filter_ids.0 = %q, want rf-123", resource.InstanceState.Attributes["retention_filter_ids.0"])
+	}
+	if resource.InstanceState.Attributes["retention_filter_ids.1"] != "rf-456" {
+		t.Fatalf("retention_filter_ids.1 = %q, want rf-456", resource.InstanceState.Attributes["retention_filter_ids.1"])
+	}
+}
+
+func TestRumRetentionFiltersOrderCreateResourceRequiresFilterIDs(t *testing.T) {
+	filter := datadogV2.NewRumRetentionFilterDataWithDefaults()
+
+	generator := &RumRetentionFiltersOrderGenerator{}
+	if _, err := generator.createResource("", nil); err == nil {
+		t.Fatal("createResource returned nil error, want missing application ID error")
+	}
+	if _, err := generator.createResource("app-123", []datadogV2.RumRetentionFilterData{*filter}); err == nil {
+		t.Fatal("createResource returned nil error, want missing retention filter ID error")
+	}
+}
+
+func TestRumRetentionFiltersOrderPostConvertHookPreservesEmptyRetentionFilterIDs(t *testing.T) {
+	resource := terraformutils.NewSimpleResource(
+		"app-123",
+		"rum_retention_filters_order_app-123",
+		"datadog_rum_retention_filters_order",
+		"datadog",
+		RumRetentionFiltersOrderAllowEmptyValues,
+	)
+	resource.InstanceState.Attributes = map[string]string{
+		"application_id":         "app-123",
+		"retention_filter_ids.#": "0",
+	}
+	resource.Item = map[string]interface{}{
+		"application_id": "app-123",
+	}
+
+	generator := &RumRetentionFiltersOrderGenerator{}
+	generator.Resources = []terraformutils.Resource{resource}
+
+	if err := generator.PostConvertHook(); err != nil {
+		t.Fatalf("PostConvertHook returned error: %v", err)
+	}
+
+	retentionFilterIDs, ok := generator.Resources[0].Item["retention_filter_ids"].([]interface{})
+	if !ok {
+		t.Fatalf("retention_filter_ids = %T, want []interface{}", generator.Resources[0].Item["retention_filter_ids"])
+	}
+	if len(retentionFilterIDs) != 0 {
+		t.Fatalf("retention_filter_ids length = %d, want %d", len(retentionFilterIDs), 0)
+	}
+}
+
+func TestRumRetentionFiltersOrderInitResourcesListsApplicationsAndFilters(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+
+		switch r.URL.Path {
+		case "/api/v2/rum/applications":
+			_, _ = fmt.Fprint(w, rumApplicationListResponseJSON("app-123", "app-456"))
+		case "/api/v2/rum/applications/app-123/retention_filters":
+			_, _ = fmt.Fprint(w, rumRetentionFilterListResponseJSON("rf-123"))
+		case "/api/v2/rum/applications/app-456/retention_filters":
+			_, _ = fmt.Fprint(w, rumRetentionFilterListResponseJSON("rf-456"))
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+
+	generator := newRumRetentionFiltersOrderTestGenerator(server, nil)
+
+	if err := generator.InitResources(); err != nil {
+		t.Fatalf("InitResources returned error: %v", err)
+	}
+	if len(generator.Resources) != 2 {
+		t.Fatalf("expected 2 resources, got %d", len(generator.Resources))
+	}
+	if generator.Resources[0].InstanceState.ID != "app-123" {
+		t.Fatalf("expected first resource ID app-123, got %s", generator.Resources[0].InstanceState.ID)
+	}
+	if generator.Resources[1].InstanceState.ID != "app-456" {
+		t.Fatalf("expected second resource ID app-456, got %s", generator.Resources[1].InstanceState.ID)
+	}
+}
+
+func TestRumRetentionFiltersOrderInitResourcesUsesApplicationIDFilter(t *testing.T) {
+	requestedPaths := []string{}
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestedPaths = append(requestedPaths, r.URL.Path)
+		w.Header().Set("Content-Type", "application/json")
+
+		switch r.URL.Path {
+		case "/api/v2/rum/applications/app-123/retention_filters":
+			_, _ = fmt.Fprint(w, rumRetentionFilterListResponseJSON("rf-123"))
+		case "/api/v2/rum/applications":
+			http.Error(w, "unexpected application list request", http.StatusInternalServerError)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+
+	generator := newRumRetentionFiltersOrderTestGenerator(server, []terraformutils.ResourceFilter{
+		{
+			ServiceName:      "rum_retention_filters_order",
+			FieldPath:        "application_id",
+			AcceptableValues: []string{"app-123"},
+		},
+	})
+
+	if err := generator.InitResources(); err != nil {
+		t.Fatalf("InitResources returned error: %v", err)
+	}
+	if len(generator.Resources) != 1 {
+		t.Fatalf("expected 1 resource, got %d", len(generator.Resources))
+	}
+	if generator.Resources[0].InstanceState.ID != "app-123" {
+		t.Fatalf("expected resource ID app-123, got %s", generator.Resources[0].InstanceState.ID)
+	}
+	for _, path := range requestedPaths {
+		if path == "/api/v2/rum/applications" {
+			t.Fatalf("expected application_id filter to avoid application list, got requests %v", requestedPaths)
+		}
+	}
+}
+
+func newRumRetentionFiltersOrderTestGenerator(server *httptest.Server, filter []terraformutils.ResourceFilter) *RumRetentionFiltersOrderGenerator {
+	config := datadog.NewConfiguration()
+	config.Servers = datadog.ServerConfigurations{{URL: server.URL}}
+	config.HTTPClient = server.Client()
+
+	return &RumRetentionFiltersOrderGenerator{
+		DatadogService: DatadogService{
+			Service: terraformutils.Service{
+				Args: map[string]interface{}{
+					"auth":          context.Background(),
+					"datadogClient": datadog.NewAPIClient(config),
+				},
+				Filter: filter,
+			},
+		},
+	}
+}


### PR DESCRIPTION
Summary
- add Datadog RUM retention filter import support
- add Datadog RUM retention filters order import support
- document the new RUM retention services and wire resource connections

Notes
- `rum_retention_filter` ID-filter imports use `application_id:retention_filter_id`, matching the Datadog provider import format.
- Full imports enumerate RUM applications, then list retention filters for each application.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds import support for Datadog RUM retention filters and their order, with generators for `datadog_rum_retention_filter` and `datadog_rum_retention_filters_order`. Updates docs and provider connections, and hardens ID-based imports to avoid extra API calls.

- **New Features**
  - Added `rum_retention_filter` and `rum_retention_filters_order` generators.
  - Import formats: `<application_id>:<retention_filter_id>` for a filter; order uses the RUM application ID.
  - Full imports enumerate RUM applications, then list filters per app when no filters are provided.
  - Resource connections: both resources link to `rum_application` via `application_id`.

- **Bug Fixes**
  - Validates and parses ID imports for filters; normalizes filter IDs after import.
  - Skips unnecessary list requests when using ID or `application_id` filters; handles API responses that omit filter IDs.

<sup>Written for commit f87537bdc42e64693a9ab9177e211d9d732707b5. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for two Datadog RUM resource types: rum retention filter and rum retention filters order; these can be managed and exported.

* **Documentation**
  * Updated supported-resources docs with the new RUM types and clarified import/filter formats for importing by ID.

* **Tests**
  * Added tests covering resource generation, import parsing, listing behavior, and state post-processing for the new RUM resources.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->