### PR TITLE
feat(datadog): add team relationship imports

### DIFF
--- a/docs/datadog.md
+++ b/docs/datadog.md
@@ -216,7 +216,7 @@ Tag filters are order specific. For example, if your monitor has tags (in the or
 *   `team_sync`
     * `datadog_team_sync`
         * **_NOTE:_** Requires DataDog/datadog provider 4.5.0 or newer.
-        * **_NOTE:_** The Datadog provider currently supports the `github` team sync source
+        * **_NOTE:_** The Datadog provider currently supports the GitHub team sync source
 *   `user`
     * `datadog_user`
 

--- a/docs/datadog.md
+++ b/docs/datadog.md
@@ -192,6 +192,13 @@ Tag filters are order specific. For example, if your monitor has tags (in the or
     * `datadog_synthetics_test`
 *   `team`
     * `datadog_team`
+*   `team_connection`
+    * `datadog_team_connection`
+        * **_NOTE:_** Requires DataDog/datadog provider 4.5.0 or newer.
+        * **_NOTE:_** Team connections can be filtered by `source`
+*   `team_hierarchy_links`
+    * `datadog_team_hierarchy_links`
+        * **_NOTE:_** Team hierarchy links can be filtered by `parent_team_id` or `sub_team_id`
 *   `team_link`
     * `datadog_team_link`
         * **_NOTE:_** Importing a single team link by ID requires quoting the `team_id:link_id` filter value, for example `--filter="team_link='team-id:link-id'"`; links can also be filtered by `team_id`
@@ -206,6 +213,10 @@ Tag filters are order specific. For example, if your monitor has tags (in the or
     * `datadog_team_permission_setting`
         * **_NOTE:_** Requires DataDog/datadog provider 3.90.0 or newer.
         * **_NOTE:_** Importing a single permission setting by ID requires quoting the `team_id:action` filter value, for example `--filter="team_permission_setting='team-id:manage_membership'"`; permission settings can also be filtered by `team_id`
+*   `team_sync`
+    * `datadog_team_sync`
+        * **_NOTE:_** Requires DataDog/datadog provider 4.5.0 or newer.
+        * **_NOTE:_** The Datadog provider currently supports the `github` team sync source
 *   `user`
     * `datadog_user`
 

--- a/providers/datadog/datadog_provider.go
+++ b/providers/datadog/datadog_provider.go
@@ -206,10 +206,13 @@ func (p *DatadogProvider) GetSupportedService() map[string]terraformutils.Servic
 		"synthetics_global_variable":           &SyntheticsGlobalVariableGenerator{},
 		"synthetics_private_location":          &SyntheticsPrivateLocationGenerator{},
 		"team":                                 &TeamGenerator{},
+		"team_connection":                      &TeamConnectionGenerator{},
+		"team_hierarchy_links":                 &TeamHierarchyLinksGenerator{},
 		"team_link":                            &TeamLinkGenerator{},
 		"team_membership":                      &TeamMembershipGenerator{},
 		"team_notification_rule":               &TeamNotificationRuleGenerator{},
 		"team_permission_setting":              &TeamPermissionSettingGenerator{},
+		"team_sync":                            &TeamSyncGenerator{},
 		"user":                                 &UserGenerator{},
 		"role":                                 &RoleGenerator{},
 	}
@@ -262,6 +265,17 @@ func (p DatadogProvider) GetResourceConnections() map[string]map[string][]string
 		"rum_retention_filters_order": {
 			"rum_application": {
 				"application_id", "id",
+			},
+		},
+		"team_connection": {
+			"team": {
+				"team.id", "id",
+			},
+		},
+		"team_hierarchy_links": {
+			"team": {
+				"parent_team_id", "id",
+				"sub_team_id", "id",
 			},
 		},
 		"integration_aws_lambda_arn": {

--- a/providers/datadog/datadog_provider_test.go
+++ b/providers/datadog/datadog_provider_test.go
@@ -93,6 +93,29 @@ func TestDatadogProviderSensitiveDataScannerConnections(t *testing.T) {
 	)
 }
 
+func TestDatadogProviderTeamRelationshipConnections(t *testing.T) {
+	connections := DatadogProvider{}.GetResourceConnections()
+
+	assertDatadogConnection(
+		t,
+		connections,
+		"team_connection",
+		"team",
+		"team.id",
+		"id",
+	)
+	assertDatadogConnectionPairs(
+		t,
+		connections,
+		"team_hierarchy_links",
+		"team",
+		[]string{
+			"parent_team_id", "id",
+			"sub_team_id", "id",
+		},
+	)
+}
+
 func TestDatadogProviderMonitorJSONConnections(t *testing.T) {
 	connections := DatadogProvider{}.GetResourceConnections()
 

--- a/providers/datadog/team_connection.go
+++ b/providers/datadog/team_connection.go
@@ -1,0 +1,201 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package datadog
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/DataDog/datadog-api-client-go/v2/api/datadog"
+	"github.com/DataDog/datadog-api-client-go/v2/api/datadogV2"
+
+	"github.com/chenrui333/terraformer/terraformutils"
+)
+
+var (
+	// TeamConnectionAllowEmptyValues ...
+	TeamConnectionAllowEmptyValues = []string{}
+)
+
+// TeamConnectionGenerator ...
+type TeamConnectionGenerator struct {
+	DatadogService
+}
+
+func (g *TeamConnectionGenerator) createResources(teamConnections []datadogV2.TeamConnection) ([]terraformutils.Resource, error) {
+	resources := []terraformutils.Resource{}
+	for _, teamConnection := range teamConnections {
+		resource, err := g.createResource(teamConnection)
+		if err != nil {
+			return nil, err
+		}
+		resources = append(resources, resource)
+	}
+
+	return resources, nil
+}
+
+func (g *TeamConnectionGenerator) createResource(teamConnection datadogV2.TeamConnection) (terraformutils.Resource, error) {
+	connectionID := teamConnection.GetId()
+	if connectionID == "" {
+		return terraformutils.Resource{}, fmt.Errorf("team connection missing id")
+	}
+	teamID, teamType := teamConnectionTeamRef(teamConnection)
+	if teamID == "" {
+		return terraformutils.Resource{}, fmt.Errorf("team connection %q missing team id", connectionID)
+	}
+	connectedTeamID, connectedTeamType := teamConnectionConnectedTeamRef(teamConnection)
+	if connectedTeamID == "" {
+		return terraformutils.Resource{}, fmt.Errorf("team connection %q missing connected team id", connectionID)
+	}
+	attributes := map[string]string{
+		"team.id":             teamID,
+		"team.type":           teamType,
+		"connected_team.id":   connectedTeamID,
+		"connected_team.type": connectedTeamType,
+	}
+	if connectionAttributes, ok := teamConnection.GetAttributesOk(); ok {
+		if source, ok := connectionAttributes.GetSourceOk(); ok {
+			attributes["source"] = *source
+		}
+	}
+
+	return terraformutils.NewResource(
+		connectionID,
+		fmt.Sprintf("team_connection_%s", connectionID),
+		"datadog_team_connection",
+		"datadog",
+		attributes,
+		TeamConnectionAllowEmptyValues,
+		map[string]interface{}{},
+	), nil
+}
+
+// InitResources Generate TerraformResources from Datadog API,
+// from each team connection create 1 TerraformResource.
+// Need Team Connection ID as ID for terraform resource.
+func (g *TeamConnectionGenerator) InitResources() error {
+	datadogClient := g.Args["datadogClient"].(*datadog.APIClient)
+	auth := g.Args["auth"].(context.Context)
+	api := datadogV2.NewTeamsApi(datadogClient)
+
+	resources, filtered, err := g.filteredResources(auth, api)
+	if err != nil {
+		return err
+	}
+	if filtered {
+		g.Resources = resources
+		return nil
+	}
+
+	teamConnections, err := listTeamConnections(auth, api, *datadogV2.NewListTeamConnectionsOptionalParameters())
+	if err != nil {
+		return err
+	}
+	g.Resources, err = g.createResources(teamConnections)
+	return err
+}
+
+func (g *TeamConnectionGenerator) filteredResources(auth context.Context, api *datadogV2.TeamsApi) ([]terraformutils.Resource, bool, error) {
+	resources := []terraformutils.Resource{}
+	filtered := false
+
+	for _, filter := range g.Filter {
+		if !filter.IsApplicable("team_connection") {
+			continue
+		}
+
+		switch filter.FieldPath {
+		case "id":
+			filtered = true
+			for _, connectionID := range filter.AcceptableValues {
+				teamConnection, err := getTeamConnection(auth, api, connectionID)
+				if err != nil {
+					return nil, true, err
+				}
+				resource, err := g.createResource(teamConnection)
+				if err != nil {
+					return nil, true, err
+				}
+				resources = append(resources, resource)
+			}
+		case "source":
+			filtered = true
+			optionalParams := datadogV2.NewListTeamConnectionsOptionalParameters().WithFilterSources(filter.AcceptableValues)
+			teamConnections, err := listTeamConnections(auth, api, *optionalParams)
+			if err != nil {
+				return nil, true, err
+			}
+			filteredResources, err := g.createResources(teamConnections)
+			if err != nil {
+				return nil, true, err
+			}
+			resources = append(resources, filteredResources...)
+		}
+	}
+
+	return resources, filtered, nil
+}
+
+func getTeamConnection(auth context.Context, api *datadogV2.TeamsApi, connectionID string) (datadogV2.TeamConnection, error) {
+	optionalParams := datadogV2.NewListTeamConnectionsOptionalParameters().WithFilterConnectionIds([]string{connectionID})
+	teamConnections, err := listTeamConnections(auth, api, *optionalParams)
+	if err != nil {
+		return datadogV2.TeamConnection{}, err
+	}
+	for _, teamConnection := range teamConnections {
+		if teamConnection.GetId() == connectionID {
+			return teamConnection, nil
+		}
+	}
+	return datadogV2.TeamConnection{}, fmt.Errorf("team connection %q not found", connectionID)
+}
+
+func listTeamConnections(auth context.Context, api *datadogV2.TeamsApi, optionalParams datadogV2.ListTeamConnectionsOptionalParameters) ([]datadogV2.TeamConnection, error) {
+	pageSize := int64(100)
+	optionalParams.WithPageSize(pageSize)
+	items, cancel := api.ListTeamConnectionsWithPagination(auth, optionalParams)
+	defer cancel()
+
+	teamConnections := []datadogV2.TeamConnection{}
+	for item := range items {
+		if item.Error != nil {
+			return nil, item.Error
+		}
+		teamConnections = append(teamConnections, item.Item)
+	}
+
+	return teamConnections, nil
+}
+
+func teamConnectionTeamRef(teamConnection datadogV2.TeamConnection) (string, string) {
+	relationships, ok := teamConnection.GetRelationshipsOk()
+	if !ok {
+		return "", ""
+	}
+	team, ok := relationships.GetTeamOk()
+	if !ok {
+		return "", ""
+	}
+	data, ok := team.GetDataOk()
+	if !ok {
+		return "", ""
+	}
+	return data.GetId(), string(data.GetType())
+}
+
+func teamConnectionConnectedTeamRef(teamConnection datadogV2.TeamConnection) (string, string) {
+	relationships, ok := teamConnection.GetRelationshipsOk()
+	if !ok {
+		return "", ""
+	}
+	connectedTeam, ok := relationships.GetConnectedTeamOk()
+	if !ok {
+		return "", ""
+	}
+	data, ok := connectedTeam.GetDataOk()
+	if !ok {
+		return "", ""
+	}
+	return data.GetId(), string(data.GetType())
+}

--- a/providers/datadog/team_connection_test.go
+++ b/providers/datadog/team_connection_test.go
@@ -1,0 +1,191 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package datadog
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/DataDog/datadog-api-client-go/v2/api/datadog"
+	"github.com/DataDog/datadog-api-client-go/v2/api/datadogV2"
+	"github.com/chenrui333/terraformer/terraformutils"
+)
+
+func TestTeamConnectionCreateResource(t *testing.T) {
+	generator := &TeamConnectionGenerator{}
+	resource, err := generator.createResource(teamConnection("connection-1", "team-1", "github-team-1"))
+	if err != nil {
+		t.Fatalf("createResource returned error: %v", err)
+	}
+
+	if resource.InstanceState.ID != "connection-1" {
+		t.Fatalf("resource ID = %q, want connection-1", resource.InstanceState.ID)
+	}
+	if resource.ResourceName != "tfer--team_connection_connection-1" {
+		t.Fatalf("resource name = %q, want tfer--team_connection_connection-1", resource.ResourceName)
+	}
+	if resource.InstanceInfo.Type != "datadog_team_connection" {
+		t.Fatalf("resource type = %q, want datadog_team_connection", resource.InstanceInfo.Type)
+	}
+	if resource.InstanceState.Attributes["team.id"] != "team-1" {
+		t.Fatalf("team.id = %q, want team-1", resource.InstanceState.Attributes["team.id"])
+	}
+	if resource.InstanceState.Attributes["connected_team.id"] != "github-team-1" {
+		t.Fatalf("connected_team.id = %q, want github-team-1", resource.InstanceState.Attributes["connected_team.id"])
+	}
+}
+
+func TestTeamConnectionCreateResourceRequiresID(t *testing.T) {
+	generator := &TeamConnectionGenerator{}
+	if _, err := generator.createResource(teamConnection("", "team-1", "github-team-1")); err == nil {
+		t.Fatal("createResource returned nil error, want missing id error")
+	}
+	if _, err := generator.createResource(teamConnection("connection-1", "", "github-team-1")); err == nil {
+		t.Fatal("createResource returned nil error, want missing team id error")
+	}
+	if _, err := generator.createResource(teamConnection("connection-1", "team-1", "")); err == nil {
+		t.Fatal("createResource returned nil error, want missing connected team id error")
+	}
+}
+
+func TestTeamConnectionInitResourcesListsConnections(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		if r.URL.Path != "/api/v2/team/connections" {
+			http.NotFound(w, r)
+			return
+		}
+		_, _ = fmt.Fprint(w, teamConnectionListResponseJSON(
+			teamConnectionJSON("connection-1", "team-1", "github-team-1"),
+			teamConnectionJSON("connection-2", "team-2", "github-team-2"),
+		))
+	}))
+	defer server.Close()
+
+	generator := newTeamConnectionTestGenerator(server, nil)
+	if err := generator.InitResources(); err != nil {
+		t.Fatalf("InitResources returned error: %v", err)
+	}
+	if len(generator.Resources) != 2 {
+		t.Fatalf("expected 2 resources, got %d", len(generator.Resources))
+	}
+	if generator.Resources[0].InstanceState.ID != "connection-1" || generator.Resources[1].InstanceState.ID != "connection-2" {
+		t.Fatalf("unexpected resource IDs: %s, %s", generator.Resources[0].InstanceState.ID, generator.Resources[1].InstanceState.ID)
+	}
+}
+
+func TestTeamConnectionInitResourcesFiltersByID(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		if r.URL.Path != "/api/v2/team/connections" {
+			http.NotFound(w, r)
+			return
+		}
+		if got := r.URL.Query().Get("filter[connection_ids]"); got != "connection-1" {
+			t.Fatalf("filter[connection_ids] = %q, want connection-1", got)
+		}
+		_, _ = fmt.Fprint(w, teamConnectionListResponseJSON(teamConnectionJSON("connection-1", "team-1", "github-team-1")))
+	}))
+	defer server.Close()
+
+	generator := newTeamConnectionTestGenerator(server, []terraformutils.ResourceFilter{
+		{
+			ServiceName:      "team_connection",
+			FieldPath:        "id",
+			AcceptableValues: []string{"connection-1"},
+		},
+	})
+	if err := generator.InitResources(); err != nil {
+		t.Fatalf("InitResources returned error: %v", err)
+	}
+	if len(generator.Resources) != 1 {
+		t.Fatalf("expected 1 resource, got %d", len(generator.Resources))
+	}
+	if generator.Resources[0].InstanceState.ID != "connection-1" {
+		t.Fatalf("resource ID = %q, want connection-1", generator.Resources[0].InstanceState.ID)
+	}
+}
+
+func TestTeamConnectionInitResourcesFiltersBySource(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		if r.URL.Path != "/api/v2/team/connections" {
+			http.NotFound(w, r)
+			return
+		}
+		if got := r.URL.Query().Get("filter[sources]"); got != "github" {
+			t.Fatalf("filter[sources] = %q, want github", got)
+		}
+		_, _ = fmt.Fprint(w, teamConnectionListResponseJSON(teamConnectionJSON("connection-1", "team-1", "github-team-1")))
+	}))
+	defer server.Close()
+
+	generator := newTeamConnectionTestGenerator(server, []terraformutils.ResourceFilter{
+		{
+			ServiceName:      "team_connection",
+			FieldPath:        "source",
+			AcceptableValues: []string{"github"},
+		},
+	})
+	if err := generator.InitResources(); err != nil {
+		t.Fatalf("InitResources returned error: %v", err)
+	}
+	if len(generator.Resources) != 1 {
+		t.Fatalf("expected 1 resource, got %d", len(generator.Resources))
+	}
+}
+
+func newTeamConnectionTestGenerator(server *httptest.Server, filter []terraformutils.ResourceFilter) *TeamConnectionGenerator {
+	return &TeamConnectionGenerator{
+		DatadogService: DatadogService{
+			Service: terraformutils.Service{
+				Args: map[string]interface{}{
+					"auth":          context.Background(),
+					"datadogClient": newTeamRelationshipTestClient(server),
+				},
+				Filter: filter,
+			},
+		},
+	}
+}
+
+func newTeamRelationshipTestClient(server *httptest.Server) *datadog.APIClient {
+	config := datadog.NewConfiguration()
+	config.Servers = datadog.ServerConfigurations{{URL: server.URL}}
+	config.HTTPClient = server.Client()
+	return datadog.NewAPIClient(config)
+}
+
+func teamConnectionListResponseJSON(connections ...string) string {
+	return fmt.Sprintf("{\"data\":[%s]}", strings.Join(connections, ","))
+}
+
+func teamConnection(id string, teamID string, connectedTeamID string) datadogV2.TeamConnection {
+	teamRef := datadogV2.NewTeamRef()
+	teamRef.SetData(*datadogV2.NewTeamRefData(teamID, datadogV2.TEAMREFDATATYPE_TEAM))
+	connectedTeamRef := datadogV2.NewConnectedTeamRef()
+	connectedTeamRef.SetData(*datadogV2.NewConnectedTeamRefData(connectedTeamID, datadogV2.CONNECTEDTEAMREFDATATYPE_GITHUB_TEAM))
+	relationships := datadogV2.NewTeamConnectionRelationships()
+	relationships.SetTeam(*teamRef)
+	relationships.SetConnectedTeam(*connectedTeamRef)
+	attributes := datadogV2.NewTeamConnectionAttributes()
+	attributes.SetSource("github")
+	teamConnection := datadogV2.NewTeamConnection(id, datadogV2.TEAMCONNECTIONTYPE_TEAM_CONNECTION)
+	teamConnection.SetRelationships(*relationships)
+	teamConnection.SetAttributes(*attributes)
+	return *teamConnection
+}
+
+func teamConnectionJSON(id string, teamID string, connectedTeamID string) string {
+	return fmt.Sprintf(
+		"{\"id\":%q,\"type\":\"team_connection\",\"attributes\":{\"source\":%q},\"relationships\":{\"team\":{\"data\":{\"id\":%q,\"type\":\"team\"}},\"connected_team\":{\"data\":{\"id\":%q,\"type\":\"github_team\"}}}}",
+		id,
+		"github",
+		teamID,
+		connectedTeamID,
+	)
+}

