### PR TITLE
aws(backup): add Backup resources

### DIFF
--- a/docs/aws.md
+++ b/docs/aws.md
@@ -87,6 +87,20 @@ terraformer import aws --resources=sg --regions=us-east-1
     * `aws_autoscaling_group`
     * `aws_launch_configuration`
     * `aws_launch_template`
+*   `backup`
+    * `aws_backup_framework`
+    * `aws_backup_global_settings`
+    * `aws_backup_logically_air_gapped_vault`
+    * `aws_backup_plan`
+    * `aws_backup_region_settings`
+    * `aws_backup_report_plan`
+    * `aws_backup_restore_testing_plan`
+    * `aws_backup_restore_testing_selection`
+    * `aws_backup_selection`
+    * `aws_backup_vault`
+    * `aws_backup_vault_lock_configuration`
+    * `aws_backup_vault_notifications`
+    * `aws_backup_vault_policy`
 *   `batch`
     * `aws_batch_compute_environment`
     * `aws_batch_job_definition`

--- a/go.mod
+++ b/go.mod
@@ -400,6 +400,7 @@ require (
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/synapse/armsynapse v0.8.0
 	github.com/IBM/continuous-delivery-go-sdk/v2 v2.0.8
 	github.com/aws/aws-sdk-go-v2/service/apigatewayv2 v1.34.3
+	github.com/aws/aws-sdk-go-v2/service/backup v1.55.2
 	github.com/aws/aws-sdk-go-v2/service/directconnect v1.38.17
 	github.com/gofrs/uuid/v3 v3.1.2
 	github.com/golang-jwt/jwt/v4 v4.5.2

--- a/go.sum
+++ b/go.sum
@@ -211,6 +211,8 @@ github.com/aws/aws-sdk-go-v2/service/appsync v1.53.7 h1:SjkXYNc15FoovS9k6ML7dO7p
 github.com/aws/aws-sdk-go-v2/service/appsync v1.53.7/go.mod h1:RcoBov7Pw38ViMxlthKRr1GLgHPPseA+kY2bupWVm10=
 github.com/aws/aws-sdk-go-v2/service/autoscaling v1.66.2 h1:pPd+/Ujqf2+DmPOdB47EN7ox1iC21lu2zlOccUlfHeo=
 github.com/aws/aws-sdk-go-v2/service/autoscaling v1.66.2/go.mod h1:b3XHAIEe5I9cmeZ9MLvUqj5DRWcBuh1/hpKDPb7T6KE=
+github.com/aws/aws-sdk-go-v2/service/backup v1.55.2 h1:WhdT1PwOjTjKLGuD9lJDyNMgYmVaZgTHK06ioJKMBYE=
+github.com/aws/aws-sdk-go-v2/service/backup v1.55.2/go.mod h1:uMh3ZDoLKhXldYL1qcBYy1HsNQfKgL/w8iF2onOyoKY=
 github.com/aws/aws-sdk-go-v2/service/batch v1.64.1 h1:+Nm5tPlRgOVQB/uMvphSNyJI9WKyIdE2FlTCMXEqqns=
 github.com/aws/aws-sdk-go-v2/service/batch v1.64.1/go.mod h1:EHhfaNTxntvYHmSdHGLLSxuerqkMIlXY9lWjl+CJJxg=
 github.com/aws/aws-sdk-go-v2/service/budgets v1.43.6 h1:2C1Fx5PAPB+8Se7nwnxAElSMW5KxuDVwzBu6t2qtlfg=

--- a/providers/aws/aws_provider.go
+++ b/providers/aws/aws_provider.go
@@ -237,6 +237,7 @@ func (p *AWSProvider) GetSupportedService() map[string]terraformutils.ServiceGen
 		"api_gatewayv2":     &AwsFacade{service: &APIGatewayV2Generator{}},
 		"appsync":           &AwsFacade{service: &AppSyncGenerator{}},
 		"auto_scaling":      &AwsFacade{service: &AutoScalingGenerator{}},
+		"backup":            &AwsFacade{service: &BackupGenerator{}},
 		"batch":             &AwsFacade{service: &BatchGenerator{}},
 		"budgets":           &AwsFacade{service: &BudgetsGenerator{}},
 		"cloud9":            &AwsFacade{service: &Cloud9Generator{}},

--- a/providers/aws/backup.go
+++ b/providers/aws/backup.go
@@ -32,7 +32,7 @@ const (
 	backupRestoreTestingSelectionResourceType = "backup_restore_testing_selection"
 )
 
-var backupAllowEmptyValues = []string{"tags."}
+var backupAllowEmptyValues = []string{"tags.", "resource_type_opt_in_preference"}
 
 var backupResourceTypes = []string{
 	backupVaultResourceType,
@@ -76,6 +76,25 @@ type backupOptionalResourceLoader struct {
 	name         string
 	serviceNames []string
 	load         func() error
+}
+
+func (g *BackupGenerator) InitialCleanup() {
+	if len(g.Filter) == 0 {
+		return
+	}
+	var filteredResources []terraformutils.Resource
+	for _, resource := range g.Resources {
+		allPredicatesTrue := true
+		for _, filter := range g.Filter {
+			if filter.FieldPath == "id" {
+				allPredicatesTrue = allPredicatesTrue && backupInitialIDFilterMatchesResource(filter, resource)
+			}
+		}
+		if allPredicatesTrue && !terraformutils.ContainsResource(filteredResources, resource) {
+			filteredResources = append(filteredResources, resource)
+		}
+	}
+	g.Resources = filteredResources
 }
 
 func (g *BackupGenerator) InitResources() error {
@@ -411,10 +430,9 @@ func newBackupSelectionResource(planID string, selection backuptypes.BackupSelec
 	if iamRoleARN := StringValue(selection.IamRoleArn); iamRoleARN != "" {
 		attributes["iam_role_arn"] = iamRoleARN
 	}
-	importID := backupSelectionImportID(planID, selectionID)
 	return terraformutils.NewResource(
-		importID,
-		importID,
+		selectionID,
+		backupSelectionImportID(planID, selectionID),
 		"aws_backup_selection",
 		"aws",
 		attributes,
@@ -580,7 +598,7 @@ func (g *BackupGenerator) addBackupRegionSettings(svc *backup.Client, region str
 	if err != nil {
 		return err
 	}
-	if region == "" || len(output.ResourceTypeOptInPreference) == 0 {
+	if region == "" || !backupRegionSettingsConfigured(output) {
 		return nil
 	}
 	attributes := backupBoolMapAttributes("resource_type_opt_in_preference", output.ResourceTypeOptInPreference)
@@ -694,7 +712,7 @@ func (g *BackupGenerator) resourceMatchesInitialIDFilters(serviceName string, re
 		if filter.FieldPath != "id" || !filter.IsApplicable(serviceName) {
 			continue
 		}
-		if !filter.Filter(resource) {
+		if !backupInitialIDFilterMatchesResource(filter, resource) {
 			return false
 		}
 	}
@@ -706,7 +724,7 @@ func (g *BackupGenerator) resourceMatchesUntypedIDFilters(resource terraformutil
 		if filter.ServiceName != "" || filter.FieldPath != "id" {
 			continue
 		}
-		if !filter.Filter(resource) {
+		if !backupInitialIDFilterMatchesResource(filter, resource) {
 			return false
 		}
 	}
@@ -780,6 +798,10 @@ func backupLogicallyAirGappedVaultImportable(vault backuptypes.BackupVaultListMe
 	return vault.VaultType == backuptypes.VaultTypeLogicallyAirGappedBackupVault && StringValue(vault.BackupVaultName) != "" && vault.MinRetentionDays != nil && vault.MaxRetentionDays != nil
 }
 
+func backupRegionSettingsConfigured(output *backup.DescribeRegionSettingsOutput) bool {
+	return output != nil && (len(output.ResourceTypeOptInPreference) > 0 || len(output.ResourceTypeManagementPreference) > 0)
+}
+
 func backupVaultEvents(events []backuptypes.BackupVaultEvent) []string {
 	values := make([]string, 0, len(events))
 	for _, event := range events {
@@ -848,10 +870,13 @@ func backupRestoreTestingSelectionImportID(selectionName, planName string) strin
 func backupSelectionIDFilterCanMatch(values []string, planID, selectionID string) bool {
 	for _, value := range values {
 		if selectionID != "" {
-			if value == backupSelectionImportID(planID, selectionID) {
+			if value == selectionID || value == backupSelectionImportID(planID, selectionID) {
 				return true
 			}
 			continue
+		}
+		if !strings.Contains(value, "|") {
+			return true
 		}
 		if strings.HasPrefix(value, planID+"|") {
 			return true
@@ -878,6 +903,17 @@ func backupRestoreTestingSelectionIDFilterCanMatch(values []string, planName, se
 func backupResourceMissing(err error) bool {
 	var resourceNotFound *backuptypes.ResourceNotFoundException
 	return errors.As(err, &resourceNotFound)
+}
+
+func backupInitialIDFilterMatchesResource(filter terraformutils.ResourceFilter, resource terraformutils.Resource) bool {
+	serviceName := strings.TrimPrefix(resource.InstanceInfo.Type, resource.Provider+"_")
+	if !filter.IsApplicable(serviceName) {
+		return true
+	}
+	if serviceName == backupSelectionResourceType {
+		return backupSelectionIDFilterCanMatch(filter.AcceptableValues, resource.InstanceState.Attributes["plan_id"], resource.InstanceState.ID)
+	}
+	return filter.Filter(resource)
 }
 
 func (g *BackupGenerator) PostConvertHook() error {

--- a/providers/aws/backup.go
+++ b/providers/aws/backup.go
@@ -1,0 +1,898 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package aws
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log"
+	"strconv"
+	"strings"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/backup"
+	backuptypes "github.com/aws/aws-sdk-go-v2/service/backup/types"
+	"github.com/chenrui333/terraformer/terraformutils"
+)
+
+const (
+	backupVaultResourceType                   = "backup_vault"
+	backupLogicallyAirGappedVaultResourceType = "backup_logically_air_gapped_vault"
+	backupVaultPolicyResourceType             = "backup_vault_policy"
+	backupVaultNotificationsResourceType      = "backup_vault_notifications"
+	backupVaultLockConfigurationResourceType  = "backup_vault_lock_configuration"
+	backupPlanResourceType                    = "backup_plan"
+	backupSelectionResourceType               = "backup_selection"
+	backupRegionSettingsResourceType          = "backup_region_settings"
+	backupGlobalSettingsResourceType          = "backup_global_settings"
+	backupFrameworkResourceType               = "backup_framework"
+	backupReportPlanResourceType              = "backup_report_plan"
+	backupRestoreTestingPlanResourceType      = "backup_restore_testing_plan"
+	backupRestoreTestingSelectionResourceType = "backup_restore_testing_selection"
+)
+
+var backupAllowEmptyValues = []string{"tags."}
+
+var backupResourceTypes = []string{
+	backupVaultResourceType,
+	backupLogicallyAirGappedVaultResourceType,
+	backupVaultPolicyResourceType,
+	backupVaultNotificationsResourceType,
+	backupVaultLockConfigurationResourceType,
+	backupPlanResourceType,
+	backupSelectionResourceType,
+	backupRegionSettingsResourceType,
+	backupGlobalSettingsResourceType,
+	backupFrameworkResourceType,
+	backupReportPlanResourceType,
+	backupRestoreTestingPlanResourceType,
+	backupRestoreTestingSelectionResourceType,
+}
+
+var backupVaultResourceTypes = []string{
+	backupVaultResourceType,
+	backupLogicallyAirGappedVaultResourceType,
+	backupVaultPolicyResourceType,
+	backupVaultNotificationsResourceType,
+	backupVaultLockConfigurationResourceType,
+}
+
+var backupPlanResourceTypes = []string{
+	backupPlanResourceType,
+	backupSelectionResourceType,
+}
+
+var backupRestoreTestingResourceTypes = []string{
+	backupRestoreTestingPlanResourceType,
+	backupRestoreTestingSelectionResourceType,
+}
+
+type BackupGenerator struct {
+	AWSService
+}
+
+type backupOptionalResourceLoader struct {
+	name         string
+	serviceNames []string
+	load         func() error
+}
+
+func (g *BackupGenerator) InitResources() error {
+	config, e := g.generateConfig()
+	if e != nil {
+		return e
+	}
+	svc := backup.NewFromConfig(config)
+
+	if g.shouldLoadAnyBackupResourceType(backupVaultResourceTypes...) {
+		if err := g.loadBackupVaults(svc); err != nil {
+			return err
+		}
+	}
+	if g.shouldLoadAnyBackupResourceType(backupPlanResourceTypes...) {
+		if err := g.loadBackupPlans(svc); err != nil {
+			return err
+		}
+	}
+
+	var optionalLoaders []backupOptionalResourceLoader
+	if g.shouldLoadAnyBackupResourceType(backupFrameworkResourceType) {
+		optionalLoaders = append(optionalLoaders, backupOptionalResourceLoader{
+			name:         "frameworks",
+			serviceNames: []string{backupFrameworkResourceType},
+			load:         func() error { return g.loadBackupFrameworks(svc) },
+		})
+	}
+	if g.shouldLoadAnyBackupResourceType(backupReportPlanResourceType) {
+		optionalLoaders = append(optionalLoaders, backupOptionalResourceLoader{
+			name:         "report plans",
+			serviceNames: []string{backupReportPlanResourceType},
+			load:         func() error { return g.loadBackupReportPlans(svc) },
+		})
+	}
+	if g.shouldLoadAnyBackupResourceType(backupRestoreTestingResourceTypes...) {
+		optionalLoaders = append(optionalLoaders, backupOptionalResourceLoader{
+			name:         "restore testing plans",
+			serviceNames: backupRestoreTestingResourceTypes,
+			load:         func() error { return g.loadBackupRestoreTestingPlans(svc) },
+		})
+	}
+	if g.shouldLoadAnyBackupResourceType(backupRegionSettingsResourceType) {
+		optionalLoaders = append(optionalLoaders, backupOptionalResourceLoader{
+			name:         "region settings",
+			serviceNames: []string{backupRegionSettingsResourceType},
+			load:         func() error { return g.addBackupRegionSettings(svc, config.Region) },
+		})
+	}
+	if g.shouldLoadAnyBackupResourceType(backupGlobalSettingsResourceType) {
+		optionalLoaders = append(optionalLoaders, backupOptionalResourceLoader{
+			name:         "global settings",
+			serviceNames: []string{backupGlobalSettingsResourceType},
+			load:         func() error { return g.addBackupGlobalSettings(svc, config) },
+		})
+	}
+
+	return g.loadOptionalResources(optionalLoaders)
+}
+
+func (g *BackupGenerator) loadBackupVaults(svc *backup.Client) error {
+	p := backup.NewListBackupVaultsPaginator(svc, &backup.ListBackupVaultsInput{})
+	for p.HasMorePages() {
+		page, err := p.NextPage(context.TODO())
+		if err != nil {
+			return err
+		}
+		for _, vault := range page.BackupVaultList {
+			if err := g.addBackupVaultResources(svc, vault); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+func (g *BackupGenerator) addBackupVaultResources(svc *backup.Client, vault backuptypes.BackupVaultListMember) error {
+	name := StringValue(vault.BackupVaultName)
+	if name == "" {
+		return nil
+	}
+
+	switch vault.VaultType {
+	case backuptypes.VaultTypeLogicallyAirGappedBackupVault:
+		resource, ok := newBackupLogicallyAirGappedVaultResource(vault)
+		if ok && g.shouldAppendBackupResource(backupLogicallyAirGappedVaultResourceType, resource) {
+			g.Resources = append(g.Resources, resource)
+		}
+	case backuptypes.VaultTypeRestoreAccessBackupVault:
+		// Restore access backup vaults are AWS-managed vault views, not a Terraform resource shape.
+		return nil
+	default:
+		resource := newBackupVaultResource(name)
+		if g.shouldAppendBackupResource(backupVaultResourceType, resource) {
+			g.Resources = append(g.Resources, resource)
+		}
+	}
+
+	if g.shouldLoadBackupVaultChildResource(backupVaultPolicyResourceType, name) {
+		if err := g.addBackupVaultPolicy(svc, name); err != nil {
+			return err
+		}
+	}
+	if g.shouldLoadBackupVaultChildResource(backupVaultNotificationsResourceType, name) {
+		if err := g.addBackupVaultNotifications(svc, name); err != nil {
+			return err
+		}
+	}
+	if vault.VaultType != backuptypes.VaultTypeLogicallyAirGappedBackupVault && backupVaultLockConfigured(vault) && g.shouldLoadBackupVaultChildResource(backupVaultLockConfigurationResourceType, name) {
+		resource := newBackupVaultLockConfigurationResource(vault)
+		if g.shouldAppendBackupResource(backupVaultLockConfigurationResourceType, resource) {
+			g.Resources = append(g.Resources, resource)
+		}
+	}
+	return nil
+}
+
+func newBackupVaultResource(name string) terraformutils.Resource {
+	return terraformutils.NewResource(
+		name,
+		name,
+		"aws_backup_vault",
+		"aws",
+		map[string]string{"name": name},
+		backupAllowEmptyValues,
+		map[string]interface{}{},
+	)
+}
+
+func newBackupLogicallyAirGappedVaultResource(vault backuptypes.BackupVaultListMember) (terraformutils.Resource, bool) {
+	name := StringValue(vault.BackupVaultName)
+	if !backupLogicallyAirGappedVaultImportable(vault) {
+		return terraformutils.Resource{}, false
+	}
+	attributes := map[string]string{
+		"name":               name,
+		"min_retention_days": strconv.FormatInt(*vault.MinRetentionDays, 10),
+		"max_retention_days": strconv.FormatInt(*vault.MaxRetentionDays, 10),
+	}
+	if encryptionKeyARN := StringValue(vault.EncryptionKeyArn); encryptionKeyARN != "" {
+		attributes["encryption_key_arn"] = encryptionKeyARN
+	}
+	return terraformutils.NewResource(
+		name,
+		name,
+		"aws_backup_logically_air_gapped_vault",
+		"aws",
+		attributes,
+		backupAllowEmptyValues,
+		map[string]interface{}{},
+	), true
+}
+
+func newBackupVaultChildReferenceResource(serviceName, vaultName string) terraformutils.Resource {
+	resourceType := "aws_" + serviceName
+	resourceName := vaultName
+	if serviceName != backupVaultResourceType {
+		resourceName = backupResourceName(vaultName, strings.TrimPrefix(serviceName, "backup_vault_"))
+	}
+	return terraformutils.NewResource(
+		vaultName,
+		resourceName,
+		resourceType,
+		"aws",
+		map[string]string{"backup_vault_name": vaultName},
+		backupAllowEmptyValues,
+		map[string]interface{}{},
+	)
+}
+
+func (g *BackupGenerator) addBackupVaultPolicy(svc *backup.Client, vaultName string) error {
+	output, err := svc.GetBackupVaultAccessPolicy(context.TODO(), &backup.GetBackupVaultAccessPolicyInput{
+		BackupVaultName: aws.String(vaultName),
+	})
+	if err != nil {
+		return g.handleOptionalResourceError(backupVaultPolicyResourceType, fmt.Sprintf("vault policy for %s", vaultName), err)
+	}
+	if output == nil {
+		return nil
+	}
+	policy := StringValue(output.Policy)
+	if policy == "" {
+		return nil
+	}
+	resource := terraformutils.NewResource(
+		vaultName,
+		backupResourceName(vaultName, "policy"),
+		"aws_backup_vault_policy",
+		"aws",
+		map[string]string{
+			"backup_vault_name": vaultName,
+			"policy":            policy,
+		},
+		backupAllowEmptyValues,
+		map[string]interface{}{},
+	)
+	if g.shouldAppendBackupResource(backupVaultPolicyResourceType, resource) {
+		g.Resources = append(g.Resources, resource)
+	}
+	return nil
+}
+
+func (g *BackupGenerator) addBackupVaultNotifications(svc *backup.Client, vaultName string) error {
+	output, err := svc.GetBackupVaultNotifications(context.TODO(), &backup.GetBackupVaultNotificationsInput{
+		BackupVaultName: aws.String(vaultName),
+	})
+	if err != nil {
+		return g.handleOptionalResourceError(backupVaultNotificationsResourceType, fmt.Sprintf("vault notifications for %s", vaultName), err)
+	}
+	if output == nil {
+		return nil
+	}
+	if !backupVaultNotificationsConfigured(output) {
+		return nil
+	}
+	attributes := map[string]string{
+		"backup_vault_name": vaultName,
+		"sns_topic_arn":     StringValue(output.SNSTopicArn),
+	}
+	for key, value := range backupStringSliceAttributes("backup_vault_events", backupVaultEvents(output.BackupVaultEvents)) {
+		attributes[key] = value
+	}
+	resource := terraformutils.NewResource(
+		vaultName,
+		backupResourceName(vaultName, "notifications"),
+		"aws_backup_vault_notifications",
+		"aws",
+		attributes,
+		backupAllowEmptyValues,
+		map[string]interface{}{},
+	)
+	if g.shouldAppendBackupResource(backupVaultNotificationsResourceType, resource) {
+		g.Resources = append(g.Resources, resource)
+	}
+	return nil
+}
+
+func newBackupVaultLockConfigurationResource(vault backuptypes.BackupVaultListMember) terraformutils.Resource {
+	name := StringValue(vault.BackupVaultName)
+	attributes := map[string]string{"backup_vault_name": name}
+	if vault.MinRetentionDays != nil {
+		attributes["min_retention_days"] = strconv.FormatInt(*vault.MinRetentionDays, 10)
+	}
+	if vault.MaxRetentionDays != nil {
+		attributes["max_retention_days"] = strconv.FormatInt(*vault.MaxRetentionDays, 10)
+	}
+	return terraformutils.NewResource(
+		name,
+		backupResourceName(name, "lock_configuration"),
+		"aws_backup_vault_lock_configuration",
+		"aws",
+		attributes,
+		backupAllowEmptyValues,
+		map[string]interface{}{},
+	)
+}
+
+func (g *BackupGenerator) loadBackupPlans(svc *backup.Client) error {
+	p := backup.NewListBackupPlansPaginator(svc, &backup.ListBackupPlansInput{})
+	for p.HasMorePages() {
+		page, err := p.NextPage(context.TODO())
+		if err != nil {
+			return err
+		}
+		for _, plan := range page.BackupPlansList {
+			planID := StringValue(plan.BackupPlanId)
+			if planID == "" {
+				continue
+			}
+			resource := newBackupPlanResource(plan)
+			if g.shouldAppendBackupResource(backupPlanResourceType, resource) {
+				g.Resources = append(g.Resources, resource)
+			}
+			if g.shouldLoadBackupSelections(planID) {
+				if err := g.loadBackupSelections(svc, planID); err != nil {
+					return err
+				}
+			}
+		}
+	}
+	return nil
+}
+
+func newBackupPlanResource(plan backuptypes.BackupPlansListMember) terraformutils.Resource {
+	planID := StringValue(plan.BackupPlanId)
+	name := StringValue(plan.BackupPlanName)
+	attributes := map[string]string{}
+	if name != "" {
+		attributes["name"] = name
+	}
+	return terraformutils.NewResource(
+		planID,
+		backupPlanResourceName(planID, name),
+		"aws_backup_plan",
+		"aws",
+		attributes,
+		backupAllowEmptyValues,
+		map[string]interface{}{},
+	)
+}
+
+func (g *BackupGenerator) loadBackupSelections(svc *backup.Client, planID string) error {
+	p := backup.NewListBackupSelectionsPaginator(svc, &backup.ListBackupSelectionsInput{
+		BackupPlanId: aws.String(planID),
+	})
+	for p.HasMorePages() {
+		page, err := p.NextPage(context.TODO())
+		if err != nil {
+			return g.handleOptionalResourceError(backupSelectionResourceType, fmt.Sprintf("selections for plan %s", planID), err)
+		}
+		for _, selection := range page.BackupSelectionsList {
+			selectionID := StringValue(selection.SelectionId)
+			if selectionID == "" {
+				continue
+			}
+			resource := newBackupSelectionResource(planID, selection)
+			if g.shouldAppendBackupResource(backupSelectionResourceType, resource) {
+				g.Resources = append(g.Resources, resource)
+			}
+		}
+	}
+	return nil
+}
+
+func newBackupSelectionResource(planID string, selection backuptypes.BackupSelectionsListMember) terraformutils.Resource {
+	selectionID := StringValue(selection.SelectionId)
+	attributes := map[string]string{
+		"plan_id": planID,
+	}
+	if selectionName := StringValue(selection.SelectionName); selectionName != "" {
+		attributes["name"] = selectionName
+	}
+	if iamRoleARN := StringValue(selection.IamRoleArn); iamRoleARN != "" {
+		attributes["iam_role_arn"] = iamRoleARN
+	}
+	importID := backupSelectionImportID(planID, selectionID)
+	return terraformutils.NewResource(
+		importID,
+		importID,
+		"aws_backup_selection",
+		"aws",
+		attributes,
+		backupAllowEmptyValues,
+		map[string]interface{}{},
+	)
+}
+
+func (g *BackupGenerator) loadBackupFrameworks(svc *backup.Client) error {
+	p := backup.NewListFrameworksPaginator(svc, &backup.ListFrameworksInput{})
+	for p.HasMorePages() {
+		page, err := p.NextPage(context.TODO())
+		if err != nil {
+			return err
+		}
+		for _, framework := range page.Frameworks {
+			name := StringValue(framework.FrameworkName)
+			if name == "" {
+				continue
+			}
+			resource := terraformutils.NewResource(
+				name,
+				name,
+				"aws_backup_framework",
+				"aws",
+				map[string]string{"name": name},
+				backupAllowEmptyValues,
+				map[string]interface{}{},
+			)
+			if g.shouldAppendBackupResource(backupFrameworkResourceType, resource) {
+				g.Resources = append(g.Resources, resource)
+			}
+		}
+	}
+	return nil
+}
+
+func (g *BackupGenerator) loadBackupReportPlans(svc *backup.Client) error {
+	p := backup.NewListReportPlansPaginator(svc, &backup.ListReportPlansInput{})
+	for p.HasMorePages() {
+		page, err := p.NextPage(context.TODO())
+		if err != nil {
+			return err
+		}
+		for _, reportPlan := range page.ReportPlans {
+			name := StringValue(reportPlan.ReportPlanName)
+			if name == "" {
+				continue
+			}
+			resource := terraformutils.NewResource(
+				name,
+				name,
+				"aws_backup_report_plan",
+				"aws",
+				map[string]string{"name": name},
+				backupAllowEmptyValues,
+				map[string]interface{}{},
+			)
+			if g.shouldAppendBackupResource(backupReportPlanResourceType, resource) {
+				g.Resources = append(g.Resources, resource)
+			}
+		}
+	}
+	return nil
+}
+
+func (g *BackupGenerator) loadBackupRestoreTestingPlans(svc *backup.Client) error {
+	p := backup.NewListRestoreTestingPlansPaginator(svc, &backup.ListRestoreTestingPlansInput{})
+	for p.HasMorePages() {
+		page, err := p.NextPage(context.TODO())
+		if err != nil {
+			return err
+		}
+		for _, plan := range page.RestoreTestingPlans {
+			name := StringValue(plan.RestoreTestingPlanName)
+			if name == "" {
+				continue
+			}
+			attributes := map[string]string{"name": name}
+			if scheduleExpression := StringValue(plan.ScheduleExpression); scheduleExpression != "" {
+				attributes["schedule_expression"] = scheduleExpression
+			}
+			if scheduleExpressionTimezone := StringValue(plan.ScheduleExpressionTimezone); scheduleExpressionTimezone != "" {
+				attributes["schedule_expression_timezone"] = scheduleExpressionTimezone
+			}
+			if plan.StartWindowHours != 0 {
+				attributes["start_window_hours"] = strconv.FormatInt(int64(plan.StartWindowHours), 10)
+			}
+			resource := terraformutils.NewResource(
+				name,
+				name,
+				"aws_backup_restore_testing_plan",
+				"aws",
+				attributes,
+				backupAllowEmptyValues,
+				map[string]interface{}{},
+			)
+			if g.shouldAppendBackupResource(backupRestoreTestingPlanResourceType, resource) {
+				g.Resources = append(g.Resources, resource)
+			}
+			if g.shouldLoadBackupRestoreTestingSelections(name) {
+				if err := g.loadBackupRestoreTestingSelections(svc, name); err != nil {
+					return err
+				}
+			}
+		}
+	}
+	return nil
+}
+
+func (g *BackupGenerator) loadBackupRestoreTestingSelections(svc *backup.Client, planName string) error {
+	p := backup.NewListRestoreTestingSelectionsPaginator(svc, &backup.ListRestoreTestingSelectionsInput{
+		RestoreTestingPlanName: aws.String(planName),
+	})
+	for p.HasMorePages() {
+		page, err := p.NextPage(context.TODO())
+		if err != nil {
+			return g.handleOptionalResourceError(backupRestoreTestingSelectionResourceType, fmt.Sprintf("restore testing selections for plan %s", planName), err)
+		}
+		for _, selection := range page.RestoreTestingSelections {
+			selectionName := StringValue(selection.RestoreTestingSelectionName)
+			if selectionName == "" {
+				continue
+			}
+			resource := newBackupRestoreTestingSelectionResource(planName, selection)
+			if g.shouldAppendBackupResource(backupRestoreTestingSelectionResourceType, resource) {
+				g.Resources = append(g.Resources, resource)
+			}
+		}
+	}
+	return nil
+}
+
+func newBackupRestoreTestingSelectionResource(planName string, selection backuptypes.RestoreTestingSelectionForList) terraformutils.Resource {
+	selectionName := StringValue(selection.RestoreTestingSelectionName)
+	attributes := map[string]string{
+		"name":                      selectionName,
+		"restore_testing_plan_name": planName,
+	}
+	if iamRoleARN := StringValue(selection.IamRoleArn); iamRoleARN != "" {
+		attributes["iam_role_arn"] = iamRoleARN
+	}
+	if protectedResourceType := StringValue(selection.ProtectedResourceType); protectedResourceType != "" {
+		attributes["protected_resource_type"] = protectedResourceType
+	}
+	if selection.ValidationWindowHours != 0 {
+		attributes["validation_window_hours"] = strconv.FormatInt(int64(selection.ValidationWindowHours), 10)
+	}
+	importID := backupRestoreTestingSelectionImportID(selectionName, planName)
+	return terraformutils.NewResource(
+		importID,
+		importID,
+		"aws_backup_restore_testing_selection",
+		"aws",
+		attributes,
+		backupAllowEmptyValues,
+		map[string]interface{}{},
+	)
+}
+
+func (g *BackupGenerator) addBackupRegionSettings(svc *backup.Client, region string) error {
+	output, err := svc.DescribeRegionSettings(context.TODO(), &backup.DescribeRegionSettingsInput{})
+	if err != nil {
+		return err
+	}
+	if region == "" || len(output.ResourceTypeOptInPreference) == 0 {
+		return nil
+	}
+	attributes := backupBoolMapAttributes("resource_type_opt_in_preference", output.ResourceTypeOptInPreference)
+	for key, value := range backupBoolMapAttributes("resource_type_management_preference", output.ResourceTypeManagementPreference) {
+		attributes[key] = value
+	}
+	resource := terraformutils.NewResource(
+		region,
+		region,
+		"aws_backup_region_settings",
+		"aws",
+		attributes,
+		backupAllowEmptyValues,
+		map[string]interface{}{},
+	)
+	if g.shouldAppendBackupResource(backupRegionSettingsResourceType, resource) {
+		g.Resources = append(g.Resources, resource)
+	}
+	return nil
+}
+
+func (g *BackupGenerator) addBackupGlobalSettings(svc *backup.Client, config aws.Config) error {
+	output, err := svc.DescribeGlobalSettings(context.TODO(), &backup.DescribeGlobalSettingsInput{})
+	if err != nil {
+		return err
+	}
+	if len(output.GlobalSettings) == 0 {
+		return nil
+	}
+	accountID, err := g.getAccountNumber(config)
+	if err != nil {
+		return err
+	}
+	if StringValue(accountID) == "" {
+		return nil
+	}
+	resource := terraformutils.NewResource(
+		StringValue(accountID),
+		StringValue(accountID),
+		"aws_backup_global_settings",
+		"aws",
+		backupStringMapAttributes("global_settings", output.GlobalSettings),
+		backupAllowEmptyValues,
+		map[string]interface{}{},
+	)
+	if g.shouldAppendBackupResource(backupGlobalSettingsResourceType, resource) {
+		g.Resources = append(g.Resources, resource)
+	}
+	return nil
+}
+
+func (g *BackupGenerator) loadOptionalResources(loaders []backupOptionalResourceLoader) error {
+	for _, loader := range loaders {
+		if err := loader.load(); err != nil {
+			if g.hasTypedFilterForAny(loader.serviceNames...) {
+				return fmt.Errorf("loading Backup %s: %w", loader.name, err)
+			}
+			log.Printf("Skipping Backup %s: %v", loader.name, err)
+		}
+	}
+	return nil
+}
+
+func (g *BackupGenerator) handleOptionalResourceError(serviceName, name string, err error) error {
+	if backupResourceMissing(err) {
+		return nil
+	}
+	if g.hasTypedFilterFor(serviceName) {
+		return fmt.Errorf("loading Backup %s: %w", name, err)
+	}
+	log.Printf("Skipping Backup %s: %v", name, err)
+	return nil
+}
+
+func (g *BackupGenerator) shouldLoadBackupVaultChildResource(serviceName, vaultName string) bool {
+	return g.shouldAppendBackupResource(serviceName, newBackupVaultChildReferenceResource(serviceName, vaultName))
+}
+
+func (g *BackupGenerator) shouldLoadBackupSelections(planID string) bool {
+	if g.hasTypedBackupFilter() && !g.hasTypedFilterFor(backupSelectionResourceType) {
+		return g.hasUntypedIDFilter() && g.initialIDFiltersCanMatchBackupSelection(planID, "")
+	}
+	return g.initialIDFiltersCanMatchBackupSelection(planID, "")
+}
+
+func (g *BackupGenerator) shouldLoadBackupRestoreTestingSelections(planName string) bool {
+	if g.hasTypedBackupFilter() && !g.hasTypedFilterFor(backupRestoreTestingSelectionResourceType) {
+		return g.hasUntypedIDFilter() && g.initialIDFiltersCanMatchBackupRestoreTestingSelection(planName, "")
+	}
+	return g.initialIDFiltersCanMatchBackupRestoreTestingSelection(planName, "")
+}
+
+func (g *BackupGenerator) shouldLoadAnyBackupResourceType(serviceNames ...string) bool {
+	if !g.hasTypedBackupFilter() {
+		return true
+	}
+	return g.hasUntypedIDFilter() || g.hasTypedFilterForAny(serviceNames...)
+}
+
+func (g *BackupGenerator) shouldAppendBackupResource(serviceName string, resource terraformutils.Resource) bool {
+	if g.hasTypedBackupFilter() && !g.hasTypedFilterFor(serviceName) {
+		if !g.hasUntypedIDFilter() || !g.resourceMatchesUntypedIDFilters(resource) {
+			return false
+		}
+	}
+	return g.resourceMatchesInitialIDFilters(serviceName, resource)
+}
+
+func (g *BackupGenerator) resourceMatchesInitialIDFilters(serviceName string, resource terraformutils.Resource) bool {
+	for _, filter := range g.Filter {
+		if filter.FieldPath != "id" || !filter.IsApplicable(serviceName) {
+			continue
+		}
+		if !filter.Filter(resource) {
+			return false
+		}
+	}
+	return true
+}
+
+func (g *BackupGenerator) resourceMatchesUntypedIDFilters(resource terraformutils.Resource) bool {
+	for _, filter := range g.Filter {
+		if filter.ServiceName != "" || filter.FieldPath != "id" {
+			continue
+		}
+		if !filter.Filter(resource) {
+			return false
+		}
+	}
+	return true
+}
+
+func (g *BackupGenerator) initialIDFiltersCanMatchBackupSelection(planID, selectionID string) bool {
+	for _, filter := range g.Filter {
+		if filter.FieldPath != "id" || !filter.IsApplicable(backupSelectionResourceType) {
+			continue
+		}
+		if !backupSelectionIDFilterCanMatch(filter.AcceptableValues, planID, selectionID) {
+			return false
+		}
+	}
+	return true
+}
+
+func (g *BackupGenerator) initialIDFiltersCanMatchBackupRestoreTestingSelection(planName, selectionName string) bool {
+	for _, filter := range g.Filter {
+		if filter.FieldPath != "id" || !filter.IsApplicable(backupRestoreTestingSelectionResourceType) {
+			continue
+		}
+		if !backupRestoreTestingSelectionIDFilterCanMatch(filter.AcceptableValues, planName, selectionName) {
+			return false
+		}
+	}
+	return true
+}
+
+func (g *BackupGenerator) hasTypedBackupFilter() bool {
+	return g.hasTypedFilterForAny(backupResourceTypes...)
+}
+
+func (g *BackupGenerator) hasTypedFilterForAny(serviceNames ...string) bool {
+	for _, serviceName := range serviceNames {
+		if g.hasTypedFilterFor(serviceName) {
+			return true
+		}
+	}
+	return false
+}
+
+func (g *BackupGenerator) hasTypedFilterFor(serviceName string) bool {
+	for _, filter := range g.Filter {
+		if filter.ServiceName == serviceName {
+			return true
+		}
+	}
+	return false
+}
+
+func (g *BackupGenerator) hasUntypedIDFilter() bool {
+	for _, filter := range g.Filter {
+		if filter.ServiceName == "" && filter.FieldPath == "id" {
+			return true
+		}
+	}
+	return false
+}
+
+func backupVaultLockConfigured(vault backuptypes.BackupVaultListMember) bool {
+	return aws.ToBool(vault.Locked) || vault.LockDate != nil || vault.MinRetentionDays != nil || vault.MaxRetentionDays != nil
+}
+
+func backupVaultNotificationsConfigured(output *backup.GetBackupVaultNotificationsOutput) bool {
+	return output != nil && StringValue(output.SNSTopicArn) != "" && len(output.BackupVaultEvents) > 0
+}
+
+func backupLogicallyAirGappedVaultImportable(vault backuptypes.BackupVaultListMember) bool {
+	return vault.VaultType == backuptypes.VaultTypeLogicallyAirGappedBackupVault && StringValue(vault.BackupVaultName) != "" && vault.MinRetentionDays != nil && vault.MaxRetentionDays != nil
+}
+
+func backupVaultEvents(events []backuptypes.BackupVaultEvent) []string {
+	values := make([]string, 0, len(events))
+	for _, event := range events {
+		if event != "" {
+			values = append(values, string(event))
+		}
+	}
+	return values
+}
+
+func backupStringSliceAttributes(prefix string, values []string) map[string]string {
+	attributes := map[string]string{
+		prefix + ".#": strconv.Itoa(len(values)),
+	}
+	for i, value := range values {
+		attributes[fmt.Sprintf("%s.%d", prefix, i)] = value
+	}
+	return attributes
+}
+
+func backupStringMapAttributes(prefix string, values map[string]string) map[string]string {
+	attributes := map[string]string{
+		prefix + ".%": strconv.Itoa(len(values)),
+	}
+	for key, value := range values {
+		attributes[prefix+"."+key] = value
+	}
+	return attributes
+}
+
+func backupBoolMapAttributes(prefix string, values map[string]bool) map[string]string {
+	attributes := map[string]string{
+		prefix + ".%": strconv.Itoa(len(values)),
+	}
+	for key, value := range values {
+		attributes[prefix+"."+key] = strconv.FormatBool(value)
+	}
+	return attributes
+}
+
+func backupResourceName(parts ...string) string {
+	var nonEmptyParts []string
+	for _, part := range parts {
+		if part != "" {
+			nonEmptyParts = append(nonEmptyParts, part)
+		}
+	}
+	return strings.Join(nonEmptyParts, "-002F-")
+}
+
+func backupPlanResourceName(planID, planName string) string {
+	if planName == "" {
+		return planID
+	}
+	return backupResourceName(planName, planID)
+}
+
+func backupSelectionImportID(planID, selectionID string) string {
+	return planID + "|" + selectionID
+}
+
+func backupRestoreTestingSelectionImportID(selectionName, planName string) string {
+	return selectionName + ":" + planName
+}
+
+func backupSelectionIDFilterCanMatch(values []string, planID, selectionID string) bool {
+	for _, value := range values {
+		if selectionID != "" {
+			if value == backupSelectionImportID(planID, selectionID) {
+				return true
+			}
+			continue
+		}
+		if strings.HasPrefix(value, planID+"|") {
+			return true
+		}
+	}
+	return false
+}
+
+func backupRestoreTestingSelectionIDFilterCanMatch(values []string, planName, selectionName string) bool {
+	for _, value := range values {
+		if selectionName != "" {
+			if value == backupRestoreTestingSelectionImportID(selectionName, planName) {
+				return true
+			}
+			continue
+		}
+		if strings.HasSuffix(value, ":"+planName) {
+			return true
+		}
+	}
+	return false
+}
+
+func backupResourceMissing(err error) bool {
+	var resourceNotFound *backuptypes.ResourceNotFoundException
+	return errors.As(err, &resourceNotFound)
+}
+
+func (g *BackupGenerator) PostConvertHook() error {
+	for i, resource := range g.Resources {
+		if resource.InstanceInfo.Type == "aws_backup_vault_policy" {
+			g.wrapBackupPolicy(i)
+		}
+	}
+	return nil
+}
+
+func (g *BackupGenerator) wrapBackupPolicy(resourceIndex int) {
+	policy, ok := g.Resources[resourceIndex].Item["policy"].(string)
+	if !ok || policy == "" {
+		return
+	}
+	g.Resources[resourceIndex].Item["policy"] = fmt.Sprintf("<<POLICY\n%s\nPOLICY", g.escapeAwsInterpolation(policy))
+}

--- a/providers/aws/backup_test.go
+++ b/providers/aws/backup_test.go
@@ -1,0 +1,254 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package aws
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	backuptypes "github.com/aws/aws-sdk-go-v2/service/backup/types"
+	"github.com/chenrui333/terraformer/terraformutils"
+)
+
+func TestBackupVaultLockConfigured(t *testing.T) {
+	minRetention := int64(7)
+	maxRetention := int64(30)
+	lockDate := time.Now()
+
+	tests := []struct {
+		name  string
+		vault backuptypes.BackupVaultListMember
+		want  bool
+	}{
+		{name: "empty vault has no lock config"},
+		{name: "locked vault has lock config", vault: backuptypes.BackupVaultListMember{Locked: aws.Bool(true)}, want: true},
+		{name: "unlocked vault alone is not lock config", vault: backuptypes.BackupVaultListMember{Locked: aws.Bool(false)}},
+		{name: "lock date is lock config", vault: backuptypes.BackupVaultListMember{LockDate: &lockDate}, want: true},
+		{name: "minimum retention is lock config", vault: backuptypes.BackupVaultListMember{MinRetentionDays: &minRetention}, want: true},
+		{name: "maximum retention is lock config", vault: backuptypes.BackupVaultListMember{MaxRetentionDays: &maxRetention}, want: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := backupVaultLockConfigured(tt.vault); got != tt.want {
+				t.Fatalf("backupVaultLockConfigured() = %t, want %t", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestBackupImportIDs(t *testing.T) {
+	if got := backupSelectionImportID("plan-1", "selection-1"); got != "plan-1|selection-1" {
+		t.Fatalf("backupSelectionImportID() = %q", got)
+	}
+	if got := backupRestoreTestingSelectionImportID("selection_1", "plan_1"); got != "selection_1:plan_1" {
+		t.Fatalf("backupRestoreTestingSelectionImportID() = %q", got)
+	}
+}
+
+func TestBackupAttributeHelpers(t *testing.T) {
+	stringMap := backupStringMapAttributes("global_settings", map[string]string{
+		"isCrossAccountBackupEnabled": "true",
+		"isMpaEnabled":                "false",
+	})
+	if stringMap["global_settings.%"] != "2" {
+		t.Fatalf("global_settings.%% = %q, want 2", stringMap["global_settings.%"])
+	}
+	if stringMap["global_settings.isMpaEnabled"] != "false" {
+		t.Fatalf("global_settings.isMpaEnabled = %q", stringMap["global_settings.isMpaEnabled"])
+	}
+
+	boolMap := backupBoolMapAttributes("resource_type_opt_in_preference", map[string]bool{"EBS": true})
+	if boolMap["resource_type_opt_in_preference.%"] != "1" {
+		t.Fatalf("resource_type_opt_in_preference.%% = %q, want 1", boolMap["resource_type_opt_in_preference.%"])
+	}
+	if boolMap["resource_type_opt_in_preference.EBS"] != "true" {
+		t.Fatalf("resource_type_opt_in_preference.EBS = %q", boolMap["resource_type_opt_in_preference.EBS"])
+	}
+
+	slice := backupStringSliceAttributes("backup_vault_events", []string{"BACKUP_JOB_COMPLETED", "RESTORE_JOB_COMPLETED"})
+	if slice["backup_vault_events.#"] != "2" {
+		t.Fatalf("backup_vault_events.# = %q, want 2", slice["backup_vault_events.#"])
+	}
+	if slice["backup_vault_events.1"] != "RESTORE_JOB_COMPLETED" {
+		t.Fatalf("backup_vault_events.1 = %q", slice["backup_vault_events.1"])
+	}
+}
+
+func TestBackupResourceMissing(t *testing.T) {
+	if !backupResourceMissing(fmt.Errorf("wrapped: %w", &backuptypes.ResourceNotFoundException{})) {
+		t.Fatal("backupResourceMissing() should match wrapped ResourceNotFoundException")
+	}
+	if backupResourceMissing(errors.New("boom")) {
+		t.Fatal("backupResourceMissing() should reject unrelated errors")
+	}
+}
+
+func TestBackupLogicallyAirGappedVaultResource(t *testing.T) {
+	minRetention := int64(7)
+	maxRetention := int64(30)
+	vault := backuptypes.BackupVaultListMember{
+		BackupVaultName:  aws.String("lag-vault"),
+		VaultType:        backuptypes.VaultTypeLogicallyAirGappedBackupVault,
+		MinRetentionDays: &minRetention,
+		MaxRetentionDays: &maxRetention,
+	}
+
+	if !backupLogicallyAirGappedVaultImportable(vault) {
+		t.Fatal("backupLogicallyAirGappedVaultImportable() = false, want true")
+	}
+	resource, ok := newBackupLogicallyAirGappedVaultResource(vault)
+	if !ok {
+		t.Fatal("newBackupLogicallyAirGappedVaultResource() ok = false, want true")
+	}
+	if resource.InstanceInfo.Type != "aws_backup_logically_air_gapped_vault" {
+		t.Fatalf("resource type = %q", resource.InstanceInfo.Type)
+	}
+	if resource.InstanceState.Attributes["min_retention_days"] != "7" {
+		t.Fatalf("min_retention_days = %q", resource.InstanceState.Attributes["min_retention_days"])
+	}
+
+	vault.MaxRetentionDays = nil
+	if backupLogicallyAirGappedVaultImportable(vault) {
+		t.Fatal("backupLogicallyAirGappedVaultImportable() should reject missing max retention")
+	}
+	if _, ok := newBackupLogicallyAirGappedVaultResource(vault); ok {
+		t.Fatal("newBackupLogicallyAirGappedVaultResource() should reject missing max retention")
+	}
+}
+
+func TestBackupFilterGatesVaultChildren(t *testing.T) {
+	vault := newBackupVaultResource("vault-a")
+	policy := newBackupVaultChildReferenceResource(backupVaultPolicyResourceType, "vault-a")
+	otherPolicy := newBackupVaultChildReferenceResource(backupVaultPolicyResourceType, "vault-b")
+
+	tests := []struct {
+		name            string
+		filters         []terraformutils.ResourceFilter
+		appendVault     bool
+		appendPolicy    bool
+		loadPolicy      bool
+		loadOtherPolicy bool
+	}{
+		{
+			name:        "typed vault filter excludes children",
+			filters:     []terraformutils.ResourceFilter{{ServiceName: backupVaultResourceType, FieldPath: "id", AcceptableValues: []string{"vault-a"}}},
+			appendVault: true,
+		},
+		{
+			name:         "typed child id filter excludes parent and unrelated children",
+			filters:      []terraformutils.ResourceFilter{{ServiceName: backupVaultPolicyResourceType, FieldPath: "id", AcceptableValues: []string{"vault-a"}}},
+			appendPolicy: true,
+			loadPolicy:   true,
+		},
+		{
+			name:            "typed child non-id filter loads child type for all parents",
+			filters:         []terraformutils.ResourceFilter{{ServiceName: backupVaultPolicyResourceType, FieldPath: "policy", AcceptableValues: []string{"{}"}}},
+			appendPolicy:    true,
+			loadPolicy:      true,
+			loadOtherPolicy: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := BackupGenerator{}
+			g.Filter = tt.filters
+			if got := g.shouldAppendBackupResource(backupVaultResourceType, vault); got != tt.appendVault {
+				t.Fatalf("shouldAppendBackupResource(vault) = %t, want %t", got, tt.appendVault)
+			}
+			if got := g.shouldAppendBackupResource(backupVaultPolicyResourceType, policy); got != tt.appendPolicy {
+				t.Fatalf("shouldAppendBackupResource(policy) = %t, want %t", got, tt.appendPolicy)
+			}
+			if got := g.shouldLoadBackupVaultChildResource(backupVaultPolicyResourceType, "vault-a"); got != tt.loadPolicy {
+				t.Fatalf("shouldLoadBackupVaultChildResource(vault-a) = %t, want %t", got, tt.loadPolicy)
+			}
+			if got := g.shouldLoadBackupVaultChildResource(backupVaultPolicyResourceType, "vault-b"); got != tt.loadOtherPolicy {
+				t.Fatalf("shouldLoadBackupVaultChildResource(vault-b) = %t, want %t", got, tt.loadOtherPolicy)
+			}
+			if got := g.shouldAppendBackupResource(backupVaultPolicyResourceType, otherPolicy); got && !tt.loadOtherPolicy {
+				t.Fatalf("shouldAppendBackupResource(other policy) = true, want false")
+			}
+		})
+	}
+}
+
+func TestBackupFilterGatesSelections(t *testing.T) {
+	g := BackupGenerator{}
+	g.Filter = []terraformutils.ResourceFilter{{
+		ServiceName:      backupSelectionResourceType,
+		FieldPath:        "id",
+		AcceptableValues: []string{backupSelectionImportID("plan-a", "selection-a")},
+	}}
+
+	if !g.shouldLoadBackupSelections("plan-a") {
+		t.Fatal("shouldLoadBackupSelections(plan-a) = false, want true")
+	}
+	if g.shouldLoadBackupSelections("plan-b") {
+		t.Fatal("shouldLoadBackupSelections(plan-b) = true, want false")
+	}
+
+	selection := newBackupSelectionResource("plan-a", backuptypes.BackupSelectionsListMember{
+		SelectionId:   aws.String("selection-a"),
+		SelectionName: aws.String("daily"),
+	})
+	if !g.shouldAppendBackupResource(backupSelectionResourceType, selection) {
+		t.Fatal("shouldAppendBackupResource(selection) = false, want true")
+	}
+	plan := terraformutils.NewSimpleResource("plan-a", "plan-a", "aws_backup_plan", "aws", backupAllowEmptyValues)
+	if g.shouldAppendBackupResource(backupPlanResourceType, plan) {
+		t.Fatal("shouldAppendBackupResource(plan) = true, want false for child-only filter")
+	}
+}
+
+func TestBackupFilterGatesRestoreTestingSelections(t *testing.T) {
+	g := BackupGenerator{}
+	g.Filter = []terraformutils.ResourceFilter{{
+		ServiceName:      backupRestoreTestingSelectionResourceType,
+		FieldPath:        "id",
+		AcceptableValues: []string{backupRestoreTestingSelectionImportID("selection_a", "plan_a")},
+	}}
+
+	if !g.shouldLoadBackupRestoreTestingSelections("plan_a") {
+		t.Fatal("shouldLoadBackupRestoreTestingSelections(plan_a) = false, want true")
+	}
+	if g.shouldLoadBackupRestoreTestingSelections("plan_b") {
+		t.Fatal("shouldLoadBackupRestoreTestingSelections(plan_b) = true, want false")
+	}
+}
+
+func TestBackupPostConvertHookWrapsVaultPolicy(t *testing.T) {
+	g := BackupGenerator{}
+	g.Resources = []terraformutils.Resource{
+		terraformutils.NewResource(
+			"vault-a",
+			"vault-a-policy",
+			"aws_backup_vault_policy",
+			"aws",
+			map[string]string{},
+			backupAllowEmptyValues,
+			map[string]interface{}{},
+		),
+	}
+	g.Resources[0].Item = map[string]interface{}{
+		"policy": "{\"Condition\":{\"StringEquals\":{\"aws:PrincipalTag/name\":\"${aws:username}\"}}}",
+	}
+
+	if err := g.PostConvertHook(); err != nil {
+		t.Fatalf("PostConvertHook() error = %v", err)
+	}
+	policy, ok := g.Resources[0].Item["policy"].(string)
+	if !ok {
+		t.Fatal("policy is not a string")
+	}
+	if !strings.HasPrefix(policy, "<<POLICY\n") || !strings.HasSuffix(policy, "\nPOLICY") {
+		t.Fatalf("policy was not wrapped in heredoc: %q", policy)
+	}
+	if !strings.Contains(policy, "$${aws:username}") {
+		t.Fatalf("policy interpolation was not escaped: %q", policy)
+	}
+}

--- a/providers/aws/backup_test.go
+++ b/providers/aws/backup_test.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/backup"
 	backuptypes "github.com/aws/aws-sdk-go-v2/service/backup/types"
 	"github.com/chenrui333/terraformer/terraformutils"
 )
@@ -45,6 +46,15 @@ func TestBackupImportIDs(t *testing.T) {
 	if got := backupSelectionImportID("plan-1", "selection-1"); got != "plan-1|selection-1" {
 		t.Fatalf("backupSelectionImportID() = %q", got)
 	}
+	if !backupSelectionIDFilterCanMatch([]string{"plan-1|selection-1"}, "plan-1", "selection-1") {
+		t.Fatal("backupSelectionIDFilterCanMatch() should match composite selection ID")
+	}
+	if !backupSelectionIDFilterCanMatch([]string{"selection-1"}, "plan-1", "selection-1") {
+		t.Fatal("backupSelectionIDFilterCanMatch() should match provider state selection ID")
+	}
+	if !backupSelectionIDFilterCanMatch([]string{"selection-1"}, "plan-1", "") {
+		t.Fatal("backupSelectionIDFilterCanMatch() should let raw selection ID filters scan candidate plans")
+	}
 	if got := backupRestoreTestingSelectionImportID("selection_1", "plan_1"); got != "selection_1:plan_1" {
 		t.Fatalf("backupRestoreTestingSelectionImportID() = %q", got)
 	}
@@ -69,6 +79,10 @@ func TestBackupAttributeHelpers(t *testing.T) {
 	if boolMap["resource_type_opt_in_preference.EBS"] != "true" {
 		t.Fatalf("resource_type_opt_in_preference.EBS = %q", boolMap["resource_type_opt_in_preference.EBS"])
 	}
+	emptyBoolMap := backupBoolMapAttributes("resource_type_opt_in_preference", nil)
+	if emptyBoolMap["resource_type_opt_in_preference.%"] != "0" {
+		t.Fatalf("empty resource_type_opt_in_preference.%% = %q, want 0", emptyBoolMap["resource_type_opt_in_preference.%"])
+	}
 
 	slice := backupStringSliceAttributes("backup_vault_events", []string{"BACKUP_JOB_COMPLETED", "RESTORE_JOB_COMPLETED"})
 	if slice["backup_vault_events.#"] != "2" {
@@ -76,6 +90,39 @@ func TestBackupAttributeHelpers(t *testing.T) {
 	}
 	if slice["backup_vault_events.1"] != "RESTORE_JOB_COMPLETED" {
 		t.Fatalf("backup_vault_events.1 = %q", slice["backup_vault_events.1"])
+	}
+}
+
+func TestBackupRegionSettingsConfigured(t *testing.T) {
+	tests := []struct {
+		name   string
+		output *backup.DescribeRegionSettingsOutput
+		want   bool
+	}{
+		{name: "nil output"},
+		{name: "empty maps", output: &backup.DescribeRegionSettingsOutput{}},
+		{
+			name: "opt-in settings",
+			output: &backup.DescribeRegionSettingsOutput{
+				ResourceTypeOptInPreference: map[string]bool{"EBS": true},
+			},
+			want: true,
+		},
+		{
+			name: "management-only settings",
+			output: &backup.DescribeRegionSettingsOutput{
+				ResourceTypeManagementPreference: map[string]bool{"DynamoDB": true},
+			},
+			want: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := backupRegionSettingsConfigured(tt.output); got != tt.want {
+				t.Fatalf("backupRegionSettingsConfigured() = %t, want %t", got, tt.want)
+			}
+		})
 	}
 }
 
@@ -196,8 +243,16 @@ func TestBackupFilterGatesSelections(t *testing.T) {
 		SelectionId:   aws.String("selection-a"),
 		SelectionName: aws.String("daily"),
 	})
+	if selection.InstanceState.ID != "selection-a" {
+		t.Fatalf("selection InstanceState.ID = %q, want provider read ID selection-a", selection.InstanceState.ID)
+	}
 	if !g.shouldAppendBackupResource(backupSelectionResourceType, selection) {
 		t.Fatal("shouldAppendBackupResource(selection) = false, want true")
+	}
+	g.Resources = []terraformutils.Resource{selection}
+	g.InitialCleanup()
+	if len(g.Resources) != 1 {
+		t.Fatalf("InitialCleanup() resources len = %d, want 1", len(g.Resources))
 	}
 	plan := terraformutils.NewSimpleResource("plan-a", "plan-a", "aws_backup_plan", "aws", backupAllowEmptyValues)
 	if g.shouldAppendBackupResource(backupPlanResourceType, plan) {


### PR DESCRIPTION
## Summary

- add AWS Backup resource discovery for vaults, plans, selections, settings, frameworks, report plans, and restore testing resources
- include optional vault child resources for policies, notifications, and lock configurations when configured
- document the new backup service resources

## Notes

Uses documented Terraform import IDs, including plan-id|selection-id for backup selections and selection:plan for restore testing selections.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add AWS Backup resource discovery across vaults, plans, selections, settings, frameworks, report plans, and restore testing. Also imports optional vault policies, notifications, and lock configuration when configured, and seeds `aws_backup_selection` state IDs for correct ID-based filtering.

- **New Features**
  - Vaults and children: `aws_backup_vault`, `aws_backup_logically_air_gapped_vault`, `aws_backup_vault_policy`, `aws_backup_vault_notifications`, `aws_backup_vault_lock_configuration`.
  - Plans and selections: `aws_backup_plan`, `aws_backup_selection`, `aws_backup_restore_testing_plan`, `aws_backup_restore_testing_selection`.
  - Settings and governance: `aws_backup_region_settings`, `aws_backup_global_settings`, `aws_backup_framework`, `aws_backup_report_plan`.
  - Uses Terraform import IDs: plan-id|selection-id for `aws_backup_selection`, and selection:plan for `aws_backup_restore_testing_selection`.
  - Wraps `aws_backup_vault_policy` JSON in a heredoc and escapes interpolation. Docs list new resources.

- **Dependencies**
  - Add `github.com/aws/aws-sdk-go-v2/service/backup v1.55.2`.

<sup>Written for commit d6859d9383f4075e3a3d2209167d513627236d3c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for importing AWS Backup resources into Terraform, including vaults, plans, selections, frameworks, report/restore-testing plans, region/global settings, and related child resources.

* **Documentation**
  * Updated supported services to include AWS Backup and listed all importable Backup resource types.

* **Tests**
  * Added comprehensive tests covering import IDs, filtering behavior, optional/missing resources, attribute conversion, region settings, and post-conversion policy handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->