### PR TITLE
fix(aws): return organizations discovery errors

### DIFF
--- a/providers/aws/organization.go
+++ b/providers/aws/organization.go
@@ -63,7 +63,7 @@ func (g *OrganizationGenerator) traverseNode(svc organizationClient, parentID st
 			))
 		}
 		accountNextToken = accountsForParent.NextToken
-		if accountNextToken == nil {
+		if !organizationHasMorePages(accountNextToken) {
 			break
 		}
 	}
@@ -97,7 +97,7 @@ func (g *OrganizationGenerator) traverseNode(svc organizationClient, parentID st
 			}
 		}
 		unitNextToken = unitsForParent.NextToken
-		if unitNextToken == nil {
+		if !organizationHasMorePages(unitNextToken) {
 			break
 		}
 	}
@@ -183,9 +183,13 @@ func (g *OrganizationGenerator) addPolicyAttachments(svc organizationClient, pol
 			))
 		}
 		nextToken = targetsForPolicy.NextToken
-		if nextToken == nil {
+		if !organizationHasMorePages(nextToken) {
 			break
 		}
 	}
 	return nil
+}
+
+func organizationHasMorePages(nextToken *string) bool {
+	return aws.ToString(nextToken) != ""
 }

--- a/providers/aws/organization.go
+++ b/providers/aws/organization.go
@@ -19,59 +19,89 @@ type OrganizationGenerator struct {
 	AWSService
 }
 
