### PR TITLE
fix(aws): return ecs discovery errors

### DIFF
--- a/providers/aws/ecs.go
+++ b/providers/aws/ecs.go
@@ -77,8 +77,7 @@ func (g *EcsGenerator) InitResources() error {
 			for servicePage.HasMorePages() {
 				serviceNextPage, err := servicePage.NextPage(context.TODO())
 				if err != nil {
-					fmt.Println(err.Error())
-					continue
+					return fmt.Errorf("list ecs services for cluster %s: %w", clusterName, err)
 				}
 				for _, serviceArn := range serviceNextPage.ServiceArns {
 					serviceName := arnLastSegment(serviceArn, "/")
@@ -95,10 +94,12 @@ func (g *EcsGenerator) InitResources() error {
 						Cluster: &clusterArn,
 					})
 					if err != nil {
-						fmt.Println(err.Error())
-						continue
+						return fmt.Errorf("describe ecs service %s/%s: %w", clusterName, serviceName, err)
 					}
-					serviceDetails := serResp.Services[0]
+					serviceDetails, err := ecsServiceDetails(serResp, serviceName)
+					if err != nil {
+						return fmt.Errorf("describe ecs service %s/%s: %w", clusterName, serviceName, err)
+					}
 
 					g.Resources = append(g.Resources, terraformutils.NewResource(
 						serviceArn,
@@ -130,8 +131,7 @@ func (g *EcsGenerator) InitResources() error {
 	for taskDefinitionsPage.HasMorePages() {
 		taskDefinitionsNextPage, e := taskDefinitionsPage.NextPage(context.TODO())
 		if e != nil {
-			fmt.Println(e.Error())
-			continue
+			return fmt.Errorf("list ecs task definitions: %w", e)
 		}
 		for _, taskDefinitionArn := range taskDefinitionsNextPage.TaskDefinitionArns {
 			arnParts := strings.Split(taskDefinitionArn, ":")
@@ -165,6 +165,21 @@ func (g *EcsGenerator) InitResources() error {
 	}
 
 	return nil
+}
+
+func ecsServiceDetails(output *ecs.DescribeServicesOutput, serviceName string) (ecstypes.Service, error) {
+	if output == nil {
+		return ecstypes.Service{}, errors.New("empty describe services response")
+	}
+	if len(output.Services) > 0 {
+		return output.Services[0], nil
+	}
+	for _, failure := range output.Failures {
+		if StringValue(failure.Arn) == serviceName || arnLastSegment(StringValue(failure.Arn), "/") == serviceName {
+			return ecstypes.Service{}, fmt.Errorf("service %s was not described: %s", serviceName, StringValue(failure.Reason))
+		}
+	}
+	return ecstypes.Service{}, fmt.Errorf("service %s was not described", serviceName)
 }
 
 func (g *EcsGenerator) getOptionalEcsResources(loaders ...ecsOptionalResourceLoader) {

--- a/providers/aws/ecs_test.go
+++ b/providers/aws/ecs_test.go
@@ -4,8 +4,11 @@ package aws
 
 import (
 	"errors"
+	"strings"
 	"testing"
 
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/ecs"
 	ecstypes "github.com/aws/aws-sdk-go-v2/service/ecs/types"
 )
 
@@ -94,6 +97,48 @@ func TestEcsCapacityProviderImportable(t *testing.T) {
 				t.Fatalf("ecsCapacityProviderImportable() = %t, want %t", got, tt.want)
 			}
 		})
+	}
+}
+
+func TestEcsServiceDetails(t *testing.T) {
+	taskDefinition := "arn:aws:ecs:us-east-1:123456789012:task-definition/example:1"
+	service, err := ecsServiceDetails(&ecs.DescribeServicesOutput{
+		Services: []ecstypes.Service{
+			{TaskDefinition: &taskDefinition},
+		},
+	}, "example")
+	if err != nil {
+		t.Fatalf("ecsServiceDetails returned error: %v", err)
+	}
+	if got := aws.ToString(service.TaskDefinition); got != taskDefinition {
+		t.Fatalf("TaskDefinition = %q, want %q", got, taskDefinition)
+	}
+}
+
+func TestEcsServiceDetailsReturnsFailureReason(t *testing.T) {
+	_, err := ecsServiceDetails(&ecs.DescribeServicesOutput{
+		Failures: []ecstypes.Failure{
+			{
+				Arn:    aws.String("arn:aws:ecs:us-east-1:123456789012:service/example-cluster/example-service"),
+				Reason: aws.String("MISSING"),
+			},
+		},
+	}, "example-service")
+	if err == nil {
+		t.Fatal("expected describe services failure error")
+	}
+	if !strings.Contains(err.Error(), "service example-service was not described: MISSING") {
+		t.Fatalf("error = %q, want failure reason", err)
+	}
+}
+
+func TestEcsServiceDetailsReturnsEmptyResponseError(t *testing.T) {
+	_, err := ecsServiceDetails(nil, "example-service")
+	if err == nil {
+		t.Fatal("expected nil describe services response error")
+	}
+	if !strings.Contains(err.Error(), "empty describe services response") {
+		t.Fatalf("error = %q, want empty response context", err)
 	}
 }
 


### PR DESCRIPTION
## Summary

- Return ECS service and task-definition discovery errors instead of printing and skipping them.
- Handle empty DescribeServices responses as contextual errors instead of indexing into an empty service list.
- Add focused coverage for ECS service detail extraction and failure responses.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Improve ECS discovery by returning errors with context instead of printing and skipping, and by handling empty or failure-only DescribeServices responses to avoid index errors. This makes AWS ECS generation more reliable and easier to debug.

- **Bug Fixes**
  - Return errors when listing services or task definitions, with cluster/service context.
  - Extract service details via a helper; error on empty or failure-only DescribeServices responses.
  - Added unit tests for success, failure reason, and empty response cases.

<sup>Written for commit a90f189ab18b49501e34825c3f51080080d0e088. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