--- a/providers/datadog/team_connection_test.go
+++ b/providers/datadog/team_connection_test.go
@@ -9,6 +9,7 @@ import (
 	"net/http/httptest"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/DataDog/datadog-api-client-go/v2/api/datadog"
 	"github.com/DataDog/datadog-api-client-go/v2/api/datadogV2"
@@ -79,15 +80,14 @@ func TestTeamConnectionInitResourcesListsConnections(t *testing.T) {
 }
 
 func TestTeamConnectionInitResourcesFiltersByID(t *testing.T) {
+	filterCh := make(chan string, 1)
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		if r.URL.Path != "/api/v2/team/connections" {
 			http.NotFound(w, r)
 			return
 		}
-		if got := r.URL.Query().Get("filter[connection_ids]"); got != "connection-1" {
-			t.Fatalf("filter[connection_ids] = %q, want connection-1", got)
-		}
+		filterCh <- r.URL.Query().Get("filter[connection_ids]")
 		_, _ = fmt.Fprint(w, teamConnectionListResponseJSON(teamConnectionJSON("connection-1", "team-1", "github-team-1")))
 	}))
 	defer server.Close()
@@ -102,6 +102,7 @@ func TestTeamConnectionInitResourcesFiltersByID(t *testing.T) {
 	if err := generator.InitResources(); err != nil {
 		t.Fatalf("InitResources returned error: %v", err)
 	}
+	assertObservedQueryValue(t, filterCh, "filter[connection_ids]", "connection-1")
 	if len(generator.Resources) != 1 {
 		t.Fatalf("expected 1 resource, got %d", len(generator.Resources))
 	}
@@ -111,15 +112,14 @@ func TestTeamConnectionInitResourcesFiltersByID(t *testing.T) {
 }
 
 func TestTeamConnectionInitResourcesFiltersBySource(t *testing.T) {
+	filterCh := make(chan string, 1)
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		if r.URL.Path != "/api/v2/team/connections" {
 			http.NotFound(w, r)
 			return
 		}
-		if got := r.URL.Query().Get("filter[sources]"); got != "github" {
-			t.Fatalf("filter[sources] = %q, want github", got)
-		}
+		filterCh <- r.URL.Query().Get("filter[sources]")
 		_, _ = fmt.Fprint(w, teamConnectionListResponseJSON(teamConnectionJSON("connection-1", "team-1", "github-team-1")))
 	}))
 	defer server.Close()
