### PR TITLE
aws(cognito): add additional Cognito resources

### DIFF
--- a/docs/aws.md
+++ b/docs/aws.md
@@ -148,6 +148,7 @@ terraformer import aws --resources=sg --regions=us-east-1
     * `aws_cognito_user_pool`
     * `aws_cognito_user_pool_client`
     * `aws_cognito_user_pool_domain`
+    * Note: `aws_cognito_user_pool_client` ID filters may use `<user_pool_id>/<client_id>`, such as `Type=cognito_user_pool_client;Name=id;Value=us-east-1_abc/client123`. Generated state stores `client123` as the resource ID and keeps `user_pool_id` separately, matching the provider read path in [providers/aws/cognito.go](../providers/aws/cognito.go).
 *   `config`
     * `aws_config_aggregate_authorization`
     * `aws_config_config_rule`

--- a/docs/aws.md
+++ b/docs/aws.md
@@ -141,7 +141,13 @@ terraformer import aws --resources=sg --regions=us-east-1
     * `aws_codepipeline_webhook`
 *   `cognito`
     * `aws_cognito_identity_pool`
+    * `aws_cognito_identity_pool_roles_attachment`
+    * `aws_cognito_identity_provider`
+    * `aws_cognito_resource_server`
+    * `aws_cognito_user_group`
     * `aws_cognito_user_pool`
+    * `aws_cognito_user_pool_client`
+    * `aws_cognito_user_pool_domain`
 *   `config`
     * `aws_config_aggregate_authorization`
     * `aws_config_config_rule`

