### PR TITLE
refactor(providers): reuse service lookup during init

### DIFF
--- a/providers/alicloud/alicloud_provider.go
+++ b/providers/alicloud/alicloud_provider.go
@@ -95,11 +95,11 @@ func (p *AliCloudProvider) GetName() string {
 func (p *AliCloudProvider) InitService(serviceName string, verbose bool) error {
 	p.Service = nil
 
-	var isSupported bool
-	if _, isSupported = p.GetSupportedService()[serviceName]; !isSupported {
+	service, isSupported := p.GetSupportedService()[serviceName]
+	if !isSupported {
 		return errors.New("alicloud: " + serviceName + " not supported service")
 	}
-	p.Service = p.GetSupportedService()[serviceName]
+	p.Service = service
 	p.Service.SetName(serviceName)
 	p.Service.SetVerbose(verbose)
 	p.Service.SetProviderName(p.GetName())

--- a/providers/auth0/auth0_provider.go
+++ b/providers/auth0/auth0_provider.go
@@ -71,11 +71,11 @@ func (p *Auth0Provider) GetConfig() cty.Value {
 func (p *Auth0Provider) InitService(serviceName string, verbose bool) error {
 	p.Service = nil
 
-	var isSupported bool
-	if _, isSupported = p.GetSupportedService()[serviceName]; !isSupported {
+	service, isSupported := p.GetSupportedService()[serviceName]
+	if !isSupported {
 		return errors.New(p.GetName() + ": " + serviceName + " not supported service")
 	}
-	p.Service = p.GetSupportedService()[serviceName]
+	p.Service = service
 	p.Service.SetName(serviceName)
 	p.Service.SetVerbose(verbose)
 	p.Service.SetProviderName(p.GetName())

--- a/providers/aws/aws_provider.go
+++ b/providers/aws/aws_provider.go
@@ -213,11 +213,11 @@ func (p *AWSProvider) GetName() string {
 func (p *AWSProvider) InitService(serviceName string, verbose bool) error {
 	p.Service = nil
 
-	var isSupported bool
-	if _, isSupported = p.GetSupportedService()[serviceName]; !isSupported {
+	service, isSupported := p.GetSupportedService()[serviceName]
+	if !isSupported {
 		return errors.New("aws: " + serviceName + " not supported service")
 	}
-	p.Service = p.GetSupportedService()[serviceName]
+	p.Service = service
 	p.Service.SetName(serviceName)
 	p.Service.SetVerbose(verbose)
 	p.Service.SetProviderName(p.GetName())

--- a/providers/azure/azure_provider.go
+++ b/providers/azure/azure_provider.go
@@ -807,11 +807,11 @@ func (p *AzureProvider) GetSupportedService() map[string]terraformutils.ServiceG
 func (p *AzureProvider) InitService(serviceName string, verbose bool) error {
 	p.Service = nil
 
-	var isSupported bool
-	if _, isSupported = p.GetSupportedService()[serviceName]; !isSupported {
+	service, isSupported := p.GetSupportedService()[serviceName]
+	if !isSupported {
 		return errors.New("azurerm: " + serviceName + " not supported service")
 	}
-	p.Service = p.GetSupportedService()[serviceName]
+	p.Service = service
 	p.Service.SetName(serviceName)
 	p.Service.SetVerbose(verbose)
 	p.Service.SetProviderName(p.GetName())

--- a/providers/azuread/azuread_provider.go
+++ b/providers/azuread/azuread_provider.go
@@ -73,11 +73,11 @@ func (p *AzureADProvider) GetSupportedService() map[string]terraformutils.Servic
 func (p *AzureADProvider) InitService(serviceName string, verbose bool) error {
 	p.Service = nil
 
-	var isSupported bool
-	if _, isSupported = p.GetSupportedService()[serviceName]; !isSupported {
+	service, isSupported := p.GetSupportedService()[serviceName]
+	if !isSupported {
 		return errors.New("azuread: " + serviceName + " not supported service")
 	}
-	p.Service = p.GetSupportedService()[serviceName]
+	p.Service = service
 	p.Service.SetName(serviceName)
 	p.Service.SetVerbose(verbose)
 	p.Service.SetProviderName(p.GetName())

--- a/providers/azuredevops/azuredevops_provider.go
+++ b/providers/azuredevops/azuredevops_provider.go
@@ -72,11 +72,11 @@ func (p *AzureDevOpsProvider) GetSupportedService() map[string]terraformutils.Se
 func (p *AzureDevOpsProvider) InitService(serviceName string, verbose bool) error {
 	p.Service = nil
 
-	var isSupported bool
-	if _, isSupported = p.GetSupportedService()[serviceName]; !isSupported {
+	service, isSupported := p.GetSupportedService()[serviceName]
+	if !isSupported {
 		return errors.New("azuredevops: " + serviceName + " not supported service")
 	}
-	p.Service = p.GetSupportedService()[serviceName]
+	p.Service = service
 	p.Service.SetName(serviceName)
 	p.Service.SetVerbose(verbose)
 	p.Service.SetProviderName(p.GetName())

--- a/providers/cloudflare/cloudflare_provider.go
+++ b/providers/cloudflare/cloudflare_provider.go
@@ -41,11 +41,11 @@ func (p *CloudflareProvider) GetSupportedService() map[string]terraformutils.Ser
 func (p *CloudflareProvider) InitService(serviceName string, verbose bool) error {
 	p.Service = nil
 
-	var isSupported bool
-	if _, isSupported = p.GetSupportedService()[serviceName]; !isSupported {
+	service, isSupported := p.GetSupportedService()[serviceName]
+	if !isSupported {
 		return errors.New("cloudflare: " + serviceName + " not supported service")
 	}
-	p.Service = p.GetSupportedService()[serviceName]
+	p.Service = service
 	p.Service.SetName(serviceName)
 	p.Service.SetVerbose(verbose)
 	p.Service.SetProviderName(p.GetName())

--- a/providers/commercetools/commercetools_provider.go
+++ b/providers/commercetools/commercetools_provider.go
@@ -47,11 +47,11 @@ func (p *CommercetoolsProvider) GetName() string {
 func (p *CommercetoolsProvider) InitService(serviceName string, verbose bool) error {
 	p.Service = nil
 
-	var isSupported bool
-	if _, isSupported = p.GetSupportedService()[serviceName]; !isSupported {
+	service, isSupported := p.GetSupportedService()[serviceName]
+	if !isSupported {
 		return errors.New(p.GetName() + ": " + serviceName + " not supported service")
 	}
-	p.Service = p.GetSupportedService()[serviceName]
+	p.Service = service
 	p.Service.SetName(serviceName)
 	p.Service.SetVerbose(verbose)
 	p.Service.SetProviderName(p.GetName())

--- a/providers/datadog/datadog_provider.go
+++ b/providers/datadog/datadog_provider.go
@@ -143,11 +143,11 @@ func (p *DatadogProvider) GetConfig() cty.Value {
 func (p *DatadogProvider) InitService(serviceName string, verbose bool) error {
 	p.Service = nil
 
-	var isSupported bool
-	if _, isSupported = p.GetSupportedService()[serviceName]; !isSupported {
+	service, isSupported := p.GetSupportedService()[serviceName]
+	if !isSupported {
 		return errors.New(p.GetName() + ": " + serviceName + " not supported service")
 	}
-	p.Service = p.GetSupportedService()[serviceName]
+	p.Service = service
 	p.Service.SetName(serviceName)
 	p.Service.SetVerbose(verbose)
 	p.Service.SetProviderName(p.GetName())

--- a/providers/digitalocean/digitalocean_provider.go
+++ b/providers/digitalocean/digitalocean_provider.go
@@ -62,11 +62,11 @@ func (p *DigitalOceanProvider) GetSupportedService() map[string]terraformutils.S
 func (p *DigitalOceanProvider) InitService(serviceName string, verbose bool) error {
 	p.Service = nil
 
-	var isSupported bool
-	if _, isSupported = p.GetSupportedService()[serviceName]; !isSupported {
+	service, isSupported := p.GetSupportedService()[serviceName]
+	if !isSupported {
 		return errors.New("digitalocean: " + serviceName + " not supported service")
 	}
-	p.Service = p.GetSupportedService()[serviceName]
+	p.Service = service
 	p.Service.SetName(serviceName)
 	p.Service.SetVerbose(verbose)
 	p.Service.SetProviderName(p.GetName())

--- a/providers/equinixmetal/equinixmetal_provider.go
+++ b/providers/equinixmetal/equinixmetal_provider.go
@@ -58,11 +58,11 @@ func (p *EquinixMetalProvider) GetSupportedService() map[string]terraformutils.S
 func (p *EquinixMetalProvider) InitService(serviceName string, verbose bool) error {
 	p.Service = nil
 
-	var isSupported bool
-	if _, isSupported = p.GetSupportedService()[serviceName]; !isSupported {
+	service, isSupported := p.GetSupportedService()[serviceName]
+	if !isSupported {
 		return errors.New("equinixmetal: " + serviceName + " not supported service")
 	}
-	p.Service = p.GetSupportedService()[serviceName]
+	p.Service = service
 	p.Service.SetName(serviceName)
 	p.Service.SetVerbose(verbose)
 	p.Service.SetProviderName(p.GetName())

--- a/providers/fastly/fastly_provider.go
+++ b/providers/fastly/fastly_provider.go
@@ -63,11 +63,11 @@ func (p *FastlyProvider) GetSupportedService() map[string]terraformutils.Service
 func (p *FastlyProvider) InitService(serviceName string, verbose bool) error {
 	p.Service = nil
 
-	var isSupported bool
-	if _, isSupported = p.GetSupportedService()[serviceName]; !isSupported {
+	service, isSupported := p.GetSupportedService()[serviceName]
+	if !isSupported {
 		return errors.New("fastly: " + serviceName + " not supported service")
 	}
-	p.Service = p.GetSupportedService()[serviceName]
+	p.Service = service
 	p.Service.SetName(serviceName)
 	p.Service.SetVerbose(verbose)
 	p.Service.SetProviderName(p.GetName())

--- a/providers/gcp/gcp_provider.go
+++ b/providers/gcp/gcp_provider.go
@@ -92,11 +92,11 @@ func (p *GCPProvider) GetName() string {
 func (p *GCPProvider) InitService(serviceName string, verbose bool) error {
 	p.Service = nil
 
-	var isSupported bool
-	if _, isSupported = p.GetSupportedService()[serviceName]; !isSupported {
+	service, isSupported := p.GetSupportedService()[serviceName]
+	if !isSupported {
 		return errors.New("gcp: " + serviceName + " not supported service")
 	}
-	p.Service = p.GetSupportedService()[serviceName]
+	p.Service = service
 	p.Service.SetName(serviceName)
 	p.Service.SetVerbose(verbose)
 	p.Service.SetProviderName(p.GetName())

--- a/providers/github/github_provider.go
+++ b/providers/github/github_provider.go
@@ -111,11 +111,11 @@ func (p *GithubProvider) GetName() string {
 func (p *GithubProvider) InitService(serviceName string, verbose bool) error {
 	p.Service = nil
 
-	var isSupported bool
-	if _, isSupported = p.GetSupportedService()[serviceName]; !isSupported {
+	service, isSupported := p.GetSupportedService()[serviceName]
+	if !isSupported {
 		return errors.New(p.GetName() + ": " + serviceName + " not supported service")
 	}
-	p.Service = p.GetSupportedService()[serviceName]
+	p.Service = service
 	p.Service.SetName(serviceName)
 	p.Service.SetVerbose(verbose)
 	p.Service.SetProviderName(p.GetName())

--- a/providers/gitlab/gitlab_provider.go
+++ b/providers/gitlab/gitlab_provider.go
@@ -74,11 +74,11 @@ func (p *GitLabProvider) GetName() string {
 func (p *GitLabProvider) InitService(serviceName string, verbose bool) error {
 	p.Service = nil
 
-	var isSupported bool
-	if _, isSupported = p.GetSupportedService()[serviceName]; !isSupported {
+	service, isSupported := p.GetSupportedService()[serviceName]
+	if !isSupported {
 		return errors.New(p.GetName() + ": " + serviceName + " not supported service")
 	}
-	p.Service = p.GetSupportedService()[serviceName]
+	p.Service = service
 	p.Service.SetName(serviceName)
 	p.Service.SetVerbose(verbose)
 	p.Service.SetProviderName(p.GetName())

--- a/providers/gmailfilter/gmailfilter_provider.go
+++ b/providers/gmailfilter/gmailfilter_provider.go
@@ -40,11 +40,11 @@ func (p *GmailfilterProvider) GetName() string {
 func (p *GmailfilterProvider) InitService(serviceName string, verbose bool) error {
 	p.Service = nil
 
-	var isSupported bool
-	if _, isSupported = p.GetSupportedService()[serviceName]; !isSupported {
+	service, isSupported := p.GetSupportedService()[serviceName]
+	if !isSupported {
 		return errors.New("gmailfilter: " + serviceName + " not supported service")
 	}
-	p.Service = p.GetSupportedService()[serviceName]
+	p.Service = service
 	p.Service.SetName(serviceName)
 	p.Service.SetVerbose(verbose)
 	p.Service.SetProviderName(p.GetName())

--- a/providers/grafana/grafana_provider.go
+++ b/providers/grafana/grafana_provider.go
@@ -99,12 +99,12 @@ func (p *GrafanaProvider) GetName() string {
 func (p *GrafanaProvider) InitService(serviceName string, verbose bool) error {
 	p.Service = nil
 
-	var isSupported bool
-	if _, isSupported = p.GetSupportedService()[serviceName]; !isSupported {
+	service, isSupported := p.GetSupportedService()[serviceName]
+	if !isSupported {
 		return errors.New(p.GetName() + ": " + serviceName + " not supported service")
 	}
 
-	p.Service = p.GetSupportedService()[serviceName]
+	p.Service = service
 	p.Service.SetName(serviceName)
 	p.Service.SetVerbose(verbose)
 	p.Service.SetProviderName(p.GetName())

--- a/providers/heroku/heroku_provider.go
+++ b/providers/heroku/heroku_provider.go
@@ -59,11 +59,11 @@ func (p *HerokuProvider) GetSupportedService() map[string]terraformutils.Service
 func (p *HerokuProvider) InitService(serviceName string, verbose bool) error {
 	p.Service = nil
 
-	var isSupported bool
-	if _, isSupported = p.GetSupportedService()[serviceName]; !isSupported {
+	service, isSupported := p.GetSupportedService()[serviceName]
+	if !isSupported {
 		return errors.New("heroku: " + serviceName + " not supported service")
 	}
-	p.Service = p.GetSupportedService()[serviceName]
+	p.Service = service
 	p.Service.SetName(serviceName)
 	p.Service.SetVerbose(verbose)
 	p.Service.SetProviderName(p.GetName())

--- a/providers/honeycombio/honeycomb_provider.go
+++ b/providers/honeycombio/honeycomb_provider.go
@@ -94,11 +94,11 @@ func (p *HoneycombProvider) GetConfig() cty.Value {
 func (p *HoneycombProvider) InitService(serviceName string, verbose bool) error {
 	p.Service = nil
 
-	var isSupported bool
-	if _, isSupported = p.GetSupportedService()[serviceName]; !isSupported {
+	service, isSupported := p.GetSupportedService()[serviceName]
+	if !isSupported {
 		return errors.New("honeycombio: " + serviceName + " is not a supported resource type")
 	}
-	p.Service = p.GetSupportedService()[serviceName]
+	p.Service = service
 	p.Service.SetName(serviceName)
 	p.Service.SetVerbose(verbose)
 	p.Service.SetProviderName(p.GetName())

--- a/providers/ibm/ibm_provider.go
+++ b/providers/ibm/ibm_provider.go
@@ -203,11 +203,11 @@ func (p *IBMProvider) GetSupportedService() map[string]terraformutils.ServiceGen
 func (p *IBMProvider) InitService(serviceName string, verbose bool) error {
 	p.Service = nil
 
-	var isSupported bool
-	if _, isSupported = p.GetSupportedService()[serviceName]; !isSupported {
+	service, isSupported := p.GetSupportedService()[serviceName]
+	if !isSupported {
 		return errors.New("IBM: " + serviceName + " not supported service")
 	}
-	p.Service = p.GetSupportedService()[serviceName]
+	p.Service = service
 	p.Service.SetName(serviceName)
 	p.Service.SetVerbose(verbose)
 	p.Service.SetProviderName(p.GetName())

--- a/providers/ionoscloud/ionoscloud_provider.go
+++ b/providers/ionoscloud/ionoscloud_provider.go
@@ -153,11 +153,11 @@ func (p *IonosCloudProvider) GetSupportedService() map[string]terraformutils.Ser
 func (p *IonosCloudProvider) InitService(serviceName string, verbose bool) error {
 	p.Service = nil
 
-	var isSupported bool
-	if _, isSupported = p.GetSupportedService()[serviceName]; !isSupported {
+	service, isSupported := p.GetSupportedService()[serviceName]
+	if !isSupported {
 		return errors.New(helpers.Ionos + ": " + serviceName + " not supported service")
 	}
-	p.Service = p.GetSupportedService()[serviceName]
+	p.Service = service
 	p.Service.SetName(serviceName)
 	p.Service.SetVerbose(verbose)
 	p.Service.SetProviderName(p.GetName())

--- a/providers/keycloak/keycloak_provider.go
+++ b/providers/keycloak/keycloak_provider.go
@@ -94,11 +94,11 @@ func (p *KeycloakProvider) GetBasicConfig() cty.Value {
 func (p *KeycloakProvider) InitService(serviceName string, verbose bool) error {
 	p.Service = nil
 
-	var isSupported bool
-	if _, isSupported = p.GetSupportedService()[serviceName]; !isSupported {
+	service, isSupported := p.GetSupportedService()[serviceName]
+	if !isSupported {
 		return errors.New(p.GetName() + ": " + serviceName + " not supported service")
 	}
-	p.Service = p.GetSupportedService()[serviceName]
+	p.Service = service
 	p.Service.SetName(serviceName)
 	p.Service.SetVerbose(verbose)
 	p.Service.SetProviderName(p.GetName())

--- a/providers/kubernetes/kubernetes_provider.go
+++ b/providers/kubernetes/kubernetes_provider.go
@@ -56,11 +56,11 @@ func (p *KubernetesProvider) GetName() string {
 func (p *KubernetesProvider) InitService(serviceName string, verbose bool) error {
 	p.Service = nil
 
-	var isSupported bool
-	if _, isSupported = p.GetSupportedService()[serviceName]; !isSupported {
+	service, isSupported := p.GetSupportedService()[serviceName]
+	if !isSupported {
 		return errors.New("kubernetes: " + serviceName + " not supported resource")
 	}
-	p.Service = p.GetSupportedService()[serviceName]
+	p.Service = service
 	p.Service.SetName(serviceName)
 	p.Service.SetVerbose(verbose)
 	p.Service.SetProviderName(p.GetName())

--- a/providers/launchdarkly/launchdarkly_provider.go
+++ b/providers/launchdarkly/launchdarkly_provider.go
@@ -91,11 +91,11 @@ func (p *LaunchDarklyProvider) GetSupportedService() map[string]terraformutils.S
 func (p *LaunchDarklyProvider) InitService(serviceName string, verbose bool) error {
 	p.Service = nil
 
-	var isSupported bool
-	if _, isSupported = p.GetSupportedService()[serviceName]; !isSupported {
+	service, isSupported := p.GetSupportedService()[serviceName]
+	if !isSupported {
 		return errors.New("launchdarkly: " + serviceName + " not supported service")
 	}
-	p.Service = p.GetSupportedService()[serviceName]
+	p.Service = service
 	p.Service.SetName(serviceName)
 	p.Service.SetVerbose(verbose)
 	p.Service.SetProviderName(p.GetName())

--- a/providers/linode/linode_provider.go
+++ b/providers/linode/linode_provider.go
@@ -55,11 +55,11 @@ func (p *LinodeProvider) GetSupportedService() map[string]terraformutils.Service
 func (p *LinodeProvider) InitService(serviceName string, verbose bool) error {
 	p.Service = nil
 
-	var isSupported bool
-	if _, isSupported = p.GetSupportedService()[serviceName]; !isSupported {
+	service, isSupported := p.GetSupportedService()[serviceName]
+	if !isSupported {
 		return errors.New("linode: " + serviceName + " not supported service")
 	}
-	p.Service = p.GetSupportedService()[serviceName]
+	p.Service = service
 	p.Service.SetName(serviceName)
 	p.Service.SetVerbose(verbose)
 	p.Service.SetProviderName(p.GetName())

--- a/providers/logzio/logzio_provider.go
+++ b/providers/logzio/logzio_provider.go
@@ -55,11 +55,11 @@ func (p *LogzioProvider) GetName() string {
 func (p *LogzioProvider) InitService(serviceName string, verbose bool) error {
 	p.Service = nil
 
-	var isSupported bool
-	if _, isSupported = p.GetSupportedService()[serviceName]; !isSupported {
+	service, isSupported := p.GetSupportedService()[serviceName]
+	if !isSupported {
 		return errors.New(p.GetName() + ": " + serviceName + " not supported service")
 	}
-	p.Service = p.GetSupportedService()[serviceName]
+	p.Service = service
 	p.Service.SetName(serviceName)
 	p.Service.SetVerbose(verbose)
 	p.Service.SetProviderName(p.GetName())

--- a/providers/mackerel/mackerel_provider.go
+++ b/providers/mackerel/mackerel_provider.go
@@ -37,11 +37,11 @@ func (p *MackerelProvider) Init(args []string) error {
 func (p *MackerelProvider) InitService(serviceName string, verbose bool) error {
 	p.Service = nil
 
-	var isSupported bool
-	if _, isSupported = p.GetSupportedService()[serviceName]; !isSupported {
+	service, isSupported := p.GetSupportedService()[serviceName]
+	if !isSupported {
 		return errors.New(p.GetName() + ": " + serviceName + " not supported service")
 	}
-	p.Service = p.GetSupportedService()[serviceName]
+	p.Service = service
 	p.Service.SetName(serviceName)
 	p.Service.SetVerbose(verbose)
 	p.Service.SetProviderName(p.GetName())

--- a/providers/mikrotik/mikrotik_provider.go
+++ b/providers/mikrotik/mikrotik_provider.go
@@ -48,11 +48,11 @@ func (p *MikrotikProvider) GetSupportedService() map[string]terraformutils.Servi
 func (p *MikrotikProvider) InitService(serviceName string, verbose bool) error {
 	p.Service = nil
 
-	var isSupported bool
-	if _, isSupported = p.GetSupportedService()[serviceName]; !isSupported {
+	service, isSupported := p.GetSupportedService()[serviceName]
+	if !isSupported {
 		return errors.New("mikrotik: " + serviceName + " not supported service")
 	}
-	p.Service = p.GetSupportedService()[serviceName]
+	p.Service = service
 	p.Service.SetName(serviceName)
 	p.Service.SetVerbose(verbose)
 	p.Service.SetProviderName(p.GetName())

--- a/providers/myrasec/myrasec_provider.go
+++ b/providers/myrasec/myrasec_provider.go
@@ -51,11 +51,11 @@ func (p *MyrasecProvider) GetSupportedService() map[string]terraformutils.Servic
 func (p *MyrasecProvider) InitService(serviceName string, verbose bool) error {
 	p.Service = nil
 
-	var isSupported bool
-	if _, isSupported = p.GetSupportedService()[serviceName]; !isSupported {
+	service, isSupported := p.GetSupportedService()[serviceName]
+	if !isSupported {
 		return errors.New("myrasec: " + serviceName + " not supported service")
 	}
-	p.Service = p.GetSupportedService()[serviceName]
+	p.Service = service
 	p.Service.SetName(serviceName)
 	p.Service.SetVerbose(verbose)
 	p.Service.SetProviderName(p.GetName())

--- a/providers/newrelic/newrelic_provider.go
+++ b/providers/newrelic/newrelic_provider.go
@@ -92,11 +92,11 @@ func (p *NewRelicProvider) GetSupportedService() map[string]terraformutils.Servi
 func (p *NewRelicProvider) InitService(serviceName string, verbose bool) error {
 	p.Service = nil
 
-	var isSupported bool
-	if _, isSupported = p.GetSupportedService()[serviceName]; !isSupported {
+	service, isSupported := p.GetSupportedService()[serviceName]
+	if !isSupported {
 		return errors.New("newrelic: " + serviceName + " not supported service")
 	}
-	p.Service = p.GetSupportedService()[serviceName]
+	p.Service = service
 	p.Service.SetName(serviceName)
 	p.Service.SetVerbose(verbose)
 	p.Service.SetArgs(map[string]interface{}{"apiKey": p.APIKey})

--- a/providers/ns1/ns1_provider.go
+++ b/providers/ns1/ns1_provider.go
@@ -49,11 +49,11 @@ func (p *Ns1Provider) GetSupportedService() map[string]terraformutils.ServiceGen
 func (p *Ns1Provider) InitService(serviceName string, verbose bool) error {
 	p.Service = nil
 
-	var isSupported bool
-	if _, isSupported = p.GetSupportedService()[serviceName]; !isSupported {
+	service, isSupported := p.GetSupportedService()[serviceName]
+	if !isSupported {
 		return errors.New("ns1: " + serviceName + " not supported service")
 	}
-	p.Service = p.GetSupportedService()[serviceName]
+	p.Service = service
 	p.Service.SetName(serviceName)
 	p.Service.SetVerbose(verbose)
 	p.Service.SetProviderName(p.GetName())

--- a/providers/octopusdeploy/octopusdeploy_provider.go
+++ b/providers/octopusdeploy/octopusdeploy_provider.go
@@ -76,11 +76,11 @@ func (p *OctopusDeployProvider) GetSupportedService() map[string]terraformutils.
 func (p *OctopusDeployProvider) InitService(serviceName string, verbose bool) error {
 	p.Service = nil
 
-	var isSupported bool
-	if _, isSupported = p.GetSupportedService()[serviceName]; !isSupported {
+	service, isSupported := p.GetSupportedService()[serviceName]
+	if !isSupported {
 		return errors.New("octopusdeploy: " + serviceName + " not supported service, see list sub-command")
 	}
-	p.Service = p.GetSupportedService()[serviceName]
+	p.Service = service
 	p.Service.SetName(serviceName)
 	p.Service.SetVerbose(verbose)
 	p.Service.SetProviderName(p.GetName())

--- a/providers/okta/okta_provider.go
+++ b/providers/okta/okta_provider.go
@@ -67,11 +67,11 @@ func (p *OktaProvider) GetName() string {
 func (p *OktaProvider) InitService(serviceName string, verbose bool) error {
 	p.Service = nil
 
-	var isSupported bool
-	if _, isSupported = p.GetSupportedService()[serviceName]; !isSupported {
+	service, isSupported := p.GetSupportedService()[serviceName]
+	if !isSupported {
 		return errors.New(p.GetName() + ": " + serviceName + " is not a supported service")
 	}
-	p.Service = p.GetSupportedService()[serviceName]
+	p.Service = service
 	p.Service.SetName(serviceName)
 	p.Service.SetProviderName(p.GetName())
 	p.Service.SetVerbose(verbose)

--- a/providers/opal/opal_provider.go
+++ b/providers/opal/opal_provider.go
@@ -94,11 +94,11 @@ func (p *OpalProvider) GetConfig() cty.Value {
 func (p *OpalProvider) InitService(serviceName string, verbose bool) error {
 	p.Service = nil
 
-	var isSupported bool
-	if _, isSupported = p.GetSupportedService()[serviceName]; !isSupported {
+	service, isSupported := p.GetSupportedService()[serviceName]
+	if !isSupported {
 		return errors.New("opal: " + serviceName + " is not a supported resource type")
 	}
-	p.Service = p.GetSupportedService()[serviceName]
+	p.Service = service
 	p.Service.SetName(serviceName)
 	p.Service.SetVerbose(verbose)
 	p.Service.SetProviderName(p.GetName())

--- a/providers/openstack/openstack_provider.go
+++ b/providers/openstack/openstack_provider.go
@@ -50,11 +50,11 @@ func (p *OpenStackProvider) GetName() string {
 func (p *OpenStackProvider) InitService(serviceName string, verbose bool) error {
 	p.Service = nil
 
-	var isSupported bool
-	if _, isSupported = p.GetSupportedService()[serviceName]; !isSupported {
+	service, isSupported := p.GetSupportedService()[serviceName]
+	if !isSupported {
 		return errors.New("openstack: " + serviceName + " not supported service")
 	}
-	p.Service = p.GetSupportedService()[serviceName]
+	p.Service = service
 	p.Service.SetName(serviceName)
 	p.Service.SetVerbose(verbose)
 	p.Service.SetProviderName(p.GetName())

--- a/providers/opsgenie/opsgenie_provider.go
+++ b/providers/opsgenie/opsgenie_provider.go
@@ -31,11 +31,11 @@ func (p *OpsgenieProvider) Init(args []string) error {
 func (p *OpsgenieProvider) InitService(serviceName string, verbose bool) error {
 	p.Service = nil
 
-	var isSupported bool
-	if _, isSupported = p.GetSupportedService()[serviceName]; !isSupported {
+	service, isSupported := p.GetSupportedService()[serviceName]
+	if !isSupported {
 		return errors.New(p.GetName() + ": " + serviceName + " not supported service")
 	}
-	p.Service = p.GetSupportedService()[serviceName]
+	p.Service = service
 	p.Service.SetName(serviceName)
 	p.Service.SetVerbose(verbose)
 	p.Service.SetProviderName(p.GetName())

--- a/providers/pagerduty/pagerduty_provider.go
+++ b/providers/pagerduty/pagerduty_provider.go
@@ -64,11 +64,11 @@ func (p *PagerDutyProvider) GetSupportedService() map[string]terraformutils.Serv
 func (p *PagerDutyProvider) InitService(serviceName string, verbose bool) error {
 	p.Service = nil
 
-	var isSupported bool
-	if _, isSupported = p.GetSupportedService()[serviceName]; !isSupported {
+	service, isSupported := p.GetSupportedService()[serviceName]
+	if !isSupported {
 		return errors.New(p.GetName() + ": " + serviceName + " not supported service")
 	}
-	p.Service = p.GetSupportedService()[serviceName]
+	p.Service = service
 	p.Service.SetName(serviceName)
 	p.Service.SetVerbose(verbose)
 	p.Service.SetProviderName(p.GetName())

--- a/providers/panos/panos_provider.go
+++ b/providers/panos/panos_provider.go
@@ -43,12 +43,12 @@ func (p *PanosProvider) GetBasicConfig() cty.Value {
 func (p *PanosProvider) InitService(serviceName string, verbose bool) error {
 	p.Service = nil
 
-	var isSupported bool
-	if _, isSupported = p.GetSupportedService()[serviceName]; !isSupported {
+	service, isSupported := p.GetSupportedService()[serviceName]
+	if !isSupported {
 		return errors.New(p.GetName() + ": " + serviceName + " not supported service")
 	}
 
-	p.Service = p.GetSupportedService()[serviceName]
+	p.Service = service
 	p.Service.SetName(serviceName)
 	p.Service.SetVerbose(verbose)
 	p.Service.SetProviderName(p.GetName())

--- a/providers/rabbitmq/rabbitmq_provider.go
+++ b/providers/rabbitmq/rabbitmq_provider.go
@@ -50,11 +50,11 @@ func (p *RBTProvider) GetBasicConfig() cty.Value {
 func (p *RBTProvider) InitService(serviceName string, verbose bool) error {
 	p.Service = nil
 
-	var isSupported bool
-	if _, isSupported = p.GetSupportedService()[serviceName]; !isSupported {
+	service, isSupported := p.GetSupportedService()[serviceName]
+	if !isSupported {
 		return errors.New(p.GetName() + ": " + serviceName + " not supported service")
 	}
-	p.Service = p.GetSupportedService()[serviceName]
+	p.Service = service
 	p.Service.SetName(serviceName)
 	p.Service.SetVerbose(verbose)
 	p.Service.SetProviderName(p.GetName())

--- a/providers/tencentcloud/tencentcloud_provider.go
+++ b/providers/tencentcloud/tencentcloud_provider.go
@@ -67,11 +67,11 @@ func (p *TencentCloudProvider) Init(args []string) error {
 func (p *TencentCloudProvider) InitService(serviceName string, verbose bool) error {
 	p.Service = nil
 
-	var isSupported bool
-	if _, isSupported = p.GetSupportedService()[serviceName]; !isSupported {
+	service, isSupported := p.GetSupportedService()[serviceName]
+	if !isSupported {
 		return errors.New("tencentcloud: " + serviceName + " not supported service")
 	}
-	p.Service = p.GetSupportedService()[serviceName]
+	p.Service = service
 	p.Service.SetName(serviceName)
 	p.Service.SetVerbose(verbose)
 	p.Service.SetProviderName(p.GetName())

--- a/providers/vultr/vultr_provider.go
+++ b/providers/vultr/vultr_provider.go
@@ -57,11 +57,11 @@ func (p *VultrProvider) GetSupportedService() map[string]terraformutils.ServiceG
 func (p *VultrProvider) InitService(serviceName string, verbose bool) error {
 	p.Service = nil
 
-	var isSupported bool
-	if _, isSupported = p.GetSupportedService()[serviceName]; !isSupported {
+	service, isSupported := p.GetSupportedService()[serviceName]
+	if !isSupported {
 		return errors.New("vultr: " + serviceName + " not supported service")
 	}
-	p.Service = p.GetSupportedService()[serviceName]
+	p.Service = service
 	p.Service.SetName(serviceName)
 	p.Service.SetVerbose(verbose)
 	p.Service.SetProviderName(p.GetName())

--- a/providers/xenorchestra/xenorchestra_provider.go
+++ b/providers/xenorchestra/xenorchestra_provider.go
@@ -72,11 +72,11 @@ func (p *XenorchestraProvider) GetSupportedService() map[string]terraformutils.S
 func (p *XenorchestraProvider) InitService(serviceName string, verbose bool) error {
 	p.Service = nil
 
-	var isSupported bool
-	if _, isSupported = p.GetSupportedService()[serviceName]; !isSupported {
+	service, isSupported := p.GetSupportedService()[serviceName]
+	if !isSupported {
 		return errors.New("xenorchestra: " + serviceName + " not supported service")
 	}
-	p.Service = p.GetSupportedService()[serviceName]
+	p.Service = service
 	p.Service.SetName(serviceName)
 	p.Service.SetVerbose(verbose)
 	p.Service.SetProviderName(p.GetName())

--- a/providers/yandex/yandex_provider.go
+++ b/providers/yandex/yandex_provider.go
@@ -66,11 +66,11 @@ func (p *YandexProvider) GetSupportedService() map[string]terraformutils.Service
 func (p *YandexProvider) InitService(serviceName string, verbose bool) error {
 	p.Service = nil
 
-	var isSupported bool
-	if _, isSupported = p.GetSupportedService()[serviceName]; !isSupported {
+	service, isSupported := p.GetSupportedService()[serviceName]
+	if !isSupported {
 		return errors.New("yandex: " + serviceName + " not supported service")
 	}
-	p.Service = p.GetSupportedService()[serviceName]
+	p.Service = service
 	p.Service.SetName(serviceName)
 	p.Service.SetVerbose(verbose)
 	p.Service.SetProviderName(p.GetName())


### PR DESCRIPTION
## Summary

- Reuse the supported-service lookup result during provider InitService.
- Avoid rebuilding provider service maps twice for the same service selection.
- Keep unsupported-service handling and provider service initialization behavior unchanged.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Refactored provider `InitService` to reuse the supported-service lookup result. This removes duplicate map rebuilds during init and keeps unsupported-service errors and initialization behavior unchanged.

<sup>Written for commit c4119c7c86fde72a78cdd4d9c7daaaa10bf1da1d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

