### PR TITLE
aws(appconfig): add AppConfig resources

### DIFF
--- a/docs/aws.md
+++ b/docs/aws.md
@@ -72,6 +72,15 @@ terraformer import aws --resources=sg --regions=us-east-1
     * `aws_apigatewayv2_route_response`
     * `aws_apigatewayv2_stage`
     * `aws_apigatewayv2_vpc_link`
+*   `appconfig`
+    * `aws_appconfig_application`
+    * `aws_appconfig_configuration_profile`
+    * `aws_appconfig_deployment`
+    * `aws_appconfig_deployment_strategy`
+    * `aws_appconfig_environment`
+    * `aws_appconfig_extension`
+    * `aws_appconfig_extension_association`
+    * `aws_appconfig_hosted_configuration_version`
 *   `appsync`
     * `aws_appsync_api_cache`
     * `aws_appsync_api_key`

--- a/go.mod
+++ b/go.mod
@@ -400,6 +400,7 @@ require (
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/synapse/armsynapse v0.8.0
 	github.com/IBM/continuous-delivery-go-sdk/v2 v2.0.8
 	github.com/aws/aws-sdk-go-v2/service/apigatewayv2 v1.34.3
+	github.com/aws/aws-sdk-go-v2/service/appconfig v1.43.15
 	github.com/aws/aws-sdk-go-v2/service/backup v1.55.2
 	github.com/aws/aws-sdk-go-v2/service/directconnect v1.38.17
 	github.com/gofrs/uuid/v3 v3.1.2

--- a/go.sum
+++ b/go.sum
@@ -207,6 +207,8 @@ github.com/aws/aws-sdk-go-v2/service/apigateway v1.39.3 h1:7MJlB7KGFd+KNKtnPgoFW
 github.com/aws/aws-sdk-go-v2/service/apigateway v1.39.3/go.mod h1:MwilTAruv11x8EFjsk1R0VfjMdCxB6JHVtanCqsTR5o=
 github.com/aws/aws-sdk-go-v2/service/apigatewayv2 v1.34.3 h1:JqFmDekar5Ije9SKKBUAmvuqardAXgCoJV78dt2BQSI=
 github.com/aws/aws-sdk-go-v2/service/apigatewayv2 v1.34.3/go.mod h1:+ONaMzn4bVIQwVsamP28xDWWZuYO+6cWupJpZOSlUNE=
+github.com/aws/aws-sdk-go-v2/service/appconfig v1.43.15 h1:PwZaY+AGC6L7bGde+ESiRWUlcWgqqrtuAORV1UtNWJU=
+github.com/aws/aws-sdk-go-v2/service/appconfig v1.43.15/go.mod h1:rvo3cSBQ0Qgt6mF6ITZTZ0ssHQJ0kBcaUpIWCaldJVQ=
 github.com/aws/aws-sdk-go-v2/service/appsync v1.53.7 h1:SjkXYNc15FoovS9k6ML7dO7pkXE3ns66RXwL+rfQVl8=
 github.com/aws/aws-sdk-go-v2/service/appsync v1.53.7/go.mod h1:RcoBov7Pw38ViMxlthKRr1GLgHPPseA+kY2bupWVm10=
 github.com/aws/aws-sdk-go-v2/service/autoscaling v1.66.2 h1:pPd+/Ujqf2+DmPOdB47EN7ox1iC21lu2zlOccUlfHeo=

--- a/providers/aws/appconfig.go
+++ b/providers/aws/appconfig.go
@@ -1,0 +1,712 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package aws
+
+import (
+	"context"
+	"errors"
+	"strconv"
+	"strings"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/appconfig"
+	appconfigtypes "github.com/aws/aws-sdk-go-v2/service/appconfig/types"
+	"github.com/chenrui333/terraformer/terraformutils"
+)
+
+const (
+	appConfigApplicationResourceType                = "appconfig_application"
+	appConfigConfigurationProfileResourceType       = "appconfig_configuration_profile"
+	appConfigDeploymentResourceType                 = "appconfig_deployment"
+	appConfigDeploymentStrategyResourceType         = "appconfig_deployment_strategy"
+	appConfigEnvironmentResourceType                = "appconfig_environment"
+	appConfigExtensionResourceType                  = "appconfig_extension"
+	appConfigExtensionAssociationResourceType       = "appconfig_extension_association"
+	appConfigHostedConfigurationVersionResourceType = "appconfig_hosted_configuration_version"
+
+	appConfigConfigurationProfileIDSeparator       = ":"
+	appConfigDeploymentIDSeparator                 = "/"
+	appConfigEnvironmentIDSeparator                = ":"
+	appConfigHostedConfigurationVersionIDSeparator = "/"
+	appConfigHostedLocationURI                     = "hosted"
+)
+
+var (
+	appConfigAllowEmptyValues = []string{"tags."}
+
+	appConfigTopLevelResourceTypes = []string{
+		appConfigApplicationResourceType,
+		appConfigDeploymentStrategyResourceType,
+		appConfigExtensionResourceType,
+		appConfigExtensionAssociationResourceType,
+	}
+	appConfigApplicationChildResourceTypes = []string{
+		appConfigConfigurationProfileResourceType,
+		appConfigDeploymentResourceType,
+		appConfigEnvironmentResourceType,
+		appConfigHostedConfigurationVersionResourceType,
+	}
+	appConfigResourceTypes = append(appConfigTopLevelResourceTypes, appConfigApplicationChildResourceTypes...)
+)
+
+type AppConfigGenerator struct {
+	AWSService
+}
+
+func (g *AppConfigGenerator) InitResources() error {
+	config, e := g.generateConfig()
+	if e != nil {
+		return e
+	}
+	svc := appconfig.NewFromConfig(config)
+
+	if g.shouldLoadApplications() {
+		if err := g.loadApplications(svc); err != nil {
+			return err
+		}
+	}
+	if g.shouldLoadTopLevelResourceType(appConfigDeploymentStrategyResourceType) {
+		if err := g.loadDeploymentStrategies(svc); err != nil {
+			return err
+		}
+	}
+	if g.shouldLoadTopLevelResourceType(appConfigExtensionResourceType) {
+		if err := g.loadExtensions(svc); err != nil {
+			return err
+		}
+	}
+	if g.shouldLoadTopLevelResourceType(appConfigExtensionAssociationResourceType) {
+		if err := g.loadExtensionAssociations(svc); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (g *AppConfigGenerator) loadApplications(svc *appconfig.Client) error {
+	p := appconfig.NewListApplicationsPaginator(svc, &appconfig.ListApplicationsInput{})
+	for p.HasMorePages() {
+		page, err := p.NextPage(context.TODO())
+		if err != nil {
+			return err
+		}
+		for _, application := range page.Items {
+			applicationID := StringValue(application.Id)
+			applicationName := StringValue(application.Name)
+			if applicationID == "" || applicationName == "" {
+				continue
+			}
+			applicationResource := newAppConfigApplicationResource(applicationID, applicationName)
+			if g.shouldAppendTopLevelResource(appConfigApplicationResourceType, applicationResource) {
+				g.Resources = append(g.Resources, applicationResource)
+			}
+			if !g.shouldLoadApplicationChildren(applicationResource) {
+				continue
+			}
+			if g.shouldLoadConfigurationProfiles(applicationID) {
+				if err := g.loadConfigurationProfiles(svc, applicationID); err != nil {
+					if appConfigResourceMissing(err) {
+						continue
+					}
+					return err
+				}
+			}
+			if g.shouldLoadEnvironments(applicationID) {
+				if err := g.loadEnvironments(svc, applicationID); err != nil {
+					if appConfigResourceMissing(err) {
+						continue
+					}
+					return err
+				}
+			}
+		}
+	}
+	return nil
+}
+
+func (g *AppConfigGenerator) loadConfigurationProfiles(svc *appconfig.Client, applicationID string) error {
+	p := appconfig.NewListConfigurationProfilesPaginator(svc, &appconfig.ListConfigurationProfilesInput{
+		ApplicationId: aws.String(applicationID),
+	})
+	for p.HasMorePages() {
+		page, err := p.NextPage(context.TODO())
+		if err != nil {
+			return err
+		}
+		for _, profile := range page.Items {
+			profileID := StringValue(profile.Id)
+			profileName := StringValue(profile.Name)
+			if profileID == "" || profileName == "" {
+				continue
+			}
+			profileResource := newAppConfigConfigurationProfileResource(applicationID, profileID, profileName)
+			if g.shouldAppendApplicationChildResource(appConfigConfigurationProfileResourceType, profileResource) {
+				g.Resources = append(g.Resources, profileResource)
+			}
+			if g.shouldLoadHostedConfigurationVersions(applicationID, profileID, StringValue(profile.LocationUri)) {
+				if err := g.loadHostedConfigurationVersions(svc, applicationID, profileID); err != nil {
+					if appConfigResourceMissing(err) {
+						continue
+					}
+					return err
+				}
+			}
+		}
+	}
+	return nil
+}
+
+func (g *AppConfigGenerator) loadHostedConfigurationVersions(svc *appconfig.Client, applicationID, configurationProfileID string) error {
+	p := appconfig.NewListHostedConfigurationVersionsPaginator(svc, &appconfig.ListHostedConfigurationVersionsInput{
+		ApplicationId:          aws.String(applicationID),
+		ConfigurationProfileId: aws.String(configurationProfileID),
+	})
+	for p.HasMorePages() {
+		page, err := p.NextPage(context.TODO())
+		if err != nil {
+			return err
+		}
+		for _, version := range page.Items {
+			versionNumber := version.VersionNumber
+			if versionNumber == 0 {
+				continue
+			}
+			resource := newAppConfigHostedConfigurationVersionResource(applicationID, configurationProfileID, versionNumber)
+			if g.shouldAppendApplicationChildResource(appConfigHostedConfigurationVersionResourceType, resource) {
+				g.Resources = append(g.Resources, resource)
+			}
+		}
+	}
+	return nil
+}
+
+func (g *AppConfigGenerator) loadEnvironments(svc *appconfig.Client, applicationID string) error {
+	p := appconfig.NewListEnvironmentsPaginator(svc, &appconfig.ListEnvironmentsInput{
+		ApplicationId: aws.String(applicationID),
+	})
+	for p.HasMorePages() {
+		page, err := p.NextPage(context.TODO())
+		if err != nil {
+			return err
+		}
+		for _, environment := range page.Items {
+			environmentID := StringValue(environment.Id)
+			environmentName := StringValue(environment.Name)
+			if environmentID == "" || environmentName == "" {
+				continue
+			}
+			environmentResource := newAppConfigEnvironmentResource(applicationID, environmentID, environmentName)
+			if g.shouldAppendApplicationChildResource(appConfigEnvironmentResourceType, environmentResource) {
+				g.Resources = append(g.Resources, environmentResource)
+			}
+			if g.shouldLoadDeployments(applicationID, environmentID) {
+				if err := g.loadDeployments(svc, applicationID, environmentID); err != nil {
+					if appConfigResourceMissing(err) {
+						continue
+					}
+					return err
+				}
+			}
+		}
+	}
+	return nil
+}
+
+func (g *AppConfigGenerator) loadDeployments(svc *appconfig.Client, applicationID, environmentID string) error {
+	p := appconfig.NewListDeploymentsPaginator(svc, &appconfig.ListDeploymentsInput{
+		ApplicationId: aws.String(applicationID),
+		EnvironmentId: aws.String(environmentID),
+	})
+	for p.HasMorePages() {
+		page, err := p.NextPage(context.TODO())
+		if err != nil {
+			return err
+		}
+		for _, deployment := range page.Items {
+			deploymentNumber := deployment.DeploymentNumber
+			if deploymentNumber == 0 {
+				continue
+			}
+			resource := newAppConfigDeploymentResource(applicationID, environmentID, deploymentNumber)
+			if g.shouldAppendApplicationChildResource(appConfigDeploymentResourceType, resource) {
+				g.Resources = append(g.Resources, resource)
+			}
+		}
+	}
+	return nil
+}
+
+func (g *AppConfigGenerator) loadDeploymentStrategies(svc *appconfig.Client) error {
+	p := appconfig.NewListDeploymentStrategiesPaginator(svc, &appconfig.ListDeploymentStrategiesInput{})
+	for p.HasMorePages() {
+		page, err := p.NextPage(context.TODO())
+		if err != nil {
+			return err
+		}
+		for _, strategy := range page.Items {
+			strategyID := StringValue(strategy.Id)
+			strategyName := StringValue(strategy.Name)
+			if strategyID == "" || strategyName == "" || !appConfigDeploymentStrategyImportable(strategyID) {
+				continue
+			}
+			resource := newAppConfigDeploymentStrategyResource(strategyID, strategyName)
+			if g.shouldAppendTopLevelResource(appConfigDeploymentStrategyResourceType, resource) {
+				g.Resources = append(g.Resources, resource)
+			}
+		}
+	}
+	return nil
+}
+
+func (g *AppConfigGenerator) loadExtensions(svc *appconfig.Client) error {
+	p := appconfig.NewListExtensionsPaginator(svc, &appconfig.ListExtensionsInput{})
+	for p.HasMorePages() {
+		page, err := p.NextPage(context.TODO())
+		if err != nil {
+			return err
+		}
+		for _, extension := range page.Items {
+			extensionID := StringValue(extension.Id)
+			extensionName := StringValue(extension.Name)
+			if extensionID == "" || extensionName == "" || !appConfigExtensionImportable(extensionID, extensionName) {
+				continue
+			}
+			resource := newAppConfigExtensionResource(extensionID, extensionName)
+			if g.shouldAppendTopLevelResource(appConfigExtensionResourceType, resource) {
+				g.Resources = append(g.Resources, resource)
+			}
+		}
+	}
+	return nil
+}
+
+func (g *AppConfigGenerator) loadExtensionAssociations(svc *appconfig.Client) error {
+	p := appconfig.NewListExtensionAssociationsPaginator(svc, &appconfig.ListExtensionAssociationsInput{})
+	for p.HasMorePages() {
+		page, err := p.NextPage(context.TODO())
+		if err != nil {
+			return err
+		}
+		for _, association := range page.Items {
+			associationID := StringValue(association.Id)
+			if associationID == "" {
+				continue
+			}
+			resource := newAppConfigExtensionAssociationResource(associationID)
+			if g.shouldAppendTopLevelResource(appConfigExtensionAssociationResourceType, resource) {
+				g.Resources = append(g.Resources, resource)
+			}
+		}
+	}
+	return nil
+}
+
+func newAppConfigApplicationResource(applicationID, name string) terraformutils.Resource {
+	return terraformutils.NewResource(
+		applicationID,
+		appConfigResourceName(name, applicationID),
+		"aws_appconfig_application",
+		"aws",
+		map[string]string{
+			"name": name,
+		},
+		appConfigAllowEmptyValues,
+		map[string]interface{}{},
+	)
+}
+
+func newAppConfigConfigurationProfileResource(applicationID, configurationProfileID, name string) terraformutils.Resource {
+	id := appConfigConfigurationProfileResourceID(configurationProfileID, applicationID)
+	return terraformutils.NewResource(
+		id,
+		appConfigResourceName(applicationID, name, configurationProfileID),
+		"aws_appconfig_configuration_profile",
+		"aws",
+		map[string]string{
+			"application_id":           applicationID,
+			"configuration_profile_id": configurationProfileID,
+			"name":                     name,
+		},
+		appConfigAllowEmptyValues,
+		map[string]interface{}{},
+	)
+}
+
+func newAppConfigDeploymentResource(applicationID, environmentID string, deploymentNumber int32) terraformutils.Resource {
+	id := appConfigDeploymentResourceID(applicationID, environmentID, deploymentNumber)
+	return terraformutils.NewResource(
+		id,
+		appConfigResourceName(applicationID, environmentID, strconv.FormatInt(int64(deploymentNumber), 10)),
+		"aws_appconfig_deployment",
+		"aws",
+		map[string]string{
+			"application_id":    applicationID,
+			"deployment_number": strconv.FormatInt(int64(deploymentNumber), 10),
+			"environment_id":    environmentID,
+		},
+		appConfigAllowEmptyValues,
+		map[string]interface{}{},
+	)
+}
+
+func newAppConfigDeploymentStrategyResource(strategyID, name string) terraformutils.Resource {
+	return terraformutils.NewResource(
+		strategyID,
+		appConfigResourceName(name, strategyID),
+		"aws_appconfig_deployment_strategy",
+		"aws",
+		map[string]string{
+			"name": name,
+		},
+		appConfigAllowEmptyValues,
+		map[string]interface{}{},
+	)
+}
+
+func newAppConfigEnvironmentResource(applicationID, environmentID, name string) terraformutils.Resource {
+	id := appConfigEnvironmentResourceID(environmentID, applicationID)
+	return terraformutils.NewResource(
+		id,
+		appConfigResourceName(applicationID, name, environmentID),
+		"aws_appconfig_environment",
+		"aws",
+		map[string]string{
+			"application_id": applicationID,
+			"environment_id": environmentID,
+			"name":           name,
+		},
+		appConfigAllowEmptyValues,
+		map[string]interface{}{},
+	)
+}
+
+func newAppConfigExtensionResource(extensionID, name string) terraformutils.Resource {
+	return terraformutils.NewResource(
+		extensionID,
+		appConfigResourceName(name, extensionID),
+		"aws_appconfig_extension",
+		"aws",
+		map[string]string{
+			"name": name,
+		},
+		appConfigAllowEmptyValues,
+		map[string]interface{}{},
+	)
+}
+
+func newAppConfigExtensionAssociationResource(associationID string) terraformutils.Resource {
+	return terraformutils.NewSimpleResource(
+		associationID,
+		associationID,
+		"aws_appconfig_extension_association",
+		"aws",
+		appConfigAllowEmptyValues,
+	)
+}
+
+func newAppConfigHostedConfigurationVersionResource(applicationID, configurationProfileID string, versionNumber int32) terraformutils.Resource {
+	id := appConfigHostedConfigurationVersionResourceID(applicationID, configurationProfileID, versionNumber)
+	return terraformutils.NewResource(
+		id,
+		appConfigResourceName(applicationID, configurationProfileID, strconv.FormatInt(int64(versionNumber), 10)),
+		"aws_appconfig_hosted_configuration_version",
+		"aws",
+		map[string]string{
+			"application_id":           applicationID,
+			"configuration_profile_id": configurationProfileID,
+			"version_number":           strconv.FormatInt(int64(versionNumber), 10),
+		},
+		appConfigAllowEmptyValues,
+		map[string]interface{}{},
+	)
+}
+
+func appConfigConfigurationProfileResourceID(configurationProfileID, applicationID string) string {
+	return strings.Join([]string{configurationProfileID, applicationID}, appConfigConfigurationProfileIDSeparator)
+}
+
+func appConfigDeploymentResourceID(applicationID, environmentID string, deploymentNumber int32) string {
+	return strings.Join([]string{applicationID, environmentID, strconv.FormatInt(int64(deploymentNumber), 10)}, appConfigDeploymentIDSeparator)
+}
+
+func appConfigEnvironmentResourceID(environmentID, applicationID string) string {
+	return strings.Join([]string{environmentID, applicationID}, appConfigEnvironmentIDSeparator)
+}
+
+func appConfigHostedConfigurationVersionResourceID(applicationID, configurationProfileID string, versionNumber int32) string {
+	return strings.Join([]string{applicationID, configurationProfileID, strconv.FormatInt(int64(versionNumber), 10)}, appConfigHostedConfigurationVersionIDSeparator)
+}
+
+func appConfigResourceName(parts ...string) string {
+	nonEmptyParts := []string{}
+	for _, part := range parts {
+		if part != "" {
+			nonEmptyParts = append(nonEmptyParts, part)
+		}
+	}
+	return strings.Join(nonEmptyParts, ":")
+}
+
+func appConfigResourceMissing(err error) bool {
+	var notFound *appconfigtypes.ResourceNotFoundException
+	return errors.As(err, &notFound)
+}
+
+func appConfigDeploymentStrategyImportable(strategyID string) bool {
+	return !strings.HasPrefix(strategyID, "AppConfig.")
+}
+
+func appConfigExtensionImportable(extensionID, extensionName string) bool {
+	return !strings.HasPrefix(extensionID, "AWS.") && !strings.HasPrefix(extensionName, "AWS.")
+}
+
+func (g *AppConfigGenerator) shouldLoadApplications() bool {
+	if g.hasUntypedIDFilter() {
+		return true
+	}
+	if g.hasTypedAppConfigFilter() {
+		return g.hasTypedFilterFor(appConfigApplicationResourceType) || g.hasTypedAppConfigApplicationChildFilter()
+	}
+	return true
+}
+
+func (g *AppConfigGenerator) shouldLoadApplicationChildren(applicationResource terraformutils.Resource) bool {
+	if g.hasTypedAppConfigFilter() && !g.hasTypedFilterFor(appConfigApplicationResourceType) && !g.hasTypedAppConfigApplicationChildFilter() && !g.hasUntypedIDFilter() {
+		return false
+	}
+	if !g.hasTypedAppConfigApplicationChildFilter() && !g.hasUntypedIDFilter() {
+		if !g.applicationMatchesPreDiscoveryFilters(applicationResource.InstanceState.ID) {
+			return false
+		}
+	}
+
+	applicationID := applicationResource.InstanceState.ID
+	for _, childServiceName := range appConfigApplicationChildResourceTypes {
+		if g.shouldLoadApplicationChildResourceType(childServiceName, applicationID) {
+			return true
+		}
+	}
+	return false
+}
+
+func (g *AppConfigGenerator) shouldLoadConfigurationProfiles(applicationID string) bool {
+	return g.shouldLoadApplicationChildResourceType(appConfigConfigurationProfileResourceType, applicationID) ||
+		g.shouldLoadApplicationChildResourceType(appConfigHostedConfigurationVersionResourceType, applicationID)
+}
+
+func (g *AppConfigGenerator) shouldLoadEnvironments(applicationID string) bool {
+	return g.shouldLoadApplicationChildResourceType(appConfigEnvironmentResourceType, applicationID) ||
+		g.shouldLoadApplicationChildResourceType(appConfigDeploymentResourceType, applicationID)
+}
+
+func (g *AppConfigGenerator) shouldLoadHostedConfigurationVersions(applicationID, configurationProfileID, locationURI string) bool {
+	if locationURI != appConfigHostedLocationURI {
+		return false
+	}
+	if !g.shouldLoadApplicationChildResourceType(appConfigHostedConfigurationVersionResourceType, applicationID) {
+		return false
+	}
+	return g.initialIDFiltersCanMatchHostedConfigurationProfile(applicationID, configurationProfileID)
+}
+
+func (g *AppConfigGenerator) shouldLoadDeployments(applicationID, environmentID string) bool {
+	if !g.shouldLoadApplicationChildResourceType(appConfigDeploymentResourceType, applicationID) {
+		return false
+	}
+	return g.initialIDFiltersCanMatchDeploymentEnvironment(applicationID, environmentID)
+}
+
+func (g *AppConfigGenerator) shouldLoadTopLevelResourceType(serviceName string) bool {
+	if g.hasUntypedIDFilter() {
+		return true
+	}
+	if g.hasTypedAppConfigFilter() {
+		return g.hasTypedFilterFor(serviceName)
+	}
+	return true
+}
+
+func (g *AppConfigGenerator) shouldLoadApplicationChildResourceType(serviceName, applicationID string) bool {
+	hasTypedChildFilter := g.hasTypedFilterFor(serviceName)
+	if g.hasTypedAppConfigApplicationChildFilter() && !hasTypedChildFilter {
+		return false
+	}
+	if g.hasTypedAppConfigFilter() && !hasTypedChildFilter && !g.hasTypedFilterFor(appConfigApplicationResourceType) && !g.hasUntypedIDFilter() {
+		return false
+	}
+	if !g.initialIDFiltersCanMatchApplicationChild(serviceName, applicationID) {
+		return false
+	}
+	if !hasTypedChildFilter && !g.hasUntypedIDFilter() {
+		return g.applicationMatchesPreDiscoveryFilters(applicationID)
+	}
+	if hasTypedChildFilter && !g.hasIDFilterFor(serviceName) && !g.hasUntypedIDFilter() && g.hasTypedFilterFor(appConfigApplicationResourceType) {
+		return g.applicationMatchesPreDiscoveryFilters(applicationID)
+	}
+	return true
+}
+
+func (g *AppConfigGenerator) applicationMatchesPreDiscoveryFilters(applicationID string) bool {
+	applicationResource := newAppConfigApplicationResource(applicationID, applicationID)
+	if !g.resourceMatchesInitialIDFilters(appConfigApplicationResourceType, applicationResource) {
+		return false
+	}
+	return !g.hasTypedNonIDFilterFor(appConfigApplicationResourceType)
+}
+
+func (g *AppConfigGenerator) shouldAppendTopLevelResource(serviceName string, resource terraformutils.Resource) bool {
+	if !g.resourceMatchesInitialIDFilters(serviceName, resource) {
+		return false
+	}
+	if g.hasTypedAppConfigFilter() && !g.hasTypedFilterFor(serviceName) && !g.hasUntypedIDFilter() {
+		return false
+	}
+	return true
+}
+
+func (g *AppConfigGenerator) shouldAppendApplicationChildResource(serviceName string, resource terraformutils.Resource) bool {
+	if g.hasTypedAppConfigApplicationChildFilter() && !g.hasTypedFilterFor(serviceName) {
+		return false
+	}
+	if g.hasTypedAppConfigFilter() && !g.hasTypedAppConfigApplicationChildFilter() && !g.hasUntypedIDFilter() {
+		if !g.hasTypedFilterFor(appConfigApplicationResourceType) || g.hasTypedNonIDFilterFor(appConfigApplicationResourceType) {
+			return false
+		}
+	}
+	return g.resourceMatchesInitialIDFilters(serviceName, resource)
+}
+
+func (g *AppConfigGenerator) resourceMatchesInitialIDFilters(serviceName string, resource terraformutils.Resource) bool {
+	for _, filter := range g.Filter {
+		if filter.FieldPath != "id" || !filter.IsApplicable(serviceName) {
+			continue
+		}
+		if !filter.Filter(resource) {
+			return false
+		}
+	}
+	return true
+}
+
+func (g *AppConfigGenerator) initialIDFiltersCanMatchApplicationChild(serviceName, applicationID string) bool {
+	for _, filter := range g.Filter {
+		if filter.FieldPath != "id" || !filter.IsApplicable(serviceName) {
+			continue
+		}
+		if !appConfigAnyAcceptableIDMatches(filter.AcceptableValues, func(value string) bool {
+			return appConfigChildIDMayBelongToApplication(serviceName, applicationID, value)
+		}) {
+			return false
+		}
+	}
+	return true
+}
+
+func (g *AppConfigGenerator) initialIDFiltersCanMatchHostedConfigurationProfile(applicationID, configurationProfileID string) bool {
+	for _, filter := range g.Filter {
+		if filter.FieldPath != "id" || !filter.IsApplicable(appConfigHostedConfigurationVersionResourceType) {
+			continue
+		}
+		if !appConfigAnyAcceptableIDMatches(filter.AcceptableValues, func(value string) bool {
+			return strings.HasPrefix(value, applicationID+appConfigHostedConfigurationVersionIDSeparator+configurationProfileID+appConfigHostedConfigurationVersionIDSeparator)
+		}) {
+			return false
+		}
+	}
+	return true
+}
+
+func (g *AppConfigGenerator) initialIDFiltersCanMatchDeploymentEnvironment(applicationID, environmentID string) bool {
+	for _, filter := range g.Filter {
+		if filter.FieldPath != "id" || !filter.IsApplicable(appConfigDeploymentResourceType) {
+			continue
+		}
+		if !appConfigAnyAcceptableIDMatches(filter.AcceptableValues, func(value string) bool {
+			return strings.HasPrefix(value, applicationID+appConfigDeploymentIDSeparator+environmentID+appConfigDeploymentIDSeparator)
+		}) {
+			return false
+		}
+	}
+	return true
+}
+
+func appConfigChildIDMayBelongToApplication(serviceName, applicationID, value string) bool {
+	switch serviceName {
+	case appConfigConfigurationProfileResourceType:
+		return strings.HasSuffix(value, appConfigConfigurationProfileIDSeparator+applicationID)
+	case appConfigEnvironmentResourceType:
+		return strings.HasSuffix(value, appConfigEnvironmentIDSeparator+applicationID)
+	case appConfigDeploymentResourceType:
+		return strings.HasPrefix(value, applicationID+appConfigDeploymentIDSeparator)
+	case appConfigHostedConfigurationVersionResourceType:
+		return strings.HasPrefix(value, applicationID+appConfigHostedConfigurationVersionIDSeparator)
+	default:
+		return value == applicationID
+	}
+}
+
+func appConfigAnyAcceptableIDMatches(values []string, match func(string) bool) bool {
+	if len(values) == 0 {
+		return true
+	}
+	for _, value := range values {
+		if match(value) {
+			return true
+		}
+	}
+	return false
+}
+
+func (g *AppConfigGenerator) hasTypedAppConfigApplicationChildFilter() bool {
+	for _, serviceName := range appConfigApplicationChildResourceTypes {
+		if g.hasTypedFilterFor(serviceName) {
+			return true
+		}
+	}
+	return false
+}
+
+func (g *AppConfigGenerator) hasTypedAppConfigFilter() bool {
+	for _, serviceName := range appConfigResourceTypes {
+		if g.hasTypedFilterFor(serviceName) {
+			return true
+		}
+	}
+	return false
+}
+
+func (g *AppConfigGenerator) hasTypedFilterFor(serviceName string) bool {
+	for _, filter := range g.Filter {
+		if filter.ServiceName == serviceName {
+			return true
+		}
+	}
+	return false
+}
+
+func (g *AppConfigGenerator) hasTypedNonIDFilterFor(serviceName string) bool {
+	for _, filter := range g.Filter {
+		if filter.ServiceName == serviceName && filter.FieldPath != "id" {
+			return true
+		}
+	}
+	return false
+}
+
+func (g *AppConfigGenerator) hasIDFilterFor(serviceName string) bool {
+	for _, filter := range g.Filter {
+		if filter.FieldPath == "id" && filter.IsApplicable(serviceName) {
+			return true
+		}
+	}
+	return false
+}
+
+func (g *AppConfigGenerator) hasUntypedIDFilter() bool {
+	for _, filter := range g.Filter {
+		if filter.ServiceName == "" && filter.FieldPath == "id" {
+			return true
+		}
+	}
+	return false
+}

--- a/providers/aws/appconfig_test.go
+++ b/providers/aws/appconfig_test.go
@@ -1,0 +1,387 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package aws
+
+import (
+	"errors"
+	"testing"
+
+	appconfigtypes "github.com/aws/aws-sdk-go-v2/service/appconfig/types"
+	"github.com/chenrui333/terraformer/terraformutils"
+)
+
+func TestAppConfigResourceIDsMatchProviderReadIDs(t *testing.T) {
+	applicationID := "app123"
+	configurationProfileID := "prof123"
+	environmentID := "env123"
+
+	tests := []struct {
+		name string
+		got  string
+		want string
+	}{
+		{
+			name: "configuration profile is configuration profile then application",
+			got:  appConfigConfigurationProfileResourceID(configurationProfileID, applicationID),
+			want: "prof123:app123",
+		},
+		{
+			name: "environment is environment then application",
+			got:  appConfigEnvironmentResourceID(environmentID, applicationID),
+			want: "env123:app123",
+		},
+		{
+			name: "deployment is application environment deployment number",
+			got:  appConfigDeploymentResourceID(applicationID, environmentID, 3),
+			want: "app123/env123/3",
+		},
+		{
+			name: "hosted configuration version is application profile version",
+			got:  appConfigHostedConfigurationVersionResourceID(applicationID, configurationProfileID, 7),
+			want: "app123/prof123/7",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.got != tt.want {
+				t.Fatalf("resource ID = %q, want %q", tt.got, tt.want)
+			}
+		})
+	}
+}
+
+func TestAppConfigResourceNamesIncludeIDs(t *testing.T) {
+	application := newAppConfigApplicationResource("app123", "orders")
+	otherApplication := newAppConfigApplicationResource("app456", "orders")
+	if application.ResourceName == otherApplication.ResourceName {
+		t.Fatalf("application resource names collide: %q", application.ResourceName)
+	}
+
+	profile := newAppConfigConfigurationProfileResource("app123", "prof123", "settings")
+	otherProfile := newAppConfigConfigurationProfileResource("app456", "prof123", "settings")
+	if profile.ResourceName == otherProfile.ResourceName {
+		t.Fatalf("configuration profile resource names collide: %q", profile.ResourceName)
+	}
+}
+
+func TestAppConfigResourceMissing(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{name: "nil", want: false},
+		{name: "resource not found", err: &appconfigtypes.ResourceNotFoundException{}, want: true},
+		{name: "wrapped resource not found", err: errors.Join(errors.New("boom"), &appconfigtypes.ResourceNotFoundException{}), want: true},
+		{name: "generic", err: errors.New("boom"), want: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := appConfigResourceMissing(tt.err); got != tt.want {
+				t.Fatalf("appConfigResourceMissing(%v) = %t, want %t", tt.err, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestAppConfigSkipsAWSManagedStandaloneResources(t *testing.T) {
+	if appConfigDeploymentStrategyImportable("AppConfig.AllAtOnce") {
+		t.Fatal("predefined deployment strategy should not be importable as a standalone resource")
+	}
+	if !appConfigDeploymentStrategyImportable("abc123") {
+		t.Fatal("customer deployment strategy should be importable")
+	}
+	if appConfigExtensionImportable("AWS.AppConfig.DeploymentEventsToAmazonSNS", "AWS.AppConfig.DeploymentEventsToAmazonSNS") {
+		t.Fatal("AWS-authored extension should not be importable as a standalone resource")
+	}
+	if !appConfigExtensionImportable("ext123", "notify") {
+		t.Fatal("customer extension should be importable")
+	}
+}
+
+func TestAppConfigFilterGatesApplicationAndChildDiscovery(t *testing.T) {
+	applicationID := "app123"
+	otherApplicationID := "app456"
+	configurationProfileID := "prof123"
+	otherConfigurationProfileID := "prof456"
+	environmentID := "env123"
+	otherEnvironmentID := "env456"
+	application := newAppConfigApplicationResource(applicationID, "orders")
+	otherApplication := newAppConfigApplicationResource(otherApplicationID, "other")
+	configurationProfile := newAppConfigConfigurationProfileResource(applicationID, configurationProfileID, "settings")
+	environment := newAppConfigEnvironmentResource(applicationID, environmentID, "prod")
+	hostedVersion := newAppConfigHostedConfigurationVersionResource(applicationID, configurationProfileID, 7)
+	deployment := newAppConfigDeploymentResource(applicationID, environmentID, 3)
+
+	tests := []struct {
+		name                  string
+		filters               []terraformutils.ResourceFilter
+		loadApplications      bool
+		appendApplication     bool
+		appendOther           bool
+		loadChildren          bool
+		loadOtherChildren     bool
+		loadProfiles          bool
+		loadOtherProfiles     bool
+		loadHosted            bool
+		loadOtherHosted       bool
+		loadEnvironments      bool
+		loadOtherEnvironments bool
+		loadDeployments       bool
+		loadOtherDeployments  bool
+		appendProfile         bool
+		appendEnvironment     bool
+		appendHosted          bool
+		appendDeployment      bool
+	}{
+		{
+			name:                  "no filters imports applications and children",
+			loadApplications:      true,
+			appendApplication:     true,
+			appendOther:           true,
+			loadChildren:          true,
+			loadOtherChildren:     true,
+			loadProfiles:          true,
+			loadOtherProfiles:     true,
+			loadHosted:            true,
+			loadOtherHosted:       true,
+			loadEnvironments:      true,
+			loadOtherEnvironments: true,
+			loadDeployments:       true,
+			loadOtherDeployments:  true,
+			appendProfile:         true,
+			appendEnvironment:     true,
+			appendHosted:          true,
+			appendDeployment:      true,
+		},
+		{
+			name: "typed application id filter limits applications and children",
+			filters: []terraformutils.ResourceFilter{
+				{ServiceName: appConfigApplicationResourceType, FieldPath: "id", AcceptableValues: []string{applicationID}},
+			},
+			loadApplications:     true,
+			appendApplication:    true,
+			loadChildren:         true,
+			loadProfiles:         true,
+			loadHosted:           true,
+			loadOtherHosted:      true,
+			loadEnvironments:     true,
+			loadDeployments:      true,
+			loadOtherDeployments: true,
+			appendProfile:        true,
+			appendEnvironment:    true,
+			appendHosted:         true,
+			appendDeployment:     true,
+		},
+		{
+			name: "typed child id filter does not import parent applications",
+			filters: []terraformutils.ResourceFilter{
+				{ServiceName: appConfigConfigurationProfileResourceType, FieldPath: "id", AcceptableValues: []string{appConfigConfigurationProfileResourceID(configurationProfileID, applicationID)}},
+			},
+			loadApplications: true,
+			loadChildren:     true,
+			loadProfiles:     true,
+			appendProfile:    true,
+		},
+		{
+			name: "typed parent and child id filters load matching child outside parent filter",
+			filters: []terraformutils.ResourceFilter{
+				{ServiceName: appConfigApplicationResourceType, FieldPath: "id", AcceptableValues: []string{otherApplicationID}},
+				{ServiceName: appConfigConfigurationProfileResourceType, FieldPath: "id", AcceptableValues: []string{appConfigConfigurationProfileResourceID(configurationProfileID, applicationID)}},
+			},
+			loadApplications:  true,
+			appendOther:       true,
+			loadChildren:      true,
+			loadProfiles:      true,
+			appendProfile:     true,
+			loadOtherChildren: false,
+		},
+		{
+			name: "typed hosted version id filter scopes profile version discovery",
+			filters: []terraformutils.ResourceFilter{
+				{ServiceName: appConfigHostedConfigurationVersionResourceType, FieldPath: "id", AcceptableValues: []string{appConfigHostedConfigurationVersionResourceID(applicationID, configurationProfileID, 7)}},
+			},
+			loadApplications: true,
+			loadChildren:     true,
+			loadProfiles:     true,
+			loadHosted:       true,
+			appendHosted:     true,
+		},
+		{
+			name: "typed deployment id filter scopes environment deployment discovery",
+			filters: []terraformutils.ResourceFilter{
+				{ServiceName: appConfigDeploymentResourceType, FieldPath: "id", AcceptableValues: []string{appConfigDeploymentResourceID(applicationID, environmentID, 3)}},
+			},
+			loadApplications: true,
+			loadChildren:     true,
+			loadEnvironments: true,
+			loadDeployments:  true,
+			appendDeployment: true,
+		},
+		{
+			name: "typed application non-id filter avoids child pre-load",
+			filters: []terraformutils.ResourceFilter{
+				{ServiceName: appConfigApplicationResourceType, FieldPath: "tags.env", AcceptableValues: []string{"prod"}},
+			},
+			loadApplications:  true,
+			appendApplication: true,
+			appendOther:       true,
+		},
+		{
+			name: "global id filter constrains typed child discovery",
+			filters: []terraformutils.ResourceFilter{
+				{FieldPath: "id", AcceptableValues: []string{otherApplicationID}},
+				{ServiceName: appConfigConfigurationProfileResourceType, FieldPath: "id", AcceptableValues: []string{appConfigConfigurationProfileResourceID(configurationProfileID, applicationID)}},
+			},
+			loadApplications: true,
+			appendOther:      true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := AppConfigGenerator{}
+			g.Filter = tt.filters
+			if got := g.shouldLoadApplications(); got != tt.loadApplications {
+				t.Fatalf("shouldLoadApplications() = %t, want %t", got, tt.loadApplications)
+			}
+			if got := g.shouldAppendTopLevelResource(appConfigApplicationResourceType, application); got != tt.appendApplication {
+				t.Fatalf("shouldAppendTopLevelResource(application) = %t, want %t", got, tt.appendApplication)
+			}
+			if got := g.shouldAppendTopLevelResource(appConfigApplicationResourceType, otherApplication); got != tt.appendOther {
+				t.Fatalf("shouldAppendTopLevelResource(other application) = %t, want %t", got, tt.appendOther)
+			}
+			if got := g.shouldLoadApplicationChildren(application); got != tt.loadChildren {
+				t.Fatalf("shouldLoadApplicationChildren(application) = %t, want %t", got, tt.loadChildren)
+			}
+			if got := g.shouldLoadApplicationChildren(otherApplication); got != tt.loadOtherChildren {
+				t.Fatalf("shouldLoadApplicationChildren(other application) = %t, want %t", got, tt.loadOtherChildren)
+			}
+			if got := g.shouldLoadConfigurationProfiles(applicationID); got != tt.loadProfiles {
+				t.Fatalf("shouldLoadConfigurationProfiles(application) = %t, want %t", got, tt.loadProfiles)
+			}
+			if got := g.shouldLoadConfigurationProfiles(otherApplicationID); got != tt.loadOtherProfiles {
+				t.Fatalf("shouldLoadConfigurationProfiles(other application) = %t, want %t", got, tt.loadOtherProfiles)
+			}
+			if got := g.shouldLoadHostedConfigurationVersions(applicationID, configurationProfileID, appConfigHostedLocationURI); got != tt.loadHosted {
+				t.Fatalf("shouldLoadHostedConfigurationVersions(profile) = %t, want %t", got, tt.loadHosted)
+			}
+			if got := g.shouldLoadHostedConfigurationVersions(applicationID, otherConfigurationProfileID, appConfigHostedLocationURI); got != tt.loadOtherHosted {
+				t.Fatalf("shouldLoadHostedConfigurationVersions(other profile) = %t, want %t", got, tt.loadOtherHosted)
+			}
+			if got := g.shouldLoadHostedConfigurationVersions(applicationID, configurationProfileID, "s3://bucket/key"); got {
+				t.Fatalf("shouldLoadHostedConfigurationVersions(non-hosted profile) = true, want false")
+			}
+			if got := g.shouldLoadEnvironments(applicationID); got != tt.loadEnvironments {
+				t.Fatalf("shouldLoadEnvironments(application) = %t, want %t", got, tt.loadEnvironments)
+			}
+			if got := g.shouldLoadEnvironments(otherApplicationID); got != tt.loadOtherEnvironments {
+				t.Fatalf("shouldLoadEnvironments(other application) = %t, want %t", got, tt.loadOtherEnvironments)
+			}
+			if got := g.shouldLoadDeployments(applicationID, environmentID); got != tt.loadDeployments {
+				t.Fatalf("shouldLoadDeployments(environment) = %t, want %t", got, tt.loadDeployments)
+			}
+			if got := g.shouldLoadDeployments(applicationID, otherEnvironmentID); got != tt.loadOtherDeployments {
+				t.Fatalf("shouldLoadDeployments(other environment) = %t, want %t", got, tt.loadOtherDeployments)
+			}
+			if got := g.shouldAppendApplicationChildResource(appConfigConfigurationProfileResourceType, configurationProfile); got != tt.appendProfile {
+				t.Fatalf("shouldAppendApplicationChildResource(profile) = %t, want %t", got, tt.appendProfile)
+			}
+			if got := g.shouldAppendApplicationChildResource(appConfigEnvironmentResourceType, environment); got != tt.appendEnvironment {
+				t.Fatalf("shouldAppendApplicationChildResource(environment) = %t, want %t", got, tt.appendEnvironment)
+			}
+			if got := g.shouldAppendApplicationChildResource(appConfigHostedConfigurationVersionResourceType, hostedVersion); got != tt.appendHosted {
+				t.Fatalf("shouldAppendApplicationChildResource(hosted version) = %t, want %t", got, tt.appendHosted)
+			}
+			if got := g.shouldAppendApplicationChildResource(appConfigDeploymentResourceType, deployment); got != tt.appendDeployment {
+				t.Fatalf("shouldAppendApplicationChildResource(deployment) = %t, want %t", got, tt.appendDeployment)
+			}
+		})
+	}
+}
+
+func TestAppConfigFilterGatesTopLevelFamilies(t *testing.T) {
+	strategy := newAppConfigDeploymentStrategyResource("strategy123", "linear")
+	extension := newAppConfigExtensionResource("ext123", "notify")
+	association := newAppConfigExtensionAssociationResource("assoc123")
+
+	tests := []struct {
+		name             string
+		filters          []terraformutils.ResourceFilter
+		loadApplications bool
+		loadStrategies   bool
+		loadExtensions   bool
+		loadAssociations bool
+		appendStrategy   bool
+		appendExtension  bool
+		appendAssoc      bool
+	}{
+		{
+			name:             "no filters loads all top-level families",
+			loadApplications: true,
+			loadStrategies:   true,
+			loadExtensions:   true,
+			loadAssociations: true,
+			appendStrategy:   true,
+			appendExtension:  true,
+			appendAssoc:      true,
+		},
+		{
+			name: "typed deployment strategy filter only loads strategies",
+			filters: []terraformutils.ResourceFilter{
+				{ServiceName: appConfigDeploymentStrategyResourceType, FieldPath: "id", AcceptableValues: []string{"strategy123"}},
+			},
+			loadStrategies: true,
+			appendStrategy: true,
+		},
+		{
+			name: "typed extension filter only loads extensions",
+			filters: []terraformutils.ResourceFilter{
+				{ServiceName: appConfigExtensionResourceType, FieldPath: "id", AcceptableValues: []string{"ext123"}},
+			},
+			loadExtensions:  true,
+			appendExtension: true,
+		},
+		{
+			name: "untyped id filter keeps broad scans available",
+			filters: []terraformutils.ResourceFilter{
+				{FieldPath: "id", AcceptableValues: []string{"assoc123"}},
+			},
+			loadApplications: true,
+			loadStrategies:   true,
+			loadExtensions:   true,
+			loadAssociations: true,
+			appendAssoc:      true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := AppConfigGenerator{}
+			g.Filter = tt.filters
+			if got := g.shouldLoadApplications(); got != tt.loadApplications {
+				t.Fatalf("shouldLoadApplications() = %t, want %t", got, tt.loadApplications)
+			}
+			if got := g.shouldLoadTopLevelResourceType(appConfigDeploymentStrategyResourceType); got != tt.loadStrategies {
+				t.Fatalf("shouldLoadTopLevelResourceType(strategy) = %t, want %t", got, tt.loadStrategies)
+			}
+			if got := g.shouldLoadTopLevelResourceType(appConfigExtensionResourceType); got != tt.loadExtensions {
+				t.Fatalf("shouldLoadTopLevelResourceType(extension) = %t, want %t", got, tt.loadExtensions)
+			}
+			if got := g.shouldLoadTopLevelResourceType(appConfigExtensionAssociationResourceType); got != tt.loadAssociations {
+				t.Fatalf("shouldLoadTopLevelResourceType(association) = %t, want %t", got, tt.loadAssociations)
+			}
+			if got := g.shouldAppendTopLevelResource(appConfigDeploymentStrategyResourceType, strategy); got != tt.appendStrategy {
+				t.Fatalf("shouldAppendTopLevelResource(strategy) = %t, want %t", got, tt.appendStrategy)
+			}
+			if got := g.shouldAppendTopLevelResource(appConfigExtensionResourceType, extension); got != tt.appendExtension {
+				t.Fatalf("shouldAppendTopLevelResource(extension) = %t, want %t", got, tt.appendExtension)
+			}
+			if got := g.shouldAppendTopLevelResource(appConfigExtensionAssociationResourceType, association); got != tt.appendAssoc {
+				t.Fatalf("shouldAppendTopLevelResource(association) = %t, want %t", got, tt.appendAssoc)
+			}
+		})
+	}
+}

--- a/providers/aws/aws_provider.go
+++ b/providers/aws/aws_provider.go
@@ -235,6 +235,7 @@ func (p *AWSProvider) GetSupportedService() map[string]terraformutils.ServiceGen
 		"alb":               &AwsFacade{service: &AlbGenerator{}},
 		"api_gateway":       &AwsFacade{service: &APIGatewayGenerator{}},
 		"api_gatewayv2":     &AwsFacade{service: &APIGatewayV2Generator{}},
+		"appconfig":         &AwsFacade{service: &AppConfigGenerator{}},
 		"appsync":           &AwsFacade{service: &AppSyncGenerator{}},
 		"auto_scaling":      &AwsFacade{service: &AutoScalingGenerator{}},
 		"backup":            &AwsFacade{service: &BackupGenerator{}},


### PR DESCRIPTION
## Summary

- add AWS AppConfig discovery for applications, configuration profiles, environments, deployments, deployment strategies, extensions, extension associations, and hosted configuration versions
- register the `appconfig` AWS resource group and document the supported resources
- add focused tests for AppConfig state IDs, managed-resource skips, and typed/untyped filter gates

## Notes

- child resources seed the ID format expected by the Terraform AWS provider read paths
- standalone AWS-managed AppConfig deployment strategies/extensions are skipped while deployments and associations can still reference their raw IDs/ARNs


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds AWS AppConfig support to the AWS provider for discovery and import of core resources. Registers the new `appconfig` group and updates docs.

- **New Features**
  - Register the `appconfig` service in the provider and docs.
  - Discover and import: applications, configuration profiles, environments, deployments, deployment strategies, extensions, extension associations, and hosted configuration versions.
  - Use child resource ID formats that match Terraform AWS provider read paths.
  - Skip AWS-managed standalone deployment strategies and extensions; deployments and associations still resolve raw IDs/ARNs.
  - Add focused tests for ID formats, skip rules, and typed/untyped filter gates.

- **Dependencies**
  - Add `github.com/aws/aws-sdk-go-v2/service/appconfig v1.43.15`.

<sup>Written for commit 34f7d4dbb144cace21cacc27db327d1c54b67571. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