@@ -134,8 +134,22 @@ func TestTeamConnectionInitResourcesFiltersBySource(t *testing.T) {
 	if err := generator.InitResources(); err != nil {
 		t.Fatalf("InitResources returned error: %v", err)
 	}
+	assertObservedQueryValue(t, filterCh, "filter[sources]", "github")
 	if len(generator.Resources) != 1 {
 		t.Fatalf("expected 1 resource, got %d", len(generator.Resources))
+	}
+}
+
+func assertObservedQueryValue(t *testing.T, observed <-chan string, name string, want string) {
+	t.Helper()
+
+	select {
+	case got := <-observed:
+		if got != want {
+			t.Fatalf("%s = %q, want %q", name, got, want)
+		}
+	case <-time.After(time.Second):
+		t.Fatalf("timed out waiting for %s query value", name)
 	}
 }
 

--- a/providers/datadog/team_hierarchy_links.go
+++ b/providers/datadog/team_hierarchy_links.go
@@ -1,0 +1,211 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package datadog
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/DataDog/datadog-api-client-go/v2/api/datadog"
+	"github.com/DataDog/datadog-api-client-go/v2/api/datadogV2"
+
+	"github.com/chenrui333/terraformer/terraformutils"
+)
+
+var (
+	// TeamHierarchyLinksAllowEmptyValues ...
+	TeamHierarchyLinksAllowEmptyValues = []string{}
+)
+
+// TeamHierarchyLinksGenerator ...
+type TeamHierarchyLinksGenerator struct {
+	DatadogService
+}
+
+func (g *TeamHierarchyLinksGenerator) createResources(teamHierarchyLinks []datadogV2.TeamHierarchyLink) ([]terraformutils.Resource, error) {
+	resources := []terraformutils.Resource{}
+	for _, teamHierarchyLink := range teamHierarchyLinks {
+		resource, err := g.createResource(teamHierarchyLink)
+		if err != nil {
+			return nil, err
+		}
+		resources = append(resources, resource)
+	}
+
+	return resources, nil
+}
+
+func (g *TeamHierarchyLinksGenerator) createResource(teamHierarchyLink datadogV2.TeamHierarchyLink) (terraformutils.Resource, error) {
+	linkID := teamHierarchyLink.GetId()
+	if linkID == "" {
+		return terraformutils.Resource{}, fmt.Errorf("team hierarchy link missing id")
+	}
+	parentTeamID := teamHierarchyLinkParentTeamID(teamHierarchyLink)
+	if parentTeamID == "" {
+		return terraformutils.Resource{}, fmt.Errorf("team hierarchy link %q missing parent team id", linkID)
+	}
+	subTeamID := teamHierarchyLinkSubTeamID(teamHierarchyLink)
+	if subTeamID == "" {
+		return terraformutils.Resource{}, fmt.Errorf("team hierarchy link %q missing sub team id", linkID)
+	}
+
+	return terraformutils.NewResource(
+		linkID,
+		fmt.Sprintf("team_hierarchy_links_%s_%s", parentTeamID, subTeamID),
+		"datadog_team_hierarchy_links",
+		"datadog",
+		map[string]string{
+			"parent_team_id": parentTeamID,
+			"sub_team_id":    subTeamID,
+		},
+		TeamHierarchyLinksAllowEmptyValues,
+		map[string]interface{}{},
+	), nil
+}
+
+// InitResources Generate TerraformResources from Datadog API,
+// from each team hierarchy link create 1 TerraformResource.
+// Need Team Hierarchy Link ID as ID for terraform resource.
+func (g *TeamHierarchyLinksGenerator) InitResources() error {
+	datadogClient := g.Args["datadogClient"].(*datadog.APIClient)
+	auth := g.Args["auth"].(context.Context)
+	api := datadogV2.NewTeamsApi(datadogClient)
+
+	resources, filtered, err := g.filteredResources(auth, api)
+	if err != nil {
+		return err
+	}
+	if filtered {
+		g.Resources = resources
+		return nil
+	}
+
+	teamHierarchyLinks, err := listTeamHierarchyLinks(auth, api, *datadogV2.NewListTeamHierarchyLinksOptionalParameters())
+	if err != nil {
+		return err
+	}
+	g.Resources, err = g.createResources(teamHierarchyLinks)
+	return err
+}
+
+func (g *TeamHierarchyLinksGenerator) filteredResources(auth context.Context, api *datadogV2.TeamsApi) ([]terraformutils.Resource, bool, error) {
+	resources := []terraformutils.Resource{}
+	filtered := false
+
+	for _, filter := range g.Filter {
+		if !filter.IsApplicable("team_hierarchy_links") {
+			continue
+		}
+
+		switch filter.FieldPath {
+		case "id":
+			filtered = true
+			for _, linkID := range filter.AcceptableValues {
+				teamHierarchyLink, err := getTeamHierarchyLink(auth, api, linkID)
+				if err != nil {
+					return nil, true, err
+				}
+				resource, err := g.createResource(teamHierarchyLink)
+				if err != nil {
+					return nil, true, err
+				}
+				resources = append(resources, resource)
+			}
+		case "parent_team_id":
+			filtered = true
+			for _, parentTeamID := range filter.AcceptableValues {
+				optionalParams := datadogV2.NewListTeamHierarchyLinksOptionalParameters().WithFilterParentTeam(parentTeamID)
+				teamHierarchyLinks, err := listTeamHierarchyLinks(auth, api, *optionalParams)
+				if err != nil {
+					return nil, true, err
+				}
+				filteredResources, err := g.createResources(teamHierarchyLinks)
+				if err != nil {
+					return nil, true, err
+				}
+				resources = append(resources, filteredResources...)
+			}
+		case "sub_team_id":
+			filtered = true
+			for _, subTeamID := range filter.AcceptableValues {
+				optionalParams := datadogV2.NewListTeamHierarchyLinksOptionalParameters().WithFilterSubTeam(subTeamID)
+				teamHierarchyLinks, err := listTeamHierarchyLinks(auth, api, *optionalParams)
+				if err != nil {
+					return nil, true, err
+				}
+				filteredResources, err := g.createResources(teamHierarchyLinks)
+				if err != nil {
+					return nil, true, err
+				}
+				resources = append(resources, filteredResources...)
+			}
+		}
+	}
+
+	return resources, filtered, nil
+}
+
+func getTeamHierarchyLink(auth context.Context, api *datadogV2.TeamsApi, linkID string) (datadogV2.TeamHierarchyLink, error) {
+	teamHierarchyLinkResponse, httpResponse, err := api.GetTeamHierarchyLink(auth, linkID)
+	if httpResponse != nil && httpResponse.Body != nil {
+		defer httpResponse.Body.Close()
+	}
+	if err != nil {
+		return datadogV2.TeamHierarchyLink{}, err
+	}
+
+	teamHierarchyLink, ok := teamHierarchyLinkResponse.GetDataOk()
+	if !ok {
+		return datadogV2.TeamHierarchyLink{}, fmt.Errorf("team hierarchy link %q not found", linkID)
+	}
+	return *teamHierarchyLink, nil
+}
+
+func listTeamHierarchyLinks(auth context.Context, api *datadogV2.TeamsApi, optionalParams datadogV2.ListTeamHierarchyLinksOptionalParameters) ([]datadogV2.TeamHierarchyLink, error) {
+	pageSize := int64(100)
+	optionalParams.WithPageSize(pageSize)
+	items, cancel := api.ListTeamHierarchyLinksWithPagination(auth, optionalParams)
+	defer cancel()
+
+	teamHierarchyLinks := []datadogV2.TeamHierarchyLink{}
+	for item := range items {
+		if item.Error != nil {
+			return nil, item.Error
+		}
+		teamHierarchyLinks = append(teamHierarchyLinks, item.Item)
+	}
+
+	return teamHierarchyLinks, nil
+}
+
+func teamHierarchyLinkParentTeamID(teamHierarchyLink datadogV2.TeamHierarchyLink) string {
+	relationships, ok := teamHierarchyLink.GetRelationshipsOk()
+	if !ok {
+		return ""
+	}
+	parentTeam, ok := relationships.GetParentTeamOk()
+	if !ok {
+		return ""
+	}
+	data, ok := parentTeam.GetDataOk()
+	if !ok {
+		return ""
+	}
+	return data.GetId()
+}
+
+func teamHierarchyLinkSubTeamID(teamHierarchyLink datadogV2.TeamHierarchyLink) string {
+	relationships, ok := teamHierarchyLink.GetRelationshipsOk()
+	if !ok {
+		return ""
+	}
+	subTeam, ok := relationships.GetSubTeamOk()
+	if !ok {
+		return ""
+	}
+	data, ok := subTeam.GetDataOk()
+	if !ok {
+		return ""
+	}
+	return data.GetId()
+}

