### PR TITLE
fix(gcp): return iam service account errors

### DIFF
--- a/providers/gcp/iam.go
+++ b/providers/gcp/iam.go
@@ -1,18 +1,18 @@
 // SPDX-License-Identifier: Apache-2.0
 
-//nolint:staticcheck // lint triage: legacy provider/API/security baseline is tracked in #175.
 package gcp
 
 import (
 	"context"
 	"errors"
+	"fmt"
 	"log"
 	"regexp"
 
 	admin "cloud.google.com/go/iam/admin/apiv1"
+	adminpb "cloud.google.com/go/iam/admin/apiv1/adminpb"
 	"google.golang.org/api/cloudresourcemanager/v1"
 	"google.golang.org/api/iterator"
-	adminpb "google.golang.org/genproto/googleapis/iam/admin/v1"
 
 	"github.com/chenrui333/terraformer/terraformutils"
 )
@@ -25,7 +25,11 @@ type IamGenerator struct {
 	GCPService
 }
 
-func (g IamGenerator) createServiceAccountResources(serviceAccountsIterator *admin.ServiceAccountIterator) []terraformutils.Resource {
+type serviceAccountIterator interface {
+	Next() (*adminpb.ServiceAccount, error)
+}
+
+func (g IamGenerator) createServiceAccountResources(serviceAccountsIterator serviceAccountIterator) ([]terraformutils.Resource, error) {
 	resources := []terraformutils.Resource{}
 	re := regexp.MustCompile(`^[a-z]`)
 	for {
@@ -34,8 +38,7 @@ func (g IamGenerator) createServiceAccountResources(serviceAccountsIterator *adm
 			break
 		}
 		if err != nil {
-			log.Println("error with service account:", err)
-			continue
+			return nil, fmt.Errorf("list iam service accounts: %w", err)
 		}
 		if !re.MatchString(serviceAccount.Email) {
 			log.Printf("skipping %s: service account email must start with [a-z]\n", serviceAccount.Name)
@@ -49,7 +52,7 @@ func (g IamGenerator) createServiceAccountResources(serviceAccountsIterator *adm
 			IamAllowEmptyValues,
 		))
 	}
-	return resources
+	return resources, nil
 }
 
 func (g *IamGenerator) createIamCustomRoleResources(rolesResponse *adminpb.ListRolesResponse, project string) []terraformutils.Resource {
@@ -125,7 +128,11 @@ func (g *IamGenerator) InitResources() error {
 		return err
 	}
 
-	g.Resources = g.createServiceAccountResources(serviceAccountsIterator)
+	serviceAccountResources, err := g.createServiceAccountResources(serviceAccountsIterator)
+	if err != nil {
+		return err
+	}
+	g.Resources = serviceAccountResources
 	g.Resources = append(g.Resources, g.createIamCustomRoleResources(rolesResponse, projectID)...)
 	g.Resources = append(g.Resources, g.createIamMemberResources(policyResponse, projectID)...)
 	return nil

--- a/providers/gcp/iam_test.go
+++ b/providers/gcp/iam_test.go
@@ -1,0 +1,88 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package gcp
+
+import (
+	"errors"
+	"strings"
+	"testing"
+
+	"cloud.google.com/go/iam/admin/apiv1/adminpb"
+	"google.golang.org/api/iterator"
+)
+
+func TestCreateServiceAccountResourcesReturnsIteratorErrors(t *testing.T) {
+	iteratorErr := errors.New("page failed")
+	generator := IamGenerator{}
+
+	_, err := generator.createServiceAccountResources(&fakeServiceAccountIterator{
+		responses: []fakeServiceAccountResponse{
+			{err: iteratorErr},
+		},
+	})
+	if err == nil {
+		t.Fatal("expected service account iterator error")
+	}
+	if !strings.Contains(err.Error(), "list iam service accounts") {
+		t.Fatalf("error = %q, want service account context", err)
+	}
+	if !errors.Is(err, iteratorErr) {
+		t.Fatalf("error does not wrap iterator error: %v", err)
+	}
+}
+
+func TestCreateServiceAccountResourcesSkipsInvalidEmails(t *testing.T) {
+	generator := IamGenerator{}
+
+	resources, err := generator.createServiceAccountResources(&fakeServiceAccountIterator{
+		responses: []fakeServiceAccountResponse{
+			{
+				serviceAccount: &adminpb.ServiceAccount{
+					Email:    "valid@example.iam.gserviceaccount.com",
+					Name:     "projects/test/serviceAccounts/valid@example.iam.gserviceaccount.com",
+					UniqueId: "123",
+				},
+			},
+			{
+				serviceAccount: &adminpb.ServiceAccount{
+					Email:    "_invalid@example.iam.gserviceaccount.com",
+					Name:     "projects/test/serviceAccounts/_invalid@example.iam.gserviceaccount.com",
+					UniqueId: "456",
+				},
+			},
+			{err: iterator.Done},
+		},
+	})
+	if err != nil {
+		t.Fatalf("createServiceAccountResources returned error: %v", err)
+	}
+	if len(resources) != 1 {
+		t.Fatalf("len(resources) = %d, want 1", len(resources))
+	}
+	resource := resources[0]
+	if got := resource.InstanceState.ID; got != "projects/test/serviceAccounts/valid@example.iam.gserviceaccount.com" {
+		t.Fatalf("resource ID = %q, want service account name", got)
+	}
+	if got := resource.ResourceName; got != "tfer--123" {
+		t.Fatalf("resource name = %q, want sanitized service account unique ID", got)
+	}
+}
+
+type fakeServiceAccountResponse struct {
+	serviceAccount *adminpb.ServiceAccount
+	err            error
+}
+
+type fakeServiceAccountIterator struct {
+	responses []fakeServiceAccountResponse
+	index     int
+}
+
+func (i *fakeServiceAccountIterator) Next() (*adminpb.ServiceAccount, error) {
+	if i.index >= len(i.responses) {
+		return nil, iterator.Done
+	}
+	response := i.responses[i.index]
+	i.index++
+	return response.serviceAccount, response.err
+}


### PR DESCRIPTION
## Summary

- Return GCP IAM service account iterator errors instead of logging and skipping failed pages.
- Move IAM proto usage to the current adminpb package and remove the stale staticcheck waiver.
- Add focused coverage for iterator error propagation and the existing invalid-email skip path.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Return iterator errors when listing GCP IAM service accounts so failures are surfaced instead of silently skipped. Also switched to the current IAM `adminpb` API and added tests for error propagation and email filtering.

- **Bug Fixes**
  - Propagate iterator errors from service account listing (`createServiceAccountResources` now returns `([]Resource, error)`; `InitResources` handles it).
  - Keep invalid-email accounts skipped as before; added focused tests.

- **Refactors**
  - Use `cloud.google.com/go/iam/admin/apiv1/adminpb` instead of `google.golang.org/genproto/googleapis/iam/admin/v1`; removed the stale staticcheck waiver.
  - Introduced a small `serviceAccountIterator` interface to enable testing.

<sup>Written for commit 3f1529a47c6533d363916acbfcebe23407e9f355. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling during GCP IAM service account discovery—errors now cause immediate failure instead of silent continuation.
  * Enhanced filtering to exclude service accounts with invalid email formats from resource generation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->