--- a/providers/aws/cognito.go
+++ b/providers/aws/cognito.go
@@ -568,7 +568,7 @@ func (g *CognitoGenerator) shouldLoadIdentityPoolChildResourceType(serviceName, 
 	if g.hasTypedIdentityPoolChildFilter() && !hasTypedChildFilter {
 		return false
 	}
-	if g.hasTypedCognitoFilter() && !hasTypedChildFilter && !g.hasTypedFilterFor(cognitoIdentityPoolResourceType) && !g.hasUntypedIDFilter() {
+	if g.hasTypedCognitoFilter() && !hasTypedChildFilter && !g.hasUntypedIDFilter() {
 		return false
 	}
 	if !g.initialIDFiltersCanMatchIdentityPoolChild(serviceName, identityPoolID) {
@@ -588,7 +588,7 @@ func (g *CognitoGenerator) shouldLoadUserPoolChildResourceType(serviceName, user
 	if g.hasTypedUserPoolChildFilter() && !hasTypedChildFilter {
 		return false
 	}
-	if g.hasTypedCognitoFilter() && !hasTypedChildFilter && !g.hasTypedFilterFor(cognitoUserPoolResourceType) && !g.hasUntypedIDFilter() {
+	if g.hasTypedCognitoFilter() && !hasTypedChildFilter && !g.hasUntypedIDFilter() {
 		return false
 	}
 	if !g.initialIDFiltersCanMatchUserPoolChild(serviceName, userPoolID) {

--- a/providers/aws/cognito.go
+++ b/providers/aws/cognito.go
@@ -555,8 +555,8 @@ func (g *CognitoGenerator) shouldLoadIdentityPoolChildResourceType(serviceName, 
 	if !hasTypedChildFilter && !g.hasUntypedIDFilter() {
 		return g.identityPoolMatchesPreDiscoveryFilters(identityPoolID)
 	}
-	if hasTypedChildFilter && !g.hasIDFilterFor(serviceName) && !g.hasUntypedIDFilter() && g.hasTypedFilterFor(cognitoIdentityPoolResourceType) {
-		return g.identityPoolMatchesPreDiscoveryFilters(identityPoolID)
+	if hasTypedChildFilter && !g.hasIDFilterFor(serviceName) && !g.hasUntypedIDFilter() && g.hasIDFilterFor(cognitoIdentityPoolResourceType) {
+		return g.identityPoolMatchesInitialIDFilters(identityPoolID)
 	}
 	return true
 }
@@ -575,8 +575,8 @@ func (g *CognitoGenerator) shouldLoadUserPoolChildResourceType(serviceName, user
 	if !hasTypedChildFilter && !g.hasUntypedIDFilter() {
 		return g.userPoolMatchesPreDiscoveryFilters(userPoolID)
 	}
-	if hasTypedChildFilter && !g.hasIDFilterFor(serviceName) && !g.hasUntypedIDFilter() && g.hasTypedFilterFor(cognitoUserPoolResourceType) {
-		return g.userPoolMatchesPreDiscoveryFilters(userPoolID)
+	if hasTypedChildFilter && !g.hasIDFilterFor(serviceName) && !g.hasUntypedIDFilter() && g.hasIDFilterFor(cognitoUserPoolResourceType) {
+		return g.userPoolMatchesInitialIDFilters(userPoolID)
 	}
 	return true
 }
@@ -599,19 +599,27 @@ func (g *CognitoGenerator) shouldAppendCognitoResource(serviceName string, resou
 }
 
 func (g *CognitoGenerator) identityPoolMatchesPreDiscoveryFilters(identityPoolID string) bool {
-	resource := terraformutils.NewSimpleResource(identityPoolID, identityPoolID, "aws_cognito_identity_pool", "aws", CognitoAllowEmptyValues)
-	if !g.resourceMatchesInitialIDFilters(cognitoIdentityPoolResourceType, resource) {
+	if !g.identityPoolMatchesInitialIDFilters(identityPoolID) {
 		return false
 	}
 	return !g.hasTypedNonIDFilterFor(cognitoIdentityPoolResourceType)
 }
 
 func (g *CognitoGenerator) userPoolMatchesPreDiscoveryFilters(userPoolID string) bool {
-	resource := terraformutils.NewSimpleResource(userPoolID, userPoolID, "aws_cognito_user_pool", "aws", CognitoAllowEmptyValues)
-	if !g.resourceMatchesInitialIDFilters(cognitoUserPoolResourceType, resource) {
+	if !g.userPoolMatchesInitialIDFilters(userPoolID) {
 		return false
 	}
 	return !g.hasTypedNonIDFilterFor(cognitoUserPoolResourceType)
+}
+
+func (g *CognitoGenerator) identityPoolMatchesInitialIDFilters(identityPoolID string) bool {
+	resource := terraformutils.NewSimpleResource(identityPoolID, identityPoolID, "aws_cognito_identity_pool", "aws", CognitoAllowEmptyValues)
+	return g.resourceMatchesInitialIDFilters(cognitoIdentityPoolResourceType, resource)
+}
+
+func (g *CognitoGenerator) userPoolMatchesInitialIDFilters(userPoolID string) bool {
+	resource := terraformutils.NewSimpleResource(userPoolID, userPoolID, "aws_cognito_user_pool", "aws", CognitoAllowEmptyValues)
+	return g.resourceMatchesInitialIDFilters(cognitoUserPoolResourceType, resource)
 }
 
 func (g *CognitoGenerator) resourceMatchesInitialIDFilters(serviceName string, resource terraformutils.Resource) bool {

--- a/providers/aws/cognito.go
+++ b/providers/aws/cognito.go
@@ -1,12 +1,19 @@
+// SPDX-License-Identifier: Apache-2.0
+
 //nolint:revive // lint triage: legacy provider/API/security baseline is tracked in #175.
 package aws
 
 import (
 	"context"
+	"errors"
+	"log"
+	"strings"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/cognitoidentity"
+	identitytypes "github.com/aws/aws-sdk-go-v2/service/cognitoidentity/types"
 	"github.com/aws/aws-sdk-go-v2/service/cognitoidentityprovider"
+	idptypes "github.com/aws/aws-sdk-go-v2/service/cognitoidentityprovider/types"
 	"github.com/chenrui333/terraformer/terraformutils"
 )
 
@@ -18,89 +25,52 @@ type CognitoGenerator struct {
 	AWSService
 }
 
-const CognitoMaxResults = 60 // Required field for Cognito API
-
-func (g *CognitoGenerator) loadIdentityPools(svc *cognitoidentity.Client) error {
-	p := cognitoidentity.NewListIdentityPoolsPaginator(svc, &cognitoidentity.ListIdentityPoolsInput{
-		MaxResults: aws.Int32(CognitoMaxResults),
-	})
-	for p.HasMorePages() {
-		page, err := p.NextPage(context.TODO())
-		if err != nil {
-			return err
-		}
-		for _, pool := range page.IdentityPools {
-			var id = *pool.IdentityPoolId
-			var resourceName = *pool.IdentityPoolName
-			g.Resources = append(g.Resources, terraformutils.NewSimpleResource(
-				id,
-				resourceName+"_"+id,
-				"aws_cognito_identity_pool",
-				"aws",
-				[]string{}))
-		}
-	}
-
-	return nil
+type cognitoOptionalResourceLoader struct {
+	name string
+	load func() error
 }
 
-func (g *CognitoGenerator) loadUserPools(svc *cognitoidentityprovider.Client) ([]string, error) {
-	p := cognitoidentityprovider.NewListUserPoolsPaginator(svc, &cognitoidentityprovider.ListUserPoolsInput{
-		MaxResults: aws.Int32(CognitoMaxResults),
-	})
-
-	var userPoolIds []string
-	for p.HasMorePages() {
-		page, err := p.NextPage(context.TODO())
-		if err != nil {
-			return nil, err
-		}
-		for _, pool := range page.UserPools {
-			id := *pool.Id
-			resourceName := *pool.Name
-			g.Resources = append(g.Resources, terraformutils.NewSimpleResource(
-				id,
-				resourceName+"_"+id,
-				"aws_cognito_user_pool",
-				"aws",
-				[]string{}))
-
-			userPoolIds = append(userPoolIds, *pool.Id)
-		}
-	}
-	return userPoolIds, nil
+type cognitoIdentityPoolRef struct {
+	id   string
+	name string
 }
 
-func (g *CognitoGenerator) loadUserPoolClients(svc *cognitoidentityprovider.Client, userPoolIds []string) error {
-	for _, userPoolID := range userPoolIds {
-		p := cognitoidentityprovider.NewListUserPoolClientsPaginator(svc, &cognitoidentityprovider.ListUserPoolClientsInput{
-			UserPoolId: aws.String(userPoolID),
-			MaxResults: aws.Int32(CognitoMaxResults),
-		})
-
-		for p.HasMorePages() {
-			page, err := p.NextPage(context.TODO())
-			if err != nil {
-				return err
-			}
-			for _, poolClient := range page.UserPoolClients {
-				id := *poolClient.ClientId
-				resourceName := *poolClient.ClientName
-				g.Resources = append(g.Resources, terraformutils.NewResource(
-					id,
-					resourceName+"_"+id,
-					"aws_cognito_user_pool_client",
-					"aws",
-					map[string]string{
-						"user_pool_id": *poolClient.UserPoolId,
-					},
-					CognitoAllowEmptyValues,
-					CognitoAdditionalFields))
-			}
-		}
-	}
-	return nil
+type cognitoUserPoolRef struct {
+	id           string
+	name         string
+	domain       string
+	customDomain string
 }
+
+const (
+	CognitoMaxResults = 60 // Required field for Cognito API
+
+	cognitoIdentityPoolResourceType                = "cognito_identity_pool"
+	cognitoIdentityPoolRolesAttachmentResourceType = "cognito_identity_pool_roles_attachment"
+	cognitoUserPoolResourceType                    = "cognito_user_pool"
+	cognitoUserPoolClientResourceType              = "cognito_user_pool_client"
+	cognitoUserGroupResourceType                   = "cognito_user_group"
+	cognitoIdentityProviderResourceType            = "cognito_identity_provider"
+	cognitoResourceServerResourceType              = "cognito_resource_server"
+	cognitoUserPoolDomainResourceType              = "cognito_user_pool_domain"
+)
+
+var cognitoIdentityPoolChildResourceTypes = []string{
+	cognitoIdentityPoolRolesAttachmentResourceType,
+}
+
+var cognitoUserPoolChildResourceTypes = []string{
+	cognitoUserPoolClientResourceType,
+	cognitoUserGroupResourceType,
+	cognitoIdentityProviderResourceType,
+	cognitoResourceServerResourceType,
+	cognitoUserPoolDomainResourceType,
+}
+
+var cognitoResourceTypes = append(
+	[]string{cognitoIdentityPoolResourceType, cognitoUserPoolResourceType},
+	append(cognitoIdentityPoolChildResourceTypes, cognitoUserPoolChildResourceTypes...)...,
+)
 
 func (g *CognitoGenerator) InitResources() error {
 	config, e := g.generateConfig()
@@ -108,21 +78,664 @@ func (g *CognitoGenerator) InitResources() error {
 		return e
 	}
 
-	svcCognitoIdentity := cognitoidentity.NewFromConfig(config)
-	if err := g.loadIdentityPools(svcCognitoIdentity); err != nil {
-		return err
+	if g.shouldLoadIdentityPools() {
+		svcCognitoIdentity := cognitoidentity.NewFromConfig(config)
+		identityPools, err := g.loadIdentityPools(svcCognitoIdentity)
+		if err != nil {
+			return err
+		}
+		g.loadOptionalResources([]cognitoOptionalResourceLoader{
+			{name: "identity pool role attachments", load: func() error { return g.loadIdentityPoolRolesAttachments(svcCognitoIdentity, identityPools) }},
+		})
 	}
-	svcCognitoIdentityProvider := cognitoidentityprovider.NewFromConfig(config)
 
-	userPoolIds, err := g.loadUserPools(svcCognitoIdentityProvider)
-	if err != nil {
-		return err
-	}
-	if err = g.loadUserPoolClients(svcCognitoIdentityProvider, userPoolIds); err != nil {
-		return err
+	if g.shouldLoadUserPools() {
+		svcCognitoIdentityProvider := cognitoidentityprovider.NewFromConfig(config)
+		userPools, err := g.loadUserPools(svcCognitoIdentityProvider)
+		if err != nil {
+			return err
+		}
+		g.loadOptionalResources([]cognitoOptionalResourceLoader{
+			{name: "user pool clients", load: func() error { return g.loadUserPoolClients(svcCognitoIdentityProvider, userPools) }},
+			{name: "user groups", load: func() error { return g.loadUserGroups(svcCognitoIdentityProvider, userPools) }},
+			{name: "identity providers", load: func() error { return g.loadIdentityProviders(svcCognitoIdentityProvider, userPools) }},
+			{name: "resource servers", load: func() error { return g.loadResourceServers(svcCognitoIdentityProvider, userPools) }},
+			{name: "user pool domains", load: func() error { return g.loadUserPoolDomains(userPools) }},
+		})
 	}
 
 	return nil
+}
+
+func (g *CognitoGenerator) loadOptionalResources(loaders []cognitoOptionalResourceLoader) {
+	for _, loader := range loaders {
+		if err := loader.load(); err != nil {
+			log.Printf("Skipping Cognito %s: %v", loader.name, err)
+		}
+	}
+}
+
+func (g *CognitoGenerator) loadIdentityPools(svc *cognitoidentity.Client) ([]cognitoIdentityPoolRef, error) {
+	p := cognitoidentity.NewListIdentityPoolsPaginator(svc, &cognitoidentity.ListIdentityPoolsInput{
+		MaxResults: aws.Int32(CognitoMaxResults),
+	})
+
+	var identityPools []cognitoIdentityPoolRef
+	for p.HasMorePages() {
+		page, err := p.NextPage(context.TODO())
+		if err != nil {
+			return nil, err
+		}
+		for _, pool := range page.IdentityPools {
+			id := StringValue(pool.IdentityPoolId)
+			resourceName := StringValue(pool.IdentityPoolName)
+			if id == "" || resourceName == "" {
+				continue
+			}
+			ref := cognitoIdentityPoolRef{id: id, name: resourceName}
+			identityPools = append(identityPools, ref)
+
+			resource := newCognitoIdentityPoolResource(ref)
+			if g.shouldAppendCognitoResource(cognitoIdentityPoolResourceType, resource) {
+				g.Resources = append(g.Resources, resource)
+			}
+		}
+	}
+
+	return identityPools, nil
+}
+
+func (g *CognitoGenerator) loadIdentityPoolRolesAttachments(svc *cognitoidentity.Client, identityPools []cognitoIdentityPoolRef) error {
+	for _, identityPool := range identityPools {
+		if !g.shouldLoadIdentityPoolChildResourceType(cognitoIdentityPoolRolesAttachmentResourceType, identityPool.id) {
+			continue
+		}
+		output, err := svc.GetIdentityPoolRoles(context.TODO(), &cognitoidentity.GetIdentityPoolRolesInput{
+			IdentityPoolId: aws.String(identityPool.id),
+		})
+		if err != nil {
+			if cognitoIdentityResourceMissing(err) {
+				continue
+			}
+			return err
+		}
+		if !cognitoIdentityPoolRolesAttachmentConfigured(output) {
+			continue
+		}
+		resource := newCognitoIdentityPoolRolesAttachmentResource(identityPool)
+		if g.shouldAppendCognitoResource(cognitoIdentityPoolRolesAttachmentResourceType, resource) {
+			g.Resources = append(g.Resources, resource)
+		}
+	}
+	return nil
+}
+
+func (g *CognitoGenerator) loadUserPools(svc *cognitoidentityprovider.Client) ([]cognitoUserPoolRef, error) {
+	p := cognitoidentityprovider.NewListUserPoolsPaginator(svc, &cognitoidentityprovider.ListUserPoolsInput{
+		MaxResults: aws.Int32(CognitoMaxResults),
+	})
+
+	var userPools []cognitoUserPoolRef
+	for p.HasMorePages() {
+		page, err := p.NextPage(context.TODO())
+		if err != nil {
+			return nil, err
+		}
+		for _, pool := range page.UserPools {
+			id := StringValue(pool.Id)
+			resourceName := StringValue(pool.Name)
+			if id == "" || resourceName == "" {
+				continue
+			}
+			ref := cognitoUserPoolRef{id: id, name: resourceName}
+			if output, err := svc.DescribeUserPool(context.TODO(), &cognitoidentityprovider.DescribeUserPoolInput{
+				UserPoolId: aws.String(id),
+			}); err == nil && output.UserPool != nil {
+				ref.domain = StringValue(output.UserPool.Domain)
+				ref.customDomain = StringValue(output.UserPool.CustomDomain)
+			} else if err != nil && !cognitoIDPResourceMissing(err) {
+				log.Printf("Skipping Cognito user pool domain metadata for %s: %v", id, err)
+			}
+			userPools = append(userPools, ref)
+
+			resource := newCognitoUserPoolResource(ref)
+			if g.shouldAppendCognitoResource(cognitoUserPoolResourceType, resource) {
+				g.Resources = append(g.Resources, resource)
+			}
+		}
+	}
+	return userPools, nil
+}
+
+func (g *CognitoGenerator) loadUserPoolClients(svc *cognitoidentityprovider.Client, userPools []cognitoUserPoolRef) error {
+	for _, userPool := range userPools {
+		if !g.shouldLoadUserPoolChildResourceType(cognitoUserPoolClientResourceType, userPool.id) {
+			continue
+		}
+		p := cognitoidentityprovider.NewListUserPoolClientsPaginator(svc, &cognitoidentityprovider.ListUserPoolClientsInput{
+			UserPoolId: aws.String(userPool.id),
+			MaxResults: aws.Int32(CognitoMaxResults),
+		})
+
+		for p.HasMorePages() {
+			page, err := p.NextPage(context.TODO())
+			if err != nil {
+				if cognitoIDPResourceMissing(err) {
+					break
+				}
+				return err
+			}
+			for _, poolClient := range page.UserPoolClients {
+				clientID := StringValue(poolClient.ClientId)
+				resourceName := StringValue(poolClient.ClientName)
+				if clientID == "" || resourceName == "" {
+					continue
+				}
+				resource := newCognitoUserPoolClientResource(userPool.id, clientID, resourceName)
+				if g.shouldAppendCognitoResource(cognitoUserPoolClientResourceType, resource) {
+					g.Resources = append(g.Resources, resource)
+				}
+			}
+		}
+	}
+	return nil
+}
+
+func (g *CognitoGenerator) loadUserGroups(svc *cognitoidentityprovider.Client, userPools []cognitoUserPoolRef) error {
+	for _, userPool := range userPools {
+		if !g.shouldLoadUserPoolChildResourceType(cognitoUserGroupResourceType, userPool.id) {
+			continue
+		}
+		p := cognitoidentityprovider.NewListGroupsPaginator(svc, &cognitoidentityprovider.ListGroupsInput{
+			UserPoolId: aws.String(userPool.id),
+		})
+
+		for p.HasMorePages() {
+			page, err := p.NextPage(context.TODO())
+			if err != nil {
+				if cognitoIDPResourceMissing(err) {
+					break
+				}
+				return err
+			}
+			for _, group := range page.Groups {
+				groupName := StringValue(group.GroupName)
+				if groupName == "" {
+					continue
+				}
+				resource := newCognitoUserGroupResource(userPool.id, groupName)
+				if g.shouldAppendCognitoResource(cognitoUserGroupResourceType, resource) {
+					g.Resources = append(g.Resources, resource)
+				}
+			}
+		}
+	}
+	return nil
+}
+
+func (g *CognitoGenerator) loadIdentityProviders(svc *cognitoidentityprovider.Client, userPools []cognitoUserPoolRef) error {
+	for _, userPool := range userPools {
+		if !g.shouldLoadUserPoolChildResourceType(cognitoIdentityProviderResourceType, userPool.id) {
+			continue
+		}
+		p := cognitoidentityprovider.NewListIdentityProvidersPaginator(svc, &cognitoidentityprovider.ListIdentityProvidersInput{
+			UserPoolId: aws.String(userPool.id),
+		})
+
+		for p.HasMorePages() {
+			page, err := p.NextPage(context.TODO())
+			if err != nil {
+				if cognitoIDPResourceMissing(err) {
+					break
+				}
+				return err
+			}
+			for _, provider := range page.Providers {
+				providerName := StringValue(provider.ProviderName)
+				if providerName == "" {
+					continue
+				}
+				resource := newCognitoIdentityProviderResource(userPool.id, providerName)
+				if g.shouldAppendCognitoResource(cognitoIdentityProviderResourceType, resource) {
+					g.Resources = append(g.Resources, resource)
+				}
+			}
+		}
+	}
+	return nil
+}
+
+func (g *CognitoGenerator) loadResourceServers(svc *cognitoidentityprovider.Client, userPools []cognitoUserPoolRef) error {
+	for _, userPool := range userPools {
+		if !g.shouldLoadUserPoolChildResourceType(cognitoResourceServerResourceType, userPool.id) {
+			continue
+		}
+		p := cognitoidentityprovider.NewListResourceServersPaginator(svc, &cognitoidentityprovider.ListResourceServersInput{
+			UserPoolId: aws.String(userPool.id),
+		})
+
+		for p.HasMorePages() {
+			page, err := p.NextPage(context.TODO())
+			if err != nil {
+				if cognitoIDPResourceMissing(err) {
+					break
+				}
+				return err
+			}
+			for _, server := range page.ResourceServers {
+				identifier := StringValue(server.Identifier)
+				if identifier == "" {
+					continue
+				}
+				resource := newCognitoResourceServerResource(userPool.id, identifier)
+				if g.shouldAppendCognitoResource(cognitoResourceServerResourceType, resource) {
+					g.Resources = append(g.Resources, resource)
+				}
+			}
+		}
+	}
+	return nil
+}
+
+func (g *CognitoGenerator) loadUserPoolDomains(userPools []cognitoUserPoolRef) error {
+	for _, userPool := range userPools {
+		for _, domain := range []string{userPool.domain, userPool.customDomain} {
+			if domain == "" {
+				continue
+			}
+			resource := newCognitoUserPoolDomainResource(userPool.id, domain)
+			if g.shouldAppendCognitoResource(cognitoUserPoolDomainResourceType, resource) {
+				g.Resources = append(g.Resources, resource)
+			}
+		}
+	}
+	return nil
+}
+
+func newCognitoIdentityPoolResource(identityPool cognitoIdentityPoolRef) terraformutils.Resource {
+	return terraformutils.NewSimpleResource(
+		identityPool.id,
+		cognitoResourceName(identityPool.name, identityPool.id),
+		"aws_cognito_identity_pool",
+		"aws",
+		[]string{})
+}
+
+func newCognitoIdentityPoolRolesAttachmentResource(identityPool cognitoIdentityPoolRef) terraformutils.Resource {
+	return terraformutils.NewResource(
+		identityPool.id,
+		cognitoResourceName(identityPool.name, "roles", identityPool.id),
+		"aws_cognito_identity_pool_roles_attachment",
+		"aws",
+		map[string]string{
+			"identity_pool_id": identityPool.id,
+		},
+		CognitoAllowEmptyValues,
+		CognitoAdditionalFields)
+}
+
+func newCognitoUserPoolResource(userPool cognitoUserPoolRef) terraformutils.Resource {
+	return terraformutils.NewSimpleResource(
+		userPool.id,
+		cognitoResourceName(userPool.name, userPool.id),
+		"aws_cognito_user_pool",
+		"aws",
+		[]string{})
+}
+
+func newCognitoUserPoolClientResource(userPoolID, clientID, clientName string) terraformutils.Resource {
+	// The AWS provider importer accepts user_pool_id/client_id, but refresh reads
+	// framework state with id=client_id and user_pool_id as a separate attribute.
+	return terraformutils.NewResource(
+		clientID,
+		cognitoResourceName(userPoolID, "client", clientName, clientID),
+		"aws_cognito_user_pool_client",
+		"aws",
+		map[string]string{
+			"user_pool_id": userPoolID,
+		},
+		CognitoAllowEmptyValues,
+		CognitoAdditionalFields)
+}
+
+func newCognitoUserGroupResource(userPoolID, groupName string) terraformutils.Resource {
+	return terraformutils.NewResource(
+		cognitoUserGroupResourceID(userPoolID, groupName),
+		cognitoResourceName(userPoolID, "group", groupName),
+		"aws_cognito_user_group",
+		"aws",
+		map[string]string{
+			"name":         groupName,
+			"user_pool_id": userPoolID,
+		},
+		CognitoAllowEmptyValues,
+		CognitoAdditionalFields)
+}
+
+func newCognitoIdentityProviderResource(userPoolID, providerName string) terraformutils.Resource {
+	return terraformutils.NewResource(
+		cognitoIdentityProviderResourceID(userPoolID, providerName),
+		cognitoResourceName(userPoolID, "idp", providerName),
+		"aws_cognito_identity_provider",
+		"aws",
+		map[string]string{
+			"provider_name": providerName,
+			"user_pool_id":  userPoolID,
+		},
+		CognitoAllowEmptyValues,
+		CognitoAdditionalFields)
+}
+
+func newCognitoResourceServerResource(userPoolID, identifier string) terraformutils.Resource {
+	return terraformutils.NewResource(
+		cognitoResourceServerResourceID(userPoolID, identifier),
+		cognitoResourceName(userPoolID, "resource-server", identifier),
+		"aws_cognito_resource_server",
+		"aws",
+		map[string]string{
+			"identifier":   identifier,
+			"user_pool_id": userPoolID,
+		},
+		CognitoAllowEmptyValues,
+		CognitoAdditionalFields)
+}
+
+func newCognitoUserPoolDomainResource(userPoolID, domain string) terraformutils.Resource {
+	return terraformutils.NewResource(
+		domain,
+		cognitoResourceName(userPoolID, "domain", domain),
+		"aws_cognito_user_pool_domain",
+		"aws",
+		map[string]string{
+			"domain":       domain,
+			"user_pool_id": userPoolID,
+		},
+		CognitoAllowEmptyValues,
+		CognitoAdditionalFields)
+}
+
+func cognitoUserGroupResourceID(userPoolID, groupName string) string {
+	return strings.Join([]string{userPoolID, groupName}, "/")
+}
+
+func cognitoIdentityProviderResourceID(userPoolID, providerName string) string {
+	return strings.Join([]string{userPoolID, providerName}, ":")
+}
+
+func cognitoResourceServerResourceID(userPoolID, identifier string) string {
+	return strings.Join([]string{userPoolID, identifier}, "|")
+}
+
+func cognitoUserPoolClientImportID(userPoolID, clientID string) string {
+	return strings.Join([]string{userPoolID, clientID}, "/")
+}
+
+func cognitoResourceName(parts ...string) string {
+	var nonempty []string
+	for _, part := range parts {
+		if part != "" {
+			nonempty = append(nonempty, part)
+		}
+	}
+	return strings.Join(nonempty, ":")
+}
+
+func (g *CognitoGenerator) shouldLoadIdentityPools() bool {
+	if g.hasUntypedIDFilter() {
+		return true
+	}
+	if g.hasTypedCognitoFilter() {
+		return g.hasTypedFilterFor(cognitoIdentityPoolResourceType) || g.hasTypedIdentityPoolChildFilter()
+	}
+	return true
+}
+
+func (g *CognitoGenerator) shouldLoadUserPools() bool {
+	if g.hasUntypedIDFilter() {
+		return true
+	}
+	if g.hasTypedCognitoFilter() {
+		return g.hasTypedFilterFor(cognitoUserPoolResourceType) || g.hasTypedUserPoolChildFilter()
+	}
+	return true
+}
+
+func (g *CognitoGenerator) shouldLoadIdentityPoolChildResourceType(serviceName, identityPoolID string) bool {
+	hasTypedChildFilter := g.hasTypedFilterFor(serviceName)
+	if g.hasTypedIdentityPoolChildFilter() && !hasTypedChildFilter {
+		return false
+	}
+	if g.hasTypedCognitoFilter() && !hasTypedChildFilter && !g.hasTypedFilterFor(cognitoIdentityPoolResourceType) && !g.hasUntypedIDFilter() {
+		return false
+	}
+	if !g.initialIDFiltersCanMatchIdentityPoolChild(serviceName, identityPoolID) {
+		return false
+	}
+	if !hasTypedChildFilter && !g.hasUntypedIDFilter() {
+		return g.identityPoolMatchesPreDiscoveryFilters(identityPoolID)
+	}
+	if hasTypedChildFilter && !g.hasIDFilterFor(serviceName) && !g.hasUntypedIDFilter() && g.hasTypedFilterFor(cognitoIdentityPoolResourceType) {
+		return g.identityPoolMatchesPreDiscoveryFilters(identityPoolID)
+	}
+	return true
+}
+
+func (g *CognitoGenerator) shouldLoadUserPoolChildResourceType(serviceName, userPoolID string) bool {
+	hasTypedChildFilter := g.hasTypedFilterFor(serviceName)
+	if g.hasTypedUserPoolChildFilter() && !hasTypedChildFilter {
+		return false
+	}
+	if g.hasTypedCognitoFilter() && !hasTypedChildFilter && !g.hasTypedFilterFor(cognitoUserPoolResourceType) && !g.hasUntypedIDFilter() {
+		return false
+	}
+	if !g.initialIDFiltersCanMatchUserPoolChild(serviceName, userPoolID) {
+		return false
+	}
+	if !hasTypedChildFilter && !g.hasUntypedIDFilter() {
+		return g.userPoolMatchesPreDiscoveryFilters(userPoolID)
+	}
+	if hasTypedChildFilter && !g.hasIDFilterFor(serviceName) && !g.hasUntypedIDFilter() && g.hasTypedFilterFor(cognitoUserPoolResourceType) {
+		return g.userPoolMatchesPreDiscoveryFilters(userPoolID)
+	}
+	return true
+}
+
+func (g *CognitoGenerator) shouldAppendCognitoResource(serviceName string, resource terraformutils.Resource) bool {
+	if !g.resourceMatchesInitialIDFilters(serviceName, resource) {
+		return false
+	}
+	if g.hasTypedCognitoFilter() && !g.hasTypedFilterFor(serviceName) && !g.hasUntypedIDFilter() {
+		return false
+	}
+	return true
+}
+
+func (g *CognitoGenerator) identityPoolMatchesPreDiscoveryFilters(identityPoolID string) bool {
+	resource := terraformutils.NewSimpleResource(identityPoolID, identityPoolID, "aws_cognito_identity_pool", "aws", CognitoAllowEmptyValues)
+	if !g.resourceMatchesInitialIDFilters(cognitoIdentityPoolResourceType, resource) {
+		return false
+	}
+	return !g.hasTypedNonIDFilterFor(cognitoIdentityPoolResourceType)
+}
+
+func (g *CognitoGenerator) userPoolMatchesPreDiscoveryFilters(userPoolID string) bool {
+	resource := terraformutils.NewSimpleResource(userPoolID, userPoolID, "aws_cognito_user_pool", "aws", CognitoAllowEmptyValues)
+	if !g.resourceMatchesInitialIDFilters(cognitoUserPoolResourceType, resource) {
+		return false
+	}
+	return !g.hasTypedNonIDFilterFor(cognitoUserPoolResourceType)
+}
+
+func (g *CognitoGenerator) resourceMatchesInitialIDFilters(serviceName string, resource terraformutils.Resource) bool {
+	for _, filter := range g.Filter {
+		if filter.FieldPath != "id" || !filter.IsApplicable(serviceName) {
+			continue
+		}
+		if !filter.Filter(resource) && !cognitoResourceMatchesAlternateIDFilter(serviceName, resource, filter.AcceptableValues) {
+			return false
+		}
+	}
+	return true
+}
+
+func cognitoResourceMatchesAlternateIDFilter(serviceName string, resource terraformutils.Resource, values []string) bool {
+	if serviceName != cognitoUserPoolClientResourceType {
+		return false
+	}
+	userPoolID := resource.InstanceState.Attributes["user_pool_id"]
+	clientID := resource.InstanceState.ID
+	if userPoolID == "" || clientID == "" {
+		return false
+	}
+	return cognitoAnyAcceptableIDMatches(values, func(value string) bool {
+		return value == cognitoUserPoolClientImportID(userPoolID, clientID)
+	})
+}
+
+func (g *CognitoGenerator) initialIDFiltersCanMatchIdentityPoolChild(serviceName, identityPoolID string) bool {
+	for _, filter := range g.Filter {
+		if filter.FieldPath != "id" || !filter.IsApplicable(serviceName) {
+			continue
+		}
+		if !cognitoAnyAcceptableIDMatches(filter.AcceptableValues, func(value string) bool {
+			return cognitoIdentityPoolChildIDMayBelongToIdentityPool(serviceName, identityPoolID, value)
+		}) {
+			return false
+		}
+	}
+	return true
+}
+
+func (g *CognitoGenerator) initialIDFiltersCanMatchUserPoolChild(serviceName, userPoolID string) bool {
+	for _, filter := range g.Filter {
+		if filter.FieldPath != "id" || !filter.IsApplicable(serviceName) {
+			continue
+		}
+		if !cognitoAnyAcceptableIDMatches(filter.AcceptableValues, func(value string) bool {
+			return cognitoUserPoolChildIDMayBelongToUserPool(serviceName, userPoolID, value)
+		}) {
+			return false
+		}
+	}
+	return true
+}
+
+func cognitoAnyAcceptableIDMatches(values []string, match func(string) bool) bool {
+	if len(values) == 0 {
+		return true
+	}
+	for _, value := range values {
+		if match(value) {
+			return true
+		}
+	}
+	return false
+}
+
+func cognitoIdentityPoolChildIDMayBelongToIdentityPool(serviceName, identityPoolID, value string) bool {
+	switch serviceName {
+	case cognitoIdentityPoolRolesAttachmentResourceType:
+		return value == identityPoolID
+	default:
+		return true
+	}
+}
+
+func cognitoUserPoolChildIDMayBelongToUserPool(serviceName, userPoolID, value string) bool {
+	switch serviceName {
+	case cognitoUserPoolClientResourceType:
+		return strings.HasPrefix(value, userPoolID+"/") || !strings.Contains(value, "/")
+	case cognitoUserGroupResourceType:
+		return strings.HasPrefix(value, userPoolID+"/")
+	case cognitoIdentityProviderResourceType:
+		return strings.HasPrefix(value, userPoolID+":")
+	case cognitoResourceServerResourceType:
+		return strings.HasPrefix(value, userPoolID+"|")
+	case cognitoUserPoolDomainResourceType:
+		return true
+	default:
+		return true
+	}
+}
+
+func (g *CognitoGenerator) hasTypedIdentityPoolChildFilter() bool {
+	for _, serviceName := range cognitoIdentityPoolChildResourceTypes {
+		if g.hasTypedFilterFor(serviceName) {
+			return true
+		}
+	}
+	return false
+}
+
+func (g *CognitoGenerator) hasTypedUserPoolChildFilter() bool {
+	for _, serviceName := range cognitoUserPoolChildResourceTypes {
+		if g.hasTypedFilterFor(serviceName) {
+			return true
+		}
+	}
+	return false
+}
+
+func (g *CognitoGenerator) hasTypedCognitoFilter() bool {
+	for _, serviceName := range cognitoResourceTypes {
+		if g.hasTypedFilterFor(serviceName) {
+			return true
+		}
+	}
+	return false
+}
+
+func (g *CognitoGenerator) hasTypedFilterFor(serviceName string) bool {
+	for _, filter := range g.Filter {
+		if filter.ServiceName == serviceName {
+			return true
+		}
+	}
+	return false
+}
+
+func (g *CognitoGenerator) hasTypedNonIDFilterFor(serviceName string) bool {
+	for _, filter := range g.Filter {
+		if filter.ServiceName == serviceName && filter.FieldPath != "id" {
+			return true
+		}
+	}
+	return false
+}
+
+func (g *CognitoGenerator) hasIDFilterFor(serviceName string) bool {
+	for _, filter := range g.Filter {
+		if filter.FieldPath == "id" && filter.IsApplicable(serviceName) {
+			return true
+		}
+	}
+	return false
+}
+
+func (g *CognitoGenerator) hasUntypedIDFilter() bool {
+	for _, filter := range g.Filter {
+		if filter.ServiceName == "" && filter.FieldPath == "id" {
+			return true
+		}
+	}
+	return false
+}
+
+func cognitoIdentityPoolRolesAttachmentConfigured(output *cognitoidentity.GetIdentityPoolRolesOutput) bool {
+	if output == nil {
+		return false
+	}
+	return len(output.Roles) > 0 || len(output.RoleMappings) > 0
+}
+
+func cognitoIdentityResourceMissing(err error) bool {
+	var notFound *identitytypes.ResourceNotFoundException
+	return errors.As(err, &notFound)
+}
+
+func cognitoIDPResourceMissing(err error) bool {
+	var notFound *idptypes.ResourceNotFoundException
+	return errors.As(err, &notFound)
 }
 
 func (g *CognitoGenerator) PostConvertHook() error {

--- a/providers/aws/cognito.go
+++ b/providers/aws/cognito.go
@@ -6,6 +6,7 @@ package aws
 import (
 	"context"
 	"errors"
+	"fmt"
 	"log"
 	"strings"
 
@@ -26,8 +27,10 @@ type CognitoGenerator struct {
 }
 
 type cognitoOptionalResourceLoader struct {
-	name string
-	load func() error
+	name         string
+	serviceNames []string
+	required     bool
+	load         func() error
 }
 
 type cognitoIdentityPoolRef struct {
@@ -84,9 +87,15 @@ func (g *CognitoGenerator) InitResources() error {
 		if err != nil {
 			return err
 		}
-		g.loadOptionalResources([]cognitoOptionalResourceLoader{
-			{name: "identity pool role attachments", load: func() error { return g.loadIdentityPoolRolesAttachments(svcCognitoIdentity, identityPools) }},
-		})
+		if err := g.loadOptionalResources([]cognitoOptionalResourceLoader{
+			{
+				name:         "identity pool role attachments",
+				serviceNames: []string{cognitoIdentityPoolRolesAttachmentResourceType},
+				load:         func() error { return g.loadIdentityPoolRolesAttachments(svcCognitoIdentity, identityPools) },
+			},
+		}); err != nil {
+			return err
+		}
 	}
 
 	if g.shouldLoadUserPools() {
@@ -95,24 +104,51 @@ func (g *CognitoGenerator) InitResources() error {
 		if err != nil {
 			return err
 		}
-		g.loadOptionalResources([]cognitoOptionalResourceLoader{
-			{name: "user pool clients", load: func() error { return g.loadUserPoolClients(svcCognitoIdentityProvider, userPools) }},
-			{name: "user groups", load: func() error { return g.loadUserGroups(svcCognitoIdentityProvider, userPools) }},
-			{name: "identity providers", load: func() error { return g.loadIdentityProviders(svcCognitoIdentityProvider, userPools) }},
-			{name: "resource servers", load: func() error { return g.loadResourceServers(svcCognitoIdentityProvider, userPools) }},
-			{name: "user pool domains", load: func() error { return g.loadUserPoolDomains(userPools) }},
-		})
+		if err := g.loadOptionalResources([]cognitoOptionalResourceLoader{
+			{
+				name:         "user pool clients",
+				serviceNames: []string{cognitoUserPoolClientResourceType},
+				required:     true,
+				load:         func() error { return g.loadUserPoolClients(svcCognitoIdentityProvider, userPools) },
+			},
+			{
+				name:         "user groups",
+				serviceNames: []string{cognitoUserGroupResourceType},
+				load:         func() error { return g.loadUserGroups(svcCognitoIdentityProvider, userPools) },
+			},
+			{
+				name:         "identity providers",
+				serviceNames: []string{cognitoIdentityProviderResourceType},
+				load:         func() error { return g.loadIdentityProviders(svcCognitoIdentityProvider, userPools) },
+			},
+			{
+				name:         "resource servers",
+				serviceNames: []string{cognitoResourceServerResourceType},
+				load:         func() error { return g.loadResourceServers(svcCognitoIdentityProvider, userPools) },
+			},
+			{
+				name:         "user pool domains",
+				serviceNames: []string{cognitoUserPoolDomainResourceType},
+				load:         func() error { return g.loadUserPoolDomains(userPools) },
+			},
+		}); err != nil {
+			return err
+		}
 	}
 
 	return nil
 }
 
-func (g *CognitoGenerator) loadOptionalResources(loaders []cognitoOptionalResourceLoader) {
+func (g *CognitoGenerator) loadOptionalResources(loaders []cognitoOptionalResourceLoader) error {
 	for _, loader := range loaders {
 		if err := loader.load(); err != nil {
+			if loader.required || g.hasTypedFilterForAny(loader.serviceNames...) {
+				return fmt.Errorf("loading Cognito %s: %w", loader.name, err)
+			}
 			log.Printf("Skipping Cognito %s: %v", loader.name, err)
 		}
 	}
+	return nil
 }
 
 func (g *CognitoGenerator) loadIdentityPools(svc *cognitoidentity.Client) ([]cognitoIdentityPoolRef, error) {
@@ -188,13 +224,15 @@ func (g *CognitoGenerator) loadUserPools(svc *cognitoidentityprovider.Client) ([
 				continue
 			}
 			ref := cognitoUserPoolRef{id: id, name: resourceName}
-			if output, err := svc.DescribeUserPool(context.TODO(), &cognitoidentityprovider.DescribeUserPoolInput{
-				UserPoolId: aws.String(id),
-			}); err == nil && output.UserPool != nil {
-				ref.domain = StringValue(output.UserPool.Domain)
-				ref.customDomain = StringValue(output.UserPool.CustomDomain)
-			} else if err != nil && !cognitoIDPResourceMissing(err) {
-				log.Printf("Skipping Cognito user pool domain metadata for %s: %v", id, err)
+			if g.shouldLoadUserPoolDomainMetadata(id) {
+				if output, err := svc.DescribeUserPool(context.TODO(), &cognitoidentityprovider.DescribeUserPoolInput{
+					UserPoolId: aws.String(id),
+				}); err == nil && output.UserPool != nil {
+					ref.domain = StringValue(output.UserPool.Domain)
+					ref.customDomain = StringValue(output.UserPool.CustomDomain)
+				} else if err != nil && !cognitoIDPResourceMissing(err) {
+					log.Printf("Skipping Cognito user pool domain metadata for %s: %v", id, err)
+				}
 			}
 			userPools = append(userPools, ref)
 
@@ -339,6 +377,9 @@ func (g *CognitoGenerator) loadResourceServers(svc *cognitoidentityprovider.Clie
 
 func (g *CognitoGenerator) loadUserPoolDomains(userPools []cognitoUserPoolRef) error {
 	for _, userPool := range userPools {
+		if !g.shouldLoadUserPoolDomainMetadata(userPool.id) {
+			continue
+		}
 		for _, domain := range []string{userPool.domain, userPool.customDomain} {
 			if domain == "" {
 				continue
@@ -540,6 +581,13 @@ func (g *CognitoGenerator) shouldLoadUserPoolChildResourceType(serviceName, user
 	return true
 }
 
+func (g *CognitoGenerator) shouldLoadUserPoolDomainMetadata(userPoolID string) bool {
+	if g.hasTypedCognitoFilter() && !g.hasUntypedIDFilter() && !g.hasTypedFilterFor(cognitoUserPoolDomainResourceType) {
+		return false
+	}
+	return g.shouldLoadUserPoolChildResourceType(cognitoUserPoolDomainResourceType, userPoolID)
+}
+
 func (g *CognitoGenerator) shouldAppendCognitoResource(serviceName string, resource terraformutils.Resource) bool {
 	if !g.resourceMatchesInitialIDFilters(serviceName, resource) {
 		return false
@@ -688,6 +736,15 @@ func (g *CognitoGenerator) hasTypedCognitoFilter() bool {
 func (g *CognitoGenerator) hasTypedFilterFor(serviceName string) bool {
 	for _, filter := range g.Filter {
 		if filter.ServiceName == serviceName {
+			return true
+		}
+	}
+	return false
+}
+
+func (g *CognitoGenerator) hasTypedFilterForAny(serviceNames ...string) bool {
+	for _, serviceName := range serviceNames {
+		if g.hasTypedFilterFor(serviceName) {
 			return true
 		}
 	}

--- a/providers/aws/cognito.go
+++ b/providers/aws/cognito.go
@@ -198,7 +198,10 @@ func (g *CognitoGenerator) loadIdentityPoolRolesAttachments(svc *cognitoidentity
 		if !cognitoIdentityPoolRolesAttachmentConfigured(output) {
 			continue
 		}
-		resource := newCognitoIdentityPoolRolesAttachmentResource(identityPool)
+		resource := newCognitoIdentityPoolRolesAttachmentResource(
+			identityPool,
+			cognitoIdentityPoolRolesAttachmentNeedsEmptyRoles(output),
+		)
 		if g.shouldAppendCognitoResource(cognitoIdentityPoolRolesAttachmentResourceType, resource) {
 			g.Resources = append(g.Resources, resource)
 		}
@@ -415,7 +418,13 @@ func newCognitoIdentityPoolResource(identityPool cognitoIdentityPoolRef) terrafo
 		[]string{})
 }
 
-func newCognitoIdentityPoolRolesAttachmentResource(identityPool cognitoIdentityPoolRef) terraformutils.Resource {
+func newCognitoIdentityPoolRolesAttachmentResource(identityPool cognitoIdentityPoolRef, preserveEmptyRoles bool) terraformutils.Resource {
+	additionalFields := CognitoAdditionalFields
+	if preserveEmptyRoles {
+		additionalFields = map[string]interface{}{
+			"roles": map[string]interface{}{},
+		}
+	}
 	return terraformutils.NewResource(
 		identityPool.id,
 		cognitoResourceName(identityPool.name, "roles", identityPool.id),
@@ -425,7 +434,7 @@ func newCognitoIdentityPoolRolesAttachmentResource(identityPool cognitoIdentityP
 			"identity_pool_id": identityPool.id,
 		},
 		CognitoAllowEmptyValues,
-		CognitoAdditionalFields)
+		additionalFields)
 }
 
 func newCognitoUserPoolResource(userPool cognitoUserPoolRef) terraformutils.Resource {
@@ -818,6 +827,13 @@ func cognitoIdentityPoolRolesAttachmentConfigured(output *cognitoidentity.GetIde
 		return false
 	}
 	return len(output.Roles) > 0 || len(output.RoleMappings) > 0
+}
+
+func cognitoIdentityPoolRolesAttachmentNeedsEmptyRoles(output *cognitoidentity.GetIdentityPoolRolesOutput) bool {
+	if output == nil {
+		return false
+	}
+	return len(output.Roles) == 0 && len(output.RoleMappings) > 0
 }
 
 func cognitoIdentityResourceMissing(err error) bool {

--- a/providers/aws/cognito.go
+++ b/providers/aws/cognito.go
@@ -230,8 +230,10 @@ func (g *CognitoGenerator) loadUserPools(svc *cognitoidentityprovider.Client) ([
 				}); err == nil && output.UserPool != nil {
 					ref.domain = StringValue(output.UserPool.Domain)
 					ref.customDomain = StringValue(output.UserPool.CustomDomain)
-				} else if err != nil && !cognitoIDPResourceMissing(err) {
-					log.Printf("Skipping Cognito user pool domain metadata for %s: %v", id, err)
+				} else if err != nil {
+					if err := g.handleUserPoolDomainMetadataError(id, err); err != nil {
+						return nil, err
+					}
 				}
 			}
 			userPools = append(userPools, ref)
@@ -390,6 +392,17 @@ func (g *CognitoGenerator) loadUserPoolDomains(userPools []cognitoUserPoolRef) e
 			}
 		}
 	}
+	return nil
+}
+
+func (g *CognitoGenerator) handleUserPoolDomainMetadataError(userPoolID string, err error) error {
+	if err == nil || cognitoIDPResourceMissing(err) {
+		return nil
+	}
+	if g.hasTypedFilterFor(cognitoUserPoolDomainResourceType) {
+		return fmt.Errorf("loading Cognito user pool domain metadata for %s: %w", userPoolID, err)
+	}
+	log.Printf("Skipping Cognito user pool domain metadata for %s: %v", userPoolID, err)
 	return nil
 }
 
@@ -596,6 +609,20 @@ func (g *CognitoGenerator) shouldAppendCognitoResource(serviceName string, resou
 		return false
 	}
 	return true
+}
+
+func (g *CognitoGenerator) InitialCleanup() {
+	if len(g.Filter) == 0 {
+		return
+	}
+	var resources []terraformutils.Resource
+	for _, resource := range g.Resources {
+		serviceName := strings.TrimPrefix(resource.InstanceInfo.Type, resource.Provider+"_")
+		if g.resourceMatchesInitialIDFilters(serviceName, resource) && !terraformutils.ContainsResource(resources, resource) {
+			resources = append(resources, resource)
+		}
+	}
+	g.Resources = resources
 }
 
 func (g *CognitoGenerator) identityPoolMatchesPreDiscoveryFilters(identityPoolID string) bool {

--- a/providers/aws/cognito_test.go
+++ b/providers/aws/cognito_test.go
@@ -95,40 +95,29 @@ func TestCognitoResourceMissing(t *testing.T) {
 func TestCognitoOptionalResourceLoaderErrors(t *testing.T) {
 	boom := errors.New("boom")
 	tests := []struct {
-		name    string
-		filters []terraformutils.ResourceFilter
-		loader  cognitoOptionalResourceLoader
-		wantErr bool
+		name         string
+		filters      []terraformutils.ResourceFilter
+		serviceNames []string
+		required     bool
+		wantErr      bool
 	}{
 		{
-			name: "optional loader error is logged for broad discovery",
-			loader: cognitoOptionalResourceLoader{
-				name:         "user groups",
-				serviceNames: []string{cognitoUserGroupResourceType},
-				load:         func() error { return boom },
-			},
+			name:         "optional loader error is logged for broad discovery",
+			serviceNames: []string{cognitoUserGroupResourceType},
 		},
 		{
 			name: "typed child filter returns loader error",
 			filters: []terraformutils.ResourceFilter{
 				{ServiceName: cognitoUserGroupResourceType, FieldPath: "id", AcceptableValues: []string{"us-east-1_abc/admins"}},
 			},
-			loader: cognitoOptionalResourceLoader{
-				name:         "user groups",
-				serviceNames: []string{cognitoUserGroupResourceType},
-				load:         func() error { return boom },
-			},
-			wantErr: true,
+			serviceNames: []string{cognitoUserGroupResourceType},
+			wantErr:      true,
 		},
 		{
-			name: "required loader returns error without typed filter",
-			loader: cognitoOptionalResourceLoader{
-				name:         "user pool clients",
-				serviceNames: []string{cognitoUserPoolClientResourceType},
-				required:     true,
-				load:         func() error { return boom },
-			},
-			wantErr: true,
+			name:         "required loader returns error without typed filter",
+			serviceNames: []string{cognitoUserPoolClientResourceType},
+			required:     true,
+			wantErr:      true,
 		},
 	}
 
@@ -136,7 +125,21 @@ func TestCognitoOptionalResourceLoaderErrors(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			g := CognitoGenerator{}
 			g.Filter = tt.filters
-			err := g.loadOptionalResources([]cognitoOptionalResourceLoader{tt.loader})
+			called := false
+			err := g.loadOptionalResources([]cognitoOptionalResourceLoader{
+				{
+					name:         "user groups",
+					serviceNames: tt.serviceNames,
+					required:     tt.required,
+					load: func() error {
+						called = true
+						return boom
+					},
+				},
+			})
+			if !called {
+				t.Fatal("loader was not called")
+			}
 			if tt.wantErr {
 				if !errors.Is(err, boom) {
 					t.Fatalf("loadOptionalResources() error = %v, want %v", err, boom)

--- a/providers/aws/cognito_test.go
+++ b/providers/aws/cognito_test.go
@@ -92,6 +92,53 @@ func TestCognitoResourceMissing(t *testing.T) {
 	}
 }
 
+func TestCognitoUserPoolDomainMetadataError(t *testing.T) {
+	boom := errors.New("boom")
+	tests := []struct {
+		name    string
+		filters []terraformutils.ResourceFilter
+		err     error
+		wantErr bool
+	}{
+		{
+			name: "broad discovery logs domain metadata error",
+			err:  boom,
+		},
+		{
+			name: "typed domain filter returns domain metadata error",
+			filters: []terraformutils.ResourceFilter{
+				{ServiceName: cognitoUserPoolDomainResourceType, FieldPath: "id", AcceptableValues: []string{"auth.example.com"}},
+			},
+			err:     boom,
+			wantErr: true,
+		},
+		{
+			name: "typed domain filter ignores missing user pool",
+			filters: []terraformutils.ResourceFilter{
+				{ServiceName: cognitoUserPoolDomainResourceType, FieldPath: "id", AcceptableValues: []string{"auth.example.com"}},
+			},
+			err: &idptypes.ResourceNotFoundException{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := CognitoGenerator{}
+			g.Filter = tt.filters
+			err := g.handleUserPoolDomainMetadataError("us-east-1_abc", tt.err)
+			if tt.wantErr {
+				if !errors.Is(err, boom) {
+					t.Fatalf("handleUserPoolDomainMetadataError() error = %v, want %v", err, boom)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("handleUserPoolDomainMetadataError() error = %v, want nil", err)
+			}
+		})
+	}
+}
+
 func TestCognitoOptionalResourceLoaderErrors(t *testing.T) {
 	boom := errors.New("boom")
 	tests := []struct {
@@ -148,6 +195,47 @@ func TestCognitoOptionalResourceLoaderErrors(t *testing.T) {
 			}
 			if err != nil {
 				t.Fatalf("loadOptionalResources() error = %v, want nil", err)
+			}
+		})
+	}
+}
+
+func TestCognitoInitialCleanupPreservesUserPoolClientImportIDFilter(t *testing.T) {
+	userPoolID := "us-east-1_abc"
+	clientID := "client123"
+	resource := newCognitoUserPoolClientResource(userPoolID, clientID, "web")
+
+	tests := []struct {
+		name        string
+		filterValue string
+		wantCount   int
+	}{
+		{
+			name:        "full import ID filter keeps client resource",
+			filterValue: cognitoUserPoolClientImportID(userPoolID, clientID),
+			wantCount:   1,
+		},
+		{
+			name:        "client ID filter keeps client resource",
+			filterValue: clientID,
+			wantCount:   1,
+		},
+		{
+			name:        "nonmatching full import ID filter removes client resource",
+			filterValue: cognitoUserPoolClientImportID(userPoolID, "other"),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := CognitoGenerator{}
+			g.Resources = []terraformutils.Resource{resource}
+			g.Filter = []terraformutils.ResourceFilter{
+				{ServiceName: cognitoUserPoolClientResourceType, FieldPath: "id", AcceptableValues: []string{tt.filterValue}},
+			}
+			g.InitialCleanup()
+			if got := len(g.Resources); got != tt.wantCount {
+				t.Fatalf("len(Resources) = %d, want %d", got, tt.wantCount)
 			}
 		})
 	}

--- a/providers/aws/cognito_test.go
+++ b/providers/aws/cognito_test.go
@@ -1,0 +1,309 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package aws
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/service/cognitoidentity"
+	identitytypes "github.com/aws/aws-sdk-go-v2/service/cognitoidentity/types"
+	idptypes "github.com/aws/aws-sdk-go-v2/service/cognitoidentityprovider/types"
+	"github.com/chenrui333/terraformer/terraformutils"
+)
+
+func TestCognitoResourceIDs(t *testing.T) {
+	tests := []struct {
+		name string
+		got  string
+		want string
+	}{
+		{name: "user group", got: cognitoUserGroupResourceID("us-east-1_abc", "admins"), want: "us-east-1_abc/admins"},
+		{name: "identity provider", got: cognitoIdentityProviderResourceID("us-east-1_abc", "Google"), want: "us-east-1_abc:Google"},
+		{name: "resource server", got: cognitoResourceServerResourceID("us-east-1_abc", "https://example.com"), want: "us-east-1_abc|https://example.com"},
+		{name: "resource name skips empty parts", got: cognitoResourceName("pool", "", "client", "web"), want: "pool:client:web"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.got != tt.want {
+				t.Fatalf("got %q, want %q", tt.got, tt.want)
+			}
+		})
+	}
+}
+
+func TestCognitoIdentityPoolRolesAttachmentConfigured(t *testing.T) {
+	tests := []struct {
+		name   string
+		output *cognitoidentity.GetIdentityPoolRolesOutput
+		want   bool
+	}{
+		{name: "nil", output: nil},
+		{name: "empty", output: &cognitoidentity.GetIdentityPoolRolesOutput{}},
+		{
+			name: "roles",
+			output: &cognitoidentity.GetIdentityPoolRolesOutput{
+				Roles: map[string]string{"authenticated": "arn:aws:iam::123456789012:role/auth"},
+			},
+			want: true,
+		},
+		{
+			name: "role mappings",
+			output: &cognitoidentity.GetIdentityPoolRolesOutput{
+				RoleMappings: map[string]identitytypes.RoleMapping{"accounts.google.com": {}},
+			},
+			want: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := cognitoIdentityPoolRolesAttachmentConfigured(tt.output); got != tt.want {
+				t.Fatalf("cognitoIdentityPoolRolesAttachmentConfigured() = %t, want %t", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestCognitoResourceMissing(t *testing.T) {
+	tests := []struct {
+		name string
+		fn   func(error) bool
+		err  error
+		want bool
+	}{
+		{name: "identity nil", fn: cognitoIdentityResourceMissing, err: nil},
+		{name: "identity missing", fn: cognitoIdentityResourceMissing, err: &identitytypes.ResourceNotFoundException{}, want: true},
+		{name: "identity wrapped missing", fn: cognitoIdentityResourceMissing, err: errors.Join(errors.New("wrapper"), &identitytypes.ResourceNotFoundException{}), want: true},
+		{name: "identity generic", fn: cognitoIdentityResourceMissing, err: errors.New("boom")},
+		{name: "idp nil", fn: cognitoIDPResourceMissing, err: nil},
+		{name: "idp missing", fn: cognitoIDPResourceMissing, err: &idptypes.ResourceNotFoundException{}, want: true},
+		{name: "idp wrapped missing", fn: cognitoIDPResourceMissing, err: errors.Join(errors.New("wrapper"), &idptypes.ResourceNotFoundException{}), want: true},
+		{name: "idp generic", fn: cognitoIDPResourceMissing, err: errors.New("boom")},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.fn(tt.err); got != tt.want {
+				t.Fatalf("missing helper = %t, want %t", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestCognitoFilterGatesUserPoolsAndChildren(t *testing.T) {
+	userPoolID := "us-east-1_abc"
+	otherUserPoolID := "us-east-1_def"
+	userPool := newCognitoUserPoolResource(cognitoUserPoolRef{id: userPoolID, name: "orders"})
+	otherUserPool := newCognitoUserPoolResource(cognitoUserPoolRef{id: otherUserPoolID, name: "other"})
+	client := newCognitoUserPoolClientResource(userPoolID, "client123", "web")
+	group := newCognitoUserGroupResource(userPoolID, "admins")
+
+	tests := []struct {
+		name             string
+		filters          []terraformutils.ResourceFilter
+		loadUserPools    bool
+		appendUserPool   bool
+		appendOtherPool  bool
+		loadClients      bool
+		loadOtherClients bool
+		appendClient     bool
+		appendGroup      bool
+	}{
+		{
+			name:             "no filters imports user pools and children",
+			loadUserPools:    true,
+			appendUserPool:   true,
+			appendOtherPool:  true,
+			loadClients:      true,
+			loadOtherClients: true,
+			appendClient:     true,
+			appendGroup:      true,
+		},
+		{
+			name: "typed user pool id filter limits parent output",
+			filters: []terraformutils.ResourceFilter{
+				{ServiceName: cognitoUserPoolResourceType, FieldPath: "id", AcceptableValues: []string{userPoolID}},
+			},
+			loadUserPools:  true,
+			appendUserPool: true,
+			loadClients:    true,
+		},
+		{
+			name: "typed child id filter skips parent output",
+			filters: []terraformutils.ResourceFilter{
+				{ServiceName: cognitoUserPoolClientResourceType, FieldPath: "id", AcceptableValues: []string{cognitoUserPoolClientImportID(userPoolID, "client123")}},
+			},
+			loadUserPools: true,
+			loadClients:   true,
+			appendClient:  true,
+		},
+		{
+			name: "typed parent id filter scopes typed child non-id discovery",
+			filters: []terraformutils.ResourceFilter{
+				{ServiceName: cognitoUserPoolResourceType, FieldPath: "id", AcceptableValues: []string{userPoolID}},
+				{ServiceName: cognitoUserPoolClientResourceType, FieldPath: "name", AcceptableValues: []string{"web"}},
+			},
+			loadUserPools:  true,
+			appendUserPool: true,
+			loadClients:    true,
+			appendClient:   true,
+		},
+		{
+			name: "typed child id filter can load outside parent filter",
+			filters: []terraformutils.ResourceFilter{
+				{ServiceName: cognitoUserPoolResourceType, FieldPath: "id", AcceptableValues: []string{otherUserPoolID}},
+				{ServiceName: cognitoUserPoolClientResourceType, FieldPath: "id", AcceptableValues: []string{cognitoUserPoolClientImportID(userPoolID, "client123")}},
+			},
+			loadUserPools:   true,
+			appendOtherPool: true,
+			loadClients:     true,
+			appendClient:    true,
+		},
+		{
+			name: "typed user pool non-id filter avoids child pre-load",
+			filters: []terraformutils.ResourceFilter{
+				{ServiceName: cognitoUserPoolResourceType, FieldPath: "tags.env", AcceptableValues: []string{"prod"}},
+			},
+			loadUserPools:   true,
+			appendUserPool:  true,
+			appendOtherPool: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := CognitoGenerator{}
+			g.Filter = tt.filters
+			if got := g.shouldLoadUserPools(); got != tt.loadUserPools {
+				t.Fatalf("shouldLoadUserPools() = %t, want %t", got, tt.loadUserPools)
+			}
+			if got := g.shouldAppendCognitoResource(cognitoUserPoolResourceType, userPool); got != tt.appendUserPool {
+				t.Fatalf("shouldAppendCognitoResource(user pool) = %t, want %t", got, tt.appendUserPool)
+			}
+			if got := g.shouldAppendCognitoResource(cognitoUserPoolResourceType, otherUserPool); got != tt.appendOtherPool {
+				t.Fatalf("shouldAppendCognitoResource(other user pool) = %t, want %t", got, tt.appendOtherPool)
+			}
+			if got := g.shouldLoadUserPoolChildResourceType(cognitoUserPoolClientResourceType, userPoolID); got != tt.loadClients {
+				t.Fatalf("shouldLoadUserPoolChildResourceType(client) = %t, want %t", got, tt.loadClients)
+			}
+			if got := g.shouldLoadUserPoolChildResourceType(cognitoUserPoolClientResourceType, otherUserPoolID); got != tt.loadOtherClients {
+				t.Fatalf("shouldLoadUserPoolChildResourceType(other client) = %t, want %t", got, tt.loadOtherClients)
+			}
+			if got := g.shouldAppendCognitoResource(cognitoUserPoolClientResourceType, client); got != tt.appendClient {
+				t.Fatalf("shouldAppendCognitoResource(client) = %t, want %t", got, tt.appendClient)
+			}
+			if got := g.shouldAppendCognitoResource(cognitoUserGroupResourceType, group); got != tt.appendGroup {
+				t.Fatalf("shouldAppendCognitoResource(group) = %t, want %t", got, tt.appendGroup)
+			}
+		})
+	}
+}
+
+func TestCognitoFilterGatesIdentityPoolsAndChildren(t *testing.T) {
+	identityPoolID := "us-east-1:11111111-1111-1111-1111-111111111111"
+	otherIdentityPoolID := "us-east-1:22222222-2222-2222-2222-222222222222"
+	identityPool := newCognitoIdentityPoolResource(cognitoIdentityPoolRef{id: identityPoolID, name: "orders"})
+	otherIdentityPool := newCognitoIdentityPoolResource(cognitoIdentityPoolRef{id: otherIdentityPoolID, name: "other"})
+	roles := newCognitoIdentityPoolRolesAttachmentResource(cognitoIdentityPoolRef{id: identityPoolID, name: "orders"})
+
+	tests := []struct {
+		name           string
+		filters        []terraformutils.ResourceFilter
+		loadPools      bool
+		appendPool     bool
+		appendOther    bool
+		loadRoles      bool
+		loadOtherRoles bool
+		appendRoles    bool
+	}{
+		{
+			name:           "no filters imports identity pools and role attachments",
+			loadPools:      true,
+			appendPool:     true,
+			appendOther:    true,
+			loadRoles:      true,
+			loadOtherRoles: true,
+			appendRoles:    true,
+		},
+		{
+			name: "typed role attachment id filter skips parent output",
+			filters: []terraformutils.ResourceFilter{
+				{ServiceName: cognitoIdentityPoolRolesAttachmentResourceType, FieldPath: "id", AcceptableValues: []string{identityPoolID}},
+			},
+			loadPools:   true,
+			loadRoles:   true,
+			appendRoles: true,
+		},
+		{
+			name: "typed identity pool id filter scopes role loading",
+			filters: []terraformutils.ResourceFilter{
+				{ServiceName: cognitoIdentityPoolResourceType, FieldPath: "id", AcceptableValues: []string{identityPoolID}},
+			},
+			loadPools:  true,
+			appendPool: true,
+			loadRoles:  true,
+		},
+		{
+			name: "typed identity pool non-id filter avoids child pre-load",
+			filters: []terraformutils.ResourceFilter{
+				{ServiceName: cognitoIdentityPoolResourceType, FieldPath: "tags.env", AcceptableValues: []string{"prod"}},
+			},
+			loadPools:   true,
+			appendPool:  true,
+			appendOther: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := CognitoGenerator{}
+			g.Filter = tt.filters
+			if got := g.shouldLoadIdentityPools(); got != tt.loadPools {
+				t.Fatalf("shouldLoadIdentityPools() = %t, want %t", got, tt.loadPools)
+			}
+			if got := g.shouldAppendCognitoResource(cognitoIdentityPoolResourceType, identityPool); got != tt.appendPool {
+				t.Fatalf("shouldAppendCognitoResource(identity pool) = %t, want %t", got, tt.appendPool)
+			}
+			if got := g.shouldAppendCognitoResource(cognitoIdentityPoolResourceType, otherIdentityPool); got != tt.appendOther {
+				t.Fatalf("shouldAppendCognitoResource(other identity pool) = %t, want %t", got, tt.appendOther)
+			}
+			if got := g.shouldLoadIdentityPoolChildResourceType(cognitoIdentityPoolRolesAttachmentResourceType, identityPoolID); got != tt.loadRoles {
+				t.Fatalf("shouldLoadIdentityPoolChildResourceType(roles) = %t, want %t", got, tt.loadRoles)
+			}
+			if got := g.shouldLoadIdentityPoolChildResourceType(cognitoIdentityPoolRolesAttachmentResourceType, otherIdentityPoolID); got != tt.loadOtherRoles {
+				t.Fatalf("shouldLoadIdentityPoolChildResourceType(other roles) = %t, want %t", got, tt.loadOtherRoles)
+			}
+			if got := g.shouldAppendCognitoResource(cognitoIdentityPoolRolesAttachmentResourceType, roles); got != tt.appendRoles {
+				t.Fatalf("shouldAppendCognitoResource(roles) = %t, want %t", got, tt.appendRoles)
+			}
+		})
+	}
+}
+
+func TestCognitoUserPoolDomainResource(t *testing.T) {
+	resource := newCognitoUserPoolDomainResource("us-east-1_abc", "auth.example.com")
+	if resource.InstanceState.ID != "auth.example.com" {
+		t.Fatalf("ID = %q, want auth.example.com", resource.InstanceState.ID)
+	}
+	if got := resource.InstanceState.Attributes["user_pool_id"]; got != "us-east-1_abc" {
+		t.Fatalf("user_pool_id = %q, want us-east-1_abc", got)
+	}
+	if got := resource.InstanceState.Attributes["domain"]; got != "auth.example.com" {
+		t.Fatalf("domain = %q, want auth.example.com", got)
+	}
+}
+
+func TestCognitoUserPoolClientResourceUsesProviderReadID(t *testing.T) {
+	resource := newCognitoUserPoolClientResource("us-east-1_abc", "client123", "web")
+	if resource.InstanceState.ID != "client123" {
+		t.Fatalf("ID = %q, want client123", resource.InstanceState.ID)
+	}
+	if got := resource.InstanceState.Attributes["user_pool_id"]; got != "us-east-1_abc" {
+		t.Fatalf("user_pool_id = %q, want us-east-1_abc", got)
+	}
+	if resource.ResourceName == "" {
+		t.Fatal("ResourceName is empty")
+	}
+}

--- a/providers/aws/cognito_test.go
+++ b/providers/aws/cognito_test.go
@@ -304,13 +304,12 @@ func TestCognitoFilterGatesUserPoolsAndChildren(t *testing.T) {
 			appendGroup:      true,
 		},
 		{
-			name: "typed user pool id filter limits parent output",
+			name: "typed user pool id filter skips child loading",
 			filters: []terraformutils.ResourceFilter{
 				{ServiceName: cognitoUserPoolResourceType, FieldPath: "id", AcceptableValues: []string{userPoolID}},
 			},
 			loadUserPools:  true,
 			appendUserPool: true,
-			loadClients:    true,
 		},
 		{
 			name: "typed child id filter skips parent output",
@@ -487,13 +486,12 @@ func TestCognitoFilterGatesIdentityPoolsAndChildren(t *testing.T) {
 			appendRoles: true,
 		},
 		{
-			name: "typed identity pool id filter scopes role loading",
+			name: "typed identity pool id filter skips child loading",
 			filters: []terraformutils.ResourceFilter{
 				{ServiceName: cognitoIdentityPoolResourceType, FieldPath: "id", AcceptableValues: []string{identityPoolID}},
 			},
 			loadPools:  true,
 			appendPool: true,
-			loadRoles:  true,
 		},
 		{
 			name: "typed identity pool non-id filter avoids child pre-load",

--- a/providers/aws/cognito_test.go
+++ b/providers/aws/cognito_test.go
@@ -92,6 +92,64 @@ func TestCognitoResourceMissing(t *testing.T) {
 	}
 }
 
+func TestCognitoOptionalResourceLoaderErrors(t *testing.T) {
+	boom := errors.New("boom")
+	tests := []struct {
+		name    string
+		filters []terraformutils.ResourceFilter
+		loader  cognitoOptionalResourceLoader
+		wantErr bool
+	}{
+		{
+			name: "optional loader error is logged for broad discovery",
+			loader: cognitoOptionalResourceLoader{
+				name:         "user groups",
+				serviceNames: []string{cognitoUserGroupResourceType},
+				load:         func() error { return boom },
+			},
+		},
+		{
+			name: "typed child filter returns loader error",
+			filters: []terraformutils.ResourceFilter{
+				{ServiceName: cognitoUserGroupResourceType, FieldPath: "id", AcceptableValues: []string{"us-east-1_abc/admins"}},
+			},
+			loader: cognitoOptionalResourceLoader{
+				name:         "user groups",
+				serviceNames: []string{cognitoUserGroupResourceType},
+				load:         func() error { return boom },
+			},
+			wantErr: true,
+		},
+		{
+			name: "required loader returns error without typed filter",
+			loader: cognitoOptionalResourceLoader{
+				name:         "user pool clients",
+				serviceNames: []string{cognitoUserPoolClientResourceType},
+				required:     true,
+				load:         func() error { return boom },
+			},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := CognitoGenerator{}
+			g.Filter = tt.filters
+			err := g.loadOptionalResources([]cognitoOptionalResourceLoader{tt.loader})
+			if tt.wantErr {
+				if !errors.Is(err, boom) {
+					t.Fatalf("loadOptionalResources() error = %v, want %v", err, boom)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("loadOptionalResources() error = %v, want nil", err)
+			}
+		})
+	}
+}
+
 func TestCognitoFilterGatesUserPoolsAndChildren(t *testing.T) {
 	userPoolID := "us-east-1_abc"
 	otherUserPoolID := "us-east-1_def"
@@ -196,6 +254,61 @@ func TestCognitoFilterGatesUserPoolsAndChildren(t *testing.T) {
 			}
 			if got := g.shouldAppendCognitoResource(cognitoUserGroupResourceType, group); got != tt.appendGroup {
 				t.Fatalf("shouldAppendCognitoResource(group) = %t, want %t", got, tt.appendGroup)
+			}
+		})
+	}
+}
+
+func TestCognitoUserPoolDomainMetadataGating(t *testing.T) {
+	userPoolID := "us-east-1_abc"
+	otherUserPoolID := "us-east-1_def"
+	tests := []struct {
+		name    string
+		filters []terraformutils.ResourceFilter
+		want    bool
+	}{
+		{name: "no filters loads domain metadata", want: true},
+		{
+			name: "typed user pool filter does not load domains",
+			filters: []terraformutils.ResourceFilter{
+				{ServiceName: cognitoUserPoolResourceType, FieldPath: "id", AcceptableValues: []string{userPoolID}},
+			},
+		},
+		{
+			name: "typed domain filter loads domain metadata",
+			filters: []terraformutils.ResourceFilter{
+				{ServiceName: cognitoUserPoolDomainResourceType, FieldPath: "id", AcceptableValues: []string{"auth.example.com"}},
+			},
+			want: true,
+		},
+		{
+			name: "typed client filter does not load domains",
+			filters: []terraformutils.ResourceFilter{
+				{ServiceName: cognitoUserPoolClientResourceType, FieldPath: "id", AcceptableValues: []string{cognitoUserPoolClientImportID(userPoolID, "client123")}},
+			},
+		},
+		{
+			name: "typed parent filter scopes typed domain discovery",
+			filters: []terraformutils.ResourceFilter{
+				{ServiceName: cognitoUserPoolResourceType, FieldPath: "id", AcceptableValues: []string{otherUserPoolID}},
+				{ServiceName: cognitoUserPoolDomainResourceType, FieldPath: "domain", AcceptableValues: []string{"auth.example.com"}},
+			},
+		},
+		{
+			name: "untyped id filter keeps domain discovery possible",
+			filters: []terraformutils.ResourceFilter{
+				{FieldPath: "id", AcceptableValues: []string{"auth.example.com"}},
+			},
+			want: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := CognitoGenerator{}
+			g.Filter = tt.filters
+			if got := g.shouldLoadUserPoolDomainMetadata(userPoolID); got != tt.want {
+				t.Fatalf("shouldLoadUserPoolDomainMetadata() = %t, want %t", got, tt.want)
 			}
 		})
 	}

--- a/providers/aws/cognito_test.go
+++ b/providers/aws/cognito_test.go
@@ -228,6 +228,19 @@ func TestCognitoFilterGatesUserPoolsAndChildren(t *testing.T) {
 			appendUserPool:  true,
 			appendOtherPool: true,
 		},
+		{
+			name: "typed user pool non-id filter does not block typed child non-id discovery",
+			filters: []terraformutils.ResourceFilter{
+				{ServiceName: cognitoUserPoolResourceType, FieldPath: "tags.env", AcceptableValues: []string{"prod"}},
+				{ServiceName: cognitoUserPoolClientResourceType, FieldPath: "name", AcceptableValues: []string{"web"}},
+			},
+			loadUserPools:    true,
+			appendUserPool:   true,
+			appendOtherPool:  true,
+			loadClients:      true,
+			loadOtherClients: true,
+			appendClient:     true,
+		},
 	}
 
 	for _, tt := range tests {
@@ -366,6 +379,19 @@ func TestCognitoFilterGatesIdentityPoolsAndChildren(t *testing.T) {
 			loadPools:   true,
 			appendPool:  true,
 			appendOther: true,
+		},
+		{
+			name: "typed identity pool non-id filter does not block typed child non-id discovery",
+			filters: []terraformutils.ResourceFilter{
+				{ServiceName: cognitoIdentityPoolResourceType, FieldPath: "tags.env", AcceptableValues: []string{"prod"}},
+				{ServiceName: cognitoIdentityPoolRolesAttachmentResourceType, FieldPath: "roles.authenticated", AcceptableValues: []string{"arn:aws:iam::123456789012:role/auth"}},
+			},
+			loadPools:      true,
+			appendPool:     true,
+			appendOther:    true,
+			loadRoles:      true,
+			loadOtherRoles: true,
+			appendRoles:    true,
 		},
 	}
 

--- a/providers/aws/cognito_test.go
+++ b/providers/aws/cognito_test.go
@@ -35,9 +35,10 @@ func TestCognitoResourceIDs(t *testing.T) {
 
 func TestCognitoIdentityPoolRolesAttachmentConfigured(t *testing.T) {
 	tests := []struct {
-		name   string
-		output *cognitoidentity.GetIdentityPoolRolesOutput
-		want   bool
+		name                string
+		output              *cognitoidentity.GetIdentityPoolRolesOutput
+		wantConfigured      bool
+		wantNeedsEmptyRoles bool
 	}{
 		{name: "nil", output: nil},
 		{name: "empty", output: &cognitoidentity.GetIdentityPoolRolesOutput{}},
@@ -46,23 +47,55 @@ func TestCognitoIdentityPoolRolesAttachmentConfigured(t *testing.T) {
 			output: &cognitoidentity.GetIdentityPoolRolesOutput{
 				Roles: map[string]string{"authenticated": "arn:aws:iam::123456789012:role/auth"},
 			},
-			want: true,
+			wantConfigured: true,
 		},
 		{
-			name: "role mappings",
+			name: "role mappings only",
 			output: &cognitoidentity.GetIdentityPoolRolesOutput{
 				RoleMappings: map[string]identitytypes.RoleMapping{"accounts.google.com": {}},
 			},
-			want: true,
+			wantConfigured:      true,
+			wantNeedsEmptyRoles: true,
+		},
+		{
+			name: "roles and role mappings",
+			output: &cognitoidentity.GetIdentityPoolRolesOutput{
+				Roles:        map[string]string{"authenticated": "arn:aws:iam::123456789012:role/auth"},
+				RoleMappings: map[string]identitytypes.RoleMapping{"accounts.google.com": {}},
+			},
+			wantConfigured: true,
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := cognitoIdentityPoolRolesAttachmentConfigured(tt.output); got != tt.want {
-				t.Fatalf("cognitoIdentityPoolRolesAttachmentConfigured() = %t, want %t", got, tt.want)
+			if got := cognitoIdentityPoolRolesAttachmentConfigured(tt.output); got != tt.wantConfigured {
+				t.Fatalf("cognitoIdentityPoolRolesAttachmentConfigured() = %t, want %t", got, tt.wantConfigured)
+			}
+			if got := cognitoIdentityPoolRolesAttachmentNeedsEmptyRoles(tt.output); got != tt.wantNeedsEmptyRoles {
+				t.Fatalf("cognitoIdentityPoolRolesAttachmentNeedsEmptyRoles() = %t, want %t", got, tt.wantNeedsEmptyRoles)
 			}
 		})
+	}
+}
+
+func TestCognitoIdentityPoolRolesAttachmentPreservesMappingOnlyRoles(t *testing.T) {
+	identityPool := cognitoIdentityPoolRef{
+		id:   "us-east-1:11111111-1111-1111-1111-111111111111",
+		name: "orders",
+	}
+	resource := newCognitoIdentityPoolRolesAttachmentResource(identityPool, true)
+	roles, ok := resource.AdditionalFields["roles"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("roles additional field = %#v, want empty map", resource.AdditionalFields["roles"])
+	}
+	if len(roles) != 0 {
+		t.Fatalf("roles additional field len = %d, want 0", len(roles))
+	}
+
+	resource = newCognitoIdentityPoolRolesAttachmentResource(identityPool, false)
+	if _, ok := resource.AdditionalFields["roles"]; ok {
+		t.Fatal("roles additional field exists for non-mapping-only attachment")
 	}
 }
 
@@ -423,7 +456,7 @@ func TestCognitoFilterGatesIdentityPoolsAndChildren(t *testing.T) {
 	otherIdentityPoolID := "us-east-1:22222222-2222-2222-2222-222222222222"
 	identityPool := newCognitoIdentityPoolResource(cognitoIdentityPoolRef{id: identityPoolID, name: "orders"})
 	otherIdentityPool := newCognitoIdentityPoolResource(cognitoIdentityPoolRef{id: otherIdentityPoolID, name: "other"})
-	roles := newCognitoIdentityPoolRolesAttachmentResource(cognitoIdentityPoolRef{id: identityPoolID, name: "orders"})
+	roles := newCognitoIdentityPoolRolesAttachmentResource(cognitoIdentityPoolRef{id: identityPoolID, name: "orders"}, false)
 
 	tests := []struct {
 		name           string


### PR DESCRIPTION
Summary
- add Cognito discovery for identity pool role attachments, user groups, identity providers, resource servers, and user pool domains
- document Cognito user pool clients and the new supported resource types
- add filter-aware Cognito parent/child discovery tests

Notes
- user pool client state keeps the provider read ID as client_id while accepting the documented user_pool_id/client_id filter form

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds discovery/import for more Amazon Cognito resources and tightens filter-aware loading so child resources only load when requested. Also keeps empty role attachment `roles` when only role mappings exist to match Terraform state.

- **New Features**
  - Discover/import `aws_cognito_identity_pool_roles_attachment`, `aws_cognito_user_group`, `aws_cognito_identity_provider`, `aws_cognito_resource_server`, `aws_cognito_user_pool_domain`.
  - Update docs to include `aws_cognito_user_pool_client` and note support for `user_pool_id/client_id` filters.

- **Bug Fixes**
  - Skip child discovery when only parent filters are set; load children only for typed child filters or matching parents, honoring `<user_pool_id>/<client_id>` for `aws_cognito_user_pool_client` and preserving targeted imports during initial cleanup.
  - Propagate loader errors only when a typed filter targets that resource; otherwise skip optional loaders and ignore `ResourceNotFoundException`.
  - Keep empty `roles` for `aws_cognito_identity_pool_roles_attachment` when only `role_mappings` are present.

<sup>Written for commit 64561d39aba4b1187048be5b82a64b6ef64bc6ea. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Support added for additional AWS Cognito resources: identity pool role attachments, identity providers, resource servers, user groups, user pool clients, and user pool domains.

* **Improvements**
  * Filter-driven, conditional discovery of Cognito resources with more resilient handling of optional or missing sub-resources and cleaner initial pruning.

* **Documentation**
  * Updated Cognito supported services list and guidance on user-pool client ID formatting and how client IDs are represented in generated state.

* **Tests**
  * Expanded Cognito test coverage for ID formats, loader gating, optional-resource behavior, domain/client metadata, and discovery control paths.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->