--- a/providers/datadog/team_hierarchy_links_test.go
+++ b/providers/datadog/team_hierarchy_links_test.go
@@ -129,6 +129,35 @@ func TestTeamHierarchyLinksInitResourcesFiltersByParentTeam(t *testing.T) {
 	}
 }
 
+func TestTeamHierarchyLinksInitResourcesFiltersBySubTeam(t *testing.T) {
+	filterCh := make(chan string, 1)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		if r.URL.Path != "/api/v2/team-hierarchy-links" {
+			http.NotFound(w, r)
+			return
+		}
+		filterCh <- r.URL.Query().Get("filter[sub_team]")
+		_, _ = fmt.Fprint(w, teamHierarchyLinksListResponseJSON(teamHierarchyLinkJSON("link-1", "parent-1", "sub-1")))
+	}))
+	defer server.Close()
+
+	generator := newTeamHierarchyLinksTestGenerator(server, []terraformutils.ResourceFilter{
+		{
+			ServiceName:      "team_hierarchy_links",
+			FieldPath:        "sub_team_id",
+			AcceptableValues: []string{"sub-1"},
+		},
+	})
+	if err := generator.InitResources(); err != nil {
+		t.Fatalf("InitResources returned error: %v", err)
+	}
+	assertObservedQueryValue(t, filterCh, "filter[sub_team]", "sub-1")
+	if len(generator.Resources) != 1 {
+		t.Fatalf("expected 1 resource, got %d", len(generator.Resources))
+	}
+}
+
 func newTeamHierarchyLinksTestGenerator(server *httptest.Server, filter []terraformutils.ResourceFilter) *TeamHierarchyLinksGenerator {
 	return &TeamHierarchyLinksGenerator{
 		DatadogService: DatadogService{

--- a/providers/datadog/team_hierarchy_links_test.go
+++ b/providers/datadog/team_hierarchy_links_test.go
@@ -101,15 +101,14 @@ func TestTeamHierarchyLinksInitResourcesFiltersByID(t *testing.T) {
 }
 
 func TestTeamHierarchyLinksInitResourcesFiltersByParentTeam(t *testing.T) {
+	filterCh := make(chan string, 1)
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		if r.URL.Path != "/api/v2/team-hierarchy-links" {
 			http.NotFound(w, r)
 			return
 		}
-		if got := r.URL.Query().Get("filter[parent_team]"); got != "parent-1" {
-			t.Fatalf("filter[parent_team] = %q, want parent-1", got)
-		}
+		filterCh <- r.URL.Query().Get("filter[parent_team]")
 		_, _ = fmt.Fprint(w, teamHierarchyLinksListResponseJSON(teamHierarchyLinkJSON("link-1", "parent-1", "sub-1")))
 	}))
 	defer server.Close()
@@ -124,6 +123,7 @@ func TestTeamHierarchyLinksInitResourcesFiltersByParentTeam(t *testing.T) {
 	if err := generator.InitResources(); err != nil {
 		t.Fatalf("InitResources returned error: %v", err)
 	}
+	assertObservedQueryValue(t, filterCh, "filter[parent_team]", "parent-1")
 	if len(generator.Resources) != 1 {
 		t.Fatalf("expected 1 resource, got %d", len(generator.Resources))
 	}

--- a/providers/datadog/team_hierarchy_links_test.go
+++ b/providers/datadog/team_hierarchy_links_test.go
@@ -1,0 +1,170 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package datadog
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/DataDog/datadog-api-client-go/v2/api/datadogV2"
+	"github.com/chenrui333/terraformer/terraformutils"
+)
+
+func TestTeamHierarchyLinksCreateResource(t *testing.T) {
+	generator := &TeamHierarchyLinksGenerator{}
+	resource, err := generator.createResource(teamHierarchyLink("link-1", "parent-team", "sub-team"))
+	if err != nil {
+		t.Fatalf("createResource returned error: %v", err)
+	}
+
+	if resource.InstanceState.ID != "link-1" {
+		t.Fatalf("resource ID = %q, want link-1", resource.InstanceState.ID)
+	}
+	if resource.InstanceState.Attributes["parent_team_id"] != "parent-team" {
+		t.Fatalf("parent_team_id = %q, want parent-team", resource.InstanceState.Attributes["parent_team_id"])
+	}
+	if resource.InstanceState.Attributes["sub_team_id"] != "sub-team" {
+		t.Fatalf("sub_team_id = %q, want sub-team", resource.InstanceState.Attributes["sub_team_id"])
+	}
+	if resource.ResourceName != "tfer--team_hierarchy_links_parent-team_sub-team" {
+		t.Fatalf("resource name = %q, want tfer--team_hierarchy_links_parent-team_sub-team", resource.ResourceName)
+	}
+}
+
+func TestTeamHierarchyLinksCreateResourceRequiresRelationships(t *testing.T) {
+	generator := &TeamHierarchyLinksGenerator{}
+	if _, err := generator.createResource(teamHierarchyLink("", "parent-team", "sub-team")); err == nil {
+		t.Fatal("createResource returned nil error, want missing id error")
+	}
+	if _, err := generator.createResource(teamHierarchyLink("link-1", "", "sub-team")); err == nil {
+		t.Fatal("createResource returned nil error, want missing parent team id error")
+	}
+	if _, err := generator.createResource(teamHierarchyLink("link-1", "parent-team", "")); err == nil {
+		t.Fatal("createResource returned nil error, want missing sub team id error")
+	}
+}
+
+func TestTeamHierarchyLinksInitResourcesListsLinks(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		if r.URL.Path != "/api/v2/team-hierarchy-links" {
+			http.NotFound(w, r)
+			return
+		}
+		_, _ = fmt.Fprint(w, teamHierarchyLinksListResponseJSON(
+			teamHierarchyLinkJSON("link-1", "parent-1", "sub-1"),
+			teamHierarchyLinkJSON("link-2", "parent-2", "sub-2"),
+		))
+	}))
+	defer server.Close()
+
+	generator := newTeamHierarchyLinksTestGenerator(server, nil)
+	if err := generator.InitResources(); err != nil {
+		t.Fatalf("InitResources returned error: %v", err)
+	}
+	if len(generator.Resources) != 2 {
+		t.Fatalf("expected 2 resources, got %d", len(generator.Resources))
+	}
+}
+
+func TestTeamHierarchyLinksInitResourcesFiltersByID(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		if r.URL.Path != "/api/v2/team-hierarchy-links/link-1" {
+			http.NotFound(w, r)
+			return
+		}
+		_, _ = fmt.Fprintf(w, "{\"data\":%s}", teamHierarchyLinkJSON("link-1", "parent-1", "sub-1"))
+	}))
+	defer server.Close()
+
+	generator := newTeamHierarchyLinksTestGenerator(server, []terraformutils.ResourceFilter{
+		{
+			ServiceName:      "team_hierarchy_links",
+			FieldPath:        "id",
+			AcceptableValues: []string{"link-1"},
+		},
+	})
+	if err := generator.InitResources(); err != nil {
+		t.Fatalf("InitResources returned error: %v", err)
+	}
+	if len(generator.Resources) != 1 {
+		t.Fatalf("expected 1 resource, got %d", len(generator.Resources))
+	}
+	if generator.Resources[0].InstanceState.Attributes["parent_team_id"] != "parent-1" {
+		t.Fatalf("parent_team_id = %q, want parent-1", generator.Resources[0].InstanceState.Attributes["parent_team_id"])
+	}
+}
+
+func TestTeamHierarchyLinksInitResourcesFiltersByParentTeam(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		if r.URL.Path != "/api/v2/team-hierarchy-links" {
+			http.NotFound(w, r)
+			return
+		}
+		if got := r.URL.Query().Get("filter[parent_team]"); got != "parent-1" {
+			t.Fatalf("filter[parent_team] = %q, want parent-1", got)
+		}
+		_, _ = fmt.Fprint(w, teamHierarchyLinksListResponseJSON(teamHierarchyLinkJSON("link-1", "parent-1", "sub-1")))
+	}))
+	defer server.Close()
+
+	generator := newTeamHierarchyLinksTestGenerator(server, []terraformutils.ResourceFilter{
+		{
+			ServiceName:      "team_hierarchy_links",
+			FieldPath:        "parent_team_id",
+			AcceptableValues: []string{"parent-1"},
+		},
+	})
+	if err := generator.InitResources(); err != nil {
+		t.Fatalf("InitResources returned error: %v", err)
+	}
+	if len(generator.Resources) != 1 {
+		t.Fatalf("expected 1 resource, got %d", len(generator.Resources))
+	}
+}
+
+func newTeamHierarchyLinksTestGenerator(server *httptest.Server, filter []terraformutils.ResourceFilter) *TeamHierarchyLinksGenerator {
+	return &TeamHierarchyLinksGenerator{
+		DatadogService: DatadogService{
+			Service: terraformutils.Service{
+				Args: map[string]interface{}{
+					"auth":          context.Background(),
+					"datadogClient": newTeamRelationshipTestClient(server),
+				},
+				Filter: filter,
+			},
+		},
+	}
+}
+
+func teamHierarchyLinksListResponseJSON(links ...string) string {
+	return fmt.Sprintf("{\"data\":[%s]}", strings.Join(links, ","))
+}
+
+func teamHierarchyLink(id string, parentTeamID string, subTeamID string) datadogV2.TeamHierarchyLink {
+	parentTeam := datadogV2.NewTeamHierarchyLinkTeam(parentTeamID, datadogV2.TEAMTYPE_TEAM)
+	subTeam := datadogV2.NewTeamHierarchyLinkTeam(subTeamID, datadogV2.TEAMTYPE_TEAM)
+	relationships := datadogV2.NewTeamHierarchyLinkRelationships(
+		*datadogV2.NewTeamHierarchyLinkTeamRelationship(*parentTeam),
+		*datadogV2.NewTeamHierarchyLinkTeamRelationship(*subTeam),
+	)
+	teamHierarchyLink := datadogV2.NewTeamHierarchyLinkWithDefaults()
+	teamHierarchyLink.SetId(id)
+	teamHierarchyLink.SetRelationships(*relationships)
+	return *teamHierarchyLink
+}
+
+func teamHierarchyLinkJSON(id string, parentTeamID string, subTeamID string) string {
+	return fmt.Sprintf(
+		"{\"id\":%q,\"type\":\"team_hierarchy_links\",\"attributes\":{\"created_at\":\"2026-01-01T00:00:00Z\",\"provisioned_by\":\"user@example.com\"},\"relationships\":{\"parent_team\":{\"data\":{\"id\":%q,\"type\":\"team\"}},\"sub_team\":{\"data\":{\"id\":%q,\"type\":\"team\"}}}}",
+		id,
+		parentTeamID,
+		subTeamID,
+	)
+}

