### PR TITLE
feat(kubernetes): import admission policies as manifests

### DIFF
--- a/docs/kubernetes.md
+++ b/docs/kubernetes.md
@@ -8,8 +8,8 @@ Example:
 ```
 
 Terraformer discovers Kubernetes API resources from the active cluster and imports resources that are available through either the typed Kubernetes client or an explicit dynamic-client import path, and the installed Terraform Kubernetes provider schema.
-Discovered CRDs and other untyped API extensions without a first-class Terraform Kubernetes provider type can be imported through `kubernetes_manifest` when the API resource is manageable and the installed provider supports that resource.
-Manifest-backed custom resources use a group/version-qualified resource selector such as `example.com/v1/widgets` to avoid collisions between CRDs that share the same plural name.
+Discovered CRDs, other untyped API extensions, and selected native APIs without a first-class Terraform Kubernetes provider type can be imported through `kubernetes_manifest` when the API resource is manageable and the installed provider supports that resource.
+Manifest-backed resources use a group/version-qualified resource selector such as `example.com/v1/widgets` or `admissionregistration.k8s.io/v1/validatingadmissionpolicybindings` to avoid collisions between API resources that share the same plural name.
 When `labels` or `annotations` are selected with full resource imports, Terraformer keeps the full resource import and skips overlapping metadata-only resources to avoid duplicate Terraform ownership of the same object metadata.
 When `env` is selected with full workload imports, Terraformer keeps the full workload import and skips overlapping environment-only resources to avoid duplicate Terraform ownership of the same container environment.
 When `configmaps` and `configmapdata` are selected together, Terraformer keeps the full `configmaps` import and skips overlapping data-only resources to avoid duplicate Terraform ownership of the same ConfigMap data.
@@ -20,6 +20,12 @@ Common supported resources include:
 
 *   `annotations`
     * `kubernetes_annotations`
+*   `admissionregistration.k8s.io/v1/mutatingadmissionpolicies`
+    * `kubernetes_manifest`
+*   `admissionregistration.k8s.io/v1/mutatingadmissionpolicybindings`
+    * `kubernetes_manifest`
+*   `admissionregistration.k8s.io/v1/validatingadmissionpolicybindings`
+    * `kubernetes_manifest`
 *   `apiservices`
     * `kubernetes_api_service_v1`
 *   `certificatesigningrequests`

--- a/providers/kubernetes/utils.go
+++ b/providers/kubernetes/utils.go
@@ -88,6 +88,23 @@ var dynamicClientResources = map[kubernetesResourceID]struct{}{
 	{group: "policy", version: "v1beta1", kind: "PodSecurityPolicy"}:            {},
 }
 
+// Native manifest imports are limited to declarative Kubernetes APIs that the
+// Terraform provider does not expose as first-class resources in every version.
+var nativeManifestResources = map[kubernetesResourceID]struct{}{
+	{group: "admissionregistration.k8s.io", version: "v1", kind: "MutatingAdmissionPolicy"}:                {},
+	{group: "admissionregistration.k8s.io", version: "v1", kind: "MutatingAdmissionPolicyBinding"}:         {},
+	{group: "admissionregistration.k8s.io", version: "v1", kind: "ValidatingAdmissionPolicy"}:              {},
+	{group: "admissionregistration.k8s.io", version: "v1", kind: "ValidatingAdmissionPolicyBinding"}:       {},
+	{group: "admissionregistration.k8s.io", version: "v1beta1", kind: "MutatingAdmissionPolicy"}:           {},
+	{group: "admissionregistration.k8s.io", version: "v1beta1", kind: "MutatingAdmissionPolicyBinding"}:    {},
+	{group: "admissionregistration.k8s.io", version: "v1beta1", kind: "ValidatingAdmissionPolicy"}:         {},
+	{group: "admissionregistration.k8s.io", version: "v1beta1", kind: "ValidatingAdmissionPolicyBinding"}:  {},
+	{group: "admissionregistration.k8s.io", version: "v1alpha1", kind: "MutatingAdmissionPolicy"}:          {},
+	{group: "admissionregistration.k8s.io", version: "v1alpha1", kind: "MutatingAdmissionPolicyBinding"}:   {},
+	{group: "admissionregistration.k8s.io", version: "v1alpha1", kind: "ValidatingAdmissionPolicy"}:        {},
+	{group: "admissionregistration.k8s.io", version: "v1alpha1", kind: "ValidatingAdmissionPolicyBinding"}: {},
+}
+
 // client-go group accessor names collapse DNS groups to their first label
 // (for example, rbac.authorization.k8s.io -> RbacV1), so require exact API
 // groups before reflection to avoid treating CRDs like apps.example.com as
@@ -189,7 +206,11 @@ func selectImportResourceName(
 	}
 
 	// Keep native typed-client resources on explicit provider resources only.
-	// The manifest fallback is for CRDs and other untyped API extensions.
+	// The manifest fallback is for CRDs, other untyped API extensions, and
+	// explicitly allowed native APIs without first-class provider resources.
+	if supportsNativeManifestResource(group, version, resource.Kind) && supportsManifestResource(resource, hasResourceType) {
+		return manifestTerraformResourceName, true, true
+	}
 	if supportsTypedClientResource(clientset, group, version, resource.Kind) {
 		return "", false, false
 	}
@@ -201,6 +222,11 @@ func selectImportResourceName(
 
 func supportsDynamicClientResource(group, version, kind string) bool {
 	_, ok := dynamicClientResources[kubernetesResourceID{group: group, version: version, kind: kind}]
+	return ok
+}
+
+func supportsNativeManifestResource(group, version, kind string) bool {
+	_, ok := nativeManifestResources[kubernetesResourceID{group: group, version: version, kind: kind}]
 	return ok
 }
 

--- a/providers/kubernetes/utils_test.go
+++ b/providers/kubernetes/utils_test.go
@@ -519,6 +519,22 @@ func TestSelectImportResourceName(t *testing.T) {
 			wantOK:      true,
 		},
 		{
+			name:    "falls back to manifest for native admission policy binding",
+			group:   "admissionregistration.k8s.io",
+			version: "v1",
+			resource: metav1.APIResource{
+				Name:  "validatingadmissionpolicybindings",
+				Kind:  "ValidatingAdmissionPolicyBinding",
+				Verbs: manageableVerbs,
+			},
+			supportedTypes: map[string]struct{}{
+				manifestTerraformResourceName: {},
+			},
+			want:        manifestTerraformResourceName,
+			wantDynamic: true,
+			wantOK:      true,
+		},
+		{
 			name:    "skips native typed resource without first-class provider type",
 			version: "v1",
 			resource: metav1.APIResource{
@@ -644,6 +660,33 @@ func TestSupportsDynamicClientResource(t *testing.T) {
 			got := supportsDynamicClientResource(tt.group, tt.version, tt.kind)
 			if got != tt.want {
 				t.Fatalf("supportsDynamicClientResource(%q, %q, %q) = %t, want %t", tt.group, tt.version, tt.kind, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestSupportsNativeManifestResource(t *testing.T) {
+	tests := []struct {
+		name    string
+		group   string
+		version string
+		kind    string
+		want    bool
+	}{
+		{name: "mutating admission policy v1", group: "admissionregistration.k8s.io", version: "v1", kind: "MutatingAdmissionPolicy", want: true},
+		{name: "validating admission policy binding v1", group: "admissionregistration.k8s.io", version: "v1", kind: "ValidatingAdmissionPolicyBinding", want: true},
+		{name: "validating admission policy beta", group: "admissionregistration.k8s.io", version: "v1beta1", kind: "ValidatingAdmissionPolicy", want: true},
+		{name: "mutating admission policy binding alpha", group: "admissionregistration.k8s.io", version: "v1alpha1", kind: "MutatingAdmissionPolicyBinding", want: true},
+		{name: "webhook has first-class provider resource", group: "admissionregistration.k8s.io", version: "v1", kind: "ValidatingWebhookConfiguration", want: false},
+		{name: "other native resource is not manifest-backed", group: "coordination.k8s.io", version: "v1", kind: "Lease", want: false},
+		{name: "custom resource is handled by general manifest fallback", group: "example.com", version: "v1", kind: "Widget", want: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := supportsNativeManifestResource(tt.group, tt.version, tt.kind)
+			if got != tt.want {
+				t.Fatalf("supportsNativeManifestResource(%q, %q, %q) = %t, want %t", tt.group, tt.version, tt.kind, got, tt.want)
 			}
 		})
 	}


### PR DESCRIPTION
## Summary

Adds a narrow native `kubernetes_manifest` fallback for admission policy APIs that do not consistently have first-class Terraform Kubernetes provider resources:

- mutating admission policies
- mutating admission policy bindings
- validating admission policy bindings
- beta/alpha validating admission policy APIs when no provider resource exists

The fallback is still gated on manageable API verbs and an installed `kubernetes_manifest` provider schema. Existing first-class resources, such as `kubernetes_validating_admission_policy_v1`, continue to win when available.

## Notes

`kubernetes_token_request_v1` was left out of this gap pass because it is not a persistent import target; the provider create path mints a new token and its read/update/delete paths are no-ops.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a targeted `kubernetes_manifest` fallback to import Kubernetes admission policies and bindings when the provider lacks first-class resources. Supports v1, v1beta1, and v1alpha1 while preferring typed resources when available.

- **New Features**
  - Enables manifest import for `admissionregistration.k8s.io` Mutating/ValidatingAdmissionPolicy and their Bindings (v1, v1beta1, v1alpha1).
  - Only used when the provider has no first-class type and the API is manageable; typed resources still win.
  - Docs updated with group/version-qualified selectors and supported resources; tests cover selection logic and the allowed set.

<sup>Written for commit 29e3008a40e56217af959c0659f29415203ff52f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Kubernetes resource documentation to clarify guidance on supported native APIs and custom resource extensions.

* **New Features**
  * Added support for Kubernetes admission policy resources (mutating and validating policies, and their bindings) using declarative resource configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->