### PR TITLE
fix(providers): handle empty init auth args

### DIFF
--- a/providers/datadog/datadog_provider.go
+++ b/providers/datadog/datadog_provider.go
@@ -32,48 +32,48 @@ func (p *DatadogProvider) Init(args []string) error {
 	appKeyArg := optionalInitArg(args, 1)
 	apiURLArg := optionalInitArg(args, 2)
 	validateArg := optionalInitArg(args, 3)
+	var apiKey, appKey, apiURL string
+	validate := true
 
 	switch {
 	case validateArg != "":
-		validate, validateErr := strconv.ParseBool(validateArg)
+		parsedValidate, validateErr := strconv.ParseBool(validateArg)
 		if validateErr != nil {
 			return fmt.Errorf(`invalid validate arg : %w`, validateErr)
 		}
-		p.validate = validate
+		validate = parsedValidate
 	case os.Getenv("DATADOG_VALIDATE") != "":
-		validate, validateErr := strconv.ParseBool(os.Getenv("DATADOG_VALIDATE"))
+		parsedValidate, validateErr := strconv.ParseBool(os.Getenv("DATADOG_VALIDATE"))
 		if validateErr != nil {
 			return fmt.Errorf(`invalid DATADOG_VALIDATE env var : %w`, validateErr)
 		}
-		p.validate = validate
-	default:
-		p.validate = true
+		validate = parsedValidate
 	}
 
 	if apiKeyArg != "" {
-		p.apiKey = apiKeyArg
+		apiKey = apiKeyArg
 	} else {
-		if apiKey := os.Getenv("DATADOG_API_KEY"); apiKey != "" {
-			p.apiKey = apiKey
-		} else if p.validate {
+		if envAPIKey := os.Getenv("DATADOG_API_KEY"); envAPIKey != "" {
+			apiKey = envAPIKey
+		} else if validate {
 			return errors.New("api-key requirement")
 		}
 	}
 
 	if appKeyArg != "" {
-		p.appKey = appKeyArg
+		appKey = appKeyArg
 	} else {
-		if appKey := os.Getenv("DATADOG_APP_KEY"); appKey != "" {
-			p.appKey = appKey
-		} else if p.validate {
+		if envAppKey := os.Getenv("DATADOG_APP_KEY"); envAppKey != "" {
+			appKey = envAppKey
+		} else if validate {
 			return errors.New("app-key requirement")
 		}
 	}
 
 	if apiURLArg != "" {
-		p.apiURL = apiURLArg
+		apiURL = apiURLArg
 	} else if v := os.Getenv("DATADOG_HOST"); v != "" {
-		p.apiURL = v
+		apiURL = v
 	}
 
 	// Initialize the Datadog V1 API client
@@ -82,20 +82,20 @@ func (p *DatadogProvider) Init(args []string) error {
 		datadog.ContextAPIKeys,
 		map[string]datadog.APIKey{
 			"apiKeyAuth": {
-				Key: p.apiKey,
+				Key: apiKey,
 			},
 			"appKeyAuth": {
-				Key: p.appKey,
+				Key: appKey,
 			},
 		},
 	)
-	if p.apiURL != "" {
-		parsedAPIURL, parseErr := url.Parse(p.apiURL)
+	if apiURL != "" {
+		parsedAPIURL, parseErr := url.Parse(apiURL)
 		if parseErr != nil {
 			return fmt.Errorf(`invalid API Url : %w`, parseErr)
 		}
 		if parsedAPIURL.Host == "" || parsedAPIURL.Scheme == "" {
-			return fmt.Errorf(`missing protocol or host : %v`, p.apiURL)
+			return fmt.Errorf(`missing protocol or host : %v`, apiURL)
 		}
 		// If api url is passed, set and use the api name and protocol on ServerIndex{1}
 		auth = context.WithValue(auth, datadog.ContextServerIndex, 1)
@@ -107,6 +107,10 @@ func (p *DatadogProvider) Init(args []string) error {
 	configV1 := datadog.NewConfiguration()
 	datadogClient := datadog.NewAPIClient(configV1)
 
+	p.apiKey = apiKey
+	p.appKey = appKey
+	p.apiURL = apiURL
+	p.validate = validate
 	p.auth = auth
 	p.datadogClient = datadogClient
 

--- a/providers/datadog/datadog_provider_test.go
+++ b/providers/datadog/datadog_provider_test.go
@@ -22,6 +22,35 @@ func TestDatadogProviderInitHandlesShortArgs(t *testing.T) {
 	}
 }
 
+func TestDatadogProviderInitClearsStaleOptionalState(t *testing.T) {
+	t.Setenv("DATADOG_API_KEY", "")
+	t.Setenv("DATADOG_APP_KEY", "")
+	t.Setenv("DATADOG_HOST", "")
+	t.Setenv("DATADOG_VALIDATE", "false")
+	provider := DatadogProvider{
+		apiKey:   "old-api-key",
+		appKey:   "old-app-key",
+		apiURL:   "https://old.example.com",
+		validate: true,
+	}
+
+	if err := provider.Init([]string{"", "", "", ""}); err != nil {
+		t.Fatalf("expected Init to accept empty args with validation disabled: %v", err)
+	}
+	if provider.apiKey != "" {
+		t.Fatalf("apiKey = %q, want empty", provider.apiKey)
+	}
+	if provider.appKey != "" {
+		t.Fatalf("appKey = %q, want empty", provider.appKey)
+	}
+	if provider.apiURL != "" {
+		t.Fatalf("apiURL = %q, want empty", provider.apiURL)
+	}
+	if provider.validate {
+		t.Fatal("validate = true, want false")
+	}
+}
+
 func TestDatadogProviderInitReturnsCredentialErrorForShortArgs(t *testing.T) {
 	t.Setenv("DATADOG_API_KEY", "")
 	t.Setenv("DATADOG_APP_KEY", "")

--- a/providers/github/github_errors_test.go
+++ b/providers/github/github_errors_test.go
@@ -39,6 +39,51 @@ func TestGithubProviderInitRequiresOwner(t *testing.T) {
 	}
 }
 
+func TestGithubProviderInitUsesEnvTokenForEmptyTokenArg(t *testing.T) {
+	t.Setenv("GITHUB_TOKEN", "env-token")
+	t.Setenv("GITHUB_APP_ID", "")
+	t.Setenv("GITHUB_APP_INSTALLATION_ID", "")
+	t.Setenv("GITHUB_APP_PEM_FILE", "")
+	var provider GithubProvider
+
+	if err := provider.Init([]string{"test-org", "", ""}); err != nil {
+		t.Fatalf("Init returned error: %v", err)
+	}
+	if provider.token != "env-token" {
+		t.Fatalf("token = %q, want env-token", provider.token)
+	}
+	if provider.baseURL != githubDefaultURL {
+		t.Fatalf("baseURL = %q, want %q", provider.baseURL, githubDefaultURL)
+	}
+}
+
+func TestGithubProviderInitClearsStaleOptionalAuthConfig(t *testing.T) {
+	t.Setenv("GITHUB_TOKEN", "env-token")
+	t.Setenv("GITHUB_APP_ID", "")
+	t.Setenv("GITHUB_APP_INSTALLATION_ID", "")
+	t.Setenv("GITHUB_APP_PEM_FILE", "")
+	provider := GithubProvider{
+		token:          "old-token",
+		baseURL:        "https://github.example.com/api/v3/",
+		appID:          123,
+		installationID: 456,
+		pem:            "old-pem",
+	}
+
+	if err := provider.Init([]string{"test-org"}); err != nil {
+		t.Fatalf("Init returned error: %v", err)
+	}
+	if provider.token != "env-token" {
+		t.Fatalf("token = %q, want env-token", provider.token)
+	}
+	if provider.baseURL != githubDefaultURL {
+		t.Fatalf("baseURL = %q, want %q", provider.baseURL, githubDefaultURL)
+	}
+	if provider.appID != 0 || provider.installationID != 0 || provider.pem != "" {
+		t.Fatalf("app auth = (%d, %d, %q), want cleared", provider.appID, provider.installationID, provider.pem)
+	}
+}
+
 func TestGithubServiceCreateClientReturnsAppAuthError(t *testing.T) {
 	service := &GithubService{}
 	service.SetArgs(map[string]interface{}{

--- a/providers/github/github_errors_test.go
+++ b/providers/github/github_errors_test.go
@@ -57,6 +57,22 @@ func TestGithubProviderInitUsesEnvTokenForEmptyTokenArg(t *testing.T) {
 	}
 }
 
+func TestGithubProviderInitReturnsTokenErrorForEmptyTokenArgWithoutEnv(t *testing.T) {
+	t.Setenv("GITHUB_TOKEN", "")
+	t.Setenv("GITHUB_APP_ID", "")
+	t.Setenv("GITHUB_APP_INSTALLATION_ID", "")
+	t.Setenv("GITHUB_APP_PEM_FILE", "")
+	var provider GithubProvider
+
+	err := provider.Init([]string{"test-org", "", ""})
+	if err == nil {
+		t.Fatal("expected missing token error")
+	}
+	if !strings.Contains(err.Error(), "token requirement") {
+		t.Fatalf("Init error = %q, want token requirement", err)
+	}
+}
+
 func TestGithubProviderInitClearsStaleOptionalAuthConfig(t *testing.T) {
 	t.Setenv("GITHUB_TOKEN", "env-token")
 	t.Setenv("GITHUB_APP_ID", "")

--- a/providers/github/github_provider.go
+++ b/providers/github/github_provider.go
@@ -64,39 +64,41 @@ func (p *GithubProvider) Init(args []string) error {
 		return errors.New("github: owner is required")
 	}
 
-	if appIDValue, ok := os.LookupEnv("GITHUB_APP_ID"); ok {
+	p.owner = args[0]
+	p.token = ""
+	p.baseURL = githubDefaultURL
+	p.appID = 0
+	p.installationID = 0
+	p.pem = ""
+
+	if appIDValue := os.Getenv("GITHUB_APP_ID"); appIDValue != "" {
 		appID, err := strconv.ParseInt(appIDValue, 10, 64)
 		if err != nil {
 			return err
 		}
 		p.appID = appID
 	}
-	if installationIDValue, ok := os.LookupEnv("GITHUB_APP_INSTALLATION_ID"); ok {
+	if installationIDValue := os.Getenv("GITHUB_APP_INSTALLATION_ID"); installationIDValue != "" {
 		installationID, err := strconv.ParseInt(installationIDValue, 10, 64)
 		if err != nil {
 			return err
 		}
 		p.installationID = installationID
 	}
-	if pem, ok := os.LookupEnv("GITHUB_APP_PEM_FILE"); ok {
+	if pem := os.Getenv("GITHUB_APP_PEM_FILE"); pem != "" {
 		p.pem = strings.ReplaceAll(pem, `\n`, "\n")
 	}
 
-	p.owner = args[0]
-	if len(args) < 2 {
-		if os.Getenv("GITHUB_TOKEN") == "" {
+	if len(args) > 1 && args[1] != "" {
+		p.token = args[1]
+	} else {
+		if os.Getenv("GITHUB_TOKEN") == "" && len(args) < 2 {
 			return errors.New("token requirement")
 		}
 		p.token = os.Getenv("GITHUB_TOKEN")
-	} else {
-		p.token = args[1]
 	}
-	if len(args) > 2 {
-		if args[2] != "" {
-			p.baseURL = args[2]
-		} else {
-			p.baseURL = githubDefaultURL
-		}
+	if len(args) > 2 && args[2] != "" {
+		p.baseURL = args[2]
 	}
 	return nil
 }

--- a/providers/github/github_provider.go
+++ b/providers/github/github_provider.go
@@ -92,10 +92,11 @@ func (p *GithubProvider) Init(args []string) error {
 	if len(args) > 1 && args[1] != "" {
 		p.token = args[1]
 	} else {
-		if os.Getenv("GITHUB_TOKEN") == "" && len(args) < 2 {
+		token := os.Getenv("GITHUB_TOKEN")
+		if token == "" && (p.appID == 0 || p.installationID == 0 || p.pem == "") {
 			return errors.New("token requirement")
 		}
-		p.token = os.Getenv("GITHUB_TOKEN")
+		p.token = token
 	}
 	if len(args) > 2 && args[2] != "" {
 		p.baseURL = args[2]

--- a/providers/gitlab/gitlab_errors_test.go
+++ b/providers/gitlab/gitlab_errors_test.go
@@ -37,6 +37,39 @@ func TestGitLabProviderInitRequiresGroup(t *testing.T) {
 	}
 }
 
+func TestGitLabProviderInitUsesEnvTokenForEmptyTokenArg(t *testing.T) {
+	t.Setenv("GITLAB_TOKEN", "env-token")
+	var provider GitLabProvider
+
+	if err := provider.Init([]string{"test-group", "", ""}); err != nil {
+		t.Fatalf("Init returned error: %v", err)
+	}
+	if provider.token != "env-token" {
+		t.Fatalf("token = %q, want env-token", provider.token)
+	}
+	if provider.baseURL != gitLabDefaultURL {
+		t.Fatalf("baseURL = %q, want %q", provider.baseURL, gitLabDefaultURL)
+	}
+}
+
+func TestGitLabProviderInitClearsStaleOptionalConfig(t *testing.T) {
+	t.Setenv("GITLAB_TOKEN", "env-token")
+	provider := GitLabProvider{
+		token:   "old-token",
+		baseURL: "https://gitlab.example.com/api/v4/",
+	}
+
+	if err := provider.Init([]string{"test-group"}); err != nil {
+		t.Fatalf("Init returned error: %v", err)
+	}
+	if provider.token != "env-token" {
+		t.Fatalf("token = %q, want env-token", provider.token)
+	}
+	if provider.baseURL != gitLabDefaultURL {
+		t.Fatalf("baseURL = %q, want %q", provider.baseURL, gitLabDefaultURL)
+	}
+}
+
 func TestCreateProjectsReturnsProjectListError(t *testing.T) {
 	ctx := context.Background()
 	client := newErrorGitLabClient(t)

--- a/providers/gitlab/gitlab_errors_test.go
+++ b/providers/gitlab/gitlab_errors_test.go
@@ -52,6 +52,19 @@ func TestGitLabProviderInitUsesEnvTokenForEmptyTokenArg(t *testing.T) {
 	}
 }
 
+func TestGitLabProviderInitReturnsTokenErrorForEmptyTokenArgWithoutEnv(t *testing.T) {
+	t.Setenv("GITLAB_TOKEN", "")
+	var provider GitLabProvider
+
+	err := provider.Init([]string{"test-group", "", ""})
+	if err == nil {
+		t.Fatal("expected missing token error")
+	}
+	if !strings.Contains(err.Error(), "token requirement") {
+		t.Fatalf("Init error = %q, want token requirement", err)
+	}
+}
+
 func TestGitLabProviderInitClearsStaleOptionalConfig(t *testing.T) {
 	t.Setenv("GITLAB_TOKEN", "env-token")
 	provider := GitLabProvider{

--- a/providers/gitlab/gitlab_errors_test.go
+++ b/providers/gitlab/gitlab_errors_test.go
@@ -37,6 +37,28 @@ func TestGitLabProviderInitRequiresGroup(t *testing.T) {
 	}
 }
 
+func TestGitLabProviderInitClearsStaleStateOnMissingGroup(t *testing.T) {
+	provider := GitLabProvider{
+		group:   "old-group",
+		token:   "old-token",
+		baseURL: "https://gitlab.example.com/api/v4/",
+	}
+
+	err := provider.Init(nil)
+	if err == nil {
+		t.Fatal("expected missing group error")
+	}
+	if provider.group != "" {
+		t.Fatalf("group = %q, want empty", provider.group)
+	}
+	if provider.token != "" {
+		t.Fatalf("token = %q, want empty", provider.token)
+	}
+	if provider.baseURL != gitLabDefaultURL {
+		t.Fatalf("baseURL = %q, want %q", provider.baseURL, gitLabDefaultURL)
+	}
+}
+
 func TestGitLabProviderInitUsesEnvTokenForEmptyTokenArg(t *testing.T) {
 	t.Setenv("GITLAB_TOKEN", "env-token")
 	var provider GitLabProvider

--- a/providers/gitlab/gitlab_provider.go
+++ b/providers/gitlab/gitlab_provider.go
@@ -43,13 +43,15 @@ func (p *GitLabProvider) GetConfig() cty.Value {
 
 // Init GitLabProvider with group
 func (p *GitLabProvider) Init(args []string) error {
+	p.group = ""
+	p.token = ""
+	p.baseURL = gitLabDefaultURL
+
 	if len(args) < 1 || args[0] == "" {
 		return errors.New("gitlab: group is required")
 	}
 
 	p.group = args[0]
-	p.token = ""
-	p.baseURL = gitLabDefaultURL
 	if len(args) > 1 && args[1] != "" {
 		p.token = args[1]
 	} else {

--- a/providers/gitlab/gitlab_provider.go
+++ b/providers/gitlab/gitlab_provider.go
@@ -48,19 +48,18 @@ func (p *GitLabProvider) Init(args []string) error {
 	}
 
 	p.group = args[0]
+	p.token = ""
 	p.baseURL = gitLabDefaultURL
-	if len(args) < 2 {
-		if os.Getenv("GITLAB_TOKEN") == "" {
+	if len(args) > 1 && args[1] != "" {
+		p.token = args[1]
+	} else {
+		if os.Getenv("GITLAB_TOKEN") == "" && len(args) < 2 {
 			return errors.New("token requirement")
 		}
 		p.token = os.Getenv("GITLAB_TOKEN")
-	} else {
-		p.token = args[1]
 	}
-	if len(args) > 2 {
-		if args[2] != "" {
-			p.baseURL = args[2]
-		}
+	if len(args) > 2 && args[2] != "" {
+		p.baseURL = args[2]
 	}
 	return nil
 }

--- a/providers/gitlab/gitlab_provider.go
+++ b/providers/gitlab/gitlab_provider.go
@@ -53,10 +53,11 @@ func (p *GitLabProvider) Init(args []string) error {
 	if len(args) > 1 && args[1] != "" {
 		p.token = args[1]
 	} else {
-		if os.Getenv("GITLAB_TOKEN") == "" && len(args) < 2 {
+		token := os.Getenv("GITLAB_TOKEN")
+		if token == "" {
 			return errors.New("token requirement")
 		}
-		p.token = os.Getenv("GITLAB_TOKEN")
+		p.token = token
 	}
 	if len(args) > 2 && args[2] != "" {
 		p.baseURL = args[2]

--- a/providers/newrelic/newrelic_provider.go
+++ b/providers/newrelic/newrelic_provider.go
@@ -21,6 +21,7 @@ type NewRelicProvider struct { //nolint
 func (p *NewRelicProvider) Init(args []string) error {
 	apiKey := os.Getenv("NEW_RELIC_API_KEY")
 	accountID := 0
+	accountIDSet := false
 	region := "US"
 
 	if len(args) > 0 && args[0] != "" {
@@ -32,12 +33,14 @@ func (p *NewRelicProvider) Init(args []string) error {
 			return err
 		}
 		accountID = parsedAccountID
+		accountIDSet = true
 	} else if accountIDs := os.Getenv("NEW_RELIC_ACCOUNT_ID"); accountIDs != "" {
 		parsedAccountID, err := strconv.Atoi(accountIDs)
 		if err != nil {
 			return err
 		}
 		accountID = parsedAccountID
+		accountIDSet = true
 	}
 	if len(args) > 2 && args[2] != "" {
 		region = args[2]
@@ -45,6 +48,12 @@ func (p *NewRelicProvider) Init(args []string) error {
 	p.APIKey = apiKey
 	p.accountID = accountID
 	p.Region = region
+	if !accountIDSet {
+		return errors.New("newrelic: account id is required")
+	}
+	if accountID <= 0 {
+		return errors.New("newrelic: account id must be greater than 0")
+	}
 	return nil
 }
 

--- a/providers/newrelic/newrelic_provider.go
+++ b/providers/newrelic/newrelic_provider.go
@@ -23,18 +23,17 @@ func (p *NewRelicProvider) Init(args []string) error {
 	accountID := 0
 	region := "US"
 
-	if accountIDs := os.Getenv("NEW_RELIC_ACCOUNT_ID"); accountIDs != "" {
-		parsedAccountID, err := strconv.Atoi(accountIDs)
-		if err != nil {
-			return err
-		}
-		accountID = parsedAccountID
-	}
 	if len(args) > 0 && args[0] != "" {
 		apiKey = args[0]
 	}
 	if len(args) > 1 && args[1] != "" {
 		parsedAccountID, err := strconv.Atoi(args[1])
+		if err != nil {
+			return err
+		}
+		accountID = parsedAccountID
+	} else if accountIDs := os.Getenv("NEW_RELIC_ACCOUNT_ID"); accountIDs != "" {
+		parsedAccountID, err := strconv.Atoi(accountIDs)
 		if err != nil {
 			return err
 		}

--- a/providers/newrelic/newrelic_provider.go
+++ b/providers/newrelic/newrelic_provider.go
@@ -19,32 +19,33 @@ type NewRelicProvider struct { //nolint
 }
 
 func (p *NewRelicProvider) Init(args []string) error {
-	if apiKey := os.Getenv("NEW_RELIC_API_KEY"); apiKey != "" {
-		p.APIKey = os.Getenv("NEW_RELIC_API_KEY")
-	}
+	apiKey := os.Getenv("NEW_RELIC_API_KEY")
+	accountID := 0
+	region := "US"
+
 	if accountIDs := os.Getenv("NEW_RELIC_ACCOUNT_ID"); accountIDs != "" {
-		accountID, err := strconv.Atoi(accountIDs)
+		parsedAccountID, err := strconv.Atoi(accountIDs)
 		if err != nil {
 			return err
 		}
-		p.accountID = accountID
+		accountID = parsedAccountID
 	}
-	if len(args) > 0 {
-		p.APIKey = args[0]
+	if len(args) > 0 && args[0] != "" {
+		apiKey = args[0]
 	}
-	if len(args) > 1 {
-		accountID, err := strconv.Atoi(args[1])
+	if len(args) > 1 && args[1] != "" {
+		parsedAccountID, err := strconv.Atoi(args[1])
 		if err != nil {
 			return err
 		}
-		p.accountID = accountID
+		accountID = parsedAccountID
 	}
-	if len(args) > 2 {
-		p.Region = args[2]
+	if len(args) > 2 && args[2] != "" {
+		region = args[2]
 	}
-	if p.Region == "" {
-		p.Region = "US"
-	}
+	p.APIKey = apiKey
+	p.accountID = accountID
+	p.Region = region
 	return nil
 }
 

--- a/providers/newrelic/newrelic_provider_test.go
+++ b/providers/newrelic/newrelic_provider_test.go
@@ -2,7 +2,10 @@
 
 package newrelic
 
-import "testing"
+import (
+	"strings"
+	"testing"
+)
 
 func TestNewRelicProviderInitHandlesMissingRegionArg(t *testing.T) {
 	t.Setenv("NEW_RELIC_API_KEY", "")
@@ -49,7 +52,21 @@ func TestNewRelicProviderInitPrefersArgAccountIDOverInvalidEnv(t *testing.T) {
 	}
 }
 
-func TestNewRelicProviderInitClearsStaleOptionalState(t *testing.T) {
+func TestNewRelicProviderInitRejectsZeroAccountID(t *testing.T) {
+	t.Setenv("NEW_RELIC_API_KEY", "")
+	t.Setenv("NEW_RELIC_ACCOUNT_ID", "")
+
+	var provider NewRelicProvider
+	err := provider.Init([]string{"api-key", "0"})
+	if err == nil {
+		t.Fatal("expected invalid account ID error")
+	}
+	if !strings.Contains(err.Error(), "account id must be greater than 0") {
+		t.Fatalf("Init error = %q, want positive account ID requirement", err)
+	}
+}
+
+func TestNewRelicProviderInitReturnsMissingAccountIDError(t *testing.T) {
 	t.Setenv("NEW_RELIC_API_KEY", "")
 	t.Setenv("NEW_RELIC_ACCOUNT_ID", "")
 	provider := NewRelicProvider{
@@ -58,8 +75,12 @@ func TestNewRelicProviderInitClearsStaleOptionalState(t *testing.T) {
 		Region:    "EU",
 	}
 
-	if err := provider.Init([]string{"", "", ""}); err != nil {
-		t.Fatalf("expected Init to accept empty args: %v", err)
+	err := provider.Init([]string{"", "", ""})
+	if err == nil {
+		t.Fatal("expected missing account ID error")
+	}
+	if !strings.Contains(err.Error(), "account id is required") {
+		t.Fatalf("Init error = %q, want account ID requirement", err)
 	}
 	if provider.APIKey != "" {
 		t.Fatalf("APIKey = %q, want empty", provider.APIKey)

--- a/providers/newrelic/newrelic_provider_test.go
+++ b/providers/newrelic/newrelic_provider_test.go
@@ -16,3 +16,45 @@ func TestNewRelicProviderInitHandlesMissingRegionArg(t *testing.T) {
 		t.Fatalf("Region = %q, want US", provider.Region)
 	}
 }
+
+func TestNewRelicProviderInitUsesEnvForEmptyArgs(t *testing.T) {
+	t.Setenv("NEW_RELIC_API_KEY", "env-key")
+	t.Setenv("NEW_RELIC_ACCOUNT_ID", "123")
+
+	var provider NewRelicProvider
+	if err := provider.Init([]string{"", "", "EU"}); err != nil {
+		t.Fatalf("expected Init to use env values for empty args: %v", err)
+	}
+	if provider.APIKey != "env-key" {
+		t.Fatalf("APIKey = %q, want env-key", provider.APIKey)
+	}
+	if provider.accountID != 123 {
+		t.Fatalf("accountID = %d, want 123", provider.accountID)
+	}
+	if provider.Region != "EU" {
+		t.Fatalf("Region = %q, want EU", provider.Region)
+	}
+}
+
+func TestNewRelicProviderInitClearsStaleOptionalState(t *testing.T) {
+	t.Setenv("NEW_RELIC_API_KEY", "")
+	t.Setenv("NEW_RELIC_ACCOUNT_ID", "")
+	provider := NewRelicProvider{
+		APIKey:    "old-key",
+		accountID: 123,
+		Region:    "EU",
+	}
+
+	if err := provider.Init([]string{"", "", ""}); err != nil {
+		t.Fatalf("expected Init to accept empty args: %v", err)
+	}
+	if provider.APIKey != "" {
+		t.Fatalf("APIKey = %q, want empty", provider.APIKey)
+	}
+	if provider.accountID != 0 {
+		t.Fatalf("accountID = %d, want 0", provider.accountID)
+	}
+	if provider.Region != "US" {
+		t.Fatalf("Region = %q, want US", provider.Region)
+	}
+}

--- a/providers/newrelic/newrelic_provider_test.go
+++ b/providers/newrelic/newrelic_provider_test.go
@@ -36,6 +36,19 @@ func TestNewRelicProviderInitUsesEnvForEmptyArgs(t *testing.T) {
 	}
 }
 
+func TestNewRelicProviderInitPrefersArgAccountIDOverInvalidEnv(t *testing.T) {
+	t.Setenv("NEW_RELIC_API_KEY", "")
+	t.Setenv("NEW_RELIC_ACCOUNT_ID", "not-a-number")
+
+	var provider NewRelicProvider
+	if err := provider.Init([]string{"api-key", "123"}); err != nil {
+		t.Fatalf("expected Init to prefer arg account ID over invalid env: %v", err)
+	}
+	if provider.accountID != 123 {
+		t.Fatalf("accountID = %d, want 123", provider.accountID)
+	}
+}
+
 func TestNewRelicProviderInitClearsStaleOptionalState(t *testing.T) {
 	t.Setenv("NEW_RELIC_API_KEY", "")
 	t.Setenv("NEW_RELIC_ACCOUNT_ID", "")

--- a/providers/opsgenie/opsgenie_provider.go
+++ b/providers/opsgenie/opsgenie_provider.go
@@ -16,13 +16,12 @@ type OpsgenieProvider struct { //nolint
 }
 
 func (p *OpsgenieProvider) Init(args []string) error {
-	if apiKey := os.Getenv("OPSGENIE_API_KEY"); apiKey != "" {
-		p.APIKey = apiKey
-	}
+	apiKey := os.Getenv("OPSGENIE_API_KEY")
 	if len(args) > 0 && args[0] != "" {
-		p.APIKey = args[0]
+		apiKey = args[0]
 	}
-	if p.APIKey == "" {
+	p.APIKey = apiKey
+	if apiKey == "" {
 		return errors.New("required API Key missing")
 	}
 

--- a/providers/opsgenie/opsgenie_provider_test.go
+++ b/providers/opsgenie/opsgenie_provider_test.go
@@ -20,6 +20,19 @@ func TestOpsgenieProviderInitReturnsMissingAPIKeyWithNoArgs(t *testing.T) {
 	}
 }
 
+func TestOpsgenieProviderInitDoesNotReuseStaleAPIKey(t *testing.T) {
+	t.Setenv("OPSGENIE_API_KEY", "")
+	provider := OpsgenieProvider{APIKey: "old-key"}
+
+	err := provider.Init(nil)
+	if err == nil {
+		t.Fatal("expected missing API key error")
+	}
+	if provider.APIKey != "" {
+		t.Fatalf("APIKey = %q, want empty after failed init", provider.APIKey)
+	}
+}
+
 func TestOpsgenieProviderInitUsesEnvAPIKey(t *testing.T) {
 	t.Setenv("OPSGENIE_API_KEY", "env-key")
 	var provider OpsgenieProvider


### PR DESCRIPTION
## Summary

- Treat empty optional auth/config args as absent so GitHub, GitLab, and New Relic can use their documented environment fallbacks.
- Rebuild Datadog, GitHub, GitLab, New Relic, and Opsgenie init state from the current inputs instead of retaining stale credentials or endpoints.
- Add regression coverage for empty-arg env fallback and stale init state.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Treat empty optional auth/config args and empty env vars as absent, and rebuild provider init state on each call. Restores env fallbacks, enforces required inputs, and clears stale credentials across `datadog`, `github`, `gitlab`, `newrelic`, and `opsgenie`.

- **Bug Fixes**
  - Ignore empty args/env; prefer non-empty args; rebuild provider state each init.
  - `github`/`gitlab`: reset state and default base URL when blank; env token fallback; `github` still requires a token unless App auth is complete; `gitlab` now clears init state before validation (including on missing group).
  - `newrelic`: require account ID and it must be > 0; use env for empty args; prefer arg account ID over invalid env; default Region to "US".
  - `datadog`/`opsgenie`: do not reuse old keys; `datadog` validate flag respects arg/env and only enforces keys when validate=true.
  - Added tests for env fallback, ignoring empty values, stale state clearing (including `gitlab` missing group and `opsgenie` failed init), and New Relic account ID validation.

<sup>Written for commit 8640af69c3a594648f81b6bfedb9acfd69d42454. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Init routines across providers no longer retain stale credentials or optional config when reinitialized and now clear prior state on failure.

* **Improvements**
  * Credential, endpoint and validation sourcing now consistently prefer explicit args, then environment, with sensible defaults and clearer validation behavior.
  * Datadog and others better handle custom host/URL inputs and auth context setup.

* **Tests**
  * Added tests verifying env fallbacks, validation errors, and clearing of stale state during Init.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->