### PR TITLE
refactor(providers): share service selection setup

### DIFF
--- a/providers/alicloud/alicloud_provider.go
+++ b/providers/alicloud/alicloud_provider.go
@@ -93,14 +93,9 @@ func (p *AliCloudProvider) GetName() string {
 
 // InitService Initializes the AliCloud service
 func (p *AliCloudProvider) InitService(serviceName string, verbose bool) error {
-	p.Service = nil
-
-	service, isSupported := p.GetSupportedService()[serviceName]
-	if !isSupported {
+	if !terraformutils.SelectProviderService(&p.Provider, p.GetSupportedService(), serviceName, verbose, p.GetName()) {
 		return errors.New("alicloud: " + serviceName + " not supported service")
 	}
-	p.Service = service
-	terraformutils.ConfigureService(p.Service, serviceName, verbose, p.GetName())
 	p.Service.SetArgs(map[string]interface{}{
 		"region":  p.region,
 		"profile": p.profile,

--- a/providers/auth0/auth0_provider.go
+++ b/providers/auth0/auth0_provider.go
@@ -69,14 +69,9 @@ func (p *Auth0Provider) GetConfig() cty.Value {
 }
 
 func (p *Auth0Provider) InitService(serviceName string, verbose bool) error {
-	p.Service = nil
-
-	service, isSupported := p.GetSupportedService()[serviceName]
-	if !isSupported {
+	if !terraformutils.SelectProviderService(&p.Provider, p.GetSupportedService(), serviceName, verbose, p.GetName()) {
 		return errors.New(p.GetName() + ": " + serviceName + " not supported service")
 	}
-	p.Service = service
-	terraformutils.ConfigureService(p.Service, serviceName, verbose, p.GetName())
 	p.Service.SetArgs(map[string]interface{}{
 		"domain":            p.domain,
 		"client_id":         p.clientID,

--- a/providers/aws/aws_provider.go
+++ b/providers/aws/aws_provider.go
@@ -211,14 +211,9 @@ func (p *AWSProvider) GetName() string {
 }
 
 func (p *AWSProvider) InitService(serviceName string, verbose bool) error {
-	p.Service = nil
-
-	service, isSupported := p.GetSupportedService()[serviceName]
-	if !isSupported {
+	if !terraformutils.SelectProviderService(&p.Provider, p.GetSupportedService(), serviceName, verbose, p.GetName()) {
 		return errors.New("aws: " + serviceName + " not supported service")
 	}
-	p.Service = service
-	terraformutils.ConfigureService(p.Service, serviceName, verbose, p.GetName())
 	p.Service.SetArgs(map[string]interface{}{
 		"region":                 p.region,
 		"profile":                p.profile,

--- a/providers/azure/azure_provider.go
+++ b/providers/azure/azure_provider.go
@@ -805,14 +805,9 @@ func (p *AzureProvider) GetSupportedService() map[string]terraformutils.ServiceG
 }
 
 func (p *AzureProvider) InitService(serviceName string, verbose bool) error {
-	p.Service = nil
-
-	service, isSupported := p.GetSupportedService()[serviceName]
-	if !isSupported {
+	if !terraformutils.SelectProviderService(&p.Provider, p.GetSupportedService(), serviceName, verbose, p.GetName()) {
 		return errors.New("azurerm: " + serviceName + " not supported service")
 	}
-	p.Service = service
-	terraformutils.ConfigureService(p.Service, serviceName, verbose, p.GetName())
 	p.Service.SetArgs(map[string]interface{}{
 		"config":         p.config,
 		"credential":     p.credential,

--- a/providers/azuread/azuread_provider.go
+++ b/providers/azuread/azuread_provider.go
@@ -71,14 +71,9 @@ func (p *AzureADProvider) GetSupportedService() map[string]terraformutils.Servic
 }
 
 func (p *AzureADProvider) InitService(serviceName string, verbose bool) error {
-	p.Service = nil
-
-	service, isSupported := p.GetSupportedService()[serviceName]
-	if !isSupported {
+	if !terraformutils.SelectProviderService(&p.Provider, p.GetSupportedService(), serviceName, verbose, p.GetName()) {
 		return errors.New("azuread: " + serviceName + " not supported service")
 	}
-	p.Service = service
-	terraformutils.ConfigureService(p.Service, serviceName, verbose, p.GetName())
 	p.Service.SetArgs(map[string]interface{}{
 		"tenant_id":     p.tenantID,
 		"client_id":     p.clientID,

--- a/providers/azuredevops/azuredevops_provider.go
+++ b/providers/azuredevops/azuredevops_provider.go
@@ -70,14 +70,9 @@ func (p *AzureDevOpsProvider) GetSupportedService() map[string]terraformutils.Se
 }
 
 func (p *AzureDevOpsProvider) InitService(serviceName string, verbose bool) error {
-	p.Service = nil
-
-	service, isSupported := p.GetSupportedService()[serviceName]
-	if !isSupported {
+	if !terraformutils.SelectProviderService(&p.Provider, p.GetSupportedService(), serviceName, verbose, p.GetName()) {
 		return errors.New("azuredevops: " + serviceName + " not supported service")
 	}
-	p.Service = service
-	terraformutils.ConfigureService(p.Service, serviceName, verbose, p.GetName())
 	p.Service.SetArgs(map[string]interface{}{
 		"organizationURL":     p.organizationURL,
 		"personalAccessToken": p.personalAccessToken,

--- a/providers/cloudflare/cloudflare_provider.go
+++ b/providers/cloudflare/cloudflare_provider.go
@@ -53,14 +53,9 @@ func (p *CloudflareProvider) GetSupportedService() map[string]terraformutils.Ser
 }
 
 func (p *CloudflareProvider) InitService(serviceName string, verbose bool) error {
-	p.Service = nil
-
-	service, isSupported := p.GetSupportedService()[serviceName]
-	if !isSupported {
+	if !terraformutils.SelectProviderService(&p.Provider, p.GetSupportedService(), serviceName, verbose, p.GetName()) {
 		return errors.New("cloudflare: " + serviceName + " not supported service")
 	}
-	p.Service = service
-	terraformutils.ConfigureService(p.Service, serviceName, verbose, p.GetName())
 
 	return nil
 }

--- a/providers/commercetools/commercetools_provider.go
+++ b/providers/commercetools/commercetools_provider.go
@@ -45,14 +45,9 @@ func (p *CommercetoolsProvider) GetName() string {
 }
 
 func (p *CommercetoolsProvider) InitService(serviceName string, verbose bool) error {
-	p.Service = nil
-
-	service, isSupported := p.GetSupportedService()[serviceName]
-	if !isSupported {
+	if !terraformutils.SelectProviderService(&p.Provider, p.GetSupportedService(), serviceName, verbose, p.GetName()) {
 		return errors.New(p.GetName() + ": " + serviceName + " not supported service")
 	}
-	p.Service = service
-	terraformutils.ConfigureService(p.Service, serviceName, verbose, p.GetName())
 	p.Service.SetArgs(map[string]interface{}{
 		"client_id":     p.clientID,
 		"client_secret": p.clientSecret,

--- a/providers/datadog/datadog_provider.go
+++ b/providers/datadog/datadog_provider.go
@@ -141,14 +141,9 @@ func (p *DatadogProvider) GetConfig() cty.Value {
 
 // InitService ...
 func (p *DatadogProvider) InitService(serviceName string, verbose bool) error {
-	p.Service = nil
-
-	service, isSupported := p.GetSupportedService()[serviceName]
-	if !isSupported {
+	if !terraformutils.SelectProviderService(&p.Provider, p.GetSupportedService(), serviceName, verbose, p.GetName()) {
 		return errors.New(p.GetName() + ": " + serviceName + " not supported service")
 	}
-	p.Service = service
-	terraformutils.ConfigureService(p.Service, serviceName, verbose, p.GetName())
 	p.Service.SetArgs(map[string]interface{}{
 		"api-key":       p.apiKey,
 		"app-key":       p.appKey,

--- a/providers/digitalocean/digitalocean_provider.go
+++ b/providers/digitalocean/digitalocean_provider.go
@@ -60,14 +60,9 @@ func (p *DigitalOceanProvider) GetSupportedService() map[string]terraformutils.S
 }
 
 func (p *DigitalOceanProvider) InitService(serviceName string, verbose bool) error {
-	p.Service = nil
-
-	service, isSupported := p.GetSupportedService()[serviceName]
-	if !isSupported {
+	if !terraformutils.SelectProviderService(&p.Provider, p.GetSupportedService(), serviceName, verbose, p.GetName()) {
 		return errors.New("digitalocean: " + serviceName + " not supported service")
 	}
-	p.Service = service
-	terraformutils.ConfigureService(p.Service, serviceName, verbose, p.GetName())
 	p.Service.SetArgs(map[string]interface{}{
 		"token": p.token,
 	})

--- a/providers/equinixmetal/equinixmetal_provider.go
+++ b/providers/equinixmetal/equinixmetal_provider.go
@@ -56,14 +56,9 @@ func (p *EquinixMetalProvider) GetSupportedService() map[string]terraformutils.S
 }
 
 func (p *EquinixMetalProvider) InitService(serviceName string, verbose bool) error {
-	p.Service = nil
-
-	service, isSupported := p.GetSupportedService()[serviceName]
-	if !isSupported {
+	if !terraformutils.SelectProviderService(&p.Provider, p.GetSupportedService(), serviceName, verbose, p.GetName()) {
 		return errors.New("equinixmetal: " + serviceName + " not supported service")
 	}
-	p.Service = service
-	terraformutils.ConfigureService(p.Service, serviceName, verbose, p.GetName())
 	p.Service.SetArgs(map[string]interface{}{
 		"auth_token": p.authToken,
 		"project_id": p.projectID,

--- a/providers/fastly/fastly_provider.go
+++ b/providers/fastly/fastly_provider.go
@@ -61,14 +61,9 @@ func (p *FastlyProvider) GetSupportedService() map[string]terraformutils.Service
 }
 
 func (p *FastlyProvider) InitService(serviceName string, verbose bool) error {
-	p.Service = nil
-
-	service, isSupported := p.GetSupportedService()[serviceName]
-	if !isSupported {
+	if !terraformutils.SelectProviderService(&p.Provider, p.GetSupportedService(), serviceName, verbose, p.GetName()) {
 		return errors.New("fastly: " + serviceName + " not supported service")
 	}
-	p.Service = service
-	terraformutils.ConfigureService(p.Service, serviceName, verbose, p.GetName())
 	p.Service.SetArgs(map[string]interface{}{
 		"customer_id": p.customerID,
 		"api_key":     p.apiKey,

--- a/providers/gcp/gcp_provider.go
+++ b/providers/gcp/gcp_provider.go
@@ -90,14 +90,9 @@ func (p *GCPProvider) GetName() string {
 }
 
 func (p *GCPProvider) InitService(serviceName string, verbose bool) error {
-	p.Service = nil
-
-	service, isSupported := p.GetSupportedService()[serviceName]
-	if !isSupported {
+	if !terraformutils.SelectProviderService(&p.Provider, p.GetSupportedService(), serviceName, verbose, p.GetName()) {
 		return errors.New("gcp: " + serviceName + " not supported service")
 	}
-	p.Service = service
-	terraformutils.ConfigureService(p.Service, serviceName, verbose, p.GetName())
 	p.Service.SetArgs(map[string]interface{}{
 		"region":  p.region,
 		"project": p.projectName,

--- a/providers/github/github_provider.go
+++ b/providers/github/github_provider.go
@@ -109,14 +109,9 @@ func (p *GithubProvider) GetName() string {
 }
 
 func (p *GithubProvider) InitService(serviceName string, verbose bool) error {
-	p.Service = nil
-
-	service, isSupported := p.GetSupportedService()[serviceName]
-	if !isSupported {
+	if !terraformutils.SelectProviderService(&p.Provider, p.GetSupportedService(), serviceName, verbose, p.GetName()) {
 		return errors.New(p.GetName() + ": " + serviceName + " not supported service")
 	}
-	p.Service = service
-	terraformutils.ConfigureService(p.Service, serviceName, verbose, p.GetName())
 	p.Service.SetArgs(map[string]interface{}{
 		"owner":           p.owner,
 		"token":           p.token,

--- a/providers/gitlab/gitlab_provider.go
+++ b/providers/gitlab/gitlab_provider.go
@@ -72,14 +72,9 @@ func (p *GitLabProvider) GetName() string {
 }
 
 func (p *GitLabProvider) InitService(serviceName string, verbose bool) error {
-	p.Service = nil
-
-	service, isSupported := p.GetSupportedService()[serviceName]
-	if !isSupported {
+	if !terraformutils.SelectProviderService(&p.Provider, p.GetSupportedService(), serviceName, verbose, p.GetName()) {
 		return errors.New(p.GetName() + ": " + serviceName + " not supported service")
 	}
-	p.Service = service
-	terraformutils.ConfigureService(p.Service, serviceName, verbose, p.GetName())
 	p.Service.SetArgs(map[string]interface{}{
 		"group":    p.group,
 		"token":    p.token,

--- a/providers/gmailfilter/gmailfilter_provider.go
+++ b/providers/gmailfilter/gmailfilter_provider.go
@@ -38,14 +38,9 @@ func (p *GmailfilterProvider) GetName() string {
 }
 
 func (p *GmailfilterProvider) InitService(serviceName string, verbose bool) error {
-	p.Service = nil
-
-	service, isSupported := p.GetSupportedService()[serviceName]
-	if !isSupported {
+	if !terraformutils.SelectProviderService(&p.Provider, p.GetSupportedService(), serviceName, verbose, p.GetName()) {
 		return errors.New("gmailfilter: " + serviceName + " not supported service")
 	}
-	p.Service = service
-	terraformutils.ConfigureService(p.Service, serviceName, verbose, p.GetName())
 	p.Service.SetArgs(map[string]interface{}{
 		"credentials":           p.credentials,
 		"impersonatedUserEmail": p.impersonatedUserEmail,

--- a/providers/grafana/grafana_provider.go
+++ b/providers/grafana/grafana_provider.go
@@ -97,15 +97,10 @@ func (p *GrafanaProvider) GetName() string {
 }
 
 func (p *GrafanaProvider) InitService(serviceName string, verbose bool) error {
-	p.Service = nil
-
-	service, isSupported := p.GetSupportedService()[serviceName]
-	if !isSupported {
+	if !terraformutils.SelectProviderService(&p.Provider, p.GetSupportedService(), serviceName, verbose, p.GetName()) {
 		return errors.New(p.GetName() + ": " + serviceName + " not supported service")
 	}
 
-	p.Service = service
-	terraformutils.ConfigureService(p.Service, serviceName, verbose, p.GetName())
 	p.Service.SetArgs(map[string]interface{}{
 		"org_id":               p.orgID,
 		"url":                  p.url,

--- a/providers/heroku/heroku_provider.go
+++ b/providers/heroku/heroku_provider.go
@@ -57,14 +57,9 @@ func (p *HerokuProvider) GetSupportedService() map[string]terraformutils.Service
 }
 
 func (p *HerokuProvider) InitService(serviceName string, verbose bool) error {
-	p.Service = nil
-
-	service, isSupported := p.GetSupportedService()[serviceName]
-	if !isSupported {
+	if !terraformutils.SelectProviderService(&p.Provider, p.GetSupportedService(), serviceName, verbose, p.GetName()) {
 		return errors.New("heroku: " + serviceName + " not supported service")
 	}
-	p.Service = service
-	terraformutils.ConfigureService(p.Service, serviceName, verbose, p.GetName())
 	p.Service.SetArgs(map[string]interface{}{
 		"api_key": p.apiKey,
 		"team":    p.team,

--- a/providers/honeycombio/honeycomb_provider.go
+++ b/providers/honeycombio/honeycomb_provider.go
@@ -92,14 +92,9 @@ func (p *HoneycombProvider) GetConfig() cty.Value {
 }
 
 func (p *HoneycombProvider) InitService(serviceName string, verbose bool) error {
-	p.Service = nil
-
-	service, isSupported := p.GetSupportedService()[serviceName]
-	if !isSupported {
+	if !terraformutils.SelectProviderService(&p.Provider, p.GetSupportedService(), serviceName, verbose, p.GetName()) {
 		return errors.New("honeycombio: " + serviceName + " is not a supported resource type")
 	}
-	p.Service = service
-	terraformutils.ConfigureService(p.Service, serviceName, verbose, p.GetName())
 	p.Service.SetArgs(map[string]interface{}{
 		"api_key":  p.apiKey,
 		"api_url":  p.apiURL,

--- a/providers/ibm/ibm_provider.go
+++ b/providers/ibm/ibm_provider.go
@@ -201,14 +201,9 @@ func (p *IBMProvider) GetSupportedService() map[string]terraformutils.ServiceGen
 }
 
 func (p *IBMProvider) InitService(serviceName string, verbose bool) error {
-	p.Service = nil
-
-	service, isSupported := p.GetSupportedService()[serviceName]
-	if !isSupported {
+	if !terraformutils.SelectProviderService(&p.Provider, p.GetSupportedService(), serviceName, verbose, p.GetName()) {
 		return errors.New("IBM: " + serviceName + " not supported service")
 	}
-	p.Service = service
-	terraformutils.ConfigureService(p.Service, serviceName, verbose, p.GetName())
 
 	p.Service.SetArgs(map[string]interface{}{
 		"resource_group": p.ResourceGroup,

--- a/providers/ionoscloud/ionoscloud_provider.go
+++ b/providers/ionoscloud/ionoscloud_provider.go
@@ -151,14 +151,9 @@ func (p *IonosCloudProvider) GetSupportedService() map[string]terraformutils.Ser
 }
 
 func (p *IonosCloudProvider) InitService(serviceName string, verbose bool) error {
-	p.Service = nil
-
-	service, isSupported := p.GetSupportedService()[serviceName]
-	if !isSupported {
+	if !terraformutils.SelectProviderService(&p.Provider, p.GetSupportedService(), serviceName, verbose, p.GetName()) {
 		return errors.New(helpers.Ionos + ": " + serviceName + " not supported service")
 	}
-	p.Service = service
-	terraformutils.ConfigureService(p.Service, serviceName, verbose, p.GetName())
 	p.Service.SetArgs(map[string]interface{}{
 		"username": p.username,
 		"password": p.password,

--- a/providers/keycloak/keycloak_provider.go
+++ b/providers/keycloak/keycloak_provider.go
@@ -92,14 +92,9 @@ func (p *KeycloakProvider) GetBasicConfig() cty.Value {
 }
 
 func (p *KeycloakProvider) InitService(serviceName string, verbose bool) error {
-	p.Service = nil
-
-	service, isSupported := p.GetSupportedService()[serviceName]
-	if !isSupported {
+	if !terraformutils.SelectProviderService(&p.Provider, p.GetSupportedService(), serviceName, verbose, p.GetName()) {
 		return errors.New(p.GetName() + ": " + serviceName + " not supported service")
 	}
-	p.Service = service
-	terraformutils.ConfigureService(p.Service, serviceName, verbose, p.GetName())
 	p.Service.SetArgs(map[string]interface{}{
 		"url":                      p.url,
 		"base_path":                p.basePath,

--- a/providers/kubernetes/kubernetes_provider.go
+++ b/providers/kubernetes/kubernetes_provider.go
@@ -54,14 +54,9 @@ func (p *KubernetesProvider) GetName() string {
 }
 
 func (p *KubernetesProvider) InitService(serviceName string, verbose bool) error {
-	p.Service = nil
-
-	service, isSupported := p.GetSupportedService()[serviceName]
-	if !isSupported {
+	if !terraformutils.SelectProviderService(&p.Provider, p.GetSupportedService(), serviceName, verbose, p.GetName()) {
 		return errors.New("kubernetes: " + serviceName + " not supported resource")
 	}
-	p.Service = service
-	terraformutils.ConfigureService(p.Service, serviceName, verbose, p.GetName())
 	return nil
 }
 

--- a/providers/launchdarkly/launchdarkly_provider.go
+++ b/providers/launchdarkly/launchdarkly_provider.go
@@ -89,14 +89,9 @@ func (p *LaunchDarklyProvider) GetSupportedService() map[string]terraformutils.S
 }
 
 func (p *LaunchDarklyProvider) InitService(serviceName string, verbose bool) error {
-	p.Service = nil
-
-	service, isSupported := p.GetSupportedService()[serviceName]
-	if !isSupported {
+	if !terraformutils.SelectProviderService(&p.Provider, p.GetSupportedService(), serviceName, verbose, p.GetName()) {
 		return errors.New("launchdarkly: " + serviceName + " not supported service")
 	}
-	p.Service = service
-	terraformutils.ConfigureService(p.Service, serviceName, verbose, p.GetName())
 	p.Service.SetArgs(map[string]interface{}{
 		"api_key": p.apiKey,
 		"client":  p.client,

--- a/providers/linode/linode_provider.go
+++ b/providers/linode/linode_provider.go
@@ -53,14 +53,9 @@ func (p *LinodeProvider) GetSupportedService() map[string]terraformutils.Service
 }
 
 func (p *LinodeProvider) InitService(serviceName string, verbose bool) error {
-	p.Service = nil
-
-	service, isSupported := p.GetSupportedService()[serviceName]
-	if !isSupported {
+	if !terraformutils.SelectProviderService(&p.Provider, p.GetSupportedService(), serviceName, verbose, p.GetName()) {
 		return errors.New("linode: " + serviceName + " not supported service")
 	}
-	p.Service = service
-	terraformutils.ConfigureService(p.Service, serviceName, verbose, p.GetName())
 	p.Service.SetArgs(map[string]interface{}{
 		"token": p.token,
 	})

--- a/providers/logzio/logzio_provider.go
+++ b/providers/logzio/logzio_provider.go
@@ -53,14 +53,9 @@ func (p *LogzioProvider) GetName() string {
 }
 
 func (p *LogzioProvider) InitService(serviceName string, verbose bool) error {
-	p.Service = nil
-
-	service, isSupported := p.GetSupportedService()[serviceName]
-	if !isSupported {
+	if !terraformutils.SelectProviderService(&p.Provider, p.GetSupportedService(), serviceName, verbose, p.GetName()) {
 		return errors.New(p.GetName() + ": " + serviceName + " not supported service")
 	}
-	p.Service = service
-	terraformutils.ConfigureService(p.Service, serviceName, verbose, p.GetName())
 	p.Service.SetArgs(map[string]interface{}{
 		"api_token": p.apiToken,
 		"base_url":  p.baseURL,

--- a/providers/mackerel/mackerel_provider.go
+++ b/providers/mackerel/mackerel_provider.go
@@ -35,14 +35,9 @@ func (p *MackerelProvider) Init(args []string) error {
 
 // InitService ...
 func (p *MackerelProvider) InitService(serviceName string, verbose bool) error {
-	p.Service = nil
-
-	service, isSupported := p.GetSupportedService()[serviceName]
-	if !isSupported {
+	if !terraformutils.SelectProviderService(&p.Provider, p.GetSupportedService(), serviceName, verbose, p.GetName()) {
 		return errors.New(p.GetName() + ": " + serviceName + " not supported service")
 	}
-	p.Service = service
-	terraformutils.ConfigureService(p.Service, serviceName, verbose, p.GetName())
 	p.Service.SetArgs(map[string]interface{}{
 		"api-key":        p.apiKey,
 		"mackerelClient": p.mackerelClient,

--- a/providers/mikrotik/mikrotik_provider.go
+++ b/providers/mikrotik/mikrotik_provider.go
@@ -46,14 +46,9 @@ func (p *MikrotikProvider) GetSupportedService() map[string]terraformutils.Servi
 }
 
 func (p *MikrotikProvider) InitService(serviceName string, verbose bool) error {
-	p.Service = nil
-
-	service, isSupported := p.GetSupportedService()[serviceName]
-	if !isSupported {
+	if !terraformutils.SelectProviderService(&p.Provider, p.GetSupportedService(), serviceName, verbose, p.GetName()) {
 		return errors.New("mikrotik: " + serviceName + " not supported service")
 	}
-	p.Service = service
-	terraformutils.ConfigureService(p.Service, serviceName, verbose, p.GetName())
 	p.Service.SetArgs(map[string]interface{}{
 		"host":           p.Host,
 		"user":           p.Username,

--- a/providers/myrasec/myrasec_provider.go
+++ b/providers/myrasec/myrasec_provider.go
@@ -49,14 +49,9 @@ func (p *MyrasecProvider) GetSupportedService() map[string]terraformutils.Servic
 
 // InitService
 func (p *MyrasecProvider) InitService(serviceName string, verbose bool) error {
-	p.Service = nil
-
-	service, isSupported := p.GetSupportedService()[serviceName]
-	if !isSupported {
+	if !terraformutils.SelectProviderService(&p.Provider, p.GetSupportedService(), serviceName, verbose, p.GetName()) {
 		return errors.New("myrasec: " + serviceName + " not supported service")
 	}
-	p.Service = service
-	terraformutils.ConfigureService(p.Service, serviceName, verbose, p.GetName())
 
 	return nil
 }

--- a/providers/newrelic/newrelic_provider.go
+++ b/providers/newrelic/newrelic_provider.go
@@ -90,14 +90,9 @@ func (p *NewRelicProvider) GetSupportedService() map[string]terraformutils.Servi
 }
 
 func (p *NewRelicProvider) InitService(serviceName string, verbose bool) error {
-	p.Service = nil
-
-	service, isSupported := p.GetSupportedService()[serviceName]
-	if !isSupported {
+	if !terraformutils.SelectProviderService(&p.Provider, p.GetSupportedService(), serviceName, verbose, p.GetName()) {
 		return errors.New("newrelic: " + serviceName + " not supported service")
 	}
-	p.Service = service
-	terraformutils.ConfigureService(p.Service, serviceName, verbose, p.GetName())
 	p.Service.SetArgs(map[string]interface{}{"apiKey": p.APIKey})
 
 	return nil

--- a/providers/ns1/ns1_provider.go
+++ b/providers/ns1/ns1_provider.go
@@ -47,14 +47,9 @@ func (p *Ns1Provider) GetSupportedService() map[string]terraformutils.ServiceGen
 }
 
 func (p *Ns1Provider) InitService(serviceName string, verbose bool) error {
-	p.Service = nil
-
-	service, isSupported := p.GetSupportedService()[serviceName]
-	if !isSupported {
+	if !terraformutils.SelectProviderService(&p.Provider, p.GetSupportedService(), serviceName, verbose, p.GetName()) {
 		return errors.New("ns1: " + serviceName + " not supported service")
 	}
-	p.Service = service
-	terraformutils.ConfigureService(p.Service, serviceName, verbose, p.GetName())
 	p.Service.SetArgs(map[string]interface{}{
 		"api_key": p.apiKey,
 	})

--- a/providers/octopusdeploy/octopusdeploy_provider.go
+++ b/providers/octopusdeploy/octopusdeploy_provider.go
@@ -74,14 +74,9 @@ func (p *OctopusDeployProvider) GetSupportedService() map[string]terraformutils.
 }
 
 func (p *OctopusDeployProvider) InitService(serviceName string, verbose bool) error {
-	p.Service = nil
-
-	service, isSupported := p.GetSupportedService()[serviceName]
-	if !isSupported {
+	if !terraformutils.SelectProviderService(&p.Provider, p.GetSupportedService(), serviceName, verbose, p.GetName()) {
 		return errors.New("octopusdeploy: " + serviceName + " not supported service, see list sub-command")
 	}
-	p.Service = service
-	terraformutils.ConfigureService(p.Service, serviceName, verbose, p.GetName())
 	p.Service.SetArgs(map[string]interface{}{
 		"api_key": p.apiKey,
 		"address": p.address,

--- a/providers/okta/okta_provider.go
+++ b/providers/okta/okta_provider.go
@@ -65,14 +65,9 @@ func (p *OktaProvider) GetName() string {
 }
 
 func (p *OktaProvider) InitService(serviceName string, verbose bool) error {
-	p.Service = nil
-
-	service, isSupported := p.GetSupportedService()[serviceName]
-	if !isSupported {
+	if !terraformutils.SelectProviderService(&p.Provider, p.GetSupportedService(), serviceName, verbose, p.GetName()) {
 		return errors.New(p.GetName() + ": " + serviceName + " is not a supported service")
 	}
-	p.Service = service
-	terraformutils.ConfigureService(p.Service, serviceName, verbose, p.GetName())
 	p.Service.SetArgs(map[string]interface{}{
 		"org_name":  p.orgName,
 		"base_url":  p.baseURL,

--- a/providers/opal/opal_provider.go
+++ b/providers/opal/opal_provider.go
@@ -92,14 +92,9 @@ func (p *OpalProvider) GetConfig() cty.Value {
 }
 
 func (p *OpalProvider) InitService(serviceName string, verbose bool) error {
-	p.Service = nil
-
-	service, isSupported := p.GetSupportedService()[serviceName]
-	if !isSupported {
+	if !terraformutils.SelectProviderService(&p.Provider, p.GetSupportedService(), serviceName, verbose, p.GetName()) {
 		return errors.New("opal: " + serviceName + " is not a supported resource type")
 	}
-	p.Service = service
-	terraformutils.ConfigureService(p.Service, serviceName, verbose, p.GetName())
 	p.Service.SetArgs(map[string]interface{}{
 		"token":    p.token,
 		"base_url": p.baseURL,

--- a/providers/openstack/openstack_provider.go
+++ b/providers/openstack/openstack_provider.go
@@ -48,14 +48,9 @@ func (p *OpenStackProvider) GetName() string {
 }
 
 func (p *OpenStackProvider) InitService(serviceName string, verbose bool) error {
-	p.Service = nil
-
-	service, isSupported := p.GetSupportedService()[serviceName]
-	if !isSupported {
+	if !terraformutils.SelectProviderService(&p.Provider, p.GetSupportedService(), serviceName, verbose, p.GetName()) {
 		return errors.New("openstack: " + serviceName + " not supported service")
 	}
-	p.Service = service
-	terraformutils.ConfigureService(p.Service, serviceName, verbose, p.GetName())
 	p.Service.SetArgs(map[string]interface{}{
 		"region": p.region,
 	})

--- a/providers/opsgenie/opsgenie_provider.go
+++ b/providers/opsgenie/opsgenie_provider.go
@@ -29,14 +29,9 @@ func (p *OpsgenieProvider) Init(args []string) error {
 }
 
 func (p *OpsgenieProvider) InitService(serviceName string, verbose bool) error {
-	p.Service = nil
-
-	service, isSupported := p.GetSupportedService()[serviceName]
-	if !isSupported {
+	if !terraformutils.SelectProviderService(&p.Provider, p.GetSupportedService(), serviceName, verbose, p.GetName()) {
 		return errors.New(p.GetName() + ": " + serviceName + " not supported service")
 	}
-	p.Service = service
-	terraformutils.ConfigureService(p.Service, serviceName, verbose, p.GetName())
 	p.Service.SetArgs(map[string]interface{}{
 		"api-key": p.APIKey,
 	})

--- a/providers/pagerduty/pagerduty_provider.go
+++ b/providers/pagerduty/pagerduty_provider.go
@@ -62,14 +62,9 @@ func (p *PagerDutyProvider) GetSupportedService() map[string]terraformutils.Serv
 }
 
 func (p *PagerDutyProvider) InitService(serviceName string, verbose bool) error {
-	p.Service = nil
-
-	service, isSupported := p.GetSupportedService()[serviceName]
-	if !isSupported {
+	if !terraformutils.SelectProviderService(&p.Provider, p.GetSupportedService(), serviceName, verbose, p.GetName()) {
 		return errors.New(p.GetName() + ": " + serviceName + " not supported service")
 	}
-	p.Service = service
-	terraformutils.ConfigureService(p.Service, serviceName, verbose, p.GetName())
 	p.Service.SetArgs(map[string]interface{}{
 		"token": p.token,
 	})

--- a/providers/panos/panos_provider.go
+++ b/providers/panos/panos_provider.go
@@ -41,15 +41,10 @@ func (p *PanosProvider) GetBasicConfig() cty.Value {
 }
 
 func (p *PanosProvider) InitService(serviceName string, verbose bool) error {
-	p.Service = nil
-
-	service, isSupported := p.GetSupportedService()[serviceName]
-	if !isSupported {
+	if !terraformutils.SelectProviderService(&p.Provider, p.GetSupportedService(), serviceName, verbose, p.GetName()) {
 		return errors.New(p.GetName() + ": " + serviceName + " not supported service")
 	}
 
-	p.Service = service
-	terraformutils.ConfigureService(p.Service, serviceName, verbose, p.GetName())
 	p.Service.SetArgs(map[string]interface{}{
 		"vsys": p.vsys,
 	})

--- a/providers/rabbitmq/rabbitmq_provider.go
+++ b/providers/rabbitmq/rabbitmq_provider.go
@@ -48,14 +48,9 @@ func (p *RBTProvider) GetBasicConfig() cty.Value {
 }
 
 func (p *RBTProvider) InitService(serviceName string, verbose bool) error {
-	p.Service = nil
-
-	service, isSupported := p.GetSupportedService()[serviceName]
-	if !isSupported {
+	if !terraformutils.SelectProviderService(&p.Provider, p.GetSupportedService(), serviceName, verbose, p.GetName()) {
 		return errors.New(p.GetName() + ": " + serviceName + " not supported service")
 	}
-	p.Service = service
-	terraformutils.ConfigureService(p.Service, serviceName, verbose, p.GetName())
 	p.Service.SetArgs(map[string]interface{}{
 		"endpoint": p.endpoint,
 		"username": p.username,

--- a/providers/tencentcloud/tencentcloud_provider.go
+++ b/providers/tencentcloud/tencentcloud_provider.go
@@ -65,14 +65,9 @@ func (p *TencentCloudProvider) Init(args []string) error {
 }
 
 func (p *TencentCloudProvider) InitService(serviceName string, verbose bool) error {
-	p.Service = nil
-
-	service, isSupported := p.GetSupportedService()[serviceName]
-	if !isSupported {
+	if !terraformutils.SelectProviderService(&p.Provider, p.GetSupportedService(), serviceName, verbose, p.GetName()) {
 		return errors.New("tencentcloud: " + serviceName + " not supported service")
 	}
-	p.Service = service
-	terraformutils.ConfigureService(p.Service, serviceName, verbose, p.GetName())
 	p.Service.SetArgs(map[string]interface{}{
 		"region":     p.region,
 		"credential": p.credential,

--- a/providers/vault/vault_provider.go
+++ b/providers/vault/vault_provider.go
@@ -47,16 +47,12 @@ func (p *Provider) GetName() string {
 }
 
 func (p *Provider) InitService(serviceName string, verbose bool) error {
-	p.Service = nil
-
-	if service, ok := p.GetSupportedService()[serviceName]; ok {
-		p.Service = service
-		terraformutils.ConfigureService(p.Service, serviceName, verbose, p.GetName())
+	if terraformutils.SelectProviderService(&p.Provider, p.GetSupportedService(), serviceName, verbose, p.GetName()) {
 		p.Service.SetArgs(map[string]interface{}{
 			"token":   p.token,
 			"address": p.address,
 		})
-		if err := service.(*ServiceGenerator).setVaultClient(); err != nil {
+		if err := p.Service.(*ServiceGenerator).setVaultClient(); err != nil {
 			return err
 		}
 		return nil

--- a/providers/vultr/vultr_provider.go
+++ b/providers/vultr/vultr_provider.go
@@ -55,14 +55,9 @@ func (p *VultrProvider) GetSupportedService() map[string]terraformutils.ServiceG
 }
 
 func (p *VultrProvider) InitService(serviceName string, verbose bool) error {
-	p.Service = nil
-
-	service, isSupported := p.GetSupportedService()[serviceName]
-	if !isSupported {
+	if !terraformutils.SelectProviderService(&p.Provider, p.GetSupportedService(), serviceName, verbose, p.GetName()) {
 		return errors.New("vultr: " + serviceName + " not supported service")
 	}
-	p.Service = service
-	terraformutils.ConfigureService(p.Service, serviceName, verbose, p.GetName())
 	p.Service.SetArgs(map[string]interface{}{
 		"api_key": p.apiKey,
 	})

--- a/providers/xenorchestra/xenorchestra_provider.go
+++ b/providers/xenorchestra/xenorchestra_provider.go
@@ -70,14 +70,9 @@ func (p *XenorchestraProvider) GetSupportedService() map[string]terraformutils.S
 }
 
 func (p *XenorchestraProvider) InitService(serviceName string, verbose bool) error {
-	p.Service = nil
-
-	service, isSupported := p.GetSupportedService()[serviceName]
-	if !isSupported {
+	if !terraformutils.SelectProviderService(&p.Provider, p.GetSupportedService(), serviceName, verbose, p.GetName()) {
 		return errors.New("xenorchestra: " + serviceName + " not supported service")
 	}
-	p.Service = service
-	terraformutils.ConfigureService(p.Service, serviceName, verbose, p.GetName())
 	p.Service.SetArgs(map[string]interface{}{
 		"url":      p.url,
 		"username": p.user,

--- a/providers/yandex/yandex_provider.go
+++ b/providers/yandex/yandex_provider.go
@@ -64,14 +64,9 @@ func (p *YandexProvider) GetSupportedService() map[string]terraformutils.Service
 }
 
 func (p *YandexProvider) InitService(serviceName string, verbose bool) error {
-	p.Service = nil
-
-	service, isSupported := p.GetSupportedService()[serviceName]
-	if !isSupported {
+	if !terraformutils.SelectProviderService(&p.Provider, p.GetSupportedService(), serviceName, verbose, p.GetName()) {
 		return errors.New("yandex: " + serviceName + " not supported service")
 	}
-	p.Service = service
-	terraformutils.ConfigureService(p.Service, serviceName, verbose, p.GetName())
 	p.Service.SetArgs(map[string]interface{}{
 		KeyFolderID:           p.folderID,
 		KeyToken:              p.token,

--- a/terraformutils/base_provider.go
+++ b/terraformutils/base_provider.go
@@ -29,6 +29,17 @@ type Provider struct {
 	Config  cty.Value
 }
 
+func SelectProviderService(provider *Provider, services map[string]ServiceGenerator, name string, verbose bool, providerName string) bool {
+	provider.Service = nil
+	service, ok := services[name]
+	if !ok {
+		return false
+	}
+	provider.Service = service
+	ConfigureService(service, name, verbose, providerName)
+	return true
+}
+
 func (p *Provider) Init(_ []string) error {
 	panic("implement me")
 }

--- a/terraformutils/base_provider_test.go
+++ b/terraformutils/base_provider_test.go
@@ -32,6 +32,30 @@ func TestProviderGetBasicConfig(t *testing.T) {
 	}
 }
 
+func TestSelectProviderService(t *testing.T) {
+	service := &Service{}
+	provider := &Provider{Service: &Service{Name: "stale"}}
+
+	if ok := SelectProviderService(provider, map[string]ServiceGenerator{
+		"vpc": service,
+	}, "vpc", true, "aws"); !ok {
+		t.Fatal("expected service selection to succeed")
+	}
+	if provider.Service != service {
+		t.Fatalf("expected selected service to be stored, got %T", provider.Service)
+	}
+	if service.GetName() != "vpc" || service.GetProviderName() != "aws" || !service.Verbose {
+		t.Fatalf("expected service metadata to be configured, got name=%q provider=%q verbose=%t", service.GetName(), service.GetProviderName(), service.Verbose)
+	}
+
+	if ok := SelectProviderService(provider, map[string]ServiceGenerator{}, "missing", false, "aws"); ok {
+		t.Fatal("expected missing service selection to fail")
+	}
+	if provider.Service != nil {
+		t.Fatalf("expected missing service to clear stale provider service, got %T", provider.Service)
+	}
+}
+
 func TestProviderInitPanics(t *testing.T) {
 	defer func() {
 		if r := recover(); r == nil {


### PR DESCRIPTION
## Summary

- Add a shared terraformutils helper for provider service selection.
- Centralize stale service clearing, supported-service lookup, and metadata setup.
- Keep provider-specific service args and unsupported-service errors unchanged.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Centralized provider service selection with `terraformutils.SelectProviderService` to remove duplicated init code and ensure consistent service metadata configuration. Behavior is unchanged: provider-specific service args and unsupported-service errors stay the same.

- **Refactors**
  - Added `terraformutils.SelectProviderService` to handle lookup, clear stale `p.Service`, and call `ConfigureService`.
  - Switched all providers to use the helper; simplified `InitService` implementations.
  - Updated Vault to use the selected `p.Service` before setting args and initializing the client.
  - Added a unit test to validate selection and metadata setup.

<sup>Written for commit 1e1b5ca982bc5d2dcc9370f223e6169597aad191. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