--- a/providers/datadog/team_sync.go
+++ b/providers/datadog/team_sync.go
@@ -1,0 +1,131 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package datadog
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/DataDog/datadog-api-client-go/v2/api/datadog"
+	"github.com/DataDog/datadog-api-client-go/v2/api/datadogV2"
+
+	"github.com/chenrui333/terraformer/terraformutils"
+)
+
+var (
+	// TeamSyncAllowEmptyValues ...
+	TeamSyncAllowEmptyValues = []string{}
+)
+
+// TeamSyncGenerator ...
+type TeamSyncGenerator struct {
+	DatadogService
+}
+
+// InitResources Generate TerraformResources from Datadog API,
+// from each configured team sync source create 1 TerraformResource.
+// Need Team Sync source as ID for terraform resource.
+func (g *TeamSyncGenerator) InitResources() error {
+	datadogClient := g.Args["datadogClient"].(*datadog.APIClient)
+	auth := g.Args["auth"].(context.Context)
+	api := datadogV2.NewTeamsApi(datadogClient)
+
+	resources, filtered, err := g.filteredResources(auth, api)
+	if err != nil {
+		return err
+	}
+	if filtered {
+		g.Resources = resources
+		return nil
+	}
+
+	teamSync, found, err := getTeamSync(auth, api, datadogV2.TEAMSYNCATTRIBUTESSOURCE_GITHUB)
+	if err != nil {
+		return err
+	}
+	if found {
+		resource, err := g.createResource(teamSync)
+		if err != nil {
+			return err
+		}
+		g.Resources = []terraformutils.Resource{resource}
+	}
+	return nil
+}
+
+func (g *TeamSyncGenerator) filteredResources(auth context.Context, api *datadogV2.TeamsApi) ([]terraformutils.Resource, bool, error) {
+	resources := []terraformutils.Resource{}
+	filtered := false
+
+	for _, filter := range g.Filter {
+		if !filter.IsApplicable("team_sync") {
+			continue
+		}
+
+		switch filter.FieldPath {
+		case "id", "source":
+			filtered = true
+			for _, value := range filter.AcceptableValues {
+				teamSync, found, err := getTeamSync(auth, api, datadogV2.TeamSyncAttributesSource(value))
+				if err != nil {
+					return nil, true, err
+				}
+				if !found {
+					continue
+				}
+				resource, err := g.createResource(teamSync)
+				if err != nil {
+					return nil, true, err
+				}
+				resources = append(resources, resource)
+			}
+		}
+	}
+
+	return resources, filtered, nil
+}
+
+func (g *TeamSyncGenerator) createResource(teamSync datadogV2.TeamSyncData) (terraformutils.Resource, error) {
+	attributes := teamSync.GetAttributes()
+	source := string(attributes.GetSource())
+	if source == "" {
+		return terraformutils.Resource{}, fmt.Errorf("team sync missing source")
+	}
+	syncType := string(attributes.GetType())
+	if syncType == "" {
+		return terraformutils.Resource{}, fmt.Errorf("team sync %q missing type", source)
+	}
+
+	return terraformutils.NewResource(
+		source,
+		fmt.Sprintf("team_sync_%s", source),
+		"datadog_team_sync",
+		"datadog",
+		map[string]string{
+			"source": source,
+			"type":   syncType,
+		},
+		TeamSyncAllowEmptyValues,
+		map[string]interface{}{},
+	), nil
+}
+
+func getTeamSync(auth context.Context, api *datadogV2.TeamsApi, source datadogV2.TeamSyncAttributesSource) (datadogV2.TeamSyncData, bool, error) {
+	teamSyncResponse, httpResponse, err := api.GetTeamSync(auth, source)
+	if httpResponse != nil && httpResponse.Body != nil {
+		defer httpResponse.Body.Close()
+	}
+	if err != nil {
+		if httpResponse != nil && httpResponse.StatusCode == http.StatusNotFound {
+			return datadogV2.TeamSyncData{}, false, nil
+		}
+		return datadogV2.TeamSyncData{}, false, err
+	}
+
+	teamSyncData := teamSyncResponse.GetData()
+	if len(teamSyncData) == 0 {
+		return datadogV2.TeamSyncData{}, false, nil
+	}
+	return teamSyncData[0], true, nil
+}

