### PR TITLE
feat(cloudflare): expand email routing and workers imports

### DIFF
--- a/docs/cloudflare.md
+++ b/docs/cloudflare.md
@@ -90,4 +90,7 @@ List of supported Cloudflare services:
 * `web_analytics`
   * `cloudflare_web_analytics_site`
 * `workers`
+  * `cloudflare_workers_cron_trigger`
+  * `cloudflare_workers_custom_domain`
+  * `cloudflare_workers_for_platforms_dispatch_namespace`
   * `cloudflare_workers_route`

--- a/docs/cloudflare.md
+++ b/docs/cloudflare.md
@@ -35,6 +35,15 @@ List of supported Cloudflare services:
 * `dns`
   * `cloudflare_dns_record`
   * `cloudflare_zone`
+* `email_routing`
+  * `cloudflare_email_routing_address`
+  * `cloudflare_email_routing_catch_all`
+  * `cloudflare_email_routing_dns`
+  * `cloudflare_email_routing_rule`
+  * `cloudflare_email_routing_settings`
+
+  Avoid importing `email_routing` with `dns` when you intend to manage Email Routing DNS records
+  through `cloudflare_email_routing_dns`.
 * `firewall`
   * `cloudflare_access_rule`
   * `cloudflare_filter`

--- a/providers/cloudflare/cloudflare_provider.go
+++ b/providers/cloudflare/cloudflare_provider.go
@@ -37,6 +37,7 @@ func (p *CloudflareProvider) GetSupportedService() map[string]terraformutils.Ser
 		"account_member": &AccountMemberGenerator{},
 		"certificates":   &CertificatesGenerator{},
 		"lists":          &ListsGenerator{},
+		"email_routing":  &EmailRoutingGenerator{},
 		"load_balancing": &LoadBalancingGenerator{},
 		"logpush":        &LogpushGenerator{},
 		"magic_wan":      &MagicWANGenerator{},

--- a/providers/cloudflare/email_routing.go
+++ b/providers/cloudflare/email_routing.go
@@ -4,8 +4,10 @@ package cloudflare
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
+	"net/http"
 
 	"github.com/chenrui333/terraformer/terraformutils"
 	cf "github.com/cloudflare/cloudflare-go"
@@ -15,12 +17,39 @@ type EmailRoutingGenerator struct {
 	CloudflareService
 }
 
+type emailRoutingAddress struct {
+	ID    string `json:"id,omitempty"`
+	Tag   string `json:"tag,omitempty"`
+	Email string `json:"email,omitempty"`
+}
+
+type emailRoutingRule struct {
+	ID   string `json:"id,omitempty"`
+	Tag  string `json:"tag,omitempty"`
+	Name string `json:"name,omitempty"`
+}
+
+type emailRoutingDNSResult struct {
+	Record []cf.DNSRecord    `json:"record,omitempty"`
+	Errors []json.RawMessage `json:"errors,omitempty"`
+}
+
 func cloudflareNotFoundError(err error) bool {
 	var notFoundErr *cf.NotFoundError
 	return errors.As(err, &notFoundErr)
 }
 
-func emailRoutingRuleID(rule cf.EmailRoutingRule) string {
+func emailRoutingAddressID(address emailRoutingAddress) string {
+	if address.ID != "" {
+		return address.ID
+	}
+	return address.Tag
+}
+
+func emailRoutingRuleID(rule emailRoutingRule) string {
+	if rule.ID != "" {
+		return rule.ID
+	}
 	return rule.Tag
 }
 
@@ -46,14 +75,14 @@ func (g *EmailRoutingGenerator) appendEmailRoutingSettingsResource(zone cf.Zone,
 }
 
 func (g *EmailRoutingGenerator) appendEmailRoutingDNSResource(ctx context.Context, api *cf.API, zone cf.Zone) error {
-	settings, err := api.GetEmailRoutingDNSSettings(ctx, cf.ZoneIdentifier(zone.ID))
+	hasDNSSettings, err := emailRoutingDNSSettingsExist(ctx, api, zone.ID)
 	if err != nil {
 		if cloudflareNotFoundError(err) {
 			return nil
 		}
 		return fmt.Errorf("get email routing DNS settings for zone %q: %w", zone.ID, err)
 	}
-	if len(settings) == 0 {
+	if !hasDNSSettings {
 		return nil
 	}
 
@@ -71,75 +100,126 @@ func (g *EmailRoutingGenerator) appendEmailRoutingDNSResource(ctx context.Contex
 	return nil
 }
 
-func (g *EmailRoutingGenerator) appendEmailRoutingAddressResources(ctx context.Context, api *cf.API, account *cf.ResourceContainer) error {
-	params := cf.ListEmailRoutingAddressParameters{
-		ResultInfo: cf.ResultInfo{Page: 1, PerPage: cloudflarePageSize},
+func emailRoutingDNSSettingsExist(ctx context.Context, api *cf.API, zoneID string) (bool, error) {
+	response, err := api.Raw(ctx, http.MethodGet, fmt.Sprintf("/zones/%s/email/routing/dns", zoneID), nil, nil)
+	if err != nil {
+		return false, err
 	}
+	var records []cf.DNSRecord
+	if err := json.Unmarshal(response.Result, &records); err == nil {
+		return len(records) > 0, nil
+	}
+	var result emailRoutingDNSResult
+	if err := json.Unmarshal(response.Result, &result); err != nil {
+		return false, err
+	}
+	return len(result.Record) > 0 || len(result.Errors) > 0, nil
+}
+
+func listEmailRoutingAddresses(ctx context.Context, api *cf.API, accountID string) ([]emailRoutingAddress, error) {
+	var addresses []emailRoutingAddress
+	page, cursor := 1, ""
 	for {
-		addresses, info, err := api.ListEmailRoutingDestinationAddresses(ctx, account, params)
+		response, err := api.Raw(
+			ctx,
+			http.MethodGet,
+			fmt.Sprintf("/accounts/%s/email/routing/addresses?%s", accountID, cloudflarePaginationQuery(page, cursor)),
+			nil,
+			nil,
+		)
 		if err != nil {
-			if cloudflareNotFoundError(err) {
-				return nil
-			}
-			return fmt.Errorf("list email routing destination addresses for account %q: %w", account.Identifier, err)
+			return nil, err
 		}
-		for _, address := range addresses {
-			if address.Tag == "" {
-				continue
-			}
-			resource := terraformutils.NewResource(
-				address.Tag,
-				cloudflareResourceName(account.Identifier, address.Email, address.Tag),
-				"cloudflare_email_routing_address",
-				"cloudflare",
-				map[string]string{"account_id": account.Identifier},
-				[]string{},
-				map[string]interface{}{},
-			)
-			setCloudflareImportID(&resource, fmt.Sprintf("%s/%s", account.Identifier, address.Tag))
-			g.Resources = append(g.Resources, resource)
+		var pageAddresses []emailRoutingAddress
+		if err := json.Unmarshal(response.Result, &pageAddresses); err != nil {
+			return nil, err
 		}
-		if info == nil || !info.HasMorePages() {
+		addresses = append(addresses, pageAddresses...)
+		if !cloudflareAdvancePagination(response.ResultInfo, &page, &cursor) {
 			break
 		}
-		params.ResultInfo = info.Next()
+	}
+	return addresses, nil
+}
+
+func listEmailRoutingRules(ctx context.Context, api *cf.API, zoneID string) ([]emailRoutingRule, error) {
+	var rules []emailRoutingRule
+	page, cursor := 1, ""
+	for {
+		response, err := api.Raw(
+			ctx,
+			http.MethodGet,
+			fmt.Sprintf("/zones/%s/email/routing/rules?%s", zoneID, cloudflarePaginationQuery(page, cursor)),
+			nil,
+			nil,
+		)
+		if err != nil {
+			return nil, err
+		}
+		var pageRules []emailRoutingRule
+		if err := json.Unmarshal(response.Result, &pageRules); err != nil {
+			return nil, err
+		}
+		rules = append(rules, pageRules...)
+		if !cloudflareAdvancePagination(response.ResultInfo, &page, &cursor) {
+			break
+		}
+	}
+	return rules, nil
+}
+
+func (g *EmailRoutingGenerator) appendEmailRoutingAddressResources(ctx context.Context, api *cf.API, account *cf.ResourceContainer) error {
+	addresses, err := listEmailRoutingAddresses(ctx, api, account.Identifier)
+	if err != nil {
+		if cloudflareNotFoundError(err) {
+			return nil
+		}
+		return fmt.Errorf("list email routing destination addresses for account %q: %w", account.Identifier, err)
+	}
+	for _, address := range addresses {
+		addressID := emailRoutingAddressID(address)
+		if addressID == "" {
+			continue
+		}
+		resource := terraformutils.NewResource(
+			addressID,
+			cloudflareResourceName(account.Identifier, address.Email, addressID),
+			"cloudflare_email_routing_address",
+			"cloudflare",
+			map[string]string{"account_id": account.Identifier},
+			[]string{},
+			map[string]interface{}{},
+		)
+		setCloudflareImportID(&resource, fmt.Sprintf("%s/%s", account.Identifier, addressID))
+		g.Resources = append(g.Resources, resource)
 	}
 	return nil
 }
 
 func (g *EmailRoutingGenerator) appendEmailRoutingRuleResources(ctx context.Context, api *cf.API, zone cf.Zone) error {
-	params := cf.ListEmailRoutingRulesParameters{
-		ResultInfo: cf.ResultInfo{Page: 1, PerPage: cloudflarePageSize},
+	rules, err := listEmailRoutingRules(ctx, api, zone.ID)
+	if err != nil {
+		if cloudflareNotFoundError(err) {
+			return nil
+		}
+		return fmt.Errorf("list email routing rules for zone %q: %w", zone.ID, err)
 	}
-	for {
-		rules, info, err := api.ListEmailRoutingRules(ctx, cf.ZoneIdentifier(zone.ID), params)
-		if err != nil {
-			if cloudflareNotFoundError(err) {
-				return nil
-			}
-			return fmt.Errorf("list email routing rules for zone %q: %w", zone.ID, err)
+	for _, rule := range rules {
+		ruleID := emailRoutingRuleID(rule)
+		if ruleID == "" {
+			continue
 		}
-		for _, rule := range rules {
-			ruleID := emailRoutingRuleID(rule)
-			if ruleID == "" {
-				continue
-			}
-			resource := terraformutils.NewResource(
-				ruleID,
-				cloudflareResourceName(zone.Name, rule.Name, ruleID),
-				"cloudflare_email_routing_rule",
-				"cloudflare",
-				map[string]string{"zone_id": zone.ID},
-				[]string{},
-				map[string]interface{}{},
-			)
-			setCloudflareImportID(&resource, fmt.Sprintf("%s/%s", zone.ID, ruleID))
-			g.Resources = append(g.Resources, resource)
-		}
-		if info == nil || !info.HasMorePages() {
-			break
-		}
-		params.ResultInfo = info.Next()
+		resource := terraformutils.NewResource(
+			ruleID,
+			cloudflareResourceName(zone.Name, rule.Name, ruleID),
+			"cloudflare_email_routing_rule",
+			"cloudflare",
+			map[string]string{"zone_id": zone.ID},
+			[]string{},
+			map[string]interface{}{},
+		)
+		setCloudflareImportID(&resource, fmt.Sprintf("%s/%s", zone.ID, ruleID))
+		g.Resources = append(g.Resources, resource)
 	}
 	return nil
 }

--- a/providers/cloudflare/email_routing.go
+++ b/providers/cloudflare/email_routing.go
@@ -175,10 +175,12 @@ func (g *EmailRoutingGenerator) InitResources() error {
 		return err
 	}
 
-	if account, err := g.accountResourceContainer(); err == nil {
-		if err := g.appendEmailRoutingAddressResources(ctx, api, account); err != nil {
-			return err
-		}
+	account, err := g.accountResourceContainer()
+	if err != nil {
+		return err
+	}
+	if err := g.appendEmailRoutingAddressResources(ctx, api, account); err != nil {
+		return err
 	}
 
 	zones, err := cloudflareZones(ctx, api)

--- a/providers/cloudflare/email_routing.go
+++ b/providers/cloudflare/email_routing.go
@@ -175,12 +175,11 @@ func (g *EmailRoutingGenerator) InitResources() error {
 		return err
 	}
 
-	account, err := g.accountResourceContainer()
-	if err != nil {
-		return err
-	}
-	if err := g.appendEmailRoutingAddressResources(ctx, api, account); err != nil {
-		return err
+	accountID := g.accountID()
+	if accountID != "" {
+		if err := g.appendEmailRoutingAddressResources(ctx, api, cf.AccountIdentifier(accountID)); err != nil {
+			return err
+		}
 	}
 
 	zones, err := cloudflareZones(ctx, api)

--- a/providers/cloudflare/email_routing.go
+++ b/providers/cloudflare/email_routing.go
@@ -1,0 +1,211 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package cloudflare
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/chenrui333/terraformer/terraformutils"
+	cf "github.com/cloudflare/cloudflare-go"
+)
+
+type EmailRoutingGenerator struct {
+	CloudflareService
+}
+
+func cloudflareNotFoundError(err error) bool {
+	var notFoundErr *cf.NotFoundError
+	return errors.As(err, &notFoundErr)
+}
+
+func emailRoutingRuleID(rule cf.EmailRoutingRule) string {
+	return rule.Tag
+}
+
+func emailRoutingCatchAllID(rule cf.EmailRoutingCatchAllRule, zoneID string) string {
+	if rule.Tag != "" {
+		return rule.Tag
+	}
+	return zoneID
+}
+
+func (g *EmailRoutingGenerator) appendEmailRoutingSettingsResource(zone cf.Zone, settings cf.EmailRoutingSettings) {
+	resource := terraformutils.NewResource(
+		zone.ID,
+		cloudflareResourceName(zone.Name, settings.Tag),
+		"cloudflare_email_routing_settings",
+		"cloudflare",
+		map[string]string{"zone_id": zone.ID},
+		[]string{},
+		map[string]interface{}{},
+	)
+	setCloudflareImportID(&resource, zone.ID)
+	g.Resources = append(g.Resources, resource)
+}
+
+func (g *EmailRoutingGenerator) appendEmailRoutingDNSResource(ctx context.Context, api *cf.API, zone cf.Zone) error {
+	settings, err := api.GetEmailRoutingDNSSettings(ctx, cf.ZoneIdentifier(zone.ID))
+	if err != nil {
+		if cloudflareNotFoundError(err) {
+			return nil
+		}
+		return fmt.Errorf("get email routing DNS settings for zone %q: %w", zone.ID, err)
+	}
+	if len(settings) == 0 {
+		return nil
+	}
+
+	resource := terraformutils.NewResource(
+		zone.ID,
+		cloudflareResourceName(zone.Name, "dns"),
+		"cloudflare_email_routing_dns",
+		"cloudflare",
+		map[string]string{"zone_id": zone.ID},
+		[]string{},
+		map[string]interface{}{},
+	)
+	setCloudflareImportID(&resource, zone.ID)
+	g.Resources = append(g.Resources, resource)
+	return nil
+}
+
+func (g *EmailRoutingGenerator) appendEmailRoutingAddressResources(ctx context.Context, api *cf.API, account *cf.ResourceContainer) error {
+	params := cf.ListEmailRoutingAddressParameters{
+		ResultInfo: cf.ResultInfo{Page: 1, PerPage: cloudflarePageSize},
+	}
+	for {
+		addresses, info, err := api.ListEmailRoutingDestinationAddresses(ctx, account, params)
+		if err != nil {
+			if cloudflareNotFoundError(err) {
+				return nil
+			}
+			return fmt.Errorf("list email routing destination addresses for account %q: %w", account.Identifier, err)
+		}
+		for _, address := range addresses {
+			if address.Tag == "" {
+				continue
+			}
+			resource := terraformutils.NewResource(
+				address.Tag,
+				cloudflareResourceName(account.Identifier, address.Email, address.Tag),
+				"cloudflare_email_routing_address",
+				"cloudflare",
+				map[string]string{"account_id": account.Identifier},
+				[]string{},
+				map[string]interface{}{},
+			)
+			setCloudflareImportID(&resource, fmt.Sprintf("%s/%s", account.Identifier, address.Tag))
+			g.Resources = append(g.Resources, resource)
+		}
+		if info == nil || !info.HasMorePages() {
+			break
+		}
+		params.ResultInfo = info.Next()
+	}
+	return nil
+}
+
+func (g *EmailRoutingGenerator) appendEmailRoutingRuleResources(ctx context.Context, api *cf.API, zone cf.Zone) error {
+	params := cf.ListEmailRoutingRulesParameters{
+		ResultInfo: cf.ResultInfo{Page: 1, PerPage: cloudflarePageSize},
+	}
+	for {
+		rules, info, err := api.ListEmailRoutingRules(ctx, cf.ZoneIdentifier(zone.ID), params)
+		if err != nil {
+			if cloudflareNotFoundError(err) {
+				return nil
+			}
+			return fmt.Errorf("list email routing rules for zone %q: %w", zone.ID, err)
+		}
+		for _, rule := range rules {
+			ruleID := emailRoutingRuleID(rule)
+			if ruleID == "" {
+				continue
+			}
+			resource := terraformutils.NewResource(
+				ruleID,
+				cloudflareResourceName(zone.Name, rule.Name, ruleID),
+				"cloudflare_email_routing_rule",
+				"cloudflare",
+				map[string]string{"zone_id": zone.ID},
+				[]string{},
+				map[string]interface{}{},
+			)
+			setCloudflareImportID(&resource, fmt.Sprintf("%s/%s", zone.ID, ruleID))
+			g.Resources = append(g.Resources, resource)
+		}
+		if info == nil || !info.HasMorePages() {
+			break
+		}
+		params.ResultInfo = info.Next()
+	}
+	return nil
+}
+
+func (g *EmailRoutingGenerator) appendEmailRoutingCatchAllResource(ctx context.Context, api *cf.API, zone cf.Zone) error {
+	rule, err := api.GetEmailRoutingCatchAllRule(ctx, cf.ZoneIdentifier(zone.ID))
+	if err != nil {
+		if cloudflareNotFoundError(err) {
+			return nil
+		}
+		return fmt.Errorf("get email routing catch-all rule for zone %q: %w", zone.ID, err)
+	}
+	ruleID := emailRoutingCatchAllID(rule, zone.ID)
+
+	resource := terraformutils.NewResource(
+		ruleID,
+		cloudflareResourceName(zone.Name, "catch_all", ruleID),
+		"cloudflare_email_routing_catch_all",
+		"cloudflare",
+		map[string]string{"zone_id": zone.ID},
+		[]string{},
+		map[string]interface{}{},
+	)
+	setCloudflareImportID(&resource, zone.ID)
+	g.Resources = append(g.Resources, resource)
+	return nil
+}
+
+func (g *EmailRoutingGenerator) InitResources() error {
+	ctx := context.Background()
+	api, err := g.initializeAPI()
+	if err != nil {
+		return err
+	}
+
+	if account, err := g.accountResourceContainer(); err == nil {
+		if err := g.appendEmailRoutingAddressResources(ctx, api, account); err != nil {
+			return err
+		}
+	}
+
+	zones, err := cloudflareZones(ctx, api)
+	if err != nil {
+		return err
+	}
+	for _, zone := range zones {
+		settings, err := api.GetEmailRoutingSettings(ctx, cf.ZoneIdentifier(zone.ID))
+		if err != nil {
+			if cloudflareNotFoundError(err) {
+				continue
+			}
+			return fmt.Errorf("get email routing settings for zone %q: %w", zone.ID, err)
+		}
+		if !settings.Enabled {
+			continue
+		}
+		g.appendEmailRoutingSettingsResource(zone, settings)
+		if err := g.appendEmailRoutingDNSResource(ctx, api, zone); err != nil {
+			return err
+		}
+		if err := g.appendEmailRoutingRuleResources(ctx, api, zone); err != nil {
+			return err
+		}
+		if err := g.appendEmailRoutingCatchAllResource(ctx, api, zone); err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/providers/cloudflare/workers.go
+++ b/providers/cloudflare/workers.go
@@ -23,10 +23,6 @@ func (g *WorkersGenerator) InitResources() error {
 	if err != nil {
 		return err
 	}
-	account, err := g.accountResourceContainer()
-	if err != nil {
-		return err
-	}
 	zones, err := cloudflareZones(ctx, api)
 	if err != nil {
 		return err
@@ -48,13 +44,18 @@ func (g *WorkersGenerator) InitResources() error {
 			))
 		}
 	}
-	if err := g.appendWorkerCustomDomainResources(ctx, api, account.Identifier); err != nil {
+	accountID := g.accountID()
+	if accountID == "" {
+		return nil
+	}
+	account := cf.AccountIdentifier(accountID)
+	if err := g.appendWorkerCustomDomainResources(ctx, api, accountID); err != nil {
 		return err
 	}
 	if err := g.appendWorkerCronTriggerResources(ctx, api, account); err != nil {
 		return err
 	}
-	if err := g.appendWorkersForPlatformsDispatchNamespaceResources(ctx, api, account.Identifier); err != nil {
+	if err := g.appendWorkersForPlatformsDispatchNamespaceResources(ctx, api, accountID); err != nil {
 		return err
 	}
 	return nil

--- a/providers/cloudflare/workers.go
+++ b/providers/cloudflare/workers.go
@@ -284,9 +284,8 @@ func (g *WorkersGenerator) appendWorkersForPlatformsDispatchNamespaceResources(
 			"cloudflare_workers_for_platforms_dispatch_namespace",
 			"cloudflare",
 			map[string]string{
-				"account_id":     accountID,
-				"namespace_name": namespace.NamespaceName,
-				"name":           namespace.NamespaceName,
+				"account_id": accountID,
+				"name":       namespace.NamespaceName,
 			},
 			[]string{},
 			map[string]interface{}{},

--- a/providers/cloudflare/workers.go
+++ b/providers/cloudflare/workers.go
@@ -7,6 +7,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"strconv"
 
 	"github.com/chenrui333/terraformer/terraformutils"
 	cf "github.com/cloudflare/cloudflare-go"
@@ -19,6 +20,10 @@ type WorkersGenerator struct {
 func (g *WorkersGenerator) InitResources() error {
 	ctx := context.Background()
 	api, err := g.initializeAPI()
+	if err != nil {
+		return err
+	}
+	account, err := g.accountResourceContainer()
 	if err != nil {
 		return err
 	}
@@ -42,6 +47,15 @@ func (g *WorkersGenerator) InitResources() error {
 				map[string]interface{}{},
 			))
 		}
+	}
+	if err := g.appendWorkerCustomDomainResources(ctx, api, account.Identifier); err != nil {
+		return err
+	}
+	if err := g.appendWorkerCronTriggerResources(ctx, api, account); err != nil {
+		return err
+	}
+	if err := g.appendWorkersForPlatformsDispatchNamespaceResources(ctx, api, account.Identifier); err != nil {
+		return err
 	}
 	return nil
 }
@@ -70,4 +84,214 @@ func listWorkerRoutes(ctx context.Context, api *cf.API, zoneID string) ([]cf.Wor
 		}
 	}
 	return routes, nil
+}
+
+func listWorkerCustomDomains(ctx context.Context, api *cf.API, accountID string) ([]cf.WorkersDomain, error) {
+	var domains []cf.WorkersDomain
+	page, cursor := 1, ""
+	for {
+		response, err := api.Raw(
+			ctx,
+			http.MethodGet,
+			fmt.Sprintf("/accounts/%s/workers/domains?%s", accountID, cloudflarePaginationQuery(page, cursor)),
+			nil,
+			nil,
+		)
+		if err != nil {
+			return nil, err
+		}
+		var pageDomains []cf.WorkersDomain
+		if err := json.Unmarshal(response.Result, &pageDomains); err != nil {
+			return nil, err
+		}
+		domains = append(domains, pageDomains...)
+		if !cloudflareAdvancePagination(response.ResultInfo, &page, &cursor) {
+			break
+		}
+	}
+	return domains, nil
+}
+
+func listWorkerScripts(ctx context.Context, api *cf.API, accountID string) ([]cf.WorkerMetaData, error) {
+	var scripts []cf.WorkerMetaData
+	page, cursor := 1, ""
+	for {
+		response, err := api.Raw(
+			ctx,
+			http.MethodGet,
+			fmt.Sprintf("/accounts/%s/workers/scripts?%s", accountID, cloudflarePaginationQuery(page, cursor)),
+			nil,
+			nil,
+		)
+		if err != nil {
+			return nil, err
+		}
+		var pageScripts []cf.WorkerMetaData
+		if err := json.Unmarshal(response.Result, &pageScripts); err != nil {
+			return nil, err
+		}
+		scripts = append(scripts, pageScripts...)
+		if !cloudflareAdvancePagination(response.ResultInfo, &page, &cursor) {
+			break
+		}
+	}
+	return scripts, nil
+}
+
+func listWorkersForPlatformsDispatchNamespaces(
+	ctx context.Context,
+	api *cf.API,
+	accountID string,
+) ([]cf.WorkersForPlatformsDispatchNamespace, error) {
+	var namespaces []cf.WorkersForPlatformsDispatchNamespace
+	page, cursor := 1, ""
+	for {
+		response, err := api.Raw(
+			ctx,
+			http.MethodGet,
+			fmt.Sprintf("/accounts/%s/workers/dispatch/namespaces?%s", accountID, cloudflarePaginationQuery(page, cursor)),
+			nil,
+			nil,
+		)
+		if err != nil {
+			return nil, err
+		}
+		var pageNamespaces []cf.WorkersForPlatformsDispatchNamespace
+		if err := json.Unmarshal(response.Result, &pageNamespaces); err != nil {
+			return nil, err
+		}
+		namespaces = append(namespaces, pageNamespaces...)
+		if !cloudflareAdvancePagination(response.ResultInfo, &page, &cursor) {
+			break
+		}
+	}
+	return namespaces, nil
+}
+
+func workerCustomDomainAttributes(accountID string, domain cf.WorkersDomain) map[string]string {
+	attributes := map[string]string{
+		"account_id": accountID,
+		"hostname":   domain.Hostname,
+		"service":    domain.Service,
+	}
+	if domain.Environment != "" {
+		attributes["environment"] = domain.Environment
+	}
+	if domain.ZoneID != "" {
+		attributes["zone_id"] = domain.ZoneID
+	}
+	if domain.ZoneName != "" {
+		attributes["zone_name"] = domain.ZoneName
+	}
+	return attributes
+}
+
+func workerCronTriggerAttributes(
+	accountID string,
+	scriptName string,
+	schedules []cf.WorkerCronTrigger,
+) map[string]string {
+	attributes := map[string]string{
+		"account_id":  accountID,
+		"script_name": scriptName,
+		"schedules.#": strconv.Itoa(len(schedules)),
+	}
+	for index, schedule := range schedules {
+		attributes[fmt.Sprintf("schedules.%d.cron", index)] = schedule.Cron
+	}
+	return attributes
+}
+
+func (g *WorkersGenerator) appendWorkerCustomDomainResources(ctx context.Context, api *cf.API, accountID string) error {
+	domains, err := listWorkerCustomDomains(ctx, api, accountID)
+	if err != nil {
+		return err
+	}
+	for _, domain := range domains {
+		if domain.ID == "" {
+			continue
+		}
+		resource := terraformutils.NewResource(
+			domain.ID,
+			cloudflareResourceName(accountID, domain.Hostname, domain.ID),
+			"cloudflare_workers_custom_domain",
+			"cloudflare",
+			workerCustomDomainAttributes(accountID, domain),
+			[]string{},
+			map[string]interface{}{},
+		)
+		setCloudflareImportID(&resource, accountID+"/"+domain.ID)
+		g.Resources = append(g.Resources, resource)
+	}
+	return nil
+}
+
+func (g *WorkersGenerator) appendWorkerCronTriggerResources(
+	ctx context.Context,
+	api *cf.API,
+	account *cf.ResourceContainer,
+) error {
+	scripts, err := listWorkerScripts(ctx, api, account.Identifier)
+	if err != nil {
+		return err
+	}
+	for _, script := range scripts {
+		if script.ID == "" {
+			continue
+		}
+		schedules, err := api.ListWorkerCronTriggers(ctx, account, cf.ListWorkerCronTriggersParams{ScriptName: script.ID})
+		if err != nil {
+			if cloudflareNotFoundError(err) {
+				continue
+			}
+			return err
+		}
+		if len(schedules) == 0 {
+			continue
+		}
+		resource := terraformutils.NewResource(
+			script.ID,
+			cloudflareResourceName(account.Identifier, script.ID, "cron_trigger"),
+			"cloudflare_workers_cron_trigger",
+			"cloudflare",
+			workerCronTriggerAttributes(account.Identifier, script.ID, schedules),
+			[]string{},
+			map[string]interface{}{},
+		)
+		setCloudflareImportID(&resource, account.Identifier+"/"+script.ID)
+		g.Resources = append(g.Resources, resource)
+	}
+	return nil
+}
+
+func (g *WorkersGenerator) appendWorkersForPlatformsDispatchNamespaceResources(
+	ctx context.Context,
+	api *cf.API,
+	accountID string,
+) error {
+	namespaces, err := listWorkersForPlatformsDispatchNamespaces(ctx, api, accountID)
+	if err != nil {
+		return err
+	}
+	for _, namespace := range namespaces {
+		if namespace.NamespaceName == "" {
+			continue
+		}
+		resource := terraformutils.NewResource(
+			namespace.NamespaceName,
+			cloudflareResourceName(accountID, namespace.NamespaceName),
+			"cloudflare_workers_for_platforms_dispatch_namespace",
+			"cloudflare",
+			map[string]string{
+				"account_id":     accountID,
+				"namespace_name": namespace.NamespaceName,
+				"name":           namespace.NamespaceName,
+			},
+			[]string{},
+			map[string]interface{}{},
+		)
+		setCloudflareImportID(&resource, accountID+"/"+namespace.NamespaceName)
+		g.Resources = append(g.Resources, resource)
+	}
+	return nil
 }

--- a/providers/cloudflare/workers.go
+++ b/providers/cloudflare/workers.go
@@ -284,8 +284,9 @@ func (g *WorkersGenerator) appendWorkersForPlatformsDispatchNamespaceResources(
 			"cloudflare_workers_for_platforms_dispatch_namespace",
 			"cloudflare",
 			map[string]string{
-				"account_id": accountID,
-				"name":       namespace.NamespaceName,
+				"account_id":     accountID,
+				"name":           namespace.NamespaceName,
+				"namespace_name": namespace.NamespaceName,
 			},
 			[]string{},
 			map[string]interface{}{},


### PR DESCRIPTION
Summary
- Add an `email_routing` Cloudflare service generator for Email Routing settings, DNS setup, destination addresses, routing rules, and catch-all rules.
- Expand the existing `workers` generator with custom domains, cron triggers, and Workers for Platforms dispatch namespaces.
- Document the newly supported Cloudflare resources and the Email Routing DNS ownership caveat.

Notes
- Zone-scoped Email Routing resources are only emitted for zones where Email Routing is enabled.
- Workers cron triggers seed schedules before refresh because the provider preserves that field from prior state.
- Account-scoped resources use provider-shaped composite import IDs.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Email Routing support — manage email routing settings, destination addresses, routing rules, catch‑all rules, and related DNS entries for enabled zones (account-level addresses supported when an account ID is configured).
  * Added Workers account‑scoped resources — manage worker custom domains, cron triggers, and dispatch namespaces.

* **Documentation**
  * Cloudflare docs updated to list Email Routing as supported, warn about importing Email Routing DNS alongside other DNS imports, and add the new Workers resources.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->