### PR TITLE
fix(providers): clear service state before selection

### DIFF
--- a/cmd/init_service_state_test.go
+++ b/cmd/init_service_state_test.go
@@ -1,0 +1,37 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package cmd
+
+import "testing"
+
+func TestProvidersClearServiceOnUnsupportedInitService(t *testing.T) {
+	for name, genFn := range providerGenerators() {
+		t.Run(name, func(t *testing.T) {
+			provider := genFn()
+			services := provider.GetSupportedService()
+			if len(services) == 0 {
+				t.Skip("provider has no supported services")
+			}
+
+			var validService string
+			for service := range services {
+				validService = service
+				break
+			}
+
+			if err := provider.InitService(validService, false); err != nil {
+				t.Fatalf("expected supported service %q to initialize: %v", validService, err)
+			}
+			if provider.GetService() == nil {
+				t.Fatalf("expected supported service %q to set provider service", validService)
+			}
+
+			if err := provider.InitService("__unsupported_service__", false); err == nil {
+				t.Fatal("expected unsupported service to fail")
+			}
+			if provider.GetService() != nil {
+				t.Fatalf("expected unsupported service to clear stale provider service, got %T", provider.GetService())
+			}
+		})
+	}
+}

--- a/providers/alicloud/alicloud_provider.go
+++ b/providers/alicloud/alicloud_provider.go
@@ -93,6 +93,8 @@ func (p *AliCloudProvider) GetName() string {
 
 // InitService Initializes the AliCloud service
 func (p *AliCloudProvider) InitService(serviceName string, verbose bool) error {
+	p.Service = nil
+
 	var isSupported bool
 	if _, isSupported = p.GetSupportedService()[serviceName]; !isSupported {
 		return errors.New("alicloud: " + serviceName + " not supported service")

--- a/providers/auth0/auth0_provider.go
+++ b/providers/auth0/auth0_provider.go
@@ -69,6 +69,8 @@ func (p *Auth0Provider) GetConfig() cty.Value {
 }
 
 func (p *Auth0Provider) InitService(serviceName string, verbose bool) error {
+	p.Service = nil
+
 	var isSupported bool
 	if _, isSupported = p.GetSupportedService()[serviceName]; !isSupported {
 		return errors.New(p.GetName() + ": " + serviceName + " not supported service")

--- a/providers/aws/aws_provider.go
+++ b/providers/aws/aws_provider.go
@@ -211,6 +211,8 @@ func (p *AWSProvider) GetName() string {
 }
 
 func (p *AWSProvider) InitService(serviceName string, verbose bool) error {
+	p.Service = nil
+
 	var isSupported bool
 	if _, isSupported = p.GetSupportedService()[serviceName]; !isSupported {
 		return errors.New("aws: " + serviceName + " not supported service")

--- a/providers/azure/azure_provider.go
+++ b/providers/azure/azure_provider.go
@@ -805,6 +805,8 @@ func (p *AzureProvider) GetSupportedService() map[string]terraformutils.ServiceG
 }
 
 func (p *AzureProvider) InitService(serviceName string, verbose bool) error {
+	p.Service = nil
+
 	var isSupported bool
 	if _, isSupported = p.GetSupportedService()[serviceName]; !isSupported {
 		return errors.New("azurerm: " + serviceName + " not supported service")

--- a/providers/azuread/azuread_provider.go
+++ b/providers/azuread/azuread_provider.go
@@ -71,6 +71,8 @@ func (p *AzureADProvider) GetSupportedService() map[string]terraformutils.Servic
 }
 
 func (p *AzureADProvider) InitService(serviceName string, verbose bool) error {
+	p.Service = nil
+
 	var isSupported bool
 	if _, isSupported = p.GetSupportedService()[serviceName]; !isSupported {
 		return errors.New("azuread: " + serviceName + " not supported service")

--- a/providers/azuredevops/azuredevops_provider.go
+++ b/providers/azuredevops/azuredevops_provider.go
@@ -70,6 +70,8 @@ func (p *AzureDevOpsProvider) GetSupportedService() map[string]terraformutils.Se
 }
 
 func (p *AzureDevOpsProvider) InitService(serviceName string, verbose bool) error {
+	p.Service = nil
+
 	var isSupported bool
 	if _, isSupported = p.GetSupportedService()[serviceName]; !isSupported {
 		return errors.New("azuredevops: " + serviceName + " not supported service")

--- a/providers/cloudflare/cloudflare_provider.go
+++ b/providers/cloudflare/cloudflare_provider.go
@@ -39,6 +39,8 @@ func (p *CloudflareProvider) GetSupportedService() map[string]terraformutils.Ser
 }
 
 func (p *CloudflareProvider) InitService(serviceName string, verbose bool) error {
+	p.Service = nil
+
 	var isSupported bool
 	if _, isSupported = p.GetSupportedService()[serviceName]; !isSupported {
 		return errors.New("cloudflare: " + serviceName + " not supported service")

--- a/providers/commercetools/commercetools_provider.go
+++ b/providers/commercetools/commercetools_provider.go
@@ -45,6 +45,8 @@ func (p *CommercetoolsProvider) GetName() string {
 }
 
 func (p *CommercetoolsProvider) InitService(serviceName string, verbose bool) error {
+	p.Service = nil
+
 	var isSupported bool
 	if _, isSupported = p.GetSupportedService()[serviceName]; !isSupported {
 		return errors.New(p.GetName() + ": " + serviceName + " not supported service")

--- a/providers/datadog/datadog_provider.go
+++ b/providers/datadog/datadog_provider.go
@@ -141,6 +141,8 @@ func (p *DatadogProvider) GetConfig() cty.Value {
 
 // InitService ...
 func (p *DatadogProvider) InitService(serviceName string, verbose bool) error {
+	p.Service = nil
+
 	var isSupported bool
 	if _, isSupported = p.GetSupportedService()[serviceName]; !isSupported {
 		return errors.New(p.GetName() + ": " + serviceName + " not supported service")

--- a/providers/digitalocean/digitalocean_provider.go
+++ b/providers/digitalocean/digitalocean_provider.go
@@ -60,6 +60,8 @@ func (p *DigitalOceanProvider) GetSupportedService() map[string]terraformutils.S
 }
 
 func (p *DigitalOceanProvider) InitService(serviceName string, verbose bool) error {
+	p.Service = nil
+
 	var isSupported bool
 	if _, isSupported = p.GetSupportedService()[serviceName]; !isSupported {
 		return errors.New("digitalocean: " + serviceName + " not supported service")

--- a/providers/equinixmetal/equinixmetal_provider.go
+++ b/providers/equinixmetal/equinixmetal_provider.go
@@ -56,6 +56,8 @@ func (p *EquinixMetalProvider) GetSupportedService() map[string]terraformutils.S
 }
 
 func (p *EquinixMetalProvider) InitService(serviceName string, verbose bool) error {
+	p.Service = nil
+
 	var isSupported bool
 	if _, isSupported = p.GetSupportedService()[serviceName]; !isSupported {
 		return errors.New("equinixmetal: " + serviceName + " not supported service")

--- a/providers/fastly/fastly_provider.go
+++ b/providers/fastly/fastly_provider.go
@@ -61,6 +61,8 @@ func (p *FastlyProvider) GetSupportedService() map[string]terraformutils.Service
 }
 
 func (p *FastlyProvider) InitService(serviceName string, verbose bool) error {
+	p.Service = nil
+
 	var isSupported bool
 	if _, isSupported = p.GetSupportedService()[serviceName]; !isSupported {
 		return errors.New("fastly: " + serviceName + " not supported service")

--- a/providers/gcp/gcp_provider.go
+++ b/providers/gcp/gcp_provider.go
@@ -90,6 +90,8 @@ func (p *GCPProvider) GetName() string {
 }
 
 func (p *GCPProvider) InitService(serviceName string, verbose bool) error {
+	p.Service = nil
+
 	var isSupported bool
 	if _, isSupported = p.GetSupportedService()[serviceName]; !isSupported {
 		return errors.New("gcp: " + serviceName + " not supported service")

--- a/providers/github/github_provider.go
+++ b/providers/github/github_provider.go
@@ -109,6 +109,8 @@ func (p *GithubProvider) GetName() string {
 }
 
 func (p *GithubProvider) InitService(serviceName string, verbose bool) error {
+	p.Service = nil
+
 	var isSupported bool
 	if _, isSupported = p.GetSupportedService()[serviceName]; !isSupported {
 		return errors.New(p.GetName() + ": " + serviceName + " not supported service")

--- a/providers/gitlab/gitlab_provider.go
+++ b/providers/gitlab/gitlab_provider.go
@@ -72,6 +72,8 @@ func (p *GitLabProvider) GetName() string {
 }
 
 func (p *GitLabProvider) InitService(serviceName string, verbose bool) error {
+	p.Service = nil
+
 	var isSupported bool
 	if _, isSupported = p.GetSupportedService()[serviceName]; !isSupported {
 		return errors.New(p.GetName() + ": " + serviceName + " not supported service")

--- a/providers/gmailfilter/gmailfilter_provider.go
+++ b/providers/gmailfilter/gmailfilter_provider.go
@@ -38,6 +38,8 @@ func (p *GmailfilterProvider) GetName() string {
 }
 
 func (p *GmailfilterProvider) InitService(serviceName string, verbose bool) error {
+	p.Service = nil
+
 	var isSupported bool
 	if _, isSupported = p.GetSupportedService()[serviceName]; !isSupported {
 		return errors.New("gmailfilter: " + serviceName + " not supported service")

--- a/providers/grafana/grafana_provider.go
+++ b/providers/grafana/grafana_provider.go
@@ -97,6 +97,8 @@ func (p *GrafanaProvider) GetName() string {
 }
 
 func (p *GrafanaProvider) InitService(serviceName string, verbose bool) error {
+	p.Service = nil
+
 	var isSupported bool
 	if _, isSupported = p.GetSupportedService()[serviceName]; !isSupported {
 		return errors.New(p.GetName() + ": " + serviceName + " not supported service")

--- a/providers/heroku/heroku_provider.go
+++ b/providers/heroku/heroku_provider.go
@@ -57,6 +57,8 @@ func (p *HerokuProvider) GetSupportedService() map[string]terraformutils.Service
 }
 
 func (p *HerokuProvider) InitService(serviceName string, verbose bool) error {
+	p.Service = nil
+
 	var isSupported bool
 	if _, isSupported = p.GetSupportedService()[serviceName]; !isSupported {
 		return errors.New("heroku: " + serviceName + " not supported service")

--- a/providers/honeycombio/honeycomb_provider.go
+++ b/providers/honeycombio/honeycomb_provider.go
@@ -92,6 +92,8 @@ func (p *HoneycombProvider) GetConfig() cty.Value {
 }
 
 func (p *HoneycombProvider) InitService(serviceName string, verbose bool) error {
+	p.Service = nil
+
 	var isSupported bool
 	if _, isSupported = p.GetSupportedService()[serviceName]; !isSupported {
 		return errors.New("honeycombio: " + serviceName + " is not a supported resource type")

--- a/providers/ibm/ibm_provider.go
+++ b/providers/ibm/ibm_provider.go
@@ -201,6 +201,8 @@ func (p *IBMProvider) GetSupportedService() map[string]terraformutils.ServiceGen
 }
 
 func (p *IBMProvider) InitService(serviceName string, verbose bool) error {
+	p.Service = nil
+
 	var isSupported bool
 	if _, isSupported = p.GetSupportedService()[serviceName]; !isSupported {
 		return errors.New("IBM: " + serviceName + " not supported service")

--- a/providers/ionoscloud/ionoscloud_provider.go
+++ b/providers/ionoscloud/ionoscloud_provider.go
@@ -151,6 +151,8 @@ func (p *IonosCloudProvider) GetSupportedService() map[string]terraformutils.Ser
 }
 
 func (p *IonosCloudProvider) InitService(serviceName string, verbose bool) error {
+	p.Service = nil
+
 	var isSupported bool
 	if _, isSupported = p.GetSupportedService()[serviceName]; !isSupported {
 		return errors.New(helpers.Ionos + ": " + serviceName + " not supported service")

--- a/providers/keycloak/keycloak_provider.go
+++ b/providers/keycloak/keycloak_provider.go
@@ -92,6 +92,8 @@ func (p *KeycloakProvider) GetBasicConfig() cty.Value {
 }
 
 func (p *KeycloakProvider) InitService(serviceName string, verbose bool) error {
+	p.Service = nil
+
 	var isSupported bool
 	if _, isSupported = p.GetSupportedService()[serviceName]; !isSupported {
 		return errors.New(p.GetName() + ": " + serviceName + " not supported service")

--- a/providers/kubernetes/kubernetes_provider.go
+++ b/providers/kubernetes/kubernetes_provider.go
@@ -54,6 +54,8 @@ func (p *KubernetesProvider) GetName() string {
 }
 
 func (p *KubernetesProvider) InitService(serviceName string, verbose bool) error {
+	p.Service = nil
+
 	var isSupported bool
 	if _, isSupported = p.GetSupportedService()[serviceName]; !isSupported {
 		return errors.New("kubernetes: " + serviceName + " not supported resource")

--- a/providers/launchdarkly/launchdarkly_provider.go
+++ b/providers/launchdarkly/launchdarkly_provider.go
@@ -89,6 +89,8 @@ func (p *LaunchDarklyProvider) GetSupportedService() map[string]terraformutils.S
 }
 
 func (p *LaunchDarklyProvider) InitService(serviceName string, verbose bool) error {
+	p.Service = nil
+
 	var isSupported bool
 	if _, isSupported = p.GetSupportedService()[serviceName]; !isSupported {
 		return errors.New("launchdarkly: " + serviceName + " not supported service")

--- a/providers/linode/linode_provider.go
+++ b/providers/linode/linode_provider.go
@@ -53,6 +53,8 @@ func (p *LinodeProvider) GetSupportedService() map[string]terraformutils.Service
 }
 
 func (p *LinodeProvider) InitService(serviceName string, verbose bool) error {
+	p.Service = nil
+
 	var isSupported bool
 	if _, isSupported = p.GetSupportedService()[serviceName]; !isSupported {
 		return errors.New("linode: " + serviceName + " not supported service")

--- a/providers/logzio/logzio_provider.go
+++ b/providers/logzio/logzio_provider.go
@@ -53,6 +53,8 @@ func (p *LogzioProvider) GetName() string {
 }
 
 func (p *LogzioProvider) InitService(serviceName string, verbose bool) error {
+	p.Service = nil
+
 	var isSupported bool
 	if _, isSupported = p.GetSupportedService()[serviceName]; !isSupported {
 		return errors.New(p.GetName() + ": " + serviceName + " not supported service")

--- a/providers/mackerel/mackerel_provider.go
+++ b/providers/mackerel/mackerel_provider.go
@@ -35,6 +35,8 @@ func (p *MackerelProvider) Init(args []string) error {
 
 // InitService ...
 func (p *MackerelProvider) InitService(serviceName string, verbose bool) error {
+	p.Service = nil
+
 	var isSupported bool
 	if _, isSupported = p.GetSupportedService()[serviceName]; !isSupported {
 		return errors.New(p.GetName() + ": " + serviceName + " not supported service")

--- a/providers/mikrotik/mikrotik_provider.go
+++ b/providers/mikrotik/mikrotik_provider.go
@@ -46,6 +46,8 @@ func (p *MikrotikProvider) GetSupportedService() map[string]terraformutils.Servi
 }
 
 func (p *MikrotikProvider) InitService(serviceName string, verbose bool) error {
+	p.Service = nil
+
 	var isSupported bool
 	if _, isSupported = p.GetSupportedService()[serviceName]; !isSupported {
 		return errors.New("mikrotik: " + serviceName + " not supported service")

--- a/providers/myrasec/myrasec_provider.go
+++ b/providers/myrasec/myrasec_provider.go
@@ -49,6 +49,8 @@ func (p *MyrasecProvider) GetSupportedService() map[string]terraformutils.Servic
 
 // InitService
 func (p *MyrasecProvider) InitService(serviceName string, verbose bool) error {
+	p.Service = nil
+
 	var isSupported bool
 	if _, isSupported = p.GetSupportedService()[serviceName]; !isSupported {
 		return errors.New("myrasec: " + serviceName + " not supported service")

--- a/providers/newrelic/newrelic_provider.go
+++ b/providers/newrelic/newrelic_provider.go
@@ -90,6 +90,8 @@ func (p *NewRelicProvider) GetSupportedService() map[string]terraformutils.Servi
 }
 
 func (p *NewRelicProvider) InitService(serviceName string, verbose bool) error {
+	p.Service = nil
+
 	var isSupported bool
 	if _, isSupported = p.GetSupportedService()[serviceName]; !isSupported {
 		return errors.New("newrelic: " + serviceName + " not supported service")

--- a/providers/ns1/ns1_provider.go
+++ b/providers/ns1/ns1_provider.go
@@ -47,6 +47,8 @@ func (p *Ns1Provider) GetSupportedService() map[string]terraformutils.ServiceGen
 }
 
 func (p *Ns1Provider) InitService(serviceName string, verbose bool) error {
+	p.Service = nil
+
 	var isSupported bool
 	if _, isSupported = p.GetSupportedService()[serviceName]; !isSupported {
 		return errors.New("ns1: " + serviceName + " not supported service")

--- a/providers/octopusdeploy/octopusdeploy_provider.go
+++ b/providers/octopusdeploy/octopusdeploy_provider.go
@@ -74,6 +74,8 @@ func (p *OctopusDeployProvider) GetSupportedService() map[string]terraformutils.
 }
 
 func (p *OctopusDeployProvider) InitService(serviceName string, verbose bool) error {
+	p.Service = nil
+
 	var isSupported bool
 	if _, isSupported = p.GetSupportedService()[serviceName]; !isSupported {
 		return errors.New("octopusdeploy: " + serviceName + " not supported service, see list sub-command")

--- a/providers/okta/okta_provider.go
+++ b/providers/okta/okta_provider.go
@@ -65,6 +65,8 @@ func (p *OktaProvider) GetName() string {
 }
 
 func (p *OktaProvider) InitService(serviceName string, verbose bool) error {
+	p.Service = nil
+
 	var isSupported bool
 	if _, isSupported = p.GetSupportedService()[serviceName]; !isSupported {
 		return errors.New(p.GetName() + ": " + serviceName + " is not a supported service")

--- a/providers/opal/opal_provider.go
+++ b/providers/opal/opal_provider.go
@@ -92,6 +92,8 @@ func (p *OpalProvider) GetConfig() cty.Value {
 }
 
 func (p *OpalProvider) InitService(serviceName string, verbose bool) error {
+	p.Service = nil
+
 	var isSupported bool
 	if _, isSupported = p.GetSupportedService()[serviceName]; !isSupported {
 		return errors.New("opal: " + serviceName + " is not a supported resource type")

--- a/providers/openstack/openstack_provider.go
+++ b/providers/openstack/openstack_provider.go
@@ -48,6 +48,8 @@ func (p *OpenStackProvider) GetName() string {
 }
 
 func (p *OpenStackProvider) InitService(serviceName string, verbose bool) error {
+	p.Service = nil
+
 	var isSupported bool
 	if _, isSupported = p.GetSupportedService()[serviceName]; !isSupported {
 		return errors.New("openstack: " + serviceName + " not supported service")

--- a/providers/opsgenie/opsgenie_provider.go
+++ b/providers/opsgenie/opsgenie_provider.go
@@ -29,6 +29,8 @@ func (p *OpsgenieProvider) Init(args []string) error {
 }
 
 func (p *OpsgenieProvider) InitService(serviceName string, verbose bool) error {
+	p.Service = nil
+
 	var isSupported bool
 	if _, isSupported = p.GetSupportedService()[serviceName]; !isSupported {
 		return errors.New(p.GetName() + ": " + serviceName + " not supported service")

--- a/providers/pagerduty/pagerduty_provider.go
+++ b/providers/pagerduty/pagerduty_provider.go
@@ -62,6 +62,8 @@ func (p *PagerDutyProvider) GetSupportedService() map[string]terraformutils.Serv
 }
 
 func (p *PagerDutyProvider) InitService(serviceName string, verbose bool) error {
+	p.Service = nil
+
 	var isSupported bool
 	if _, isSupported = p.GetSupportedService()[serviceName]; !isSupported {
 		return errors.New(p.GetName() + ": " + serviceName + " not supported service")

--- a/providers/panos/panos_provider.go
+++ b/providers/panos/panos_provider.go
@@ -41,6 +41,8 @@ func (p *PanosProvider) GetBasicConfig() cty.Value {
 }
 
 func (p *PanosProvider) InitService(serviceName string, verbose bool) error {
+	p.Service = nil
+
 	var isSupported bool
 	if _, isSupported = p.GetSupportedService()[serviceName]; !isSupported {
 		return errors.New(p.GetName() + ": " + serviceName + " not supported service")

--- a/providers/rabbitmq/rabbitmq_provider.go
+++ b/providers/rabbitmq/rabbitmq_provider.go
@@ -48,6 +48,8 @@ func (p *RBTProvider) GetBasicConfig() cty.Value {
 }
 
 func (p *RBTProvider) InitService(serviceName string, verbose bool) error {
+	p.Service = nil
+
 	var isSupported bool
 	if _, isSupported = p.GetSupportedService()[serviceName]; !isSupported {
 		return errors.New(p.GetName() + ": " + serviceName + " not supported service")

--- a/providers/tencentcloud/tencentcloud_provider.go
+++ b/providers/tencentcloud/tencentcloud_provider.go
@@ -65,6 +65,8 @@ func (p *TencentCloudProvider) Init(args []string) error {
 }
 
 func (p *TencentCloudProvider) InitService(serviceName string, verbose bool) error {
+	p.Service = nil
+
 	var isSupported bool
 	if _, isSupported = p.GetSupportedService()[serviceName]; !isSupported {
 		return errors.New("tencentcloud: " + serviceName + " not supported service")

--- a/providers/vault/vault_provider.go
+++ b/providers/vault/vault_provider.go
@@ -47,6 +47,8 @@ func (p *Provider) GetName() string {
 }
 
 func (p *Provider) InitService(serviceName string, verbose bool) error {
+	p.Service = nil
+
 	if service, ok := p.GetSupportedService()[serviceName]; ok {
 		p.Service = service
 		p.Service.SetName(serviceName)

--- a/providers/vultr/vultr_provider.go
+++ b/providers/vultr/vultr_provider.go
@@ -55,6 +55,8 @@ func (p *VultrProvider) GetSupportedService() map[string]terraformutils.ServiceG
 }
 
 func (p *VultrProvider) InitService(serviceName string, verbose bool) error {
+	p.Service = nil
+
 	var isSupported bool
 	if _, isSupported = p.GetSupportedService()[serviceName]; !isSupported {
 		return errors.New("vultr: " + serviceName + " not supported service")

--- a/providers/xenorchestra/xenorchestra_provider.go
+++ b/providers/xenorchestra/xenorchestra_provider.go
@@ -70,6 +70,8 @@ func (p *XenorchestraProvider) GetSupportedService() map[string]terraformutils.S
 }
 
 func (p *XenorchestraProvider) InitService(serviceName string, verbose bool) error {
+	p.Service = nil
+
 	var isSupported bool
 	if _, isSupported = p.GetSupportedService()[serviceName]; !isSupported {
 		return errors.New("xenorchestra: " + serviceName + " not supported service")

--- a/providers/yandex/yandex_provider.go
+++ b/providers/yandex/yandex_provider.go
@@ -64,6 +64,8 @@ func (p *YandexProvider) GetSupportedService() map[string]terraformutils.Service
 }
 
 func (p *YandexProvider) InitService(serviceName string, verbose bool) error {
+	p.Service = nil
+
 	var isSupported bool
 	if _, isSupported = p.GetSupportedService()[serviceName]; !isSupported {
 		return errors.New("yandex: " + serviceName + " not supported service")


### PR DESCRIPTION
## Summary

- Clear the selected provider service before every InitService selection.
- Prevent unsupported service initialization from leaving a stale service attached to reused provider instances.
- Add a provider registry contract test covering every registered provider generator.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Clear provider service state before each `InitService` call to prevent stale services when an unsupported service is requested. Adds a registry test to ensure all providers reset state and fail cleanly.

- **Bug Fixes**
  - Clear `Service` before selection across all providers to avoid stale state reuse on unsupported service init.
  - Add `TestProvidersClearServiceOnUnsupportedInitService` to verify valid init succeeds, unsupported init errors, and state is cleared for every registered provider.

<sup>Written for commit 3e1a1a3f3f8a1db24e5ccf7bca34c0dee41335fc. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