--- a/providers/datadog/team_sync_test.go
+++ b/providers/datadog/team_sync_test.go
@@ -1,0 +1,162 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package datadog
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/DataDog/datadog-api-client-go/v2/api/datadogV2"
+	"github.com/chenrui333/terraformer/terraformutils"
+)
+
+func TestTeamSyncCreateResource(t *testing.T) {
+	attributes := datadogV2.NewTeamSyncAttributes(datadogV2.TEAMSYNCATTRIBUTESSOURCE_GITHUB, datadogV2.TEAMSYNCATTRIBUTESTYPE_LINK)
+	teamSync := datadogV2.NewTeamSyncData(*attributes, datadogV2.TEAMSYNCBULKTYPE_TEAM_SYNC_BULK)
+
+	generator := &TeamSyncGenerator{}
+	resource, err := generator.createResource(*teamSync)
+	if err != nil {
+		t.Fatalf("createResource returned error: %v", err)
+	}
+	if resource.InstanceState.ID != "github" {
+		t.Fatalf("resource ID = %q, want github", resource.InstanceState.ID)
+	}
+	if resource.InstanceState.Attributes["source"] != "github" {
+		t.Fatalf("source = %q, want github", resource.InstanceState.Attributes["source"])
+	}
+	if resource.InstanceState.Attributes["type"] != "link" {
+		t.Fatalf("type = %q, want link", resource.InstanceState.Attributes["type"])
+	}
+	if resource.ResourceName != "tfer--team_sync_github" {
+		t.Fatalf("resource name = %q, want tfer--team_sync_github", resource.ResourceName)
+	}
+}
+
+func TestTeamSyncCreateResourceRequiresSourceAndType(t *testing.T) {
+	generator := &TeamSyncGenerator{}
+	if _, err := generator.createResource(datadogV2.TeamSyncData{}); err == nil {
+		t.Fatal("createResource returned nil error, want missing source error")
+	}
+
+	teamSync := datadogV2.TeamSyncData{
+		Attributes: datadogV2.TeamSyncAttributes{
+			Source: datadogV2.TEAMSYNCATTRIBUTESSOURCE_GITHUB,
+		},
+	}
+	if _, err := generator.createResource(teamSync); err == nil {
+		t.Fatal("createResource returned nil error, want missing type error")
+	}
+}
+
+func TestTeamSyncInitResourcesGetsGitHubSource(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		if r.URL.Path != "/api/v2/team/sync" {
+			http.NotFound(w, r)
+			return
+		}
+		if got := r.URL.Query().Get("filter[source]"); got != "github" {
+			t.Fatalf("filter[source] = %q, want github", got)
+		}
+		_, _ = fmt.Fprint(w, teamSyncResponseJSON(teamSyncJSON("github", "link")))
+	}))
+	defer server.Close()
+
+	generator := newTeamSyncTestGenerator(server, nil)
+	if err := generator.InitResources(); err != nil {
+		t.Fatalf("InitResources returned error: %v", err)
+	}
+	if len(generator.Resources) != 1 {
+		t.Fatalf("expected 1 resource, got %d", len(generator.Resources))
+	}
+	if generator.Resources[0].InstanceState.ID != "github" {
+		t.Fatalf("resource ID = %q, want github", generator.Resources[0].InstanceState.ID)
+	}
+}
+
+func TestTeamSyncInitResourcesSkipsEmptyResponse(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = fmt.Fprint(w, "{\"data\":[]}")
+	}))
+	defer server.Close()
+
+	generator := newTeamSyncTestGenerator(server, nil)
+	if err := generator.InitResources(); err != nil {
+		t.Fatalf("InitResources returned error: %v", err)
+	}
+	if len(generator.Resources) != 0 {
+		t.Fatalf("expected 0 resources, got %d", len(generator.Resources))
+	}
+}
+
+func TestTeamSyncInitResourcesSkipsNotFound(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.NotFound(w, r)
+	}))
+	defer server.Close()
+
+	generator := newTeamSyncTestGenerator(server, nil)
+	if err := generator.InitResources(); err != nil {
+		t.Fatalf("InitResources returned error: %v", err)
+	}
+	if len(generator.Resources) != 0 {
+		t.Fatalf("expected 0 resources, got %d", len(generator.Resources))
+	}
+}
+
+func TestTeamSyncInitResourcesFiltersBySource(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		if got := r.URL.Query().Get("filter[source]"); got != "github" {
+			t.Fatalf("filter[source] = %q, want github", got)
+		}
+		_, _ = fmt.Fprint(w, teamSyncResponseJSON(teamSyncJSON("github", "provision")))
+	}))
+	defer server.Close()
+
+	generator := newTeamSyncTestGenerator(server, []terraformutils.ResourceFilter{
+		{
+			ServiceName:      "team_sync",
+			FieldPath:        "source",
+			AcceptableValues: []string{"github"},
+		},
+	})
+	if err := generator.InitResources(); err != nil {
+		t.Fatalf("InitResources returned error: %v", err)
+	}
+	if len(generator.Resources) != 1 {
+		t.Fatalf("expected 1 resource, got %d", len(generator.Resources))
+	}
+}
+
+func newTeamSyncTestGenerator(server *httptest.Server, filter []terraformutils.ResourceFilter) *TeamSyncGenerator {
+	return &TeamSyncGenerator{
+		DatadogService: DatadogService{
+			Service: terraformutils.Service{
+				Args: map[string]interface{}{
+					"auth":          context.Background(),
+					"datadogClient": newTeamRelationshipTestClient(server),
+				},
+				Filter: filter,
+			},
+		},
+	}
+}
+
+func teamSyncResponseJSON(teamSync string) string {
+	return fmt.Sprintf("{\"data\":[%s]}", teamSync)
+}
+
+func teamSyncJSON(source string, syncType string) string {
+	return fmt.Sprintf(
+		"{\"id\":%q,\"type\":\"team_sync_bulk\",\"attributes\":{\"source\":%q,\"type\":%q,\"frequency\":\"once\",\"sync_membership\":false}}",
+		source,
+		source,
+		syncType,
+	)
+}

--- a/providers/datadog/team_sync_test.go
+++ b/providers/datadog/team_sync_test.go
@@ -53,15 +53,14 @@ func TestTeamSyncCreateResourceRequiresSourceAndType(t *testing.T) {
 }
 
 func TestTeamSyncInitResourcesGetsGitHubSource(t *testing.T) {
+	filterCh := make(chan string, 1)
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		if r.URL.Path != "/api/v2/team/sync" {
 			http.NotFound(w, r)
 			return
 		}
-		if got := r.URL.Query().Get("filter[source]"); got != "github" {
-			t.Fatalf("filter[source] = %q, want github", got)
-		}
+		filterCh <- r.URL.Query().Get("filter[source]")
 		_, _ = fmt.Fprint(w, teamSyncResponseJSON(teamSyncJSON("github", "link")))
 	}))
 	defer server.Close()
@@ -70,6 +69,7 @@ func TestTeamSyncInitResourcesGetsGitHubSource(t *testing.T) {
 	if err := generator.InitResources(); err != nil {
 		t.Fatalf("InitResources returned error: %v", err)
 	}
+	assertObservedQueryValue(t, filterCh, "filter[source]", "github")
 	if len(generator.Resources) != 1 {
 		t.Fatalf("expected 1 resource, got %d", len(generator.Resources))
 	}
@@ -110,11 +110,10 @@ func TestTeamSyncInitResourcesSkipsNotFound(t *testing.T) {
 }
 
 func TestTeamSyncInitResourcesFiltersBySource(t *testing.T) {
+	filterCh := make(chan string, 1)
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
-		if got := r.URL.Query().Get("filter[source]"); got != "github" {
-			t.Fatalf("filter[source] = %q, want github", got)
-		}
+		filterCh <- r.URL.Query().Get("filter[source]")
 		_, _ = fmt.Fprint(w, teamSyncResponseJSON(teamSyncJSON("github", "provision")))
 	}))
 	defer server.Close()
@@ -129,6 +128,7 @@ func TestTeamSyncInitResourcesFiltersBySource(t *testing.T) {
 	if err := generator.InitResources(); err != nil {
 		t.Fatalf("InitResources returned error: %v", err)
 	}
+	assertObservedQueryValue(t, filterCh, "filter[source]", "github")
 	if len(generator.Resources) != 1 {
 		t.Fatalf("expected 1 resource, got %d", len(generator.Resources))
 	}


### PR DESCRIPTION
Summary
- add Datadog import generators for team_connection, team_hierarchy_links, and team_sync
- register the new services, document provider version notes and filters, and wire team references for --connect
- cover list, filtered import, state seeding, and singleton not-found behavior with unit tests

Notes
- team_connection and team_sync require DataDog/datadog provider 4.5.0 or newer.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds Datadog team relationship imports for `team_connection`, `team_hierarchy_links`, and `team_sync`. Registers generators, wires `--connect` refs to `team`, updates docs, and adds tests (including sub-team filter coverage).

- **New Features**
  - New generators: `datadog_team_connection`, `datadog_team_hierarchy_links`, `datadog_team_sync`.
  - Filters: `team_connection` by `id`/`source`, `team_hierarchy_links` by `id`/`parent_team_id`/`sub_team_id`, `team_sync` by `id`/`source`.
  - `--connect` wiring: `team_connection.team.id -> team.id`, `team_hierarchy_links.parent_team_id|sub_team_id -> team.id`.

- **Migration**
  - `datadog_team_connection` and `datadog_team_sync` require `DataDog/datadog` >= 4.5.0.
  - `datadog_team_sync` currently supports the `github` source only.

<sup>Written for commit 49e139125c1682aaf0b51506dd87031b68f985e1. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for Datadog resources: team_connection, team_hierarchy_links, and team_sync.
  * Filtering: team_connection (by source); team_hierarchy_links (by parent_team_id or sub_team_id).
  * team_sync requires Datadog provider >= 4.5.0 and currently supports GitHub as the sync source.

* **Documentation**
  * Updated "Supported Datadog resources" section to include the new resources and filter notes.

* **Tests**
  * Added tests covering resource generation, validation, and filter behaviors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->