-func (g *OrganizationGenerator) traverseNode(svc *organizations.Client, parentID string) {
-	accountsForParent, err := svc.ListAccountsForParent(context.TODO(),
-		&organizations.ListAccountsForParentInput{ParentId: aws.String(parentID)})
-	if err != nil {
-		return
-	}
-	for _, account := range accountsForParent.Accounts {
-		g.Resources = append(g.Resources, terraformutils.NewResource(
-			StringValue(account.Id),
-			StringValue(account.Name),
-			"aws_organizations_organization",
-			"aws",
-			map[string]string{
-				"id":  StringValue(account.Id),
-				"arn": StringValue(account.Arn),
-			},
-			organizationAllowEmptyValues,
-			map[string]interface{}{},
-		))
-		g.Resources = append(g.Resources, terraformutils.NewResource(
-			StringValue(account.Id),
-			StringValue(account.Name),
-			"aws_organizations_account",
-			"aws",
-			map[string]string{
-				"id":  StringValue(account.Id),
-				"arn": StringValue(account.Arn),
-			},
-			organizationAllowEmptyValues,
-			map[string]interface{}{},
-		))
+type organizationClient interface {
+	ListAccountsForParent(context.Context, *organizations.ListAccountsForParentInput, ...func(*organizations.Options)) (*organizations.ListAccountsForParentOutput, error)
+	ListOrganizationalUnitsForParent(context.Context, *organizations.ListOrganizationalUnitsForParentInput, ...func(*organizations.Options)) (*organizations.ListOrganizationalUnitsForParentOutput, error)
+	ListTargetsForPolicy(context.Context, *organizations.ListTargetsForPolicyInput, ...func(*organizations.Options)) (*organizations.ListTargetsForPolicyOutput, error)
+}
+
+func (g *OrganizationGenerator) traverseNode(svc organizationClient, parentID string) error {
+	var accountNextToken *string
+	for {
+		accountsForParent, err := svc.ListAccountsForParent(context.TODO(),
+			&organizations.ListAccountsForParentInput{
+				ParentId:  aws.String(parentID),
+				NextToken: accountNextToken,
+			})
+		if err != nil {
+			return fmt.Errorf("list organization accounts for parent %s: %w", parentID, err)
+		}
+		for _, account := range accountsForParent.Accounts {
+			g.Resources = append(g.Resources, terraformutils.NewResource(
+				StringValue(account.Id),
+				StringValue(account.Name),
+				"aws_organizations_organization",
+				"aws",
+				map[string]string{
+					"id":  StringValue(account.Id),
+					"arn": StringValue(account.Arn),
+				},
+				organizationAllowEmptyValues,
+				map[string]interface{}{},
+			))
+			g.Resources = append(g.Resources, terraformutils.NewResource(
+				StringValue(account.Id),
+				StringValue(account.Name),
+				"aws_organizations_account",
+				"aws",
+				map[string]string{
+					"id":  StringValue(account.Id),
+					"arn": StringValue(account.Arn),
+				},
+				organizationAllowEmptyValues,
+				map[string]interface{}{},
+			))
+		}
+		accountNextToken = accountsForParent.NextToken
+		if accountNextToken == nil {
+			break
+		}
 	}
 
-	unitsForParent, err := svc.ListOrganizationalUnitsForParent(context.TODO(),
-		&organizations.ListOrganizationalUnitsForParentInput{ParentId: aws.String(parentID)})
-	if err != nil {
-		return
+	var unitNextToken *string
+	for {
+		unitsForParent, err := svc.ListOrganizationalUnitsForParent(context.TODO(),
+			&organizations.ListOrganizationalUnitsForParentInput{
+				ParentId:  aws.String(parentID),
+				NextToken: unitNextToken,
+			})
+		if err != nil {
+			return fmt.Errorf("list organization units for parent %s: %w", parentID, err)
+		}
+		for _, unit := range unitsForParent.OrganizationalUnits {
+			unitID := StringValue(unit.Id)
+			g.Resources = append(g.Resources, terraformutils.NewResource(
+				unitID,
+				StringValue(unit.Name),
+				"aws_organizations_organizational_unit",
+				"aws",
+				map[string]string{
+					"id":  unitID,
+					"arn": StringValue(unit.Arn),
+				},
+				organizationAllowEmptyValues,
+				map[string]interface{}{},
+			))
+			if err := g.traverseNode(svc, unitID); err != nil {
+				return err
+			}
+		}
+		unitNextToken = unitsForParent.NextToken
+		if unitNextToken == nil {
+			break
+		}
 	}
-	for _, unit := range unitsForParent.OrganizationalUnits {
-		g.Resources = append(g.Resources, terraformutils.NewResource(
-			StringValue(unit.Id),
-			StringValue(unit.Name),
-			"aws_organizations_organizational_unit",
-			"aws",
-			map[string]string{
-				"id":  StringValue(unit.Id),
-				"arn": StringValue(unit.Arn),
-			},
-			organizationAllowEmptyValues,
-			map[string]interface{}{},
-		))
-		g.traverseNode(svc, StringValue(unit.Id))
-	}
+	return nil
 }
 
 func (g *OrganizationGenerator) InitResources() error {
@@ -88,7 +118,9 @@ func (g *OrganizationGenerator) InitResources() error {
 
 	for _, root := range roots.Roots {
 		nodeID := StringValue(root.Id)
-		g.traverseNode(svc, nodeID)
+		if err := g.traverseNode(svc, nodeID); err != nil {
+			return err
+		}
 	}
 
 	p := organizations.NewListPoliciesPaginator(svc, &organizations.ListPoliciesInput{
@@ -115,28 +147,45 @@ func (g *OrganizationGenerator) InitResources() error {
 				map[string]interface{}{},
 			))
 
-			targetsForPolicy, err := svc.ListTargetsForPolicy(context.TODO(),
-				&organizations.ListTargetsForPolicyInput{PolicyId: policy.Id})
-			if err != nil {
-				fmt.Println(err.Error())
-				continue
-			}
-			for _, target := range targetsForPolicy.Targets {
-				g.Resources = append(g.Resources, terraformutils.NewResource(
-					StringValue(target.TargetId)+":"+policyID,
-					"pa-"+StringValue(target.TargetId)+":"+policyName,
-					"aws_organizations_policy_attachment",
-					"aws",
-					map[string]string{
-						"policy_id": policyID,
-						"target_id": StringValue(target.TargetId),
-					},
-					organizationAllowEmptyValues,
-					map[string]interface{}{},
-				))
+			if err := g.addPolicyAttachments(svc, policyID, policyName); err != nil {
+				return err
 			}
 		}
 	}
 
+	return nil
+}
+
+func (g *OrganizationGenerator) addPolicyAttachments(svc organizationClient, policyID, policyName string) error {
+	var nextToken *string
+	for {
+		targetsForPolicy, err := svc.ListTargetsForPolicy(context.TODO(),
+			&organizations.ListTargetsForPolicyInput{
+				PolicyId:  aws.String(policyID),
+				NextToken: nextToken,
+			})
+		if err != nil {
+			return fmt.Errorf("list organization targets for policy %s: %w", policyID, err)
+		}
+		for _, target := range targetsForPolicy.Targets {
+			targetID := StringValue(target.TargetId)
+			g.Resources = append(g.Resources, terraformutils.NewResource(
+				targetID+":"+policyID,
+				"pa-"+targetID+":"+policyName,
+				"aws_organizations_policy_attachment",
+				"aws",
+				map[string]string{
+					"policy_id": policyID,
+					"target_id": targetID,
+				},
+				organizationAllowEmptyValues,
+				map[string]interface{}{},
+			))
+		}
+		nextToken = targetsForPolicy.NextToken
+		if nextToken == nil {
+			break
+		}
+	}
 	return nil
 }

--- a/providers/aws/organization_test.go
+++ b/providers/aws/organization_test.go
@@ -1,0 +1,200 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package aws
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/organizations"
+	organizationtypes "github.com/aws/aws-sdk-go-v2/service/organizations/types"
+)
+
+func TestOrganizationTraverseNodeReturnsAccountErrors(t *testing.T) {
+	listErr := errors.New("accounts unavailable")
+	generator := &OrganizationGenerator{}
+
+	err := generator.traverseNode(&fakeOrganizationClient{accountErr: listErr}, "r-root")
+	if err == nil {
+		t.Fatal("expected account listing error")
+	}
+	if !strings.Contains(err.Error(), "list organization accounts for parent r-root") {
+		t.Fatalf("error = %q, want account listing context", err)
+	}
+	if !errors.Is(err, listErr) {
+		t.Fatalf("error does not wrap account listing error: %v", err)
+	}
+}
+
+func TestOrganizationTraverseNodePaginatesChildren(t *testing.T) {
+	generator := &OrganizationGenerator{}
+	client := &fakeOrganizationClient{
+		accountsByParent: map[string][]*organizations.ListAccountsForParentOutput{
+			"r-root": {
+				{
+					Accounts: []organizationtypes.Account{
+						{Id: aws.String("111111111111"), Name: aws.String("dev"), Arn: aws.String("arn:aws:organizations::111111111111:account/o-example/111111111111")},
+					},
+					NextToken: aws.String("more"),
+				},
+				{
+					Accounts: []organizationtypes.Account{
+						{Id: aws.String("222222222222"), Name: aws.String("prod"), Arn: aws.String("arn:aws:organizations::222222222222:account/o-example/222222222222")},
+					},
+				},
+			},
+			"ou-root-child": {
+				{
+					Accounts: []organizationtypes.Account{
+						{Id: aws.String("333333333333"), Name: aws.String("shared"), Arn: aws.String("arn:aws:organizations::333333333333:account/o-example/333333333333")},
+					},
+				},
+			},
+		},
+		unitsByParent: map[string][]*organizations.ListOrganizationalUnitsForParentOutput{
+			"r-root": {
+				{
+					OrganizationalUnits: []organizationtypes.OrganizationalUnit{
+						{Id: aws.String("ou-root-child"), Name: aws.String("child"), Arn: aws.String("arn:aws:organizations::123456789012:ou/o-example/ou-root-child")},
+					},
+				},
+			},
+		},
+	}
+
+	if err := generator.traverseNode(client, "r-root"); err != nil {
+		t.Fatalf("traverseNode returned error: %v", err)
+	}
+	if len(generator.Resources) != 7 {
+		t.Fatalf("len(Resources) = %d, want 7", len(generator.Resources))
+	}
+	if client.accountCalls["r-root"] != 2 {
+		t.Fatalf("root account calls = %d, want 2", client.accountCalls["r-root"])
+	}
+	if _, ok := client.accountCalls["ou-root-child"]; !ok {
+		t.Fatal("child organizational unit was not traversed")
+	}
+}
+
+func TestOrganizationAddPolicyAttachmentsReturnsTargetErrors(t *testing.T) {
+	listErr := errors.New("targets unavailable")
+	generator := &OrganizationGenerator{}
+
+	err := generator.addPolicyAttachments(&fakeOrganizationClient{targetErr: listErr}, "p-policy", "policy")
+	if err == nil {
+		t.Fatal("expected policy target listing error")
+	}
+	if !strings.Contains(err.Error(), "list organization targets for policy p-policy") {
+		t.Fatalf("error = %q, want policy target context", err)
+	}
+	if !errors.Is(err, listErr) {
+		t.Fatalf("error does not wrap policy target listing error: %v", err)
+	}
+}
+
+func TestOrganizationAddPolicyAttachmentsPaginatesTargets(t *testing.T) {
+	generator := &OrganizationGenerator{}
+	client := &fakeOrganizationClient{
+		targetsByPolicy: map[string][]*organizations.ListTargetsForPolicyOutput{
+			"p-policy": {
+				{
+					Targets: []organizationtypes.PolicyTargetSummary{
+						{TargetId: aws.String("111111111111")},
+					},
+					NextToken: aws.String("more"),
+				},
+				{
+					Targets: []organizationtypes.PolicyTargetSummary{
+						{TargetId: aws.String("ou-root-child")},
+					},
+				},
+			},
+		},
+	}
+
+	if err := generator.addPolicyAttachments(client, "p-policy", "policy"); err != nil {
+		t.Fatalf("addPolicyAttachments returned error: %v", err)
+	}
+	if len(generator.Resources) != 2 {
+		t.Fatalf("len(Resources) = %d, want 2", len(generator.Resources))
+	}
+	if client.targetCalls["p-policy"] != 2 {
+		t.Fatalf("target calls = %d, want 2", client.targetCalls["p-policy"])
+	}
+}
+
+type fakeOrganizationClient struct {
+	accountsByParent map[string][]*organizations.ListAccountsForParentOutput
+	unitsByParent    map[string][]*organizations.ListOrganizationalUnitsForParentOutput
+	targetsByPolicy  map[string][]*organizations.ListTargetsForPolicyOutput
+	accountCalls     map[string]int
+	unitCalls        map[string]int
+	targetCalls      map[string]int
+	accountErr       error
+	unitErr          error
+	targetErr        error
+}
+
+func (c *fakeOrganizationClient) ListAccountsForParent(_ context.Context, input *organizations.ListAccountsForParentInput, _ ...func(*organizations.Options)) (*organizations.ListAccountsForParentOutput, error) {
+	if c.accountErr != nil {
+		return nil, c.accountErr
+	}
+	parentID := aws.ToString(input.ParentId)
+	call := c.incrementAccountCall(parentID)
+	return outputAt(c.accountsByParent[parentID], call), nil
+}
+
+func (c *fakeOrganizationClient) ListOrganizationalUnitsForParent(_ context.Context, input *organizations.ListOrganizationalUnitsForParentInput, _ ...func(*organizations.Options)) (*organizations.ListOrganizationalUnitsForParentOutput, error) {
+	if c.unitErr != nil {
+		return nil, c.unitErr
+	}
+	parentID := aws.ToString(input.ParentId)
+	call := c.incrementUnitCall(parentID)
+	return outputAt(c.unitsByParent[parentID], call), nil
+}
+
+func (c *fakeOrganizationClient) ListTargetsForPolicy(_ context.Context, input *organizations.ListTargetsForPolicyInput, _ ...func(*organizations.Options)) (*organizations.ListTargetsForPolicyOutput, error) {
+	if c.targetErr != nil {
+		return nil, c.targetErr
+	}
+	policyID := aws.ToString(input.PolicyId)
+	call := c.incrementTargetCall(policyID)
+	return outputAt(c.targetsByPolicy[policyID], call), nil
+}
+
+func (c *fakeOrganizationClient) incrementAccountCall(parentID string) int {
+	if c.accountCalls == nil {
+		c.accountCalls = map[string]int{}
+	}
+	call := c.accountCalls[parentID]
+	c.accountCalls[parentID]++
+	return call
+}
+
+func (c *fakeOrganizationClient) incrementUnitCall(parentID string) int {
+	if c.unitCalls == nil {
+		c.unitCalls = map[string]int{}
+	}
+	call := c.unitCalls[parentID]
+	c.unitCalls[parentID]++
+	return call
+}
+
+func (c *fakeOrganizationClient) incrementTargetCall(policyID string) int {
+	if c.targetCalls == nil {
+		c.targetCalls = map[string]int{}
+	}
+	call := c.targetCalls[policyID]
+	c.targetCalls[policyID]++
+	return call
+}
+
+func outputAt[T any](outputs []*T, index int) *T {
+	if index >= len(outputs) || outputs[index] == nil {
+		return new(T)
+	}
+	return outputs[index]
+}

--- a/providers/aws/organization_test.go
+++ b/providers/aws/organization_test.go
@@ -5,6 +5,7 @@ package aws
 import (
 	"context"
 	"errors"
+	"fmt"
 	"strings"
 	"testing"
 
@@ -79,6 +80,52 @@ func TestOrganizationTraverseNodePaginatesChildren(t *testing.T) {
 	}
 }
 
+func TestOrganizationTraverseNodeStopsOnEmptyTokens(t *testing.T) {
+	generator := &OrganizationGenerator{}
+	client := &fakeOrganizationClient{
+		accountsByParent: map[string][]*organizations.ListAccountsForParentOutput{
+			"r-root": {
+				{
+					Accounts: []organizationtypes.Account{
+						{Id: aws.String("111111111111"), Name: aws.String("dev"), Arn: aws.String("arn:aws:organizations::111111111111:account/o-example/111111111111")},
+					},
+					NextToken: aws.String(""),
+				},
+				{
+					Accounts: []organizationtypes.Account{
+						{Id: aws.String("222222222222"), Name: aws.String("prod"), Arn: aws.String("arn:aws:organizations::222222222222:account/o-example/222222222222")},
+					},
+				},
+			},
+		},
+		unitsByParent: map[string][]*organizations.ListOrganizationalUnitsForParentOutput{
+			"r-root": {
+				{
+					NextToken: aws.String(""),
+				},
+				{
+					OrganizationalUnits: []organizationtypes.OrganizationalUnit{
+						{Id: aws.String("ou-root-child"), Name: aws.String("child"), Arn: aws.String("arn:aws:organizations::123456789012:ou/o-example/ou-root-child")},
+					},
+				},
+			},
+		},
+	}
+
+	if err := generator.traverseNode(client, "r-root"); err != nil {
+		t.Fatalf("traverseNode returned error: %v", err)
+	}
+	if len(generator.Resources) != 2 {
+		t.Fatalf("len(Resources) = %d, want 2", len(generator.Resources))
+	}
+	if client.accountCalls["r-root"] != 1 {
+		t.Fatalf("root account calls = %d, want 1", client.accountCalls["r-root"])
+	}
+	if client.unitCalls["r-root"] != 1 {
+		t.Fatalf("root unit calls = %d, want 1", client.unitCalls["r-root"])
+	}
+}
+
 func TestOrganizationAddPolicyAttachmentsReturnsTargetErrors(t *testing.T) {
 	listErr := errors.New("targets unavailable")
 	generator := &OrganizationGenerator{}
@@ -126,6 +173,37 @@ func TestOrganizationAddPolicyAttachmentsPaginatesTargets(t *testing.T) {
 	}
 }
 
+func TestOrganizationAddPolicyAttachmentsStopsOnEmptyToken(t *testing.T) {
+	generator := &OrganizationGenerator{}
+	client := &fakeOrganizationClient{
+		targetsByPolicy: map[string][]*organizations.ListTargetsForPolicyOutput{
+			"p-policy": {
+				{
+					Targets: []organizationtypes.PolicyTargetSummary{
+						{TargetId: aws.String("111111111111")},
+					},
+					NextToken: aws.String(""),
+				},
+				{
+					Targets: []organizationtypes.PolicyTargetSummary{
+						{TargetId: aws.String("ou-root-child")},
+					},
+				},
+			},
+		},
+	}
+
+	if err := generator.addPolicyAttachments(client, "p-policy", "policy"); err != nil {
+		t.Fatalf("addPolicyAttachments returned error: %v", err)
+	}
+	if len(generator.Resources) != 1 {
+		t.Fatalf("len(Resources) = %d, want 1", len(generator.Resources))
+	}
+	if client.targetCalls["p-policy"] != 1 {
+		t.Fatalf("target calls = %d, want 1", client.targetCalls["p-policy"])
+	}
+}
+
 type fakeOrganizationClient struct {
 	accountsByParent map[string][]*organizations.ListAccountsForParentOutput
 	unitsByParent    map[string][]*organizations.ListOrganizationalUnitsForParentOutput
@@ -143,8 +221,12 @@ func (c *fakeOrganizationClient) ListAccountsForParent(_ context.Context, input 
 		return nil, c.accountErr
 	}
 	parentID := aws.ToString(input.ParentId)
+	outputs := c.accountsByParent[parentID]
 	call := c.incrementAccountCall(parentID)
-	return outputAt(c.accountsByParent[parentID], call), nil
+	if err := validateOrganizationNextToken("accounts", parentID, call, input.NextToken, previousAccountNextToken(outputs, call)); err != nil {
+		return nil, err
+	}
+	return outputAt(outputs, call), nil
 }
 
 func (c *fakeOrganizationClient) ListOrganizationalUnitsForParent(_ context.Context, input *organizations.ListOrganizationalUnitsForParentInput, _ ...func(*organizations.Options)) (*organizations.ListOrganizationalUnitsForParentOutput, error) {
@@ -152,8 +234,12 @@ func (c *fakeOrganizationClient) ListOrganizationalUnitsForParent(_ context.Cont
 		return nil, c.unitErr
 	}
 	parentID := aws.ToString(input.ParentId)
+	outputs := c.unitsByParent[parentID]
 	call := c.incrementUnitCall(parentID)
-	return outputAt(c.unitsByParent[parentID], call), nil
+	if err := validateOrganizationNextToken("organizational units", parentID, call, input.NextToken, previousUnitNextToken(outputs, call)); err != nil {
+		return nil, err
+	}
+	return outputAt(outputs, call), nil
 }
 
 func (c *fakeOrganizationClient) ListTargetsForPolicy(_ context.Context, input *organizations.ListTargetsForPolicyInput, _ ...func(*organizations.Options)) (*organizations.ListTargetsForPolicyOutput, error) {
@@ -161,8 +247,12 @@ func (c *fakeOrganizationClient) ListTargetsForPolicy(_ context.Context, input *
 		return nil, c.targetErr
 	}
 	policyID := aws.ToString(input.PolicyId)
+	outputs := c.targetsByPolicy[policyID]
 	call := c.incrementTargetCall(policyID)
-	return outputAt(c.targetsByPolicy[policyID], call), nil
+	if err := validateOrganizationNextToken("policy targets", policyID, call, input.NextToken, previousTargetNextToken(outputs, call)); err != nil {
+		return nil, err
+	}
+	return outputAt(outputs, call), nil
 }
 
 func (c *fakeOrganizationClient) incrementAccountCall(parentID string) int {
@@ -197,4 +287,43 @@ func outputAt[T any](outputs []*T, index int) *T {
 		return new(T)
 	}
 	return outputs[index]
+}
+
+func validateOrganizationNextToken(resourceType, id string, call int, got, previous *string) error {
+	if call == 0 {
+		if aws.ToString(got) != "" {
+			return fmt.Errorf("%s request for %s used first-page next token %q", resourceType, id, aws.ToString(got))
+		}
+		return nil
+	}
+
+	want := aws.ToString(previous)
+	if want == "" {
+		return fmt.Errorf("%s request for %s fetched page %d after empty next token", resourceType, id, call+1)
+	}
+	if aws.ToString(got) != want {
+		return fmt.Errorf("%s request for %s next token = %q, want %q", resourceType, id, aws.ToString(got), want)
+	}
+	return nil
+}
+
+func previousAccountNextToken(outputs []*organizations.ListAccountsForParentOutput, call int) *string {
+	if call == 0 || call-1 >= len(outputs) || outputs[call-1] == nil {
+		return nil
+	}
+	return outputs[call-1].NextToken
+}
+
+func previousUnitNextToken(outputs []*organizations.ListOrganizationalUnitsForParentOutput, call int) *string {
+	if call == 0 || call-1 >= len(outputs) || outputs[call-1] == nil {
+		return nil
+	}
+	return outputs[call-1].NextToken
+}
+
+func previousTargetNextToken(outputs []*organizations.ListTargetsForPolicyOutput, call int) *string {
+	if call == 0 || call-1 >= len(outputs) || outputs[call-1] == nil {
+		return nil
+	}
+	return outputs[call-1].NextToken
 }


### PR DESCRIPTION
## Summary

- Return AWS Organizations account, OU, and policy-target discovery errors instead of silently skipping them.
- Page through organization child and policy-target listings so imports do not stop at the first response page.
- Add focused coverage for traversal errors and paginated Organizations resources.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Propagates AWS Organizations discovery errors, paginates children and policy targets, and stops pagination on empty tokens to avoid extra calls. Prevents silent skips and ensures complete imports.

- **Bug Fixes**
  - Return errors for account, OU, and policy-target discovery instead of ignoring them.
  - Paginate `ListAccountsForParent`, `ListOrganizationalUnitsForParent`, and `ListTargetsForPolicy`; stop when `NextToken` is empty.

- **Refactors**
  - Introduced `organizationClient` and extracted `addPolicyAttachments` for testability and clearer flow.
  - Added focused tests for error propagation, pagination, and empty-token termination in `providers/aws/organization_test.go`.

<sup>Written for commit ec7af52f82c28ef1d29a9bb79e961075773885ba. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error propagation and handling during AWS Organizations discovery; failures now stop processing and return contextual errors.
  * Fixed pagination handling for listing accounts, organizational units, and policy targets to ensure complete and correct enumeration.

* **Refactor**
  * Reworked policy attachment collection for clearer control flow and robust error management.

* **Tests**
  * Added thorough unit tests covering pagination, error wrapping, and traversal behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->