### PR TITLE
fix(aws): stop pagination on empty tokens

### DIFF
--- a/providers/aws/api_gatewayv2.go
+++ b/providers/aws/api_gatewayv2.go
@@ -66,7 +66,7 @@ func (g *APIGatewayV2Generator) loadRestApis(svc *apigatewayv2.Client) error {
 	}
 	g.processRestApis(svc, output.Items)
 
-	for output.NextToken != nil {
+	for awsHasMorePages(output.NextToken) {
 		output, err = svc.GetApis(context.TODO(), &apigatewayv2.GetApisInput{
 			NextToken: output.NextToken,
 		})
@@ -114,7 +114,7 @@ func (g *APIGatewayV2Generator) loadStages(svc *apigatewayv2.Client, apiID strin
 	}
 	g.processStages(output.Items, apiID)
 
-	for output.NextToken != nil {
+	for awsHasMorePages(output.NextToken) {
 		output, err = svc.GetStages(context.TODO(), &apigatewayv2.GetStagesInput{
 			ApiId:     aws.String(apiID),
 			NextToken: output.NextToken,
@@ -162,7 +162,7 @@ func (g *APIGatewayV2Generator) loadModels(svc *apigatewayv2.Client, apiID strin
 	}
 	g.processModels(output.Items, apiID)
 
-	for output.NextToken != nil {
+	for awsHasMorePages(output.NextToken) {
 		output, err = svc.GetModels(context.TODO(), &apigatewayv2.GetModelsInput{
 			ApiId:     aws.String(apiID),
 			NextToken: output.NextToken,
@@ -208,7 +208,7 @@ func (g *APIGatewayV2Generator) loadRoutes(svc *apigatewayv2.Client, apiID strin
 	}
 	g.processRoutes(svc, output.Items, apiID)
 
-	for output.NextToken != nil {
+	for awsHasMorePages(output.NextToken) {
 		output, err = svc.GetRoutes(context.TODO(), &apigatewayv2.GetRoutesInput{
 			ApiId:     aws.String(apiID),
 			NextToken: output.NextToken,
@@ -262,7 +262,7 @@ func (g *APIGatewayV2Generator) loadRouteResponses(svc *apigatewayv2.Client, api
 	}
 	g.processRouteResponses(output.Items, apiID, routeID)
 
-	for output.NextToken != nil {
+	for awsHasMorePages(output.NextToken) {
 		output, err = svc.GetRouteResponses(context.TODO(), &apigatewayv2.GetRouteResponsesInput{
 			ApiId:     aws.String(apiID),
 			RouteId:   aws.String(routeID),
@@ -308,7 +308,7 @@ func (g *APIGatewayV2Generator) loadIntegrations(svc *apigatewayv2.Client, apiID
 	}
 	g.processIntegrations(svc, output.Items, apiID)
 
-	for output.NextToken != nil {
+	for awsHasMorePages(output.NextToken) {
 		output, err = svc.GetIntegrations(context.TODO(), &apigatewayv2.GetIntegrationsInput{
 			ApiId:     aws.String(apiID),
 			NextToken: output.NextToken,
@@ -363,7 +363,7 @@ func (g *APIGatewayV2Generator) loadIntegrationResponses(svc *apigatewayv2.Clien
 	}
 	g.processIntegrationResponses(output.Items, apiID, integrationID)
 
-	for output.NextToken != nil {
+	for awsHasMorePages(output.NextToken) {
 		output, err = svc.GetIntegrationResponses(context.TODO(), &apigatewayv2.GetIntegrationResponsesInput{
 			ApiId:         aws.String(apiID),
 			IntegrationId: aws.String(integrationID),
@@ -409,7 +409,7 @@ func (g *APIGatewayV2Generator) loadDeployments(svc *apigatewayv2.Client, apiID 
 	}
 	g.processDeployments(output.Items, apiID)
 
-	for output.NextToken != nil {
+	for awsHasMorePages(output.NextToken) {
 		output, err = svc.GetDeployments(context.TODO(), &apigatewayv2.GetDeploymentsInput{
 			ApiId:     aws.String(apiID),
 			NextToken: output.NextToken,
@@ -452,7 +452,7 @@ func (g *APIGatewayV2Generator) loadAuthorizers(svc *apigatewayv2.Client, apiID 
 	}
 	g.processAuthorizers(output.Items, apiID)
 
-	for output.NextToken != nil {
+	for awsHasMorePages(output.NextToken) {
 		output, err = svc.GetAuthorizers(context.TODO(), &apigatewayv2.GetAuthorizersInput{
 			ApiId:     aws.String(apiID),
 			NextToken: output.NextToken,
@@ -495,7 +495,7 @@ func (g *APIGatewayV2Generator) loadVpcLinks(svc *apigatewayv2.Client) error {
 	}
 	g.processVpcLinks(output.Items)
 
-	for output.NextToken != nil {
+	for awsHasMorePages(output.NextToken) {
 		output, err = svc.GetVpcLinks(context.TODO(), &apigatewayv2.GetVpcLinksInput{
 			NextToken: output.NextToken,
 		})
@@ -531,7 +531,7 @@ func (g *APIGatewayV2Generator) loadDomainNames(svc *apigatewayv2.Client) error 
 	}
 	g.processDomainNames(svc, output.Items)
 
-	for output.NextToken != nil {
+	for awsHasMorePages(output.NextToken) {
 		output, err = svc.GetDomainNames(context.TODO(), &apigatewayv2.GetDomainNamesInput{
 			NextToken: output.NextToken,
 		})
@@ -578,7 +578,7 @@ func (g *APIGatewayV2Generator) loadAPIMappings(svc *apigatewayv2.Client, domain
 	}
 	g.processAPIMappings(output.Items, domainName)
 
-	for output.NextToken != nil {
+	for awsHasMorePages(output.NextToken) {
 		output, err = svc.GetApiMappings(context.TODO(), &apigatewayv2.GetApiMappingsInput{
 			DomainName: aws.String(domainName),
 			NextToken:  output.NextToken,

--- a/providers/aws/cloudwatch.go
+++ b/providers/aws/cloudwatch.go
@@ -85,7 +85,7 @@ func (g *CloudWatchGenerator) createMetricAlarms(cloudwatchSvc *cloudwatch.Clien
 				cloudwatchAllowEmptyValues))
 		}
 		nextToken = output.NextToken
-		if nextToken == nil {
+		if !awsHasMorePages(nextToken) {
 			break
 		}
 	}
@@ -110,7 +110,7 @@ func (g *CloudWatchGenerator) createDashboards(cloudwatchSvc *cloudwatch.Client)
 				cloudwatchAllowEmptyValues))
 		}
 		nextToken = output.NextToken
-		if nextToken == nil {
+		if !awsHasMorePages(nextToken) {
 			break
 		}
 	}
@@ -151,7 +151,7 @@ func (g *CloudWatchGenerator) createEventBuses(eventsSvc *cloudwatchevents.Clien
 			}
 		}
 		nextToken = output.NextToken
-		if nextToken == nil {
+		if !awsHasMorePages(nextToken) {
 			break
 		}
 	}
@@ -228,13 +228,13 @@ func (g *CloudWatchGenerator) createRulesForEventBus(eventsSvc *cloudwatchevents
 						map[string]interface{}{}))
 				}
 				listTargetsNextToken = targetResponse.NextToken
-				if listTargetsNextToken == nil {
+				if !awsHasMorePages(listTargetsNextToken) {
 					break
 				}
 			}
 		}
 		listRulesNextToken = output.NextToken
-		if listRulesNextToken == nil {
+		if !awsHasMorePages(listRulesNextToken) {
 			break
 		}
 	}
@@ -264,7 +264,7 @@ func (g *CloudWatchGenerator) createArchives(eventsSvc *cloudwatchevents.Client)
 				cloudwatchAllowEmptyValues))
 		}
 		nextToken = output.NextToken
-		if nextToken == nil {
+		if !awsHasMorePages(nextToken) {
 			break
 		}
 	}
@@ -293,7 +293,7 @@ func (g *CloudWatchGenerator) createAPIDestinations(eventsSvc *cloudwatchevents.
 				cloudwatchAllowEmptyValues))
 		}
 		nextToken = output.NextToken
-		if nextToken == nil {
+		if !awsHasMorePages(nextToken) {
 			break
 		}
 	}

--- a/providers/aws/config.go
+++ b/providers/aws/config.go
@@ -120,7 +120,7 @@ func (g *ConfigGenerator) addConfigRules(svc *configservice.Client, configuratio
 			))
 		}
 		nextToken = configRules.NextToken
-		if nextToken == nil {
+		if !awsHasMorePages(nextToken) {
 			break
 		}
 	}

--- a/providers/aws/dx.go
+++ b/providers/aws/dx.go
@@ -38,7 +38,7 @@ func (g *DirectConnectGenerator) getDirectConnectGateways(svc *directconnect.Cli
 		}
 
 		// Check if there are more pages
-		if output.NextToken == nil {
+		if !awsHasMorePages(output.NextToken) {
 			break
 		}
 

--- a/providers/aws/ecs.go
+++ b/providers/aws/ecs.go
@@ -249,7 +249,7 @@ func (g *EcsGenerator) addCapacityProvidersForCluster(svc *ecs.Client, cluster *
 			))
 		}
 		nextToken = output.NextToken
-		if nextToken == nil {
+		if !awsHasMorePages(nextToken) {
 			break
 		}
 	}

--- a/providers/aws/eks.go
+++ b/providers/aws/eks.go
@@ -225,7 +225,7 @@ func (g *EksGenerator) getAccessPolicyAssociations(clusterName, principalArn str
 			))
 		}
 		nextToken = page.NextToken
-		if nextToken == nil {
+		if !awsHasMorePages(nextToken) {
 			break
 		}
 	}

--- a/providers/aws/logs.go
+++ b/providers/aws/logs.go
@@ -244,7 +244,7 @@ func (g *LogsGenerator) addResourcePolicies(svc *cloudwatchlogs.Client) error {
 				map[string]interface{}{}))
 		}
 		nextToken = output.NextToken
-		if nextToken == nil {
+		if !awsHasMorePages(nextToken) {
 			break
 		}
 	}
@@ -281,7 +281,7 @@ func (g *LogsGenerator) addAccountPolicies(svc *cloudwatchlogs.Client) error {
 					map[string]interface{}{}))
 			}
 			nextToken = output.NextToken
-			if nextToken == nil {
+			if !awsHasMorePages(nextToken) {
 				break
 			}
 		}
@@ -315,7 +315,7 @@ func (g *LogsGenerator) addQueryDefinitions(svc *cloudwatchlogs.Client) error {
 				map[string]interface{}{}))
 		}
 		nextToken = output.NextToken
-		if nextToken == nil {
+		if !awsHasMorePages(nextToken) {
 			break
 		}
 	}

--- a/providers/aws/organization.go
+++ b/providers/aws/organization.go
@@ -63,7 +63,7 @@ func (g *OrganizationGenerator) traverseNode(svc organizationClient, parentID st
 			))
 		}
 		accountNextToken = accountsForParent.NextToken
-		if !organizationHasMorePages(accountNextToken) {
+		if !awsHasMorePages(accountNextToken) {
 			break
 		}
 	}
@@ -97,7 +97,7 @@ func (g *OrganizationGenerator) traverseNode(svc organizationClient, parentID st
 			}
 		}
 		unitNextToken = unitsForParent.NextToken
-		if !organizationHasMorePages(unitNextToken) {
+		if !awsHasMorePages(unitNextToken) {
 			break
 		}
 	}
@@ -183,13 +183,9 @@ func (g *OrganizationGenerator) addPolicyAttachments(svc organizationClient, pol
 			))
 		}
 		nextToken = targetsForPolicy.NextToken
-		if !organizationHasMorePages(nextToken) {
+		if !awsHasMorePages(nextToken) {
 			break
 		}
 	}
 	return nil
-}
-
-func organizationHasMorePages(nextToken *string) bool {
-	return aws.ToString(nextToken) != ""
 }

--- a/providers/aws/pagination.go
+++ b/providers/aws/pagination.go
@@ -1,0 +1,9 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package aws
+
+import "github.com/aws/aws-sdk-go-v2/aws"
+
+func awsHasMorePages(nextToken *string) bool {
+	return aws.ToString(nextToken) != ""
+}

--- a/providers/aws/pagination_test.go
+++ b/providers/aws/pagination_test.go
@@ -1,0 +1,29 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package aws
+
+import (
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+)
+
+func TestAWSHasMorePages(t *testing.T) {
+	tests := []struct {
+		name      string
+		nextToken *string
+		want      bool
+	}{
+		{name: "nil token"},
+		{name: "empty token", nextToken: aws.String("")},
+		{name: "non-empty token", nextToken: aws.String("next"), want: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := awsHasMorePages(tt.nextToken); got != tt.want {
+				t.Fatalf("awsHasMorePages() = %t, want %t", got, tt.want)
+			}
+		})
+	}
+}

--- a/providers/aws/workspaces.go
+++ b/providers/aws/workspaces.go
@@ -74,7 +74,7 @@ func (g *WorkspacesGenerator) loadWorkspacesIPGroup(svc *workspaces.Client) erro
 				workspacesAllowEmptyValues))
 		}
 		nextToken = response.NextToken
-		if nextToken == nil {
+		if !awsHasMorePages(nextToken) {
 			break
 		}
 	}


### PR DESCRIPTION
## Summary

- Add a shared AWS pagination helper that treats nil and empty NextToken values as exhausted.
- Use it across AWS manual pagination loops in API Gateway v2, CloudWatch, Config, Direct Connect, ECS, EKS, Logs, Organizations, and WorkSpaces.
- Cover nil, empty, and non-empty token behavior with a focused unit test.
