### PR TITLE
fix(providers): clear init state before validation

### DIFF
--- a/providers/auth0/auth0_provider.go
+++ b/providers/auth0/auth0_provider.go
@@ -20,30 +20,33 @@ type Auth0Provider struct { //nolint
 }
 
 func (p *Auth0Provider) Init(_ []string) error {
+	p.domain = ""
+	p.clientID = ""
+	p.clientSecret = ""
 	p.client = nil
 
-	orgName := os.Getenv("AUTH0_DOMAIN")
-	if orgName == "" {
+	domain := os.Getenv("AUTH0_DOMAIN")
+	if domain == "" {
 		return errors.New("set AUTH0_DOMAIN env var")
 	}
-	p.domain = orgName
 
-	baseURL := os.Getenv("AUTH0_CLIENT_ID")
-	if baseURL == "" {
+	clientID := os.Getenv("AUTH0_CLIENT_ID")
+	if clientID == "" {
 		return errors.New("set AUTH0_CLIENT_ID env var")
 	}
-	p.clientID = baseURL
 
-	apiToken := os.Getenv("AUTH0_CLIENT_SECRET")
-	if apiToken == "" {
+	clientSecret := os.Getenv("AUTH0_CLIENT_SECRET")
+	if clientSecret == "" {
 		return errors.New("set AUTH0_CLIENT_SECRET env var")
 	}
-	p.clientSecret = apiToken
 
-	client, err := newManagementClient(p.domain, p.clientID, p.clientSecret)
+	client, err := newManagementClient(domain, clientID, clientSecret)
 	if err != nil {
 		return err
 	}
+	p.domain = domain
+	p.clientID = clientID
+	p.clientSecret = clientSecret
 	p.client = client
 
 	return nil

--- a/providers/auth0/auth0_provider_test.go
+++ b/providers/auth0/auth0_provider_test.go
@@ -42,3 +42,25 @@ func TestProviderInitServiceUsesInitializedClient(t *testing.T) {
 		t.Fatal("expected service to reuse provider-level management client")
 	}
 }
+
+func TestProviderInitClearsStateOnMissingClientSecret(t *testing.T) {
+	t.Setenv("AUTH0_DOMAIN", "example.auth0.com")
+	t.Setenv("AUTH0_CLIENT_ID", "client-id")
+	t.Setenv("AUTH0_CLIENT_SECRET", "client-secret")
+
+	provider := &Auth0Provider{}
+	if err := provider.Init(nil); err != nil {
+		t.Fatalf("expected provider initialization to succeed: %v", err)
+	}
+	if provider.domain != "example.auth0.com" || provider.clientID != "client-id" || provider.clientSecret != "client-secret" || provider.client == nil {
+		t.Fatalf("expected provider state to be initialized, got domain=%q clientID=%q clientSecret=%q client=%v", provider.domain, provider.clientID, provider.clientSecret, provider.client)
+	}
+
+	t.Setenv("AUTH0_CLIENT_SECRET", "")
+	if err := provider.Init(nil); err == nil {
+		t.Fatal("expected provider initialization to fail without AUTH0_CLIENT_SECRET")
+	}
+	if provider.domain != "" || provider.clientID != "" || provider.clientSecret != "" || provider.client != nil {
+		t.Fatalf("expected stale provider state to be cleared, got domain=%q clientID=%q clientSecret=%q client=%v", provider.domain, provider.clientID, provider.clientSecret, provider.client)
+	}
+}

--- a/providers/azuread/azuread_provider.go
+++ b/providers/azuread/azuread_provider.go
@@ -17,6 +17,10 @@ type AzureADProvider struct { //nolint
 }
 
 func (p *AzureADProvider) setEnvConfig() error {
+	p.tenantID = ""
+	p.clientID = ""
+	p.clientSecret = ""
+
 	tenantID := os.Getenv("ARM_TENANT_ID")
 	if tenantID == "" {
 		return errors.New("please set ARM_TENANT_ID in your environment")

--- a/providers/azuread/azuread_provider_test.go
+++ b/providers/azuread/azuread_provider_test.go
@@ -1,0 +1,27 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package azuread
+
+import "testing"
+
+func TestAzureADProviderInitClearsStateOnMissingClientSecret(t *testing.T) {
+	provider := &AzureADProvider{}
+	t.Setenv("ARM_TENANT_ID", "tenant")
+	t.Setenv("ARM_CLIENT_ID", "client")
+	t.Setenv("ARM_CLIENT_SECRET", "secret")
+
+	if err := provider.Init(nil); err != nil {
+		t.Fatalf("expected init to succeed: %v", err)
+	}
+	if provider.tenantID != "tenant" || provider.clientID != "client" || provider.clientSecret != "secret" {
+		t.Fatalf("expected provider state to be initialized, got tenantID=%q clientID=%q clientSecret=%q", provider.tenantID, provider.clientID, provider.clientSecret)
+	}
+
+	t.Setenv("ARM_CLIENT_SECRET", "")
+	if err := provider.Init(nil); err == nil {
+		t.Fatal("expected init to fail without ARM_CLIENT_SECRET")
+	}
+	if provider.tenantID != "" || provider.clientID != "" || provider.clientSecret != "" {
+		t.Fatalf("expected stale provider state to be cleared, got tenantID=%q clientID=%q clientSecret=%q", provider.tenantID, provider.clientID, provider.clientSecret)
+	}
+}

--- a/providers/azuredevops/azuredevops_provider.go
+++ b/providers/azuredevops/azuredevops_provider.go
@@ -16,6 +16,9 @@ type AzureDevOpsProvider struct { //nolint
 }
 
 func (p *AzureDevOpsProvider) setEnvConfig() error {
+	p.organizationURL = ""
+	p.personalAccessToken = ""
+
 	organizationURL := os.Getenv("AZDO_ORG_SERVICE_URL")
 	if organizationURL == "" {
 		return errors.New("environment variable AZDO_ORG_SERVICE_URL missing")

--- a/providers/azuredevops/azuredevops_provider_test.go
+++ b/providers/azuredevops/azuredevops_provider_test.go
@@ -1,0 +1,26 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package azuredevops
+
+import "testing"
+
+func TestAzureDevOpsProviderInitClearsStateOnMissingToken(t *testing.T) {
+	provider := &AzureDevOpsProvider{}
+	t.Setenv("AZDO_ORG_SERVICE_URL", "https://dev.azure.com/example")
+	t.Setenv("AZDO_PERSONAL_ACCESS_TOKEN", "pat")
+
+	if err := provider.Init(nil); err != nil {
+		t.Fatalf("expected init to succeed: %v", err)
+	}
+	if provider.organizationURL != "https://dev.azure.com/example" || provider.personalAccessToken != "pat" {
+		t.Fatalf("expected provider state to be initialized, got organizationURL=%q personalAccessToken=%q", provider.organizationURL, provider.personalAccessToken)
+	}
+
+	t.Setenv("AZDO_PERSONAL_ACCESS_TOKEN", "")
+	if err := provider.Init(nil); err == nil {
+		t.Fatal("expected init to fail without AZDO_PERSONAL_ACCESS_TOKEN")
+	}
+	if provider.organizationURL != "" || provider.personalAccessToken != "" {
+		t.Fatalf("expected stale provider state to be cleared, got organizationURL=%q personalAccessToken=%q", provider.organizationURL, provider.personalAccessToken)
+	}
+}

--- a/providers/digitalocean/digitalocean_provider.go
+++ b/providers/digitalocean/digitalocean_provider.go
@@ -15,10 +15,13 @@ type DigitalOceanProvider struct { //nolint
 }
 
 func (p *DigitalOceanProvider) Init(_ []string) error {
-	if os.Getenv("DIGITALOCEAN_TOKEN") == "" {
+	p.token = ""
+
+	token := os.Getenv("DIGITALOCEAN_TOKEN")
+	if token == "" {
 		return errors.New("set DIGITALOCEAN_TOKEN env var")
 	}
-	p.token = os.Getenv("DIGITALOCEAN_TOKEN")
+	p.token = token
 
 	return nil
 }

--- a/providers/digitalocean/digitalocean_provider_test.go
+++ b/providers/digitalocean/digitalocean_provider_test.go
@@ -1,0 +1,25 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package digitalocean
+
+import "testing"
+
+func TestDigitalOceanProviderInitClearsTokenOnMissingEnv(t *testing.T) {
+	provider := &DigitalOceanProvider{}
+	t.Setenv("DIGITALOCEAN_TOKEN", "token")
+
+	if err := provider.Init(nil); err != nil {
+		t.Fatalf("expected init to succeed: %v", err)
+	}
+	if provider.token != "token" {
+		t.Fatalf("expected token to be initialized, got %q", provider.token)
+	}
+
+	t.Setenv("DIGITALOCEAN_TOKEN", "")
+	if err := provider.Init(nil); err == nil {
+		t.Fatal("expected init to fail without DIGITALOCEAN_TOKEN")
+	}
+	if provider.token != "" {
+		t.Fatalf("expected stale token to be cleared, got %q", provider.token)
+	}
+}

--- a/providers/equinixmetal/equinixmetal_provider.go
+++ b/providers/equinixmetal/equinixmetal_provider.go
@@ -16,15 +16,20 @@ type EquinixMetalProvider struct { //nolint
 }
 
 func (p *EquinixMetalProvider) Init(_ []string) error {
-	if os.Getenv("PACKET_AUTH_TOKEN") == "" {
+	p.authToken = ""
+	p.projectID = ""
+
+	authToken := os.Getenv("PACKET_AUTH_TOKEN")
+	if authToken == "" {
 		return errors.New("set PACKET_AUTH_TOKEN env var")
 	}
-	p.authToken = os.Getenv("PACKET_AUTH_TOKEN")
 
-	if os.Getenv("METAL_PROJECT_ID") == "" {
+	projectID := os.Getenv("METAL_PROJECT_ID")
+	if projectID == "" {
 		return errors.New("set METAL_PROJECT_ID env var")
 	}
-	p.projectID = os.Getenv("METAL_PROJECT_ID")
+	p.authToken = authToken
+	p.projectID = projectID
 
 	return nil
 }

--- a/providers/equinixmetal/equinixmetal_provider_test.go
+++ b/providers/equinixmetal/equinixmetal_provider_test.go
@@ -1,0 +1,26 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package equinixmetal
+
+import "testing"
+
+func TestEquinixMetalProviderInitClearsStateOnMissingProjectID(t *testing.T) {
+	provider := &EquinixMetalProvider{}
+	t.Setenv("PACKET_AUTH_TOKEN", "auth-token")
+	t.Setenv("METAL_PROJECT_ID", "project-id")
+
+	if err := provider.Init(nil); err != nil {
+		t.Fatalf("expected init to succeed: %v", err)
+	}
+	if provider.authToken != "auth-token" || provider.projectID != "project-id" {
+		t.Fatalf("expected provider state to be initialized, got authToken=%q projectID=%q", provider.authToken, provider.projectID)
+	}
+
+	t.Setenv("METAL_PROJECT_ID", "")
+	if err := provider.Init(nil); err == nil {
+		t.Fatal("expected init to fail without METAL_PROJECT_ID")
+	}
+	if provider.authToken != "" || provider.projectID != "" {
+		t.Fatalf("expected stale provider state to be cleared, got authToken=%q projectID=%q", provider.authToken, provider.projectID)
+	}
+}

--- a/providers/fastly/fastly_provider.go
+++ b/providers/fastly/fastly_provider.go
@@ -16,15 +16,20 @@ type FastlyProvider struct { //nolint
 }
 
 func (p *FastlyProvider) Init(_ []string) error {
-	if os.Getenv("FASTLY_API_KEY") == "" {
+	p.apiKey = ""
+	p.customerID = ""
+
+	apiKey := os.Getenv("FASTLY_API_KEY")
+	if apiKey == "" {
 		return errors.New("set FASTLY_API_KEY env var")
 	}
-	p.apiKey = os.Getenv("FASTLY_API_KEY")
 
-	if os.Getenv("FASTLY_CUSTOMER_ID") == "" {
+	customerID := os.Getenv("FASTLY_CUSTOMER_ID")
+	if customerID == "" {
 		return errors.New("set FASTLY_CUSTOMER_ID env var")
 	}
-	p.customerID = os.Getenv("FASTLY_CUSTOMER_ID")
+	p.apiKey = apiKey
+	p.customerID = customerID
 
 	return nil
 }

--- a/providers/fastly/fastly_provider_test.go
+++ b/providers/fastly/fastly_provider_test.go
@@ -1,0 +1,26 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package fastly
+
+import "testing"
+
+func TestFastlyProviderInitClearsStateOnMissingCustomerID(t *testing.T) {
+	provider := &FastlyProvider{}
+	t.Setenv("FASTLY_API_KEY", "api-key")
+	t.Setenv("FASTLY_CUSTOMER_ID", "customer-id")
+
+	if err := provider.Init(nil); err != nil {
+		t.Fatalf("expected init to succeed: %v", err)
+	}
+	if provider.apiKey != "api-key" || provider.customerID != "customer-id" {
+		t.Fatalf("expected provider state to be initialized, got apiKey=%q customerID=%q", provider.apiKey, provider.customerID)
+	}
+
+	t.Setenv("FASTLY_CUSTOMER_ID", "")
+	if err := provider.Init(nil); err == nil {
+		t.Fatal("expected init to fail without FASTLY_CUSTOMER_ID")
+	}
+	if provider.apiKey != "" || provider.customerID != "" {
+		t.Fatalf("expected stale provider state to be cleared, got apiKey=%q customerID=%q", provider.apiKey, provider.customerID)
+	}
+}

--- a/providers/grafana/grafana_provider.go
+++ b/providers/grafana/grafana_provider.go
@@ -59,13 +59,21 @@ func (p *GrafanaProvider) GetConfig() cty.Value {
 }
 
 func (p *GrafanaProvider) Init(_ []string) error {
-	p.auth = os.Getenv("GRAFANA_AUTH")
-	if p.auth == "" {
+	p.auth = ""
+	p.url = ""
+	p.orgID = 0
+	p.tlsKey = ""
+	p.tlsCert = ""
+	p.caCert = ""
+	p.insecureSkipVerify = false
+
+	auth := os.Getenv("GRAFANA_AUTH")
+	if auth == "" {
 		return errors.New("Grafana API authentication must be set through `GRAFANA_AUTH` env var, either as an API token or as username:password for HTTP basic auth")
 	}
 
-	p.url = os.Getenv("GRAFANA_URL")
-	if p.url == "" {
+	url := os.Getenv("GRAFANA_URL")
+	if url == "" {
 		return errors.New("Grafana API URL must be set through `GRAFANA_URL` env var")
 	}
 
@@ -73,15 +81,13 @@ func (p *GrafanaProvider) Init(_ []string) error {
 	if err != nil {
 		orgID = 1
 	}
+	p.auth = auth
+	p.url = url
 	p.orgID = orgID
-
 	p.tlsKey = os.Getenv("HTTPS_TLS_KEY")
 	p.tlsCert = os.Getenv("HTTPS_TLS_CERT")
 	p.caCert = os.Getenv("HTTPS_CA_CERT")
-
-	if os.Getenv("HTTPS_INSECURE_SKIP_VERIFY") == "1" {
-		p.insecureSkipVerify = true
-	}
+	p.insecureSkipVerify = os.Getenv("HTTPS_INSECURE_SKIP_VERIFY") == "1"
 
 	return nil
 }

--- a/providers/grafana/grafana_provider_test.go
+++ b/providers/grafana/grafana_provider_test.go
@@ -1,0 +1,31 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package grafana
+
+import "testing"
+
+func TestGrafanaProviderInitClearsStateOnMissingURL(t *testing.T) {
+	provider := &GrafanaProvider{}
+	t.Setenv("GRAFANA_AUTH", "auth")
+	t.Setenv("GRAFANA_URL", "https://grafana.example.com")
+	t.Setenv("GRAFANA_ORG_ID", "42")
+	t.Setenv("HTTPS_TLS_KEY", "tls-key")
+	t.Setenv("HTTPS_TLS_CERT", "tls-cert")
+	t.Setenv("HTTPS_CA_CERT", "ca-cert")
+	t.Setenv("HTTPS_INSECURE_SKIP_VERIFY", "1")
+
+	if err := provider.Init(nil); err != nil {
+		t.Fatalf("expected init to succeed: %v", err)
+	}
+	if provider.auth != "auth" || provider.url != "https://grafana.example.com" || provider.orgID != 42 || !provider.insecureSkipVerify {
+		t.Fatalf("expected provider state to be initialized, got auth=%q url=%q orgID=%d insecure=%t", provider.auth, provider.url, provider.orgID, provider.insecureSkipVerify)
+	}
+
+	t.Setenv("GRAFANA_URL", "")
+	if err := provider.Init(nil); err == nil {
+		t.Fatal("expected init to fail without GRAFANA_URL")
+	}
+	if provider.auth != "" || provider.url != "" || provider.orgID != 0 || provider.tlsKey != "" || provider.tlsCert != "" || provider.caCert != "" || provider.insecureSkipVerify {
+		t.Fatalf("expected stale provider state to be cleared, got auth=%q url=%q orgID=%d tlsKey=%q tlsCert=%q caCert=%q insecure=%t", provider.auth, provider.url, provider.orgID, provider.tlsKey, provider.tlsCert, provider.caCert, provider.insecureSkipVerify)
+	}
+}

--- a/providers/ionoscloud/ionoscloud_provider.go
+++ b/providers/ionoscloud/ionoscloud_provider.go
@@ -21,6 +21,11 @@ type IonosCloudProvider struct { //nolint
 }
 
 func (p *IonosCloudProvider) Init(_ []string) error {
+	p.username = ""
+	p.password = ""
+	p.token = ""
+	p.url = ""
+
 	username := os.Getenv(ionoscloud.IonosUsernameEnvVar)
 	password := os.Getenv(ionoscloud.IonosPasswordEnvVar)
 	token := os.Getenv(ionoscloud.IonosTokenEnvVar)

--- a/providers/ionoscloud/ionoscloud_provider_test.go
+++ b/providers/ionoscloud/ionoscloud_provider_test.go
@@ -1,0 +1,57 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package ionoscloud
+
+import (
+	"testing"
+
+	sdk "github.com/ionos-cloud/sdk-go/v6"
+)
+
+func TestIonosCloudProviderInitClearsStaleTokenWhenSwitchingAuth(t *testing.T) {
+	provider := &IonosCloudProvider{}
+	t.Setenv(sdk.IonosTokenEnvVar, "token")
+	t.Setenv(sdk.IonosUsernameEnvVar, "")
+	t.Setenv(sdk.IonosPasswordEnvVar, "")
+	t.Setenv(sdk.IonosApiUrlEnvVar, "https://api.ionos.example.com")
+
+	if err := provider.Init(nil); err != nil {
+		t.Fatalf("expected token init to succeed: %v", err)
+	}
+	if provider.token != "token" || provider.url != "https://api.ionos.example.com" {
+		t.Fatalf("expected token state to be initialized, got token=%q url=%q", provider.token, provider.url)
+	}
+
+	t.Setenv(sdk.IonosTokenEnvVar, "")
+	t.Setenv(sdk.IonosUsernameEnvVar, "user")
+	t.Setenv(sdk.IonosPasswordEnvVar, "password")
+	if err := provider.Init(nil); err != nil {
+		t.Fatalf("expected username/password init to succeed: %v", err)
+	}
+	if provider.username != "user" || provider.password != "password" || provider.token != "" {
+		t.Fatalf("expected token to be cleared after auth switch, got username=%q password=%q token=%q", provider.username, provider.password, provider.token)
+	}
+}
+
+func TestIonosCloudProviderInitClearsStateOnMissingCredentials(t *testing.T) {
+	provider := &IonosCloudProvider{}
+	t.Setenv(sdk.IonosTokenEnvVar, "token")
+	t.Setenv(sdk.IonosUsernameEnvVar, "")
+	t.Setenv(sdk.IonosPasswordEnvVar, "")
+	t.Setenv(sdk.IonosApiUrlEnvVar, "")
+
+	if err := provider.Init(nil); err != nil {
+		t.Fatalf("expected init to succeed: %v", err)
+	}
+	if provider.token != "token" {
+		t.Fatalf("expected token to be initialized, got %q", provider.token)
+	}
+
+	t.Setenv(sdk.IonosTokenEnvVar, "")
+	if err := provider.Init(nil); err == nil {
+		t.Fatal("expected init to fail without credentials")
+	}
+	if provider.username != "" || provider.password != "" || provider.token != "" || provider.url != "" {
+		t.Fatalf("expected stale provider state to be cleared, got username=%q password=%q token=%q url=%q", provider.username, provider.password, provider.token, provider.url)
+	}
+}

--- a/providers/launchdarkly/launchdarkly_provider.go
+++ b/providers/launchdarkly/launchdarkly_provider.go
@@ -21,19 +21,26 @@ type LaunchDarklyProvider struct { //nolint
 const APIVersion = "20240415"
 
 func (p *LaunchDarklyProvider) Init(_ []string) error {
-	if os.Getenv("LAUNCHDARKLY_ACCESS_TOKEN") == "" {
+	p.apiKey = ""
+	p.client = nil
+	p.ctx = nil
+
+	apiKey := os.Getenv("LAUNCHDARKLY_ACCESS_TOKEN")
+	if apiKey == "" {
 		return errors.New("set LAUNCHDARKLY_ACCESS_TOKEN env var")
 	}
-	p.apiKey = os.Getenv("LAUNCHDARKLY_ACCESS_TOKEN")
 
 	cfg := ldapi.NewConfiguration()
 	cfg.AddDefaultHeader("LD-API-Version", APIVersion)
 
-	p.client = ldapi.NewAPIClient(cfg)
+	client := ldapi.NewAPIClient(cfg)
 
-	p.ctx = context.WithValue(context.Background(), ldapi.ContextAPIKeys, map[string]ldapi.APIKey{
-		"ApiKey": {Key: p.apiKey},
+	ctx := context.WithValue(context.Background(), ldapi.ContextAPIKeys, map[string]ldapi.APIKey{
+		"ApiKey": {Key: apiKey},
 	})
+	p.apiKey = apiKey
+	p.client = client
+	p.ctx = ctx
 	return nil
 }
 

--- a/providers/launchdarkly/launchdarkly_provider_test.go
+++ b/providers/launchdarkly/launchdarkly_provider_test.go
@@ -1,0 +1,25 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package launchdarkly
+
+import "testing"
+
+func TestLaunchDarklyProviderInitClearsStateOnMissingToken(t *testing.T) {
+	provider := &LaunchDarklyProvider{}
+	t.Setenv("LAUNCHDARKLY_ACCESS_TOKEN", "access-token")
+
+	if err := provider.Init(nil); err != nil {
+		t.Fatalf("expected init to succeed: %v", err)
+	}
+	if provider.apiKey != "access-token" || provider.client == nil || provider.ctx == nil {
+		t.Fatalf("expected provider state to be initialized, got apiKey=%q client=%v ctx=%v", provider.apiKey, provider.client, provider.ctx)
+	}
+
+	t.Setenv("LAUNCHDARKLY_ACCESS_TOKEN", "")
+	if err := provider.Init(nil); err == nil {
+		t.Fatal("expected init to fail without LAUNCHDARKLY_ACCESS_TOKEN")
+	}
+	if provider.apiKey != "" || provider.client != nil || provider.ctx != nil {
+		t.Fatalf("expected stale provider state to be cleared, got apiKey=%q client=%v ctx=%v", provider.apiKey, provider.client, provider.ctx)
+	}
+}

--- a/providers/linode/linode_provider.go
+++ b/providers/linode/linode_provider.go
@@ -15,10 +15,13 @@ type LinodeProvider struct { //nolint
 }
 
 func (p *LinodeProvider) Init(_ []string) error {
-	if os.Getenv("LINODE_TOKEN") == "" {
+	p.token = ""
+
+	token := os.Getenv("LINODE_TOKEN")
+	if token == "" {
 		return errors.New("set LINODE_TOKEN env var")
 	}
-	p.token = os.Getenv("LINODE_TOKEN")
+	p.token = token
 
 	return nil
 }

--- a/providers/linode/linode_provider_test.go
+++ b/providers/linode/linode_provider_test.go
@@ -1,0 +1,25 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package linode
+
+import "testing"
+
+func TestLinodeProviderInitClearsTokenOnMissingEnv(t *testing.T) {
+	provider := &LinodeProvider{}
+	t.Setenv("LINODE_TOKEN", "token")
+
+	if err := provider.Init(nil); err != nil {
+		t.Fatalf("expected init to succeed: %v", err)
+	}
+	if provider.token != "token" {
+		t.Fatalf("expected token to be initialized, got %q", provider.token)
+	}
+
+	t.Setenv("LINODE_TOKEN", "")
+	if err := provider.Init(nil); err == nil {
+		t.Fatal("expected init to fail without LINODE_TOKEN")
+	}
+	if provider.token != "" {
+		t.Fatalf("expected stale token to be cleared, got %q", provider.token)
+	}
+}

--- a/providers/ns1/ns1_provider.go
+++ b/providers/ns1/ns1_provider.go
@@ -15,10 +15,13 @@ type Ns1Provider struct { //nolint
 }
 
 func (p *Ns1Provider) Init(_ []string) error {
-	if os.Getenv("NS1_APIKEY") == "" {
+	p.apiKey = ""
+
+	apiKey := os.Getenv("NS1_APIKEY")
+	if apiKey == "" {
 		return errors.New("set NS1_APIKEY env var")
 	}
-	p.apiKey = os.Getenv("NS1_APIKEY")
+	p.apiKey = apiKey
 
 	return nil
 }

--- a/providers/ns1/ns1_provider_test.go
+++ b/providers/ns1/ns1_provider_test.go
@@ -1,0 +1,25 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package ns1
+
+import "testing"
+
+func TestNs1ProviderInitClearsAPIKeyOnMissingEnv(t *testing.T) {
+	provider := &Ns1Provider{}
+	t.Setenv("NS1_APIKEY", "api-key")
+
+	if err := provider.Init(nil); err != nil {
+		t.Fatalf("expected init to succeed: %v", err)
+	}
+	if provider.apiKey != "api-key" {
+		t.Fatalf("expected api key to be initialized, got %q", provider.apiKey)
+	}
+
+	t.Setenv("NS1_APIKEY", "")
+	if err := provider.Init(nil); err == nil {
+		t.Fatal("expected init to fail without NS1_APIKEY")
+	}
+	if provider.apiKey != "" {
+		t.Fatalf("expected stale api key to be cleared, got %q", provider.apiKey)
+	}
+}

--- a/providers/okta/okta_provider.go
+++ b/providers/okta/okta_provider.go
@@ -35,22 +35,26 @@ func (p *OktaProvider) GetResourceConnections() map[string]map[string][]string {
 }
 
 func (p *OktaProvider) Init(_ []string) error {
+	p.orgName = ""
+	p.baseURL = ""
+	p.apiToken = ""
+
 	orgName := os.Getenv("OKTA_ORG_NAME")
 	if orgName == "" {
 		return errors.New("set OKTA_ORG_NAME env var")
 	}
-	p.orgName = orgName
 
 	baseURL := os.Getenv("OKTA_BASE_URL")
 	if baseURL == "" {
 		return errors.New("set OKTA_BASE_URL env var")
 	}
-	p.baseURL = baseURL
 
 	apiToken := os.Getenv("OKTA_API_TOKEN")
 	if apiToken == "" {
 		return errors.New("set OKTA_API_TOKEN env var")
 	}
+	p.orgName = orgName
+	p.baseURL = baseURL
 	p.apiToken = apiToken
 
 	return nil

--- a/providers/okta/okta_provider_test.go
+++ b/providers/okta/okta_provider_test.go
@@ -1,0 +1,27 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package okta
+
+import "testing"
+
+func TestOktaProviderInitClearsStateOnMissingAPIToken(t *testing.T) {
+	provider := &OktaProvider{}
+	t.Setenv("OKTA_ORG_NAME", "org")
+	t.Setenv("OKTA_BASE_URL", "okta.com")
+	t.Setenv("OKTA_API_TOKEN", "api-token")
+
+	if err := provider.Init(nil); err != nil {
+		t.Fatalf("expected init to succeed: %v", err)
+	}
+	if provider.orgName != "org" || provider.baseURL != "okta.com" || provider.apiToken != "api-token" {
+		t.Fatalf("expected provider state to be initialized, got orgName=%q baseURL=%q apiToken=%q", provider.orgName, provider.baseURL, provider.apiToken)
+	}
+
+	t.Setenv("OKTA_API_TOKEN", "")
+	if err := provider.Init(nil); err == nil {
+		t.Fatal("expected init to fail without OKTA_API_TOKEN")
+	}
+	if provider.orgName != "" || provider.baseURL != "" || provider.apiToken != "" {
+		t.Fatalf("expected stale provider state to be cleared, got orgName=%q baseURL=%q apiToken=%q", provider.orgName, provider.baseURL, provider.apiToken)
+	}
+}

--- a/providers/opal/opal_provider.go
+++ b/providers/opal/opal_provider.go
@@ -67,14 +67,19 @@ func (p OpalProvider) GetResourceConnections() map[string]map[string][]string {
 }
 
 func (p *OpalProvider) Init(_ []string) error {
-	p.token = os.Getenv("OPAL_AUTH_TOKEN")
-	if p.token == "" {
+	p.token = ""
+	p.baseURL = ""
+
+	token := os.Getenv("OPAL_AUTH_TOKEN")
+	if token == "" {
 		return errors.New("the Opal API key must be set via `OPAL_AUTH_TOKEN` env var")
 	}
-	p.baseURL = os.Getenv("OPAL_BASE_URL")
-	if p.baseURL == "" {
-		p.baseURL = opalDefaultURL
+	baseURL := os.Getenv("OPAL_BASE_URL")
+	if baseURL == "" {
+		baseURL = opalDefaultURL
 	}
+	p.token = token
+	p.baseURL = baseURL
 
 	return nil
 }

--- a/providers/opal/opal_provider_test.go
+++ b/providers/opal/opal_provider_test.go
@@ -1,0 +1,26 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package opal
+
+import "testing"
+
+func TestOpalProviderInitClearsStateOnMissingToken(t *testing.T) {
+	provider := &OpalProvider{}
+	t.Setenv("OPAL_AUTH_TOKEN", "token")
+	t.Setenv("OPAL_BASE_URL", "https://opal.example.com")
+
+	if err := provider.Init(nil); err != nil {
+		t.Fatalf("expected init to succeed: %v", err)
+	}
+	if provider.token != "token" || provider.baseURL != "https://opal.example.com" {
+		t.Fatalf("expected provider state to be initialized, got token=%q baseURL=%q", provider.token, provider.baseURL)
+	}
+
+	t.Setenv("OPAL_AUTH_TOKEN", "")
+	if err := provider.Init(nil); err == nil {
+		t.Fatal("expected init to fail without OPAL_AUTH_TOKEN")
+	}
+	if provider.token != "" || provider.baseURL != "" {
+		t.Fatalf("expected stale provider state to be cleared, got token=%q baseURL=%q", provider.token, provider.baseURL)
+	}
+}

--- a/providers/vultr/vultr_provider.go
+++ b/providers/vultr/vultr_provider.go
@@ -15,10 +15,13 @@ type VultrProvider struct { //nolint
 }
 
 func (p *VultrProvider) Init(_ []string) error {
-	if os.Getenv("VULTR_API_KEY") == "" {
+	p.apiKey = ""
+
+	apiKey := os.Getenv("VULTR_API_KEY")
+	if apiKey == "" {
 		return errors.New("set VULTR_API_KEY env var")
 	}
-	p.apiKey = os.Getenv("VULTR_API_KEY")
+	p.apiKey = apiKey
 
 	return nil
 }

--- a/providers/vultr/vultr_provider_test.go
+++ b/providers/vultr/vultr_provider_test.go
@@ -1,0 +1,25 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package vultr
+
+import "testing"
+
+func TestVultrProviderInitClearsAPIKeyOnMissingEnv(t *testing.T) {
+	provider := &VultrProvider{}
+	t.Setenv("VULTR_API_KEY", "api-key")
+
+	if err := provider.Init(nil); err != nil {
+		t.Fatalf("expected init to succeed: %v", err)
+	}
+	if provider.apiKey != "api-key" {
+		t.Fatalf("expected api key to be initialized, got %q", provider.apiKey)
+	}
+
+	t.Setenv("VULTR_API_KEY", "")
+	if err := provider.Init(nil); err == nil {
+		t.Fatal("expected init to fail without VULTR_API_KEY")
+	}
+	if provider.apiKey != "" {
+		t.Fatalf("expected stale api key to be cleared, got %q", provider.apiKey)
+	}
+}

--- a/providers/xenorchestra/xenorchestra_provider.go
+++ b/providers/xenorchestra/xenorchestra_provider.go
@@ -17,20 +17,27 @@ type XenorchestraProvider struct { //nolint
 }
 
 func (p *XenorchestraProvider) Init(_ []string) error {
-	if os.Getenv("XOA_URL") == "" {
+	p.url = ""
+	p.user = ""
+	p.password = ""
+
+	url := os.Getenv("XOA_URL")
+	if url == "" {
 		return errors.New("set XOA_URL env var")
 	}
-	p.url = os.Getenv("XOA_URL")
 
-	if os.Getenv("XOA_USER") == "" {
+	user := os.Getenv("XOA_USER")
+	if user == "" {
 		return errors.New("set XOA_USER env var")
 	}
-	p.user = os.Getenv("XOA_USER")
 
-	if os.Getenv("XOA_PASSWORD") == "" {
+	password := os.Getenv("XOA_PASSWORD")
+	if password == "" {
 		return errors.New("set XOA_PASSWORD env var")
 	}
-	p.password = os.Getenv("XOA_PASSWORD")
+	p.url = url
+	p.user = user
+	p.password = password
 
 	return nil
 }

--- a/providers/xenorchestra/xenorchestra_provider_test.go
+++ b/providers/xenorchestra/xenorchestra_provider_test.go
@@ -1,0 +1,27 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package xenorchestra
+
+import "testing"
+
+func TestXenorchestraProviderInitClearsStateOnMissingPassword(t *testing.T) {
+	provider := &XenorchestraProvider{}
+	t.Setenv("XOA_URL", "https://example.com")
+	t.Setenv("XOA_USER", "user")
+	t.Setenv("XOA_PASSWORD", "password")
+
+	if err := provider.Init(nil); err != nil {
+		t.Fatalf("expected init to succeed: %v", err)
+	}
+	if provider.url != "https://example.com" || provider.user != "user" || provider.password != "password" {
+		t.Fatalf("expected provider state to be initialized, got url=%q user=%q password=%q", provider.url, provider.user, provider.password)
+	}
+
+	t.Setenv("XOA_PASSWORD", "")
+	if err := provider.Init(nil); err == nil {
+		t.Fatal("expected init to fail without XOA_PASSWORD")
+	}
+	if provider.url != "" || provider.user != "" || provider.password != "" {
+		t.Fatalf("expected stale provider state to be cleared, got url=%q user=%q password=%q", provider.url, provider.user, provider.password)
+	}
+}


### PR DESCRIPTION
## Summary

- Clear provider init state before env validation for env-configured providers.
- Prevent failed reinitialization from retaining stale credentials, endpoints, or clients.
- Add regression coverage for stale-state failure paths across the touched providers.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix reinitialization across env-configured providers by clearing state before validation to prevent stale credentials, endpoints, and clients. Adds regression tests to lock this behavior in.

- **Bug Fixes**
  - Build clients only after successful validation and assignment (e.g., `auth0`, `launchdarkly`).
  - Reset all relevant fields, including TLS and flags in `grafana`; clear old token when switching auth in `ionoscloud`.
  - Add tests covering stale-state failure paths across updated providers (`azuread`, `azuredevops`, `digitalocean`, `equinixmetal`, `fastly`, `grafana`, `ionoscloud`, `launchdarkly`, `linode`, `ns1`, `okta`, `opal`, `vultr`, `xenorchestra`).

<sup>Written for commit dd3160a482f3adf2b9d60d84d2490d11fe4ab9ab. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

