### PR TITLE
feat(datadog): add on-call imports

### DIFF
--- a/docs/datadog.md
+++ b/docs/datadog.md
@@ -147,6 +147,24 @@ Tag filters are order specific. For example, if your monitor has tags (in the or
 *   `monitor_notification_rule`
     * `datadog_monitor_notification_rule`
         * **_NOTE:_** Requires DataDog/datadog provider 3.83.0 or newer.
+*   `on_call_escalation_policy`
+    * `datadog_on_call_escalation_policy`
+        * **_NOTE:_** The Datadog API does not expose a list endpoint for On-Call escalation policies; pass IDs explicitly, for example `--filter=on_call_escalation_policy=policy-id`
+*   `on_call_schedule`
+    * `datadog_on_call_schedule`
+        * **_NOTE:_** The Datadog API does not expose a list endpoint for On-Call schedules; pass IDs explicitly, for example `--filter=on_call_schedule=schedule-id`
+*   `on_call_team_routing_rules`
+    * `datadog_on_call_team_routing_rules`
+        * **_NOTE:_** On-Call team routing rules are keyed by Datadog team ID, for example `--filter=on_call_team_routing_rules=team-id`
+*   `on_call_user_notification_channel`
+    * `datadog_on_call_user_notification_channel`
+        * **_NOTE:_** Importing a single On-Call user notification channel by ID requires `user_id,channel_id`, for example `--filter=on_call_user_notification_channel=user-id,channel-id`
+        * **_NOTE:_** To import channels for one user, filter by `user_id`, for example `--filter="Type=on_call_user_notification_channel;Name=user_id;Value=user-id"`
+        * **_NOTE:_** Push notification channels are skipped because the Datadog provider resource supports email and phone channels.
+*   `on_call_user_notification_rule`
+    * `datadog_on_call_user_notification_rule`
+        * **_NOTE:_** Importing a single On-Call user notification rule by ID requires `user_id,rule_id`, for example `--filter=on_call_user_notification_rule=user-id,rule-id`
+        * **_NOTE:_** To import notification rules for one user, filter by `user_id`, for example `--filter="Type=on_call_user_notification_rule;Name=user_id;Value=user-id"`
 *   `rum_application`
     * `datadog_rum_application`
 *   `rum_metric`

--- a/docs/datadog.md
+++ b/docs/datadog.md
@@ -158,12 +158,12 @@ Tag filters are order specific. For example, if your monitor has tags (in the or
         * **_NOTE:_** On-Call team routing rules are keyed by Datadog team ID, for example `--filter=on_call_team_routing_rules=team-id`
 *   `on_call_user_notification_channel`
     * `datadog_on_call_user_notification_channel`
-        * **_NOTE:_** Importing a single On-Call user notification channel by ID requires `user_id,channel_id`, for example `--filter=on_call_user_notification_channel=user-id,channel-id`
+        * **_NOTE:_** Importing a single On-Call user notification channel by ID requires quoting the full `user_id,channel_id` filter value, for example `--filter='"on_call_user_notification_channel=user-id,channel-id"'`
         * **_NOTE:_** To import channels for one user, filter by `user_id`, for example `--filter="Type=on_call_user_notification_channel;Name=user_id;Value=user-id"`
         * **_NOTE:_** Push notification channels are skipped because the Datadog provider resource supports email and phone channels.
 *   `on_call_user_notification_rule`
     * `datadog_on_call_user_notification_rule`
-        * **_NOTE:_** Importing a single On-Call user notification rule by ID requires `user_id,rule_id`, for example `--filter=on_call_user_notification_rule=user-id,rule-id`
+        * **_NOTE:_** Importing a single On-Call user notification rule by ID requires quoting the full `user_id,rule_id` filter value, for example `--filter='"on_call_user_notification_rule=user-id,rule-id"'`
         * **_NOTE:_** To import notification rules for one user, filter by `user_id`, for example `--filter="Type=on_call_user_notification_rule;Name=user_id;Value=user-id"`
 *   `rum_application`
     * `datadog_rum_application`

--- a/docs/datadog.md
+++ b/docs/datadog.md
@@ -158,12 +158,12 @@ Tag filters are order specific. For example, if your monitor has tags (in the or
         * **_NOTE:_** On-Call team routing rules are keyed by Datadog team ID, for example `--filter=on_call_team_routing_rules=team-id`
 *   `on_call_user_notification_channel`
     * `datadog_on_call_user_notification_channel`
-        * **_NOTE:_** Importing a single On-Call user notification channel by ID requires quoting the full `user_id,channel_id` filter value, for example `--filter='"on_call_user_notification_channel=user-id,channel-id"'`
+        * **_NOTE:_** Importing a single On-Call user notification channel by ID requires quoting the `user_id:channel_id` filter value, for example `--filter="on_call_user_notification_channel='user-id:channel-id'"`
         * **_NOTE:_** To import channels for one user, filter by `user_id`, for example `--filter="Type=on_call_user_notification_channel;Name=user_id;Value=user-id"`
         * **_NOTE:_** Push notification channels are skipped because the Datadog provider resource supports email and phone channels.
 *   `on_call_user_notification_rule`
     * `datadog_on_call_user_notification_rule`
-        * **_NOTE:_** Importing a single On-Call user notification rule by ID requires quoting the full `user_id,rule_id` filter value, for example `--filter='"on_call_user_notification_rule=user-id,rule-id"'`
+        * **_NOTE:_** Importing a single On-Call user notification rule by ID requires quoting the `user_id:rule_id` filter value, for example `--filter="on_call_user_notification_rule='user-id:rule-id'"`
         * **_NOTE:_** To import notification rules for one user, filter by `user_id`, for example `--filter="Type=on_call_user_notification_rule;Name=user_id;Value=user-id"`
 *   `rum_application`
     * `datadog_rum_application`

--- a/providers/datadog/datadog_provider.go
+++ b/providers/datadog/datadog_provider.go
@@ -272,6 +272,7 @@ func (p DatadogProvider) GetResourceConnections() map[string]map[string][]string
 			},
 			"team": {
 				"teams", "id",
+				"step.target.team", "id",
 			},
 			"user": {
 				"step.target.user", "id",

--- a/providers/datadog/datadog_provider.go
+++ b/providers/datadog/datadog_provider.go
@@ -192,6 +192,11 @@ func (p *DatadogProvider) GetSupportedService() map[string]terraformutils.Servic
 		"monitor_config_policy":                &MonitorConfigPolicyGenerator{},
 		"monitor_json":                         &MonitorJSONGenerator{},
 		"monitor_notification_rule":            &MonitorNotificationRuleGenerator{},
+		"on_call_escalation_policy":            &OnCallEscalationPolicyGenerator{},
+		"on_call_schedule":                     &OnCallScheduleGenerator{},
+		"on_call_team_routing_rules":           &OnCallTeamRoutingRulesGenerator{},
+		"on_call_user_notification_channel":    &OnCallUserNotificationChannelGenerator{},
+		"on_call_user_notification_rule":       &OnCallUserNotificationRuleGenerator{},
 		"rum_application":                      &RumApplicationGenerator{},
 		"rum_metric":                           &RumMetricGenerator{},
 		"rum_retention_filter":                 &RumRetentionFilterGenerator{},
@@ -259,6 +264,46 @@ func (p DatadogProvider) GetResourceConnections() map[string]map[string][]string
 			},
 			"monitor_json": {
 				"monitor_id", "id",
+			},
+		},
+		"on_call_escalation_policy": {
+			"on_call_schedule": {
+				"step.target.schedule", "id",
+			},
+			"team": {
+				"teams", "id",
+			},
+			"user": {
+				"step.target.user", "id",
+			},
+		},
+		"on_call_schedule": {
+			"team": {
+				"teams", "id",
+			},
+			"user": {
+				"layer.users", "id",
+			},
+		},
+		"on_call_team_routing_rules": {
+			"on_call_escalation_policy": {
+				"rule.escalation_policy", "id",
+			},
+			"team": {
+				"id", "id",
+			},
+		},
+		"on_call_user_notification_channel": {
+			"user": {
+				"user_id", "id",
+			},
+		},
+		"on_call_user_notification_rule": {
+			"on_call_user_notification_channel": {
+				"channel_id", "id",
+			},
+			"user": {
+				"user_id", "id",
 			},
 		},
 		"rum_retention_filter": {

--- a/providers/datadog/on_call_escalation_policy.go
+++ b/providers/datadog/on_call_escalation_policy.go
@@ -1,0 +1,104 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package datadog
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/DataDog/datadog-api-client-go/v2/api/datadog"
+	"github.com/DataDog/datadog-api-client-go/v2/api/datadogV2"
+
+	"github.com/chenrui333/terraformer/terraformutils"
+)
+
+var (
+	// OnCallEscalationPolicyAllowEmptyValues ...
+	OnCallEscalationPolicyAllowEmptyValues = []string{"teams"}
+)
+
+// OnCallEscalationPolicyGenerator ...
+type OnCallEscalationPolicyGenerator struct {
+	DatadogService
+}
+
+func (g *OnCallEscalationPolicyGenerator) createResource(onCallEscalationPolicy datadogV2.EscalationPolicy) (terraformutils.Resource, error) {
+	data := onCallEscalationPolicy.GetData()
+	onCallEscalationPolicyID := data.GetId()
+	if onCallEscalationPolicyID == "" {
+		return terraformutils.Resource{}, fmt.Errorf("On-Call escalation policy missing id")
+	}
+
+	return terraformutils.NewSimpleResource(
+		onCallEscalationPolicyID,
+		fmt.Sprintf("on_call_escalation_policy_%s", onCallEscalationPolicyID),
+		"datadog_on_call_escalation_policy",
+		"datadog",
+		OnCallEscalationPolicyAllowEmptyValues,
+	), nil
+}
+
+// InitResources Generate TerraformResources from Datadog API,
+// from each On-Call escalation policy create 1 TerraformResource.
+// Need On-Call Escalation Policy ID as ID for terraform resource.
+func (g *OnCallEscalationPolicyGenerator) InitResources() error {
+	datadogClient := g.Args["datadogClient"].(*datadog.APIClient)
+	auth := g.Args["auth"].(context.Context)
+	api := datadogV2.NewOnCallApi(datadogClient)
+
+	resources, filtered, err := g.filteredResources(auth, api)
+	if err != nil {
+		return err
+	}
+	if filtered {
+		g.Resources = resources
+		return nil
+	}
+
+	g.Resources = []terraformutils.Resource{}
+	return nil
+}
+
+func (g *OnCallEscalationPolicyGenerator) filteredResources(auth context.Context, api *datadogV2.OnCallApi) ([]terraformutils.Resource, bool, error) {
+	resources := []terraformutils.Resource{}
+	filtered := false
+
+	for _, filter := range g.Filter {
+		if !filter.IsApplicable("on_call_escalation_policy") || filter.FieldPath != "id" {
+			continue
+		}
+
+		filtered = true
+		for _, value := range filter.AcceptableValues {
+			onCallEscalationPolicy, err := getOnCallEscalationPolicy(auth, api, value)
+			if err != nil {
+				return nil, true, err
+			}
+			resource, err := g.createResource(onCallEscalationPolicy)
+			if err != nil {
+				return nil, true, err
+			}
+			resources = append(resources, resource)
+		}
+	}
+
+	return resources, filtered, nil
+}
+
+func getOnCallEscalationPolicy(auth context.Context, api *datadogV2.OnCallApi, policyID string) (datadogV2.EscalationPolicy, error) {
+	include := "steps.targets"
+	onCallEscalationPolicy, httpResp, err := api.GetOnCallEscalationPolicy(auth, policyID, datadogV2.GetOnCallEscalationPolicyOptionalParameters{Include: &include})
+	if httpResp != nil && httpResp.Body != nil {
+		defer httpResp.Body.Close()
+	}
+	if err != nil {
+		return datadogV2.EscalationPolicy{}, err
+	}
+
+	data := onCallEscalationPolicy.GetData()
+	if data.GetId() == "" {
+		data.SetId(policyID)
+		onCallEscalationPolicy.SetData(data)
+	}
+	return onCallEscalationPolicy, nil
+}

--- a/providers/datadog/on_call_helpers.go
+++ b/providers/datadog/on_call_helpers.go
@@ -1,0 +1,74 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package datadog
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/DataDog/datadog-api-client-go/v2/api/datadogV2"
+)
+
+type onCallUserChildImportID struct {
+	userID  string
+	childID string
+}
+
+func parseOnCallUserChildImportIDs(importIDs []string, childName string) ([]onCallUserChildImportID, error) {
+	filterIDs := []onCallUserChildImportID{}
+	for _, importID := range importIDs {
+		userID, childID, err := parseOnCallUserChildImportID(importID, childName)
+		if err != nil {
+			return nil, err
+		}
+		filterIDs = append(filterIDs, onCallUserChildImportID{userID: userID, childID: childID})
+	}
+	return filterIDs, nil
+}
+
+func parseOnCallUserChildImportID(importID string, childName string) (string, string, error) {
+	parts := strings.SplitN(importID, ",", 2)
+	if len(parts) != 2 || parts[0] == "" || parts[1] == "" {
+		return "", "", fmt.Errorf("On-Call user %s import ID %q must be formatted as user_id,%s_id", childName, importID, childName)
+	}
+	return parts[0], parts[1], nil
+}
+
+func onCallUserChildIDs(filterIDs []onCallUserChildImportID) []string {
+	ids := []string{}
+	for _, filterID := range filterIDs {
+		ids = append(ids, filterID.childID)
+	}
+	return ids
+}
+
+func listDatadogUserIDs(auth context.Context, api *datadogV2.UsersApi) ([]string, error) {
+	pageSize := int64(1000)
+	pageNumber := int64(0)
+	remaining := int64(1)
+	optionalParams := datadogV2.NewListUsersOptionalParameters()
+
+	userIDs := []string{}
+	for remaining > 0 {
+		resp, httpResp, err := api.ListUsers(auth, *optionalParams.
+			WithPageSize(pageSize).
+			WithPageNumber(pageNumber))
+		if httpResp != nil && httpResp.Body != nil {
+			_ = httpResp.Body.Close()
+		}
+		if err != nil {
+			return nil, err
+		}
+		for _, user := range resp.GetData() {
+			if userID := user.GetId(); userID != "" {
+				userIDs = append(userIDs, userID)
+			}
+		}
+
+		remaining = resp.Meta.Page.GetTotalCount() - pageSize*(pageNumber+1)
+		pageNumber++
+	}
+
+	return userIDs, nil
+}

--- a/providers/datadog/on_call_helpers.go
+++ b/providers/datadog/on_call_helpers.go
@@ -10,7 +10,7 @@ import (
 	"github.com/DataDog/datadog-api-client-go/v2/api/datadogV2"
 )
 
-const datadogListUsersMaxPageSize = int64(500)
+const datadogListUsersMaxPageSize = int64(100)
 
 type onCallUserChildImportID struct {
 	userID  string

--- a/providers/datadog/on_call_helpers.go
+++ b/providers/datadog/on_call_helpers.go
@@ -40,12 +40,16 @@ func parseOnCallUserChildImportID(importID string, childName string) (string, st
 	return parts[0], parts[1], nil
 }
 
-func onCallUserChildIDs(filterIDs []onCallUserChildImportID) []string {
+func onCallUserChildProviderImportIDs(filterIDs []onCallUserChildImportID) []string {
 	ids := []string{}
 	for _, filterID := range filterIDs {
-		ids = append(ids, filterID.childID)
+		ids = append(ids, onCallUserChildProviderImportID(filterID.userID, filterID.childID))
 	}
 	return ids
+}
+
+func onCallUserChildProviderImportID(userID string, childID string) string {
+	return fmt.Sprintf("%s,%s", userID, childID)
 }
 
 func listDatadogUserIDs(auth context.Context, api *datadogV2.UsersApi) ([]string, error) {

--- a/providers/datadog/on_call_helpers.go
+++ b/providers/datadog/on_call_helpers.go
@@ -10,6 +10,8 @@ import (
 	"github.com/DataDog/datadog-api-client-go/v2/api/datadogV2"
 )
 
+const datadogListUsersMaxPageSize = int64(500)
+
 type onCallUserChildImportID struct {
 	userID  string
 	childID string
@@ -28,9 +30,12 @@ func parseOnCallUserChildImportIDs(importIDs []string, childName string) ([]onCa
 }
 
 func parseOnCallUserChildImportID(importID string, childName string) (string, string, error) {
-	parts := strings.SplitN(importID, ",", 2)
+	parts := strings.SplitN(importID, ":", 2)
+	if len(parts) != 2 {
+		parts = strings.SplitN(importID, ",", 2)
+	}
 	if len(parts) != 2 || parts[0] == "" || parts[1] == "" {
-		return "", "", fmt.Errorf("On-Call user %s import ID %q must be formatted as user_id,%s_id", childName, importID, childName)
+		return "", "", fmt.Errorf("On-Call user %s import ID %q must be formatted as user_id:%s_id or user_id,%s_id", childName, importID, childName, childName)
 	}
 	return parts[0], parts[1], nil
 }
@@ -44,7 +49,7 @@ func onCallUserChildIDs(filterIDs []onCallUserChildImportID) []string {
 }
 
 func listDatadogUserIDs(auth context.Context, api *datadogV2.UsersApi) ([]string, error) {
-	pageSize := int64(1000)
+	pageSize := datadogListUsersMaxPageSize
 	pageNumber := int64(0)
 	remaining := int64(1)
 	optionalParams := datadogV2.NewListUsersOptionalParameters()

--- a/providers/datadog/on_call_helpers.go
+++ b/providers/datadog/on_call_helpers.go
@@ -40,16 +40,12 @@ func parseOnCallUserChildImportID(importID string, childName string) (string, st
 	return parts[0], parts[1], nil
 }
 
-func onCallUserChildProviderImportIDs(filterIDs []onCallUserChildImportID) []string {
+func onCallUserChildIDs(filterIDs []onCallUserChildImportID) []string {
 	ids := []string{}
 	for _, filterID := range filterIDs {
-		ids = append(ids, onCallUserChildProviderImportID(filterID.userID, filterID.childID))
+		ids = append(ids, filterID.childID)
 	}
 	return ids
-}
-
-func onCallUserChildProviderImportID(userID string, childID string) string {
-	return fmt.Sprintf("%s,%s", userID, childID)
 }
 
 func listDatadogUserIDs(auth context.Context, api *datadogV2.UsersApi) ([]string, error) {

--- a/providers/datadog/on_call_schedule.go
+++ b/providers/datadog/on_call_schedule.go
@@ -1,0 +1,104 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package datadog
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/DataDog/datadog-api-client-go/v2/api/datadog"
+	"github.com/DataDog/datadog-api-client-go/v2/api/datadogV2"
+
+	"github.com/chenrui333/terraformer/terraformutils"
+)
+
+var (
+	// OnCallScheduleAllowEmptyValues ...
+	OnCallScheduleAllowEmptyValues = []string{"teams"}
+)
+
+// OnCallScheduleGenerator ...
+type OnCallScheduleGenerator struct {
+	DatadogService
+}
+
+func (g *OnCallScheduleGenerator) createResource(onCallSchedule datadogV2.Schedule) (terraformutils.Resource, error) {
+	data := onCallSchedule.GetData()
+	onCallScheduleID := data.GetId()
+	if onCallScheduleID == "" {
+		return terraformutils.Resource{}, fmt.Errorf("On-Call schedule missing id")
+	}
+
+	return terraformutils.NewSimpleResource(
+		onCallScheduleID,
+		fmt.Sprintf("on_call_schedule_%s", onCallScheduleID),
+		"datadog_on_call_schedule",
+		"datadog",
+		OnCallScheduleAllowEmptyValues,
+	), nil
+}
+
+// InitResources Generate TerraformResources from Datadog API,
+// from each On-Call schedule create 1 TerraformResource.
+// Need On-Call Schedule ID as ID for terraform resource.
+func (g *OnCallScheduleGenerator) InitResources() error {
+	datadogClient := g.Args["datadogClient"].(*datadog.APIClient)
+	auth := g.Args["auth"].(context.Context)
+	api := datadogV2.NewOnCallApi(datadogClient)
+
+	resources, filtered, err := g.filteredResources(auth, api)
+	if err != nil {
+		return err
+	}
+	if filtered {
+		g.Resources = resources
+		return nil
+	}
+
+	g.Resources = []terraformutils.Resource{}
+	return nil
+}
+
+func (g *OnCallScheduleGenerator) filteredResources(auth context.Context, api *datadogV2.OnCallApi) ([]terraformutils.Resource, bool, error) {
+	resources := []terraformutils.Resource{}
+	filtered := false
+
+	for _, filter := range g.Filter {
+		if !filter.IsApplicable("on_call_schedule") || filter.FieldPath != "id" {
+			continue
+		}
+
+		filtered = true
+		for _, value := range filter.AcceptableValues {
+			onCallSchedule, err := getOnCallSchedule(auth, api, value)
+			if err != nil {
+				return nil, true, err
+			}
+			resource, err := g.createResource(onCallSchedule)
+			if err != nil {
+				return nil, true, err
+			}
+			resources = append(resources, resource)
+		}
+	}
+
+	return resources, filtered, nil
+}
+
+func getOnCallSchedule(auth context.Context, api *datadogV2.OnCallApi, scheduleID string) (datadogV2.Schedule, error) {
+	include := "layers,layers.members.user"
+	onCallSchedule, httpResp, err := api.GetOnCallSchedule(auth, scheduleID, datadogV2.GetOnCallScheduleOptionalParameters{Include: &include})
+	if httpResp != nil && httpResp.Body != nil {
+		defer httpResp.Body.Close()
+	}
+	if err != nil {
+		return datadogV2.Schedule{}, err
+	}
+
+	data := onCallSchedule.GetData()
+	if data.GetId() == "" {
+		data.SetId(scheduleID)
+		onCallSchedule.SetData(data)
+	}
+	return onCallSchedule, nil
+}

--- a/providers/datadog/on_call_team_routing_rules.go
+++ b/providers/datadog/on_call_team_routing_rules.go
@@ -95,6 +95,9 @@ func (g *OnCallTeamRoutingRulesGenerator) filteredResources(auth context.Context
 		for _, value := range filter.AcceptableValues {
 			teamRoutingRules, err := getOnCallTeamRoutingRules(auth, api, value)
 			if err != nil {
+				if errors.Is(err, errOnCallTeamRoutingRulesNotFound) {
+					continue
+				}
 				return nil, true, err
 			}
 			resource, err := g.createResource(teamRoutingRules)

--- a/providers/datadog/on_call_team_routing_rules.go
+++ b/providers/datadog/on_call_team_routing_rules.go
@@ -1,0 +1,130 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package datadog
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+
+	"github.com/DataDog/datadog-api-client-go/v2/api/datadog"
+	"github.com/DataDog/datadog-api-client-go/v2/api/datadogV2"
+
+	"github.com/chenrui333/terraformer/terraformutils"
+)
+
+var (
+	// OnCallTeamRoutingRulesAllowEmptyValues ...
+	OnCallTeamRoutingRulesAllowEmptyValues = []string{"rule.query"}
+	errOnCallTeamRoutingRulesNotFound      = errors.New("On-Call team routing rules not found")
+)
+
+// OnCallTeamRoutingRulesGenerator ...
+type OnCallTeamRoutingRulesGenerator struct {
+	DatadogService
+}
+
+func (g *OnCallTeamRoutingRulesGenerator) createResource(teamRoutingRules datadogV2.TeamRoutingRules) (terraformutils.Resource, error) {
+	data := teamRoutingRules.GetData()
+	teamID := data.GetId()
+	if teamID == "" {
+		return terraformutils.Resource{}, fmt.Errorf("On-Call team routing rules missing team id")
+	}
+
+	return terraformutils.NewSimpleResource(
+		teamID,
+		fmt.Sprintf("on_call_team_routing_rules_%s", teamID),
+		"datadog_on_call_team_routing_rules",
+		"datadog",
+		OnCallTeamRoutingRulesAllowEmptyValues,
+	), nil
+}
+
+// InitResources Generate TerraformResources from Datadog API,
+// from each team's On-Call routing rules create 1 TerraformResource.
+// Need Team ID as ID for terraform resource.
+func (g *OnCallTeamRoutingRulesGenerator) InitResources() error {
+	datadogClient := g.Args["datadogClient"].(*datadog.APIClient)
+	auth := g.Args["auth"].(context.Context)
+	onCallAPI := datadogV2.NewOnCallApi(datadogClient)
+	teamAPI := datadogV2.NewTeamsApi(datadogClient)
+
+	resources, filtered, err := g.filteredResources(auth, onCallAPI)
+	if err != nil {
+		return err
+	}
+	if filtered {
+		g.Resources = resources
+		return nil
+	}
+
+	teams, err := listTeams(auth, teamAPI)
+	if err != nil {
+		return err
+	}
+	for _, team := range teams {
+		teamRoutingRules, err := getOnCallTeamRoutingRules(auth, onCallAPI, team.GetId())
+		if err != nil {
+			if errors.Is(err, errOnCallTeamRoutingRulesNotFound) {
+				continue
+			}
+			return err
+		}
+		resource, err := g.createResource(teamRoutingRules)
+		if err != nil {
+			return err
+		}
+		resources = append(resources, resource)
+	}
+
+	g.Resources = resources
+	return nil
+}
+
+func (g *OnCallTeamRoutingRulesGenerator) filteredResources(auth context.Context, api *datadogV2.OnCallApi) ([]terraformutils.Resource, bool, error) {
+	resources := []terraformutils.Resource{}
+	filtered := false
+
+	for _, filter := range g.Filter {
+		if !filter.IsApplicable("on_call_team_routing_rules") || filter.FieldPath != "id" {
+			continue
+		}
+
+		filtered = true
+		for _, value := range filter.AcceptableValues {
+			teamRoutingRules, err := getOnCallTeamRoutingRules(auth, api, value)
+			if err != nil {
+				return nil, true, err
+			}
+			resource, err := g.createResource(teamRoutingRules)
+			if err != nil {
+				return nil, true, err
+			}
+			resources = append(resources, resource)
+		}
+	}
+
+	return resources, filtered, nil
+}
+
+func getOnCallTeamRoutingRules(auth context.Context, api *datadogV2.OnCallApi, teamID string) (datadogV2.TeamRoutingRules, error) {
+	include := "rules"
+	teamRoutingRules, httpResp, err := api.GetOnCallTeamRoutingRules(auth, teamID, datadogV2.GetOnCallTeamRoutingRulesOptionalParameters{Include: &include})
+	if httpResp != nil && httpResp.Body != nil {
+		defer httpResp.Body.Close()
+	}
+	if err != nil {
+		if httpResp != nil && httpResp.StatusCode == http.StatusNotFound {
+			return datadogV2.TeamRoutingRules{}, errOnCallTeamRoutingRulesNotFound
+		}
+		return datadogV2.TeamRoutingRules{}, err
+	}
+
+	data := teamRoutingRules.GetData()
+	if data.GetId() == "" {
+		data.SetId(teamID)
+		teamRoutingRules.SetData(data)
+	}
+	return teamRoutingRules, nil
+}

--- a/providers/datadog/on_call_test.go
+++ b/providers/datadog/on_call_test.go
@@ -50,8 +50,8 @@ func TestOnCallCreateResources(t *testing.T) {
 	if skipped {
 		t.Fatal("createResource skipped email notification channel")
 	}
-	if channelResource.InstanceState.ID != "channel-1" {
-		t.Fatalf("notification channel resource ID = %q, want channel-1", channelResource.InstanceState.ID)
+	if channelResource.InstanceState.ID != "user-1,channel-1" {
+		t.Fatalf("notification channel resource ID = %q, want user-1,channel-1", channelResource.InstanceState.ID)
 	}
 	if channelResource.InstanceState.Attributes["user_id"] != "user-1" {
 		t.Fatalf("notification channel user_id = %q, want user-1", channelResource.InstanceState.Attributes["user_id"])
@@ -69,8 +69,8 @@ func TestOnCallCreateResources(t *testing.T) {
 	if err != nil {
 		t.Fatalf("createResource notification rule returned error: %v", err)
 	}
-	if ruleResource.InstanceState.ID != "rule-1" {
-		t.Fatalf("notification rule resource ID = %q, want rule-1", ruleResource.InstanceState.ID)
+	if ruleResource.InstanceState.ID != "user-1,rule-1" {
+		t.Fatalf("notification rule resource ID = %q, want user-1,rule-1", ruleResource.InstanceState.ID)
 	}
 	if ruleResource.InstanceState.Attributes["user_id"] != "user-1" {
 		t.Fatalf("notification rule user_id = %q, want user-1", ruleResource.InstanceState.Attributes["user_id"])
@@ -333,8 +333,39 @@ func TestOnCallUserNotificationChannelInitResourcesFiltersByUserID(t *testing.T)
 	if len(generator.Resources) != 1 {
 		t.Fatalf("expected 1 resource, got %d", len(generator.Resources))
 	}
-	if generator.Resources[0].InstanceState.ID != "channel-1" {
-		t.Fatalf("resource ID = %q, want channel-1", generator.Resources[0].InstanceState.ID)
+	if generator.Resources[0].InstanceState.ID != "user-1,channel-1" {
+		t.Fatalf("resource ID = %q, want user-1,channel-1", generator.Resources[0].InstanceState.ID)
+	}
+}
+
+func TestOnCallUserNotificationChannelInitResourcesFiltersByID(t *testing.T) {
+	pathCh := make(chan string, 1)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		pathCh <- r.URL.Path
+		_, _ = fmt.Fprint(w, fmt.Sprintf("{\"data\":%s}", onCallEmailNotificationChannelJSON("channel-1")))
+	}))
+	defer server.Close()
+
+	generator := newOnCallUserNotificationChannelTestGenerator(server, []terraformutils.ResourceFilter{
+		{
+			ServiceName:      "on_call_user_notification_channel",
+			FieldPath:        "id",
+			AcceptableValues: []string{"user-1:channel-1"},
+		},
+	})
+	if err := generator.InitResources(); err != nil {
+		t.Fatalf("InitResources returned error: %v", err)
+	}
+	assertObservedQueryValue(t, pathCh, "path", "/api/v2/on-call/users/user-1/notification-channels/channel-1")
+	if len(generator.Resources) != 1 {
+		t.Fatalf("expected 1 resource, got %d", len(generator.Resources))
+	}
+	if generator.Resources[0].InstanceState.ID != "user-1,channel-1" {
+		t.Fatalf("resource ID = %q, want user-1,channel-1", generator.Resources[0].InstanceState.ID)
+	}
+	if generator.Filter[0].AcceptableValues[0] != "user-1,channel-1" {
+		t.Fatalf("rewritten id filter = %v, want [user-1,channel-1]", generator.Filter[0].AcceptableValues)
 	}
 }
 
@@ -361,8 +392,11 @@ func TestOnCallUserNotificationRuleInitResourcesFiltersByID(t *testing.T) {
 	if len(generator.Resources) != 1 {
 		t.Fatalf("expected 1 resource, got %d", len(generator.Resources))
 	}
-	if generator.Filter[0].AcceptableValues[0] != "rule-1" {
-		t.Fatalf("rewritten id filter = %v, want [rule-1]", generator.Filter[0].AcceptableValues)
+	if generator.Resources[0].InstanceState.ID != "user-1,rule-1" {
+		t.Fatalf("resource ID = %q, want user-1,rule-1", generator.Resources[0].InstanceState.ID)
+	}
+	if generator.Filter[0].AcceptableValues[0] != "user-1,rule-1" {
+		t.Fatalf("rewritten id filter = %v, want [user-1,rule-1]", generator.Filter[0].AcceptableValues)
 	}
 }
 

--- a/providers/datadog/on_call_test.go
+++ b/providers/datadog/on_call_test.go
@@ -1,0 +1,364 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package datadog
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/DataDog/datadog-api-client-go/v2/api/datadog"
+	"github.com/DataDog/datadog-api-client-go/v2/api/datadogV2"
+	"github.com/chenrui333/terraformer/terraformutils"
+)
+
+func TestOnCallCreateResources(t *testing.T) {
+	policyResource, err := (&OnCallEscalationPolicyGenerator{}).createResource(onCallEscalationPolicy(t, "policy-1"))
+	if err != nil {
+		t.Fatalf("createResource escalation policy returned error: %v", err)
+	}
+	if policyResource.InstanceState.ID != "policy-1" {
+		t.Fatalf("policy resource ID = %q, want policy-1", policyResource.InstanceState.ID)
+	}
+	if policyResource.InstanceInfo.Type != "datadog_on_call_escalation_policy" {
+		t.Fatalf("policy resource type = %q, want datadog_on_call_escalation_policy", policyResource.InstanceInfo.Type)
+	}
+
+	scheduleResource, err := (&OnCallScheduleGenerator{}).createResource(onCallSchedule(t, "schedule-1"))
+	if err != nil {
+		t.Fatalf("createResource schedule returned error: %v", err)
+	}
+	if scheduleResource.InstanceState.ID != "schedule-1" {
+		t.Fatalf("schedule resource ID = %q, want schedule-1", scheduleResource.InstanceState.ID)
+	}
+
+	routingResource, err := (&OnCallTeamRoutingRulesGenerator{}).createResource(onCallTeamRoutingRules(t, "team-1"))
+	if err != nil {
+		t.Fatalf("createResource routing rules returned error: %v", err)
+	}
+	if routingResource.InstanceState.ID != "team-1" {
+		t.Fatalf("routing rules resource ID = %q, want team-1", routingResource.InstanceState.ID)
+	}
+
+	channelResource, skipped, err := (&OnCallUserNotificationChannelGenerator{}).createResource("user-1", onCallNotificationChannel(t, onCallEmailNotificationChannelJSON("channel-1")))
+	if err != nil {
+		t.Fatalf("createResource notification channel returned error: %v", err)
+	}
+	if skipped {
+		t.Fatal("createResource skipped email notification channel")
+	}
+	if channelResource.InstanceState.ID != "channel-1" {
+		t.Fatalf("notification channel resource ID = %q, want channel-1", channelResource.InstanceState.ID)
+	}
+	if channelResource.InstanceState.Attributes["user_id"] != "user-1" {
+		t.Fatalf("notification channel user_id = %q, want user-1", channelResource.InstanceState.Attributes["user_id"])
+	}
+
+	_, skipped, err = (&OnCallUserNotificationChannelGenerator{}).createResource("user-1", onCallNotificationChannel(t, onCallPushNotificationChannelJSON("push-1")))
+	if err != nil {
+		t.Fatalf("createResource push notification channel returned error: %v", err)
+	}
+	if !skipped {
+		t.Fatal("createResource did not skip push notification channel")
+	}
+
+	ruleResource, err := (&OnCallUserNotificationRuleGenerator{}).createResource("user-1", onCallNotificationRule(t, onCallNotificationRuleJSON("rule-1", "channel-1")))
+	if err != nil {
+		t.Fatalf("createResource notification rule returned error: %v", err)
+	}
+	if ruleResource.InstanceState.ID != "rule-1" {
+		t.Fatalf("notification rule resource ID = %q, want rule-1", ruleResource.InstanceState.ID)
+	}
+	if ruleResource.InstanceState.Attributes["user_id"] != "user-1" {
+		t.Fatalf("notification rule user_id = %q, want user-1", ruleResource.InstanceState.Attributes["user_id"])
+	}
+}
+
+func TestOnCallEscalationPolicyInitResourcesFiltersByID(t *testing.T) {
+	pathCh := make(chan string, 1)
+	includeCh := make(chan string, 1)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		pathCh <- r.URL.Path
+		includeCh <- r.URL.Query().Get("include")
+		_, _ = fmt.Fprint(w, onCallEscalationPolicyResponseJSON("policy-1"))
+	}))
+	defer server.Close()
+
+	generator := newOnCallEscalationPolicyTestGenerator(server, []terraformutils.ResourceFilter{
+		{
+			ServiceName:      "on_call_escalation_policy",
+			FieldPath:        "id",
+			AcceptableValues: []string{"policy-1"},
+		},
+	})
+	if err := generator.InitResources(); err != nil {
+		t.Fatalf("InitResources returned error: %v", err)
+	}
+	assertObservedQueryValue(t, pathCh, "path", "/api/v2/on-call/escalation-policies/policy-1")
+	assertObservedQueryValue(t, includeCh, "include", "steps.targets")
+	if len(generator.Resources) != 1 {
+		t.Fatalf("expected 1 resource, got %d", len(generator.Resources))
+	}
+}
+
+func TestOnCallScheduleInitResourcesFiltersByID(t *testing.T) {
+	pathCh := make(chan string, 1)
+	includeCh := make(chan string, 1)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		pathCh <- r.URL.Path
+		includeCh <- r.URL.Query().Get("include")
+		_, _ = fmt.Fprint(w, onCallScheduleResponseJSON("schedule-1"))
+	}))
+	defer server.Close()
+
+	generator := newOnCallScheduleTestGenerator(server, []terraformutils.ResourceFilter{
+		{
+			ServiceName:      "on_call_schedule",
+			FieldPath:        "id",
+			AcceptableValues: []string{"schedule-1"},
+		},
+	})
+	if err := generator.InitResources(); err != nil {
+		t.Fatalf("InitResources returned error: %v", err)
+	}
+	assertObservedQueryValue(t, pathCh, "path", "/api/v2/on-call/schedules/schedule-1")
+	assertObservedQueryValue(t, includeCh, "include", "layers,layers.members.user")
+	if len(generator.Resources) != 1 {
+		t.Fatalf("expected 1 resource, got %d", len(generator.Resources))
+	}
+}
+
+func TestOnCallTeamRoutingRulesInitResourcesFiltersByID(t *testing.T) {
+	pathCh := make(chan string, 1)
+	includeCh := make(chan string, 1)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		pathCh <- r.URL.Path
+		includeCh <- r.URL.Query().Get("include")
+		_, _ = fmt.Fprint(w, onCallTeamRoutingRulesResponseJSON("team-1"))
+	}))
+	defer server.Close()
+
+	generator := newOnCallTeamRoutingRulesTestGenerator(server, []terraformutils.ResourceFilter{
+		{
+			ServiceName:      "on_call_team_routing_rules",
+			FieldPath:        "id",
+			AcceptableValues: []string{"team-1"},
+		},
+	})
+	if err := generator.InitResources(); err != nil {
+		t.Fatalf("InitResources returned error: %v", err)
+	}
+	assertObservedQueryValue(t, pathCh, "path", "/api/v2/on-call/teams/team-1/routing-rules")
+	assertObservedQueryValue(t, includeCh, "include", "rules")
+	if len(generator.Resources) != 1 {
+		t.Fatalf("expected 1 resource, got %d", len(generator.Resources))
+	}
+}
+
+func TestOnCallUserNotificationChannelInitResourcesFiltersByUserID(t *testing.T) {
+	pathCh := make(chan string, 1)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		pathCh <- r.URL.Path
+		_, _ = fmt.Fprint(w, onCallNotificationChannelListResponseJSON(
+			onCallEmailNotificationChannelJSON("channel-1"),
+			onCallPushNotificationChannelJSON("push-1"),
+		))
+	}))
+	defer server.Close()
+
+	generator := newOnCallUserNotificationChannelTestGenerator(server, []terraformutils.ResourceFilter{
+		{
+			ServiceName:      "on_call_user_notification_channel",
+			FieldPath:        "user_id",
+			AcceptableValues: []string{"user-1"},
+		},
+	})
+	if err := generator.InitResources(); err != nil {
+		t.Fatalf("InitResources returned error: %v", err)
+	}
+	assertObservedQueryValue(t, pathCh, "path", "/api/v2/on-call/users/user-1/notification-channels")
+	if len(generator.Resources) != 1 {
+		t.Fatalf("expected 1 resource, got %d", len(generator.Resources))
+	}
+	if generator.Resources[0].InstanceState.ID != "channel-1" {
+		t.Fatalf("resource ID = %q, want channel-1", generator.Resources[0].InstanceState.ID)
+	}
+}
+
+func TestOnCallUserNotificationRuleInitResourcesFiltersByID(t *testing.T) {
+	pathCh := make(chan string, 1)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		pathCh <- r.URL.Path
+		_, _ = fmt.Fprint(w, onCallNotificationRuleResponseJSON("rule-1", "channel-1"))
+	}))
+	defer server.Close()
+
+	generator := newOnCallUserNotificationRuleTestGenerator(server, []terraformutils.ResourceFilter{
+		{
+			ServiceName:      "on_call_user_notification_rule",
+			FieldPath:        "id",
+			AcceptableValues: []string{"user-1,rule-1"},
+		},
+	})
+	if err := generator.InitResources(); err != nil {
+		t.Fatalf("InitResources returned error: %v", err)
+	}
+	assertObservedQueryValue(t, pathCh, "path", "/api/v2/on-call/users/user-1/notification-rules/rule-1")
+	if len(generator.Resources) != 1 {
+		t.Fatalf("expected 1 resource, got %d", len(generator.Resources))
+	}
+	if generator.Filter[0].AcceptableValues[0] != "rule-1" {
+		t.Fatalf("rewritten id filter = %v, want [rule-1]", generator.Filter[0].AcceptableValues)
+	}
+}
+
+func TestDatadogProviderOnCallConnections(t *testing.T) {
+	connections := DatadogProvider{}.GetResourceConnections()
+
+	assertDatadogConnection(t, connections, "on_call_schedule", "team", "teams", "id")
+	assertDatadogConnection(t, connections, "on_call_schedule", "user", "layer.users", "id")
+	assertDatadogConnection(t, connections, "on_call_team_routing_rules", "team", "id", "id")
+	assertDatadogConnection(t, connections, "on_call_team_routing_rules", "on_call_escalation_policy", "rule.escalation_policy", "id")
+	assertDatadogConnection(t, connections, "on_call_user_notification_channel", "user", "user_id", "id")
+	assertDatadogConnection(t, connections, "on_call_user_notification_rule", "on_call_user_notification_channel", "channel_id", "id")
+	assertDatadogConnection(t, connections, "on_call_user_notification_rule", "user", "user_id", "id")
+	assertDatadogConnection(t, connections, "on_call_escalation_policy", "team", "teams", "id")
+	assertDatadogConnection(t, connections, "on_call_escalation_policy", "user", "step.target.user", "id")
+	assertDatadogConnectionPairs(
+		t,
+		connections,
+		"on_call_escalation_policy",
+		"on_call_schedule",
+		[]string{"step.target.schedule", "id"},
+	)
+}
+
+func newOnCallEscalationPolicyTestGenerator(server *httptest.Server, filter []terraformutils.ResourceFilter) *OnCallEscalationPolicyGenerator {
+	return &OnCallEscalationPolicyGenerator{DatadogService: newOnCallTestService(server, filter)}
+}
+
+func newOnCallScheduleTestGenerator(server *httptest.Server, filter []terraformutils.ResourceFilter) *OnCallScheduleGenerator {
+	return &OnCallScheduleGenerator{DatadogService: newOnCallTestService(server, filter)}
+}
+
+func newOnCallTeamRoutingRulesTestGenerator(server *httptest.Server, filter []terraformutils.ResourceFilter) *OnCallTeamRoutingRulesGenerator {
+	return &OnCallTeamRoutingRulesGenerator{DatadogService: newOnCallTestService(server, filter)}
+}
+
+func newOnCallUserNotificationChannelTestGenerator(server *httptest.Server, filter []terraformutils.ResourceFilter) *OnCallUserNotificationChannelGenerator {
+	return &OnCallUserNotificationChannelGenerator{DatadogService: newOnCallTestService(server, filter)}
+}
+
+func newOnCallUserNotificationRuleTestGenerator(server *httptest.Server, filter []terraformutils.ResourceFilter) *OnCallUserNotificationRuleGenerator {
+	return &OnCallUserNotificationRuleGenerator{DatadogService: newOnCallTestService(server, filter)}
+}
+
+func newOnCallTestService(server *httptest.Server, filter []terraformutils.ResourceFilter) DatadogService {
+	return DatadogService{
+		Service: terraformutils.Service{
+			Args: map[string]interface{}{
+				"auth":          context.Background(),
+				"datadogClient": newTeamRelationshipTestClient(server),
+			},
+			Filter: filter,
+		},
+	}
+}
+
+func onCallEscalationPolicy(t *testing.T, id string) datadogV2.EscalationPolicy {
+	t.Helper()
+
+	var response datadogV2.EscalationPolicy
+	mustUnmarshalDatadog(t, onCallEscalationPolicyResponseJSON(id), &response)
+	return response
+}
+
+func onCallSchedule(t *testing.T, id string) datadogV2.Schedule {
+	t.Helper()
+
+	var response datadogV2.Schedule
+	mustUnmarshalDatadog(t, onCallScheduleResponseJSON(id), &response)
+	return response
+}
+
+func onCallTeamRoutingRules(t *testing.T, id string) datadogV2.TeamRoutingRules {
+	t.Helper()
+
+	var response datadogV2.TeamRoutingRules
+	mustUnmarshalDatadog(t, onCallTeamRoutingRulesResponseJSON(id), &response)
+	return response
+}
+
+func onCallNotificationChannel(t *testing.T, rawData string) datadogV2.NotificationChannelData {
+	t.Helper()
+
+	var response datadogV2.NotificationChannel
+	mustUnmarshalDatadog(t, fmt.Sprintf("{\"data\":%s}", rawData), &response)
+	return response.GetData()
+}
+
+func onCallNotificationRule(t *testing.T, rawData string) datadogV2.OnCallNotificationRuleData {
+	t.Helper()
+
+	var response datadogV2.OnCallNotificationRule
+	mustUnmarshalDatadog(t, fmt.Sprintf("{\"data\":%s}", rawData), &response)
+	return response.GetData()
+}
+
+func mustUnmarshalDatadog(t *testing.T, raw string, target interface{}) {
+	t.Helper()
+
+	if err := datadog.Unmarshal([]byte(raw), target); err != nil {
+		t.Fatalf("failed to unmarshal Datadog response: %v", err)
+	}
+}
+
+func onCallEscalationPolicyResponseJSON(id string) string {
+	return fmt.Sprintf("{\"data\":{\"id\":%q,\"type\":\"policies\"}}", id)
+}
+
+func onCallScheduleResponseJSON(id string) string {
+	return fmt.Sprintf("{\"data\":{\"id\":%q,\"type\":\"schedules\"}}", id)
+}
+
+func onCallTeamRoutingRulesResponseJSON(id string) string {
+	return fmt.Sprintf("{\"data\":{\"id\":%q,\"type\":\"team_routing_rules\"}}", id)
+}
+
+func onCallNotificationChannelListResponseJSON(channels ...string) string {
+	return fmt.Sprintf("{\"data\":[%s]}", strings.Join(channels, ","))
+}
+
+func onCallEmailNotificationChannelJSON(id string) string {
+	return fmt.Sprintf(
+		"{\"id\":%q,\"type\":\"notification_channels\",\"attributes\":{\"config\":{\"type\":\"email\",\"address\":\"user@example.com\",\"formats\":[\"html\"]}}}",
+		id,
+	)
+}
+
+func onCallPushNotificationChannelJSON(id string) string {
+	return fmt.Sprintf(
+		"{\"id\":%q,\"type\":\"notification_channels\",\"attributes\":{\"config\":{\"type\":\"push\",\"name\":\"mobile\"}}}",
+		id,
+	)
+}
+
+func onCallNotificationRuleResponseJSON(id string, channelID string) string {
+	return fmt.Sprintf("{\"data\":%s}", onCallNotificationRuleJSON(id, channelID))
+}
+
+func onCallNotificationRuleJSON(id string, channelID string) string {
+	return fmt.Sprintf(
+		"{\"id\":%q,\"type\":\"notification_rules\",\"attributes\":{\"category\":\"high_urgency\",\"delay_minutes\":0},\"relationships\":{\"channel\":{\"data\":{\"id\":%q,\"type\":\"notification_channels\"}}}}",
+		id,
+		channelID,
+	)
+}

--- a/providers/datadog/on_call_test.go
+++ b/providers/datadog/on_call_test.go
@@ -77,6 +77,84 @@ func TestOnCallCreateResources(t *testing.T) {
 	}
 }
 
+func TestParseOnCallUserChildImportID(t *testing.T) {
+	testCases := []struct {
+		name      string
+		importID  string
+		wantUser  string
+		wantChild string
+		wantErr   bool
+	}{
+		{
+			name:      "colon delimiter",
+			importID:  "user-1:channel-1",
+			wantUser:  "user-1",
+			wantChild: "channel-1",
+		},
+		{
+			name:      "comma delimiter",
+			importID:  "user-1,channel-1",
+			wantUser:  "user-1",
+			wantChild: "channel-1",
+		},
+		{
+			name:     "missing delimiter",
+			importID: "user-1",
+			wantErr:  true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			gotUser, gotChild, err := parseOnCallUserChildImportID(tc.importID, "channel")
+			if tc.wantErr {
+				if err == nil {
+					t.Fatal("parseOnCallUserChildImportID returned nil error, want error")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("parseOnCallUserChildImportID returned error: %v", err)
+			}
+			if gotUser != tc.wantUser {
+				t.Fatalf("user id = %q, want %q", gotUser, tc.wantUser)
+			}
+			if gotChild != tc.wantChild {
+				t.Fatalf("child id = %q, want %q", gotChild, tc.wantChild)
+			}
+		})
+	}
+}
+
+func TestListDatadogUserIDsUsesSupportedPageSize(t *testing.T) {
+	pathCh := make(chan string, 1)
+	pageSizeCh := make(chan string, 1)
+	pageNumberCh := make(chan string, 1)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		pathCh <- r.URL.Path
+		pageSizeCh <- r.URL.Query().Get("page[size]")
+		pageNumberCh <- r.URL.Query().Get("page[number]")
+		_, _ = fmt.Fprint(w, onCallUserListResponseJSON("user-1", 1))
+	}))
+	defer server.Close()
+
+	api := datadogV2.NewUsersApi(newTeamRelationshipTestClient(server))
+	userIDs, err := listDatadogUserIDs(context.Background(), api)
+	if err != nil {
+		t.Fatalf("listDatadogUserIDs returned error: %v", err)
+	}
+	assertObservedQueryValue(t, pathCh, "path", "/api/v2/users")
+	assertObservedQueryValue(t, pageSizeCh, "page[size]", "500")
+	assertObservedQueryValue(t, pageNumberCh, "page[number]", "0")
+	if len(userIDs) != 1 {
+		t.Fatalf("expected 1 user id, got %d", len(userIDs))
+	}
+	if userIDs[0] != "user-1" {
+		t.Fatalf("user id = %q, want user-1", userIDs[0])
+	}
+}
+
 func TestOnCallEscalationPolicyInitResourcesFiltersByID(t *testing.T) {
 	pathCh := make(chan string, 1)
 	includeCh := make(chan string, 1)
@@ -335,6 +413,10 @@ func onCallTeamRoutingRulesResponseJSON(id string) string {
 
 func onCallNotificationChannelListResponseJSON(channels ...string) string {
 	return fmt.Sprintf("{\"data\":[%s]}", strings.Join(channels, ","))
+}
+
+func onCallUserListResponseJSON(id string, totalCount int) string {
+	return fmt.Sprintf("{\"data\":[{\"id\":%q,\"type\":\"users\"}],\"meta\":{\"page\":{\"total_count\":%d}}}", id, totalCount)
 }
 
 func onCallEmailNotificationChannelJSON(id string) string {

--- a/providers/datadog/on_call_test.go
+++ b/providers/datadog/on_call_test.go
@@ -50,8 +50,8 @@ func TestOnCallCreateResources(t *testing.T) {
 	if skipped {
 		t.Fatal("createResource skipped email notification channel")
 	}
-	if channelResource.InstanceState.ID != "user-1,channel-1" {
-		t.Fatalf("notification channel resource ID = %q, want user-1,channel-1", channelResource.InstanceState.ID)
+	if channelResource.InstanceState.ID != "channel-1" {
+		t.Fatalf("notification channel resource ID = %q, want channel-1", channelResource.InstanceState.ID)
 	}
 	if channelResource.InstanceState.Attributes["user_id"] != "user-1" {
 		t.Fatalf("notification channel user_id = %q, want user-1", channelResource.InstanceState.Attributes["user_id"])
@@ -69,8 +69,8 @@ func TestOnCallCreateResources(t *testing.T) {
 	if err != nil {
 		t.Fatalf("createResource notification rule returned error: %v", err)
 	}
-	if ruleResource.InstanceState.ID != "user-1,rule-1" {
-		t.Fatalf("notification rule resource ID = %q, want user-1,rule-1", ruleResource.InstanceState.ID)
+	if ruleResource.InstanceState.ID != "rule-1" {
+		t.Fatalf("notification rule resource ID = %q, want rule-1", ruleResource.InstanceState.ID)
 	}
 	if ruleResource.InstanceState.Attributes["user_id"] != "user-1" {
 		t.Fatalf("notification rule user_id = %q, want user-1", ruleResource.InstanceState.Attributes["user_id"])
@@ -333,8 +333,8 @@ func TestOnCallUserNotificationChannelInitResourcesFiltersByUserID(t *testing.T)
 	if len(generator.Resources) != 1 {
 		t.Fatalf("expected 1 resource, got %d", len(generator.Resources))
 	}
-	if generator.Resources[0].InstanceState.ID != "user-1,channel-1" {
-		t.Fatalf("resource ID = %q, want user-1,channel-1", generator.Resources[0].InstanceState.ID)
+	if generator.Resources[0].InstanceState.ID != "channel-1" {
+		t.Fatalf("resource ID = %q, want channel-1", generator.Resources[0].InstanceState.ID)
 	}
 }
 
@@ -343,7 +343,7 @@ func TestOnCallUserNotificationChannelInitResourcesFiltersByID(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		pathCh <- r.URL.Path
-		_, _ = fmt.Fprint(w, fmt.Sprintf("{\"data\":%s}", onCallEmailNotificationChannelJSON("channel-1")))
+		_, _ = fmt.Fprintf(w, "{\"data\":%s}", onCallEmailNotificationChannelJSON("channel-1"))
 	}))
 	defer server.Close()
 
@@ -361,11 +361,11 @@ func TestOnCallUserNotificationChannelInitResourcesFiltersByID(t *testing.T) {
 	if len(generator.Resources) != 1 {
 		t.Fatalf("expected 1 resource, got %d", len(generator.Resources))
 	}
-	if generator.Resources[0].InstanceState.ID != "user-1,channel-1" {
-		t.Fatalf("resource ID = %q, want user-1,channel-1", generator.Resources[0].InstanceState.ID)
+	if generator.Resources[0].InstanceState.ID != "channel-1" {
+		t.Fatalf("resource ID = %q, want channel-1", generator.Resources[0].InstanceState.ID)
 	}
-	if generator.Filter[0].AcceptableValues[0] != "user-1,channel-1" {
-		t.Fatalf("rewritten id filter = %v, want [user-1,channel-1]", generator.Filter[0].AcceptableValues)
+	if generator.Filter[0].AcceptableValues[0] != "channel-1" {
+		t.Fatalf("rewritten id filter = %v, want [channel-1]", generator.Filter[0].AcceptableValues)
 	}
 }
 
@@ -392,11 +392,11 @@ func TestOnCallUserNotificationRuleInitResourcesFiltersByID(t *testing.T) {
 	if len(generator.Resources) != 1 {
 		t.Fatalf("expected 1 resource, got %d", len(generator.Resources))
 	}
-	if generator.Resources[0].InstanceState.ID != "user-1,rule-1" {
-		t.Fatalf("resource ID = %q, want user-1,rule-1", generator.Resources[0].InstanceState.ID)
+	if generator.Resources[0].InstanceState.ID != "rule-1" {
+		t.Fatalf("resource ID = %q, want rule-1", generator.Resources[0].InstanceState.ID)
 	}
-	if generator.Filter[0].AcceptableValues[0] != "user-1,rule-1" {
-		t.Fatalf("rewritten id filter = %v, want [user-1,rule-1]", generator.Filter[0].AcceptableValues)
+	if generator.Filter[0].AcceptableValues[0] != "rule-1" {
+		t.Fatalf("rewritten id filter = %v, want [rule-1]", generator.Filter[0].AcceptableValues)
 	}
 }
 

--- a/providers/datadog/on_call_test.go
+++ b/providers/datadog/on_call_test.go
@@ -135,7 +135,7 @@ func TestListDatadogUserIDsUsesSupportedPageSize(t *testing.T) {
 		pathCh <- r.URL.Path
 		pageSizeCh <- r.URL.Query().Get("page[size]")
 		pageNumberCh <- r.URL.Query().Get("page[number]")
-		_, _ = fmt.Fprint(w, onCallUserListResponseJSON("user-1", 1))
+		_, _ = fmt.Fprint(w, onCallUserListResponseJSON(1, "user-1"))
 	}))
 	defer server.Close()
 
@@ -152,6 +152,48 @@ func TestListDatadogUserIDsUsesSupportedPageSize(t *testing.T) {
 	}
 	if userIDs[0] != "user-1" {
 		t.Fatalf("user id = %q, want user-1", userIDs[0])
+	}
+}
+
+func TestListDatadogUserIDsPaginates(t *testing.T) {
+	pathCh := make(chan string, 2)
+	pageSizeCh := make(chan string, 2)
+	pageNumberCh := make(chan string, 2)
+	requestCount := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		pathCh <- r.URL.Path
+		pageSizeCh <- r.URL.Query().Get("page[size]")
+		pageNumberCh <- r.URL.Query().Get("page[number]")
+		requestCount++
+		switch requestCount {
+		case 1:
+			_, _ = fmt.Fprint(w, onCallUserListResponseJSON(101, "user-1"))
+		default:
+			_, _ = fmt.Fprint(w, onCallUserListResponseJSON(101, "user-2"))
+		}
+	}))
+	defer server.Close()
+
+	api := datadogV2.NewUsersApi(newTeamRelationshipTestClient(server))
+	userIDs, err := listDatadogUserIDs(context.Background(), api)
+	if err != nil {
+		t.Fatalf("listDatadogUserIDs returned error: %v", err)
+	}
+	assertObservedQueryValue(t, pathCh, "path", "/api/v2/users")
+	assertObservedQueryValue(t, pageSizeCh, "page[size]", "100")
+	assertObservedQueryValue(t, pageNumberCh, "page[number]", "0")
+	assertObservedQueryValue(t, pathCh, "path", "/api/v2/users")
+	assertObservedQueryValue(t, pageSizeCh, "page[size]", "100")
+	assertObservedQueryValue(t, pageNumberCh, "page[number]", "1")
+	if len(userIDs) != 2 {
+		t.Fatalf("expected 2 user ids, got %d", len(userIDs))
+	}
+	if userIDs[0] != "user-1" {
+		t.Fatalf("first user id = %q, want user-1", userIDs[0])
+	}
+	if userIDs[1] != "user-2" {
+		t.Fatalf("second user id = %q, want user-2", userIDs[1])
 	}
 }
 
@@ -450,8 +492,12 @@ func onCallNotificationChannelListResponseJSON(channels ...string) string {
 	return fmt.Sprintf("{\"data\":[%s]}", strings.Join(channels, ","))
 }
 
-func onCallUserListResponseJSON(id string, totalCount int) string {
-	return fmt.Sprintf("{\"data\":[{\"id\":%q,\"type\":\"users\"}],\"meta\":{\"page\":{\"total_count\":%d}}}", id, totalCount)
+func onCallUserListResponseJSON(totalCount int, ids ...string) string {
+	users := []string{}
+	for _, id := range ids {
+		users = append(users, fmt.Sprintf("{\"id\":%q,\"type\":\"users\"}", id))
+	}
+	return fmt.Sprintf("{\"data\":[%s],\"meta\":{\"page\":{\"total_count\":%d}}}", strings.Join(users, ","), totalCount)
 }
 
 func onCallEmailNotificationChannelJSON(id string) string {

--- a/providers/datadog/on_call_test.go
+++ b/providers/datadog/on_call_test.go
@@ -145,7 +145,7 @@ func TestListDatadogUserIDsUsesSupportedPageSize(t *testing.T) {
 		t.Fatalf("listDatadogUserIDs returned error: %v", err)
 	}
 	assertObservedQueryValue(t, pathCh, "path", "/api/v2/users")
-	assertObservedQueryValue(t, pageSizeCh, "page[size]", "500")
+	assertObservedQueryValue(t, pageSizeCh, "page[size]", "100")
 	assertObservedQueryValue(t, pageNumberCh, "page[number]", "0")
 	if len(userIDs) != 1 {
 		t.Fatalf("expected 1 user id, got %d", len(userIDs))
@@ -239,6 +239,32 @@ func TestOnCallTeamRoutingRulesInitResourcesFiltersByID(t *testing.T) {
 	}
 }
 
+func TestOnCallTeamRoutingRulesInitResourcesSkipsMissingFilteredID(t *testing.T) {
+	pathCh := make(chan string, 1)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		pathCh <- r.URL.Path
+		w.WriteHeader(http.StatusNotFound)
+		_, _ = fmt.Fprint(w, `{"errors":["not found"]}`)
+	}))
+	defer server.Close()
+
+	generator := newOnCallTeamRoutingRulesTestGenerator(server, []terraformutils.ResourceFilter{
+		{
+			ServiceName:      "on_call_team_routing_rules",
+			FieldPath:        "id",
+			AcceptableValues: []string{"team-1"},
+		},
+	})
+	if err := generator.InitResources(); err != nil {
+		t.Fatalf("InitResources returned error: %v", err)
+	}
+	assertObservedQueryValue(t, pathCh, "path", "/api/v2/on-call/teams/team-1/routing-rules")
+	if len(generator.Resources) != 0 {
+		t.Fatalf("expected 0 resources, got %d", len(generator.Resources))
+	}
+}
+
 func TestOnCallUserNotificationChannelInitResourcesFiltersByUserID(t *testing.T) {
 	pathCh := make(chan string, 1)
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -308,7 +334,16 @@ func TestDatadogProviderOnCallConnections(t *testing.T) {
 	assertDatadogConnection(t, connections, "on_call_user_notification_channel", "user", "user_id", "id")
 	assertDatadogConnection(t, connections, "on_call_user_notification_rule", "on_call_user_notification_channel", "channel_id", "id")
 	assertDatadogConnection(t, connections, "on_call_user_notification_rule", "user", "user_id", "id")
-	assertDatadogConnection(t, connections, "on_call_escalation_policy", "team", "teams", "id")
+	assertDatadogConnectionPairs(
+		t,
+		connections,
+		"on_call_escalation_policy",
+		"team",
+		[]string{
+			"teams", "id",
+			"step.target.team", "id",
+		},
+	)
 	assertDatadogConnection(t, connections, "on_call_escalation_policy", "user", "step.target.user", "id")
 	assertDatadogConnectionPairs(
 		t,

--- a/providers/datadog/on_call_user_notification_channel.go
+++ b/providers/datadog/on_call_user_notification_channel.go
@@ -52,7 +52,7 @@ func (g *OnCallUserNotificationChannelGenerator) createResource(userID string, u
 	}
 
 	return terraformutils.NewResource(
-		notificationChannelID,
+		onCallUserChildProviderImportID(userID, notificationChannelID),
 		fmt.Sprintf("on_call_user_notification_channel_%s_%s", userID, notificationChannelID),
 		"datadog_on_call_user_notification_channel",
 		"datadog",
@@ -66,7 +66,7 @@ func (g *OnCallUserNotificationChannelGenerator) createResource(userID string, u
 
 // InitResources Generate TerraformResources from Datadog API,
 // from each On-Call user notification channel create 1 TerraformResource.
-// Need On-Call User Notification Channel ID formatted as '<user_id>:<channel_id>' for filter lookup.
+// Need On-Call User Notification Channel ID formatted as '<user_id>,<channel_id>' for provider import.
 func (g *OnCallUserNotificationChannelGenerator) InitResources() error {
 	datadogClient := g.Args["datadogClient"].(*datadog.APIClient)
 	auth := g.Args["auth"].(context.Context)
@@ -132,7 +132,7 @@ func (g *OnCallUserNotificationChannelGenerator) filteredResources(auth context.
 				}
 				resources = append(resources, resource)
 			}
-			g.Filter[filterIndex].AcceptableValues = onCallUserChildIDs(filterIDs)
+			g.Filter[filterIndex].AcceptableValues = onCallUserChildProviderImportIDs(filterIDs)
 		case "user_id":
 			filtered = true
 			for _, userID := range filter.AcceptableValues {

--- a/providers/datadog/on_call_user_notification_channel.go
+++ b/providers/datadog/on_call_user_notification_channel.go
@@ -52,7 +52,7 @@ func (g *OnCallUserNotificationChannelGenerator) createResource(userID string, u
 	}
 
 	return terraformutils.NewResource(
-		onCallUserChildProviderImportID(userID, notificationChannelID),
+		notificationChannelID,
 		fmt.Sprintf("on_call_user_notification_channel_%s_%s", userID, notificationChannelID),
 		"datadog_on_call_user_notification_channel",
 		"datadog",
@@ -66,7 +66,7 @@ func (g *OnCallUserNotificationChannelGenerator) createResource(userID string, u
 
 // InitResources Generate TerraformResources from Datadog API,
 // from each On-Call user notification channel create 1 TerraformResource.
-// Need On-Call User Notification Channel ID formatted as '<user_id>,<channel_id>' for provider import.
+// Need On-Call User Notification Channel ID formatted as '<user_id>:<channel_id>' for filter lookup.
 func (g *OnCallUserNotificationChannelGenerator) InitResources() error {
 	datadogClient := g.Args["datadogClient"].(*datadog.APIClient)
 	auth := g.Args["auth"].(context.Context)
@@ -132,7 +132,7 @@ func (g *OnCallUserNotificationChannelGenerator) filteredResources(auth context.
 				}
 				resources = append(resources, resource)
 			}
-			g.Filter[filterIndex].AcceptableValues = onCallUserChildProviderImportIDs(filterIDs)
+			g.Filter[filterIndex].AcceptableValues = onCallUserChildIDs(filterIDs)
 		case "user_id":
 			filtered = true
 			for _, userID := range filter.AcceptableValues {

--- a/providers/datadog/on_call_user_notification_channel.go
+++ b/providers/datadog/on_call_user_notification_channel.go
@@ -66,7 +66,7 @@ func (g *OnCallUserNotificationChannelGenerator) createResource(userID string, u
 
 // InitResources Generate TerraformResources from Datadog API,
 // from each On-Call user notification channel create 1 TerraformResource.
-// Need On-Call User Notification Channel ID formatted as '<user_id>,<channel_id>' for filter lookup.
+// Need On-Call User Notification Channel ID formatted as '<user_id>:<channel_id>' for filter lookup.
 func (g *OnCallUserNotificationChannelGenerator) InitResources() error {
 	datadogClient := g.Args["datadogClient"].(*datadog.APIClient)
 	auth := g.Args["auth"].(context.Context)

--- a/providers/datadog/on_call_user_notification_channel.go
+++ b/providers/datadog/on_call_user_notification_channel.go
@@ -1,0 +1,198 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package datadog
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/DataDog/datadog-api-client-go/v2/api/datadog"
+	"github.com/DataDog/datadog-api-client-go/v2/api/datadogV2"
+
+	"github.com/chenrui333/terraformer/terraformutils"
+)
+
+var (
+	// OnCallUserNotificationChannelAllowEmptyValues ...
+	OnCallUserNotificationChannelAllowEmptyValues = []string{"email.formats"}
+)
+
+// OnCallUserNotificationChannelGenerator ...
+type OnCallUserNotificationChannelGenerator struct {
+	DatadogService
+}
+
+func (g *OnCallUserNotificationChannelGenerator) createResources(userID string, userNotificationChannels []datadogV2.NotificationChannelData) ([]terraformutils.Resource, error) {
+	resources := []terraformutils.Resource{}
+	for _, userNotificationChannel := range userNotificationChannels {
+		resource, skipped, err := g.createResource(userID, userNotificationChannel)
+		if err != nil {
+			return nil, err
+		}
+		if skipped {
+			continue
+		}
+		resources = append(resources, resource)
+	}
+
+	return resources, nil
+}
+
+func (g *OnCallUserNotificationChannelGenerator) createResource(userID string, userNotificationChannel datadogV2.NotificationChannelData) (terraformutils.Resource, bool, error) {
+	notificationChannelID := userNotificationChannel.GetId()
+	if notificationChannelID == "" {
+		return terraformutils.Resource{}, false, fmt.Errorf("On-Call user notification channel missing id")
+	}
+	if userID == "" {
+		return terraformutils.Resource{}, false, fmt.Errorf("On-Call user notification channel %q missing user id", notificationChannelID)
+	}
+	if !isSupportedOnCallUserNotificationChannel(userNotificationChannel) {
+		return terraformutils.Resource{}, true, nil
+	}
+
+	return terraformutils.NewResource(
+		notificationChannelID,
+		fmt.Sprintf("on_call_user_notification_channel_%s_%s", userID, notificationChannelID),
+		"datadog_on_call_user_notification_channel",
+		"datadog",
+		map[string]string{
+			"user_id": userID,
+		},
+		OnCallUserNotificationChannelAllowEmptyValues,
+		map[string]interface{}{},
+	), false, nil
+}
+
+// InitResources Generate TerraformResources from Datadog API,
+// from each On-Call user notification channel create 1 TerraformResource.
+// Need On-Call User Notification Channel ID formatted as '<user_id>,<channel_id>' for filter lookup.
+func (g *OnCallUserNotificationChannelGenerator) InitResources() error {
+	datadogClient := g.Args["datadogClient"].(*datadog.APIClient)
+	auth := g.Args["auth"].(context.Context)
+	onCallAPI := datadogV2.NewOnCallApi(datadogClient)
+	usersAPI := datadogV2.NewUsersApi(datadogClient)
+
+	resources, filtered, err := g.filteredResources(auth, onCallAPI)
+	if err != nil {
+		return err
+	}
+	if filtered {
+		g.Resources = resources
+		return nil
+	}
+
+	userIDs, err := listDatadogUserIDs(auth, usersAPI)
+	if err != nil {
+		return err
+	}
+	for _, userID := range userIDs {
+		userNotificationChannels, err := listOnCallUserNotificationChannels(auth, onCallAPI, userID)
+		if err != nil {
+			return err
+		}
+		userResources, err := g.createResources(userID, userNotificationChannels)
+		if err != nil {
+			return err
+		}
+		resources = append(resources, userResources...)
+	}
+
+	g.Resources = resources
+	return nil
+}
+
+func (g *OnCallUserNotificationChannelGenerator) filteredResources(auth context.Context, api *datadogV2.OnCallApi) ([]terraformutils.Resource, bool, error) {
+	resources := []terraformutils.Resource{}
+	filtered := false
+
+	for filterIndex, filter := range g.Filter {
+		if !filter.IsApplicable("on_call_user_notification_channel") {
+			continue
+		}
+
+		switch filter.FieldPath {
+		case "id":
+			filtered = true
+			filterIDs, err := parseOnCallUserChildImportIDs(filter.AcceptableValues, "channel")
+			if err != nil {
+				return nil, true, err
+			}
+			for _, filterID := range filterIDs {
+				userNotificationChannel, err := getOnCallUserNotificationChannel(auth, api, filterID.userID, filterID.childID)
+				if err != nil {
+					return nil, true, err
+				}
+				resource, skipped, err := g.createResource(filterID.userID, userNotificationChannel)
+				if err != nil {
+					return nil, true, err
+				}
+				if skipped {
+					continue
+				}
+				resources = append(resources, resource)
+			}
+			g.Filter[filterIndex].AcceptableValues = onCallUserChildIDs(filterIDs)
+		case "user_id":
+			filtered = true
+			for _, userID := range filter.AcceptableValues {
+				userNotificationChannels, err := listOnCallUserNotificationChannels(auth, api, userID)
+				if err != nil {
+					return nil, true, err
+				}
+				userResources, err := g.createResources(userID, userNotificationChannels)
+				if err != nil {
+					return nil, true, err
+				}
+				resources = append(resources, userResources...)
+			}
+		}
+	}
+
+	return resources, filtered, nil
+}
+
+func getOnCallUserNotificationChannel(auth context.Context, api *datadogV2.OnCallApi, userID string, channelID string) (datadogV2.NotificationChannelData, error) {
+	userNotificationChannel, httpResp, err := api.GetUserNotificationChannel(auth, userID, channelID)
+	if httpResp != nil && httpResp.Body != nil {
+		defer httpResp.Body.Close()
+	}
+	if err != nil {
+		return datadogV2.NotificationChannelData{}, err
+	}
+
+	data := userNotificationChannel.GetData()
+	if data.GetId() == "" {
+		data.SetId(channelID)
+	}
+	return data, nil
+}
+
+func listOnCallUserNotificationChannels(auth context.Context, api *datadogV2.OnCallApi, userID string) ([]datadogV2.NotificationChannelData, error) {
+	userNotificationChannels, httpResp, err := api.ListUserNotificationChannels(auth, userID)
+	if httpResp != nil && httpResp.Body != nil {
+		defer httpResp.Body.Close()
+	}
+	if err != nil {
+		if httpResp != nil && httpResp.StatusCode == http.StatusNotFound {
+			return []datadogV2.NotificationChannelData{}, nil
+		}
+		return nil, err
+	}
+	return userNotificationChannels.GetData(), nil
+}
+
+func isSupportedOnCallUserNotificationChannel(userNotificationChannel datadogV2.NotificationChannelData) bool {
+	attributes := userNotificationChannel.GetAttributes()
+	config, ok := attributes.GetConfigOk()
+	if !ok {
+		return false
+	}
+
+	switch config.GetActualInstance().(type) {
+	case *datadogV2.NotificationChannelEmailConfig, *datadogV2.NotificationChannelPhoneConfig:
+		return true
+	default:
+		return false
+	}
+}

--- a/providers/datadog/on_call_user_notification_rule.go
+++ b/providers/datadog/on_call_user_notification_rule.go
@@ -46,7 +46,7 @@ func (g *OnCallUserNotificationRuleGenerator) createResource(userID string, user
 	}
 
 	return terraformutils.NewResource(
-		notificationRuleID,
+		onCallUserChildProviderImportID(userID, notificationRuleID),
 		fmt.Sprintf("on_call_user_notification_rule_%s_%s", userID, notificationRuleID),
 		"datadog_on_call_user_notification_rule",
 		"datadog",
@@ -60,7 +60,7 @@ func (g *OnCallUserNotificationRuleGenerator) createResource(userID string, user
 
 // InitResources Generate TerraformResources from Datadog API,
 // from each On-Call user notification rule create 1 TerraformResource.
-// Need On-Call User Notification Rule ID formatted as '<user_id>:<rule_id>' for filter lookup.
+// Need On-Call User Notification Rule ID formatted as '<user_id>,<rule_id>' for provider import.
 func (g *OnCallUserNotificationRuleGenerator) InitResources() error {
 	datadogClient := g.Args["datadogClient"].(*datadog.APIClient)
 	auth := g.Args["auth"].(context.Context)
@@ -123,7 +123,7 @@ func (g *OnCallUserNotificationRuleGenerator) filteredResources(auth context.Con
 				}
 				resources = append(resources, resource)
 			}
-			g.Filter[filterIndex].AcceptableValues = onCallUserChildIDs(filterIDs)
+			g.Filter[filterIndex].AcceptableValues = onCallUserChildProviderImportIDs(filterIDs)
 		case "user_id":
 			filtered = true
 			for _, userID := range filter.AcceptableValues {

--- a/providers/datadog/on_call_user_notification_rule.go
+++ b/providers/datadog/on_call_user_notification_rule.go
@@ -60,7 +60,7 @@ func (g *OnCallUserNotificationRuleGenerator) createResource(userID string, user
 
 // InitResources Generate TerraformResources from Datadog API,
 // from each On-Call user notification rule create 1 TerraformResource.
-// Need On-Call User Notification Rule ID formatted as '<user_id>,<rule_id>' for filter lookup.
+// Need On-Call User Notification Rule ID formatted as '<user_id>:<rule_id>' for filter lookup.
 func (g *OnCallUserNotificationRuleGenerator) InitResources() error {
 	datadogClient := g.Args["datadogClient"].(*datadog.APIClient)
 	auth := g.Args["auth"].(context.Context)

--- a/providers/datadog/on_call_user_notification_rule.go
+++ b/providers/datadog/on_call_user_notification_rule.go
@@ -1,0 +1,175 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package datadog
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/DataDog/datadog-api-client-go/v2/api/datadog"
+	"github.com/DataDog/datadog-api-client-go/v2/api/datadogV2"
+
+	"github.com/chenrui333/terraformer/terraformutils"
+)
+
+var (
+	// OnCallUserNotificationRuleAllowEmptyValues ...
+	OnCallUserNotificationRuleAllowEmptyValues = []string{}
+)
+
+// OnCallUserNotificationRuleGenerator ...
+type OnCallUserNotificationRuleGenerator struct {
+	DatadogService
+}
+
+func (g *OnCallUserNotificationRuleGenerator) createResources(userID string, userNotificationRules []datadogV2.OnCallNotificationRuleData) ([]terraformutils.Resource, error) {
+	resources := []terraformutils.Resource{}
+	for _, userNotificationRule := range userNotificationRules {
+		resource, err := g.createResource(userID, userNotificationRule)
+		if err != nil {
+			return nil, err
+		}
+		resources = append(resources, resource)
+	}
+
+	return resources, nil
+}
+
+func (g *OnCallUserNotificationRuleGenerator) createResource(userID string, userNotificationRule datadogV2.OnCallNotificationRuleData) (terraformutils.Resource, error) {
+	notificationRuleID := userNotificationRule.GetId()
+	if notificationRuleID == "" {
+		return terraformutils.Resource{}, fmt.Errorf("On-Call user notification rule missing id")
+	}
+	if userID == "" {
+		return terraformutils.Resource{}, fmt.Errorf("On-Call user notification rule %q missing user id", notificationRuleID)
+	}
+
+	return terraformutils.NewResource(
+		notificationRuleID,
+		fmt.Sprintf("on_call_user_notification_rule_%s_%s", userID, notificationRuleID),
+		"datadog_on_call_user_notification_rule",
+		"datadog",
+		map[string]string{
+			"user_id": userID,
+		},
+		OnCallUserNotificationRuleAllowEmptyValues,
+		map[string]interface{}{},
+	), nil
+}
+
+// InitResources Generate TerraformResources from Datadog API,
+// from each On-Call user notification rule create 1 TerraformResource.
+// Need On-Call User Notification Rule ID formatted as '<user_id>,<rule_id>' for filter lookup.
+func (g *OnCallUserNotificationRuleGenerator) InitResources() error {
+	datadogClient := g.Args["datadogClient"].(*datadog.APIClient)
+	auth := g.Args["auth"].(context.Context)
+	onCallAPI := datadogV2.NewOnCallApi(datadogClient)
+	usersAPI := datadogV2.NewUsersApi(datadogClient)
+
+	resources, filtered, err := g.filteredResources(auth, onCallAPI)
+	if err != nil {
+		return err
+	}
+	if filtered {
+		g.Resources = resources
+		return nil
+	}
+
+	userIDs, err := listDatadogUserIDs(auth, usersAPI)
+	if err != nil {
+		return err
+	}
+	for _, userID := range userIDs {
+		userNotificationRules, err := listOnCallUserNotificationRules(auth, onCallAPI, userID)
+		if err != nil {
+			return err
+		}
+		userResources, err := g.createResources(userID, userNotificationRules)
+		if err != nil {
+			return err
+		}
+		resources = append(resources, userResources...)
+	}
+
+	g.Resources = resources
+	return nil
+}
+
+func (g *OnCallUserNotificationRuleGenerator) filteredResources(auth context.Context, api *datadogV2.OnCallApi) ([]terraformutils.Resource, bool, error) {
+	resources := []terraformutils.Resource{}
+	filtered := false
+
+	for filterIndex, filter := range g.Filter {
+		if !filter.IsApplicable("on_call_user_notification_rule") {
+			continue
+		}
+
+		switch filter.FieldPath {
+		case "id":
+			filtered = true
+			filterIDs, err := parseOnCallUserChildImportIDs(filter.AcceptableValues, "rule")
+			if err != nil {
+				return nil, true, err
+			}
+			for _, filterID := range filterIDs {
+				userNotificationRule, err := getOnCallUserNotificationRule(auth, api, filterID.userID, filterID.childID)
+				if err != nil {
+					return nil, true, err
+				}
+				resource, err := g.createResource(filterID.userID, userNotificationRule)
+				if err != nil {
+					return nil, true, err
+				}
+				resources = append(resources, resource)
+			}
+			g.Filter[filterIndex].AcceptableValues = onCallUserChildIDs(filterIDs)
+		case "user_id":
+			filtered = true
+			for _, userID := range filter.AcceptableValues {
+				userNotificationRules, err := listOnCallUserNotificationRules(auth, api, userID)
+				if err != nil {
+					return nil, true, err
+				}
+				userResources, err := g.createResources(userID, userNotificationRules)
+				if err != nil {
+					return nil, true, err
+				}
+				resources = append(resources, userResources...)
+			}
+		}
+	}
+
+	return resources, filtered, nil
+}
+
+func getOnCallUserNotificationRule(auth context.Context, api *datadogV2.OnCallApi, userID string, ruleID string) (datadogV2.OnCallNotificationRuleData, error) {
+	userNotificationRule, httpResp, err := api.GetUserNotificationRule(auth, userID, ruleID)
+	if httpResp != nil && httpResp.Body != nil {
+		defer httpResp.Body.Close()
+	}
+	if err != nil {
+		return datadogV2.OnCallNotificationRuleData{}, err
+	}
+
+	data := userNotificationRule.GetData()
+	if data.GetId() == "" {
+		data.SetId(ruleID)
+	}
+	return data, nil
+}
+
+func listOnCallUserNotificationRules(auth context.Context, api *datadogV2.OnCallApi, userID string) ([]datadogV2.OnCallNotificationRuleData, error) {
+	include := "channel"
+	userNotificationRules, httpResp, err := api.ListUserNotificationRules(auth, userID, datadogV2.ListUserNotificationRulesOptionalParameters{Include: &include})
+	if httpResp != nil && httpResp.Body != nil {
+		defer httpResp.Body.Close()
+	}
+	if err != nil {
+		if httpResp != nil && httpResp.StatusCode == http.StatusNotFound {
+			return []datadogV2.OnCallNotificationRuleData{}, nil
+		}
+		return nil, err
+	}
+	return userNotificationRules.GetData(), nil
+}

--- a/providers/datadog/on_call_user_notification_rule.go
+++ b/providers/datadog/on_call_user_notification_rule.go
@@ -46,7 +46,7 @@ func (g *OnCallUserNotificationRuleGenerator) createResource(userID string, user
 	}
 
 	return terraformutils.NewResource(
-		onCallUserChildProviderImportID(userID, notificationRuleID),
+		notificationRuleID,
 		fmt.Sprintf("on_call_user_notification_rule_%s_%s", userID, notificationRuleID),
 		"datadog_on_call_user_notification_rule",
 		"datadog",
@@ -60,7 +60,7 @@ func (g *OnCallUserNotificationRuleGenerator) createResource(userID string, user
 
 // InitResources Generate TerraformResources from Datadog API,
 // from each On-Call user notification rule create 1 TerraformResource.
-// Need On-Call User Notification Rule ID formatted as '<user_id>,<rule_id>' for provider import.
+// Need On-Call User Notification Rule ID formatted as '<user_id>:<rule_id>' for filter lookup.
 func (g *OnCallUserNotificationRuleGenerator) InitResources() error {
 	datadogClient := g.Args["datadogClient"].(*datadog.APIClient)
 	auth := g.Args["auth"].(context.Context)
@@ -123,7 +123,7 @@ func (g *OnCallUserNotificationRuleGenerator) filteredResources(auth context.Con
 				}
 				resources = append(resources, resource)
 			}
-			g.Filter[filterIndex].AcceptableValues = onCallUserChildProviderImportIDs(filterIDs)
+			g.Filter[filterIndex].AcceptableValues = onCallUserChildIDs(filterIDs)
 		case "user_id":
 			filtered = true
 			for _, userID := range filter.AcceptableValues {


### PR DESCRIPTION
Summary
- Add Datadog On-Call import support for escalation policies, schedules, team routing rules, user notification channels, and user notification rules.
- Document ID-filter-only On-Call resources and composite user notification IDs.
- Wire On-Call resources into Datadog service registration and --connect mappings with focused tests.

Notes
- On-Call escalation policies and schedules are filter-only because the Datadog API does not expose list endpoints.
- Push notification channels are skipped because the Datadog provider resource supports email and phone channels.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds import support for Datadog On‑Call resources and refines edge cases for user child imports. Uses provider import IDs for child resources to ensure consistent filtering and imports.

- **New Features**
  - Generators for `datadog_on_call_escalation_policy`, `datadog_on_call_schedule`, `datadog_on_call_team_routing_rules`, `datadog_on_call_user_notification_channel`, and `datadog_on_call_user_notification_rule`.
  - Filter rules: policies/schedules are ID‑only; team routing rules keyed by team ID; channels/rules accept composite IDs (`user_id:child_id` or `user_id,child_id`) or `user_id`; push channels are skipped.
  - Added `--connect` mappings across schedules, escalation policies, teams, users, channels, and rules.

- **Bug Fixes**
  - Robust composite ID parsing with `:` or `,`; rewrite `id` filters to provider import IDs (`user_id,child_id`) for consistent imports.
  - Reliable pagination for user discovery (100/page) with tests, and safe 404 handling for users, user child lists, and team routing rules.
  - Keep IDs on reads when the API omits them (including user notification channels and rules) and include related objects in reads to support `--connect` mappings.

<sup>Written for commit aed12fc66c94d07ed36b0337a098ef9d870e8b0b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Support for Datadog On-Call resources: escalation policies, schedules, team routing rules, user notification channels, and user notification rules.

* **Documentation**
  * Updated supported-resources guide with import guidance requiring explicit IDs and correctly formatted filter values; notes that push notification channels are skipped.

* **Tests**
  * Added comprehensive tests for On-Call generation, filtering, import ID parsing, and API behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->