### PR TITLE
refactor(providers): share service metadata setup

### DIFF
--- a/providers/alicloud/alicloud_provider.go
+++ b/providers/alicloud/alicloud_provider.go
@@ -100,9 +100,7 @@ func (p *AliCloudProvider) InitService(serviceName string, verbose bool) error {
 		return errors.New("alicloud: " + serviceName + " not supported service")
 	}
 	p.Service = service
-	p.Service.SetName(serviceName)
-	p.Service.SetVerbose(verbose)
-	p.Service.SetProviderName(p.GetName())
+	terraformutils.ConfigureService(p.Service, serviceName, verbose, p.GetName())
 	p.Service.SetArgs(map[string]interface{}{
 		"region":  p.region,
 		"profile": p.profile,

--- a/providers/auth0/auth0_provider.go
+++ b/providers/auth0/auth0_provider.go
@@ -76,9 +76,7 @@ func (p *Auth0Provider) InitService(serviceName string, verbose bool) error {
 		return errors.New(p.GetName() + ": " + serviceName + " not supported service")
 	}
 	p.Service = service
-	p.Service.SetName(serviceName)
-	p.Service.SetVerbose(verbose)
-	p.Service.SetProviderName(p.GetName())
+	terraformutils.ConfigureService(p.Service, serviceName, verbose, p.GetName())
 	p.Service.SetArgs(map[string]interface{}{
 		"domain":            p.domain,
 		"client_id":         p.clientID,

--- a/providers/aws/aws_provider.go
+++ b/providers/aws/aws_provider.go
@@ -218,9 +218,7 @@ func (p *AWSProvider) InitService(serviceName string, verbose bool) error {
 		return errors.New("aws: " + serviceName + " not supported service")
 	}
 	p.Service = service
-	p.Service.SetName(serviceName)
-	p.Service.SetVerbose(verbose)
-	p.Service.SetProviderName(p.GetName())
+	terraformutils.ConfigureService(p.Service, serviceName, verbose, p.GetName())
 	p.Service.SetArgs(map[string]interface{}{
 		"region":                 p.region,
 		"profile":                p.profile,

--- a/providers/azure/azure_provider.go
+++ b/providers/azure/azure_provider.go
@@ -812,9 +812,7 @@ func (p *AzureProvider) InitService(serviceName string, verbose bool) error {
 		return errors.New("azurerm: " + serviceName + " not supported service")
 	}
 	p.Service = service
-	p.Service.SetName(serviceName)
-	p.Service.SetVerbose(verbose)
-	p.Service.SetProviderName(p.GetName())
+	terraformutils.ConfigureService(p.Service, serviceName, verbose, p.GetName())
 	p.Service.SetArgs(map[string]interface{}{
 		"config":         p.config,
 		"credential":     p.credential,

--- a/providers/azuread/azuread_provider.go
+++ b/providers/azuread/azuread_provider.go
@@ -78,9 +78,7 @@ func (p *AzureADProvider) InitService(serviceName string, verbose bool) error {
 		return errors.New("azuread: " + serviceName + " not supported service")
 	}
 	p.Service = service
-	p.Service.SetName(serviceName)
-	p.Service.SetVerbose(verbose)
-	p.Service.SetProviderName(p.GetName())
+	terraformutils.ConfigureService(p.Service, serviceName, verbose, p.GetName())
 	p.Service.SetArgs(map[string]interface{}{
 		"tenant_id":     p.tenantID,
 		"client_id":     p.clientID,

--- a/providers/azuredevops/azuredevops_provider.go
+++ b/providers/azuredevops/azuredevops_provider.go
@@ -77,9 +77,7 @@ func (p *AzureDevOpsProvider) InitService(serviceName string, verbose bool) erro
 		return errors.New("azuredevops: " + serviceName + " not supported service")
 	}
 	p.Service = service
-	p.Service.SetName(serviceName)
-	p.Service.SetVerbose(verbose)
-	p.Service.SetProviderName(p.GetName())
+	terraformutils.ConfigureService(p.Service, serviceName, verbose, p.GetName())
 	p.Service.SetArgs(map[string]interface{}{
 		"organizationURL":     p.organizationURL,
 		"personalAccessToken": p.personalAccessToken,

--- a/providers/cloudflare/cloudflare_provider.go
+++ b/providers/cloudflare/cloudflare_provider.go
@@ -60,9 +60,7 @@ func (p *CloudflareProvider) InitService(serviceName string, verbose bool) error
 		return errors.New("cloudflare: " + serviceName + " not supported service")
 	}
 	p.Service = service
-	p.Service.SetName(serviceName)
-	p.Service.SetVerbose(verbose)
-	p.Service.SetProviderName(p.GetName())
+	terraformutils.ConfigureService(p.Service, serviceName, verbose, p.GetName())
 
 	return nil
 }

--- a/providers/commercetools/commercetools_provider.go
+++ b/providers/commercetools/commercetools_provider.go
@@ -52,9 +52,7 @@ func (p *CommercetoolsProvider) InitService(serviceName string, verbose bool) er
 		return errors.New(p.GetName() + ": " + serviceName + " not supported service")
 	}
 	p.Service = service
-	p.Service.SetName(serviceName)
-	p.Service.SetVerbose(verbose)
-	p.Service.SetProviderName(p.GetName())
+	terraformutils.ConfigureService(p.Service, serviceName, verbose, p.GetName())
 	p.Service.SetArgs(map[string]interface{}{
 		"client_id":     p.clientID,
 		"client_secret": p.clientSecret,

--- a/providers/datadog/datadog_provider.go
+++ b/providers/datadog/datadog_provider.go
@@ -148,9 +148,7 @@ func (p *DatadogProvider) InitService(serviceName string, verbose bool) error {
 		return errors.New(p.GetName() + ": " + serviceName + " not supported service")
 	}
 	p.Service = service
-	p.Service.SetName(serviceName)
-	p.Service.SetVerbose(verbose)
-	p.Service.SetProviderName(p.GetName())
+	terraformutils.ConfigureService(p.Service, serviceName, verbose, p.GetName())
 	p.Service.SetArgs(map[string]interface{}{
 		"api-key":       p.apiKey,
 		"app-key":       p.appKey,

--- a/providers/digitalocean/digitalocean_provider.go
+++ b/providers/digitalocean/digitalocean_provider.go
@@ -67,9 +67,7 @@ func (p *DigitalOceanProvider) InitService(serviceName string, verbose bool) err
 		return errors.New("digitalocean: " + serviceName + " not supported service")
 	}
 	p.Service = service
-	p.Service.SetName(serviceName)
-	p.Service.SetVerbose(verbose)
-	p.Service.SetProviderName(p.GetName())
+	terraformutils.ConfigureService(p.Service, serviceName, verbose, p.GetName())
 	p.Service.SetArgs(map[string]interface{}{
 		"token": p.token,
 	})

--- a/providers/equinixmetal/equinixmetal_provider.go
+++ b/providers/equinixmetal/equinixmetal_provider.go
@@ -63,9 +63,7 @@ func (p *EquinixMetalProvider) InitService(serviceName string, verbose bool) err
 		return errors.New("equinixmetal: " + serviceName + " not supported service")
 	}
 	p.Service = service
-	p.Service.SetName(serviceName)
-	p.Service.SetVerbose(verbose)
-	p.Service.SetProviderName(p.GetName())
+	terraformutils.ConfigureService(p.Service, serviceName, verbose, p.GetName())
 	p.Service.SetArgs(map[string]interface{}{
 		"auth_token": p.authToken,
 		"project_id": p.projectID,

--- a/providers/fastly/fastly_provider.go
+++ b/providers/fastly/fastly_provider.go
@@ -68,9 +68,7 @@ func (p *FastlyProvider) InitService(serviceName string, verbose bool) error {
 		return errors.New("fastly: " + serviceName + " not supported service")
 	}
 	p.Service = service
-	p.Service.SetName(serviceName)
-	p.Service.SetVerbose(verbose)
-	p.Service.SetProviderName(p.GetName())
+	terraformutils.ConfigureService(p.Service, serviceName, verbose, p.GetName())
 	p.Service.SetArgs(map[string]interface{}{
 		"customer_id": p.customerID,
 		"api_key":     p.apiKey,

--- a/providers/gcp/gcp_provider.go
+++ b/providers/gcp/gcp_provider.go
@@ -97,9 +97,7 @@ func (p *GCPProvider) InitService(serviceName string, verbose bool) error {
 		return errors.New("gcp: " + serviceName + " not supported service")
 	}
 	p.Service = service
-	p.Service.SetName(serviceName)
-	p.Service.SetVerbose(verbose)
-	p.Service.SetProviderName(p.GetName())
+	terraformutils.ConfigureService(p.Service, serviceName, verbose, p.GetName())
 	p.Service.SetArgs(map[string]interface{}{
 		"region":  p.region,
 		"project": p.projectName,

--- a/providers/github/github_provider.go
+++ b/providers/github/github_provider.go
@@ -116,9 +116,7 @@ func (p *GithubProvider) InitService(serviceName string, verbose bool) error {
 		return errors.New(p.GetName() + ": " + serviceName + " not supported service")
 	}
 	p.Service = service
-	p.Service.SetName(serviceName)
-	p.Service.SetVerbose(verbose)
-	p.Service.SetProviderName(p.GetName())
+	terraformutils.ConfigureService(p.Service, serviceName, verbose, p.GetName())
 	p.Service.SetArgs(map[string]interface{}{
 		"owner":           p.owner,
 		"token":           p.token,

--- a/providers/gitlab/gitlab_provider.go
+++ b/providers/gitlab/gitlab_provider.go
@@ -79,9 +79,7 @@ func (p *GitLabProvider) InitService(serviceName string, verbose bool) error {
 		return errors.New(p.GetName() + ": " + serviceName + " not supported service")
 	}
 	p.Service = service
-	p.Service.SetName(serviceName)
-	p.Service.SetVerbose(verbose)
-	p.Service.SetProviderName(p.GetName())
+	terraformutils.ConfigureService(p.Service, serviceName, verbose, p.GetName())
 	p.Service.SetArgs(map[string]interface{}{
 		"group":    p.group,
 		"token":    p.token,

--- a/providers/gmailfilter/gmailfilter_provider.go
+++ b/providers/gmailfilter/gmailfilter_provider.go
@@ -45,9 +45,7 @@ func (p *GmailfilterProvider) InitService(serviceName string, verbose bool) erro
 		return errors.New("gmailfilter: " + serviceName + " not supported service")
 	}
 	p.Service = service
-	p.Service.SetName(serviceName)
-	p.Service.SetVerbose(verbose)
-	p.Service.SetProviderName(p.GetName())
+	terraformutils.ConfigureService(p.Service, serviceName, verbose, p.GetName())
 	p.Service.SetArgs(map[string]interface{}{
 		"credentials":           p.credentials,
 		"impersonatedUserEmail": p.impersonatedUserEmail,

--- a/providers/grafana/grafana_provider.go
+++ b/providers/grafana/grafana_provider.go
@@ -105,9 +105,7 @@ func (p *GrafanaProvider) InitService(serviceName string, verbose bool) error {
 	}
 
 	p.Service = service
-	p.Service.SetName(serviceName)
-	p.Service.SetVerbose(verbose)
-	p.Service.SetProviderName(p.GetName())
+	terraformutils.ConfigureService(p.Service, serviceName, verbose, p.GetName())
 	p.Service.SetArgs(map[string]interface{}{
 		"org_id":               p.orgID,
 		"url":                  p.url,

--- a/providers/heroku/heroku_provider.go
+++ b/providers/heroku/heroku_provider.go
@@ -64,9 +64,7 @@ func (p *HerokuProvider) InitService(serviceName string, verbose bool) error {
 		return errors.New("heroku: " + serviceName + " not supported service")
 	}
 	p.Service = service
-	p.Service.SetName(serviceName)
-	p.Service.SetVerbose(verbose)
-	p.Service.SetProviderName(p.GetName())
+	terraformutils.ConfigureService(p.Service, serviceName, verbose, p.GetName())
 	p.Service.SetArgs(map[string]interface{}{
 		"api_key": p.apiKey,
 		"team":    p.team,

--- a/providers/honeycombio/honeycomb_provider.go
+++ b/providers/honeycombio/honeycomb_provider.go
@@ -99,9 +99,7 @@ func (p *HoneycombProvider) InitService(serviceName string, verbose bool) error 
 		return errors.New("honeycombio: " + serviceName + " is not a supported resource type")
 	}
 	p.Service = service
-	p.Service.SetName(serviceName)
-	p.Service.SetVerbose(verbose)
-	p.Service.SetProviderName(p.GetName())
+	terraformutils.ConfigureService(p.Service, serviceName, verbose, p.GetName())
 	p.Service.SetArgs(map[string]interface{}{
 		"api_key":  p.apiKey,
 		"api_url":  p.apiURL,

--- a/providers/ibm/ibm_provider.go
+++ b/providers/ibm/ibm_provider.go
@@ -208,9 +208,7 @@ func (p *IBMProvider) InitService(serviceName string, verbose bool) error {
 		return errors.New("IBM: " + serviceName + " not supported service")
 	}
 	p.Service = service
-	p.Service.SetName(serviceName)
-	p.Service.SetVerbose(verbose)
-	p.Service.SetProviderName(p.GetName())
+	terraformutils.ConfigureService(p.Service, serviceName, verbose, p.GetName())
 
 	p.Service.SetArgs(map[string]interface{}{
 		"resource_group": p.ResourceGroup,

--- a/providers/ionoscloud/ionoscloud_provider.go
+++ b/providers/ionoscloud/ionoscloud_provider.go
@@ -158,9 +158,7 @@ func (p *IonosCloudProvider) InitService(serviceName string, verbose bool) error
 		return errors.New(helpers.Ionos + ": " + serviceName + " not supported service")
 	}
 	p.Service = service
-	p.Service.SetName(serviceName)
-	p.Service.SetVerbose(verbose)
-	p.Service.SetProviderName(p.GetName())
+	terraformutils.ConfigureService(p.Service, serviceName, verbose, p.GetName())
 	p.Service.SetArgs(map[string]interface{}{
 		"username": p.username,
 		"password": p.password,

--- a/providers/keycloak/keycloak_provider.go
+++ b/providers/keycloak/keycloak_provider.go
@@ -99,9 +99,7 @@ func (p *KeycloakProvider) InitService(serviceName string, verbose bool) error {
 		return errors.New(p.GetName() + ": " + serviceName + " not supported service")
 	}
 	p.Service = service
-	p.Service.SetName(serviceName)
-	p.Service.SetVerbose(verbose)
-	p.Service.SetProviderName(p.GetName())
+	terraformutils.ConfigureService(p.Service, serviceName, verbose, p.GetName())
 	p.Service.SetArgs(map[string]interface{}{
 		"url":                      p.url,
 		"base_path":                p.basePath,

--- a/providers/kubernetes/kubernetes_provider.go
+++ b/providers/kubernetes/kubernetes_provider.go
@@ -61,9 +61,7 @@ func (p *KubernetesProvider) InitService(serviceName string, verbose bool) error
 		return errors.New("kubernetes: " + serviceName + " not supported resource")
 	}
 	p.Service = service
-	p.Service.SetName(serviceName)
-	p.Service.SetVerbose(verbose)
-	p.Service.SetProviderName(p.GetName())
+	terraformutils.ConfigureService(p.Service, serviceName, verbose, p.GetName())
 	return nil
 }
 

--- a/providers/launchdarkly/launchdarkly_provider.go
+++ b/providers/launchdarkly/launchdarkly_provider.go
@@ -96,9 +96,7 @@ func (p *LaunchDarklyProvider) InitService(serviceName string, verbose bool) err
 		return errors.New("launchdarkly: " + serviceName + " not supported service")
 	}
 	p.Service = service
-	p.Service.SetName(serviceName)
-	p.Service.SetVerbose(verbose)
-	p.Service.SetProviderName(p.GetName())
+	terraformutils.ConfigureService(p.Service, serviceName, verbose, p.GetName())
 	p.Service.SetArgs(map[string]interface{}{
 		"api_key": p.apiKey,
 		"client":  p.client,

--- a/providers/linode/linode_provider.go
+++ b/providers/linode/linode_provider.go
@@ -60,9 +60,7 @@ func (p *LinodeProvider) InitService(serviceName string, verbose bool) error {
 		return errors.New("linode: " + serviceName + " not supported service")
 	}
 	p.Service = service
-	p.Service.SetName(serviceName)
-	p.Service.SetVerbose(verbose)
-	p.Service.SetProviderName(p.GetName())
+	terraformutils.ConfigureService(p.Service, serviceName, verbose, p.GetName())
 	p.Service.SetArgs(map[string]interface{}{
 		"token": p.token,
 	})

--- a/providers/logzio/logzio_provider.go
+++ b/providers/logzio/logzio_provider.go
@@ -60,9 +60,7 @@ func (p *LogzioProvider) InitService(serviceName string, verbose bool) error {
 		return errors.New(p.GetName() + ": " + serviceName + " not supported service")
 	}
 	p.Service = service
-	p.Service.SetName(serviceName)
-	p.Service.SetVerbose(verbose)
-	p.Service.SetProviderName(p.GetName())
+	terraformutils.ConfigureService(p.Service, serviceName, verbose, p.GetName())
 	p.Service.SetArgs(map[string]interface{}{
 		"api_token": p.apiToken,
 		"base_url":  p.baseURL,

--- a/providers/mackerel/mackerel_provider.go
+++ b/providers/mackerel/mackerel_provider.go
@@ -42,9 +42,7 @@ func (p *MackerelProvider) InitService(serviceName string, verbose bool) error {
 		return errors.New(p.GetName() + ": " + serviceName + " not supported service")
 	}
 	p.Service = service
-	p.Service.SetName(serviceName)
-	p.Service.SetVerbose(verbose)
-	p.Service.SetProviderName(p.GetName())
+	terraformutils.ConfigureService(p.Service, serviceName, verbose, p.GetName())
 	p.Service.SetArgs(map[string]interface{}{
 		"api-key":        p.apiKey,
 		"mackerelClient": p.mackerelClient,

--- a/providers/mikrotik/mikrotik_provider.go
+++ b/providers/mikrotik/mikrotik_provider.go
@@ -53,9 +53,7 @@ func (p *MikrotikProvider) InitService(serviceName string, verbose bool) error {
 		return errors.New("mikrotik: " + serviceName + " not supported service")
 	}
 	p.Service = service
-	p.Service.SetName(serviceName)
-	p.Service.SetVerbose(verbose)
-	p.Service.SetProviderName(p.GetName())
+	terraformutils.ConfigureService(p.Service, serviceName, verbose, p.GetName())
 	p.Service.SetArgs(map[string]interface{}{
 		"host":           p.Host,
 		"user":           p.Username,

--- a/providers/myrasec/myrasec_provider.go
+++ b/providers/myrasec/myrasec_provider.go
@@ -56,9 +56,7 @@ func (p *MyrasecProvider) InitService(serviceName string, verbose bool) error {
 		return errors.New("myrasec: " + serviceName + " not supported service")
 	}
 	p.Service = service
-	p.Service.SetName(serviceName)
-	p.Service.SetVerbose(verbose)
-	p.Service.SetProviderName(p.GetName())
+	terraformutils.ConfigureService(p.Service, serviceName, verbose, p.GetName())
 
 	return nil
 }

--- a/providers/newrelic/newrelic_provider.go
+++ b/providers/newrelic/newrelic_provider.go
@@ -97,10 +97,8 @@ func (p *NewRelicProvider) InitService(serviceName string, verbose bool) error {
 		return errors.New("newrelic: " + serviceName + " not supported service")
 	}
 	p.Service = service
-	p.Service.SetName(serviceName)
-	p.Service.SetVerbose(verbose)
+	terraformutils.ConfigureService(p.Service, serviceName, verbose, p.GetName())
 	p.Service.SetArgs(map[string]interface{}{"apiKey": p.APIKey})
-	p.Service.SetProviderName(p.GetName())
 
 	return nil
 }

--- a/providers/ns1/ns1_provider.go
+++ b/providers/ns1/ns1_provider.go
@@ -54,9 +54,7 @@ func (p *Ns1Provider) InitService(serviceName string, verbose bool) error {
 		return errors.New("ns1: " + serviceName + " not supported service")
 	}
 	p.Service = service
-	p.Service.SetName(serviceName)
-	p.Service.SetVerbose(verbose)
-	p.Service.SetProviderName(p.GetName())
+	terraformutils.ConfigureService(p.Service, serviceName, verbose, p.GetName())
 	p.Service.SetArgs(map[string]interface{}{
 		"api_key": p.apiKey,
 	})

--- a/providers/octopusdeploy/octopusdeploy_provider.go
+++ b/providers/octopusdeploy/octopusdeploy_provider.go
@@ -81,9 +81,7 @@ func (p *OctopusDeployProvider) InitService(serviceName string, verbose bool) er
 		return errors.New("octopusdeploy: " + serviceName + " not supported service, see list sub-command")
 	}
 	p.Service = service
-	p.Service.SetName(serviceName)
-	p.Service.SetVerbose(verbose)
-	p.Service.SetProviderName(p.GetName())
+	terraformutils.ConfigureService(p.Service, serviceName, verbose, p.GetName())
 	p.Service.SetArgs(map[string]interface{}{
 		"api_key": p.apiKey,
 		"address": p.address,

--- a/providers/okta/okta_provider.go
+++ b/providers/okta/okta_provider.go
@@ -72,9 +72,7 @@ func (p *OktaProvider) InitService(serviceName string, verbose bool) error {
 		return errors.New(p.GetName() + ": " + serviceName + " is not a supported service")
 	}
 	p.Service = service
-	p.Service.SetName(serviceName)
-	p.Service.SetProviderName(p.GetName())
-	p.Service.SetVerbose(verbose)
+	terraformutils.ConfigureService(p.Service, serviceName, verbose, p.GetName())
 	p.Service.SetArgs(map[string]interface{}{
 		"org_name":  p.orgName,
 		"base_url":  p.baseURL,

--- a/providers/opal/opal_provider.go
+++ b/providers/opal/opal_provider.go
@@ -99,9 +99,7 @@ func (p *OpalProvider) InitService(serviceName string, verbose bool) error {
 		return errors.New("opal: " + serviceName + " is not a supported resource type")
 	}
 	p.Service = service
-	p.Service.SetName(serviceName)
-	p.Service.SetVerbose(verbose)
-	p.Service.SetProviderName(p.GetName())
+	terraformutils.ConfigureService(p.Service, serviceName, verbose, p.GetName())
 	p.Service.SetArgs(map[string]interface{}{
 		"token":    p.token,
 		"base_url": p.baseURL,

--- a/providers/openstack/openstack_provider.go
+++ b/providers/openstack/openstack_provider.go
@@ -55,9 +55,7 @@ func (p *OpenStackProvider) InitService(serviceName string, verbose bool) error 
 		return errors.New("openstack: " + serviceName + " not supported service")
 	}
 	p.Service = service
-	p.Service.SetName(serviceName)
-	p.Service.SetVerbose(verbose)
-	p.Service.SetProviderName(p.GetName())
+	terraformutils.ConfigureService(p.Service, serviceName, verbose, p.GetName())
 	p.Service.SetArgs(map[string]interface{}{
 		"region": p.region,
 	})

--- a/providers/opsgenie/opsgenie_provider.go
+++ b/providers/opsgenie/opsgenie_provider.go
@@ -36,9 +36,7 @@ func (p *OpsgenieProvider) InitService(serviceName string, verbose bool) error {
 		return errors.New(p.GetName() + ": " + serviceName + " not supported service")
 	}
 	p.Service = service
-	p.Service.SetName(serviceName)
-	p.Service.SetVerbose(verbose)
-	p.Service.SetProviderName(p.GetName())
+	terraformutils.ConfigureService(p.Service, serviceName, verbose, p.GetName())
 	p.Service.SetArgs(map[string]interface{}{
 		"api-key": p.APIKey,
 	})

--- a/providers/pagerduty/pagerduty_provider.go
+++ b/providers/pagerduty/pagerduty_provider.go
@@ -69,9 +69,7 @@ func (p *PagerDutyProvider) InitService(serviceName string, verbose bool) error 
 		return errors.New(p.GetName() + ": " + serviceName + " not supported service")
 	}
 	p.Service = service
-	p.Service.SetName(serviceName)
-	p.Service.SetVerbose(verbose)
-	p.Service.SetProviderName(p.GetName())
+	terraformutils.ConfigureService(p.Service, serviceName, verbose, p.GetName())
 	p.Service.SetArgs(map[string]interface{}{
 		"token": p.token,
 	})

--- a/providers/panos/panos_provider.go
+++ b/providers/panos/panos_provider.go
@@ -49,9 +49,7 @@ func (p *PanosProvider) InitService(serviceName string, verbose bool) error {
 	}
 
 	p.Service = service
-	p.Service.SetName(serviceName)
-	p.Service.SetVerbose(verbose)
-	p.Service.SetProviderName(p.GetName())
+	terraformutils.ConfigureService(p.Service, serviceName, verbose, p.GetName())
 	p.Service.SetArgs(map[string]interface{}{
 		"vsys": p.vsys,
 	})

--- a/providers/rabbitmq/rabbitmq_provider.go
+++ b/providers/rabbitmq/rabbitmq_provider.go
@@ -55,9 +55,7 @@ func (p *RBTProvider) InitService(serviceName string, verbose bool) error {
 		return errors.New(p.GetName() + ": " + serviceName + " not supported service")
 	}
 	p.Service = service
-	p.Service.SetName(serviceName)
-	p.Service.SetVerbose(verbose)
-	p.Service.SetProviderName(p.GetName())
+	terraformutils.ConfigureService(p.Service, serviceName, verbose, p.GetName())
 	p.Service.SetArgs(map[string]interface{}{
 		"endpoint": p.endpoint,
 		"username": p.username,

--- a/providers/tencentcloud/tencentcloud_provider.go
+++ b/providers/tencentcloud/tencentcloud_provider.go
@@ -72,9 +72,7 @@ func (p *TencentCloudProvider) InitService(serviceName string, verbose bool) err
 		return errors.New("tencentcloud: " + serviceName + " not supported service")
 	}
 	p.Service = service
-	p.Service.SetName(serviceName)
-	p.Service.SetVerbose(verbose)
-	p.Service.SetProviderName(p.GetName())
+	terraformutils.ConfigureService(p.Service, serviceName, verbose, p.GetName())
 	p.Service.SetArgs(map[string]interface{}{
 		"region":     p.region,
 		"credential": p.credential,

--- a/providers/vault/vault_provider.go
+++ b/providers/vault/vault_provider.go
@@ -51,9 +51,7 @@ func (p *Provider) InitService(serviceName string, verbose bool) error {
 
 	if service, ok := p.GetSupportedService()[serviceName]; ok {
 		p.Service = service
-		p.Service.SetName(serviceName)
-		p.Service.SetVerbose(verbose)
-		p.Service.SetProviderName(p.GetName())
+		terraformutils.ConfigureService(p.Service, serviceName, verbose, p.GetName())
 		p.Service.SetArgs(map[string]interface{}{
 			"token":   p.token,
 			"address": p.address,

--- a/providers/vultr/vultr_provider.go
+++ b/providers/vultr/vultr_provider.go
@@ -62,9 +62,7 @@ func (p *VultrProvider) InitService(serviceName string, verbose bool) error {
 		return errors.New("vultr: " + serviceName + " not supported service")
 	}
 	p.Service = service
-	p.Service.SetName(serviceName)
-	p.Service.SetVerbose(verbose)
-	p.Service.SetProviderName(p.GetName())
+	terraformutils.ConfigureService(p.Service, serviceName, verbose, p.GetName())
 	p.Service.SetArgs(map[string]interface{}{
 		"api_key": p.apiKey,
 	})

--- a/providers/xenorchestra/xenorchestra_provider.go
+++ b/providers/xenorchestra/xenorchestra_provider.go
@@ -77,9 +77,7 @@ func (p *XenorchestraProvider) InitService(serviceName string, verbose bool) err
 		return errors.New("xenorchestra: " + serviceName + " not supported service")
 	}
 	p.Service = service
-	p.Service.SetName(serviceName)
-	p.Service.SetVerbose(verbose)
-	p.Service.SetProviderName(p.GetName())
+	terraformutils.ConfigureService(p.Service, serviceName, verbose, p.GetName())
 	p.Service.SetArgs(map[string]interface{}{
 		"url":      p.url,
 		"username": p.user,

--- a/providers/yandex/yandex_provider.go
+++ b/providers/yandex/yandex_provider.go
@@ -71,9 +71,7 @@ func (p *YandexProvider) InitService(serviceName string, verbose bool) error {
 		return errors.New("yandex: " + serviceName + " not supported service")
 	}
 	p.Service = service
-	p.Service.SetName(serviceName)
-	p.Service.SetVerbose(verbose)
-	p.Service.SetProviderName(p.GetName())
+	terraformutils.ConfigureService(p.Service, serviceName, verbose, p.GetName())
 	p.Service.SetArgs(map[string]interface{}{
 		KeyFolderID:           p.folderID,
 		KeyToken:              p.token,

--- a/terraformutils/service.go
+++ b/terraformutils/service.go
@@ -37,6 +37,12 @@ type Service struct {
 	Verbose      bool
 }
 
+func ConfigureService(service ServiceGenerator, name string, verbose bool, providerName string) {
+	service.SetName(name)
+	service.SetVerbose(verbose)
+	service.SetProviderName(providerName)
+}
+
 func (s *Service) SetProviderName(providerName string) {
 	s.ProviderName = providerName
 }

--- a/terraformutils/service_accessors_test.go
+++ b/terraformutils/service_accessors_test.go
@@ -24,6 +24,22 @@ func TestServiceSetGetProviderName(t *testing.T) {
 	}
 }
 
+func TestConfigureService(t *testing.T) {
+	s := &Service{}
+
+	ConfigureService(s, "vpc", true, "aws")
+
+	if got := s.GetName(); got != "vpc" {
+		t.Errorf("GetName() = %q, want %q", got, "vpc")
+	}
+	if got := s.GetProviderName(); got != "aws" {
+		t.Errorf("GetProviderName() = %q, want %q", got, "aws")
+	}
+	if !s.Verbose {
+		t.Error("Verbose should be true")
+	}
+}
+
 func TestServiceSetGetArgs(t *testing.T) {
 	s := &Service{}
 	args := map[string]interface{}{"region": "us-east-1"}


### PR DESCRIPTION
## Summary

- Add a shared terraformutils helper for provider service metadata setup.
- Replace repeated InitService SetName/SetVerbose/SetProviderName blocks across providers.
- Keep provider-specific service args and unsupported-service handling unchanged.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Centralized service metadata setup with `terraformutils.ConfigureService` to remove repeated SetName/SetVerbose/SetProviderName calls across all providers. Provider-specific args and unsupported-service checks are unchanged.

- **Refactors**
  - Added `terraformutils.ConfigureService(service, name, verbose, providerName)`.
  - Replaced per-provider metadata initialization with the helper.
  - Added a unit test for `ConfigureService`.

<sup>Written for commit baef38e70deb4393c06301fc500c1b0c67bf5fe7. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Consolidated common service initialization logic across multiple provider integrations, reducing code duplication and improving maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->