### PR TITLE
fix(terraformutils): omit empty provider service names

### DIFF
--- a/terraformutils/providers_mapping.go
+++ b/terraformutils/providers_mapping.go
@@ -53,7 +53,7 @@ func (p *ProvidersMapping) AddServiceToProvider(service string) ProviderGenerato
 }
 
 func (p *ProvidersMapping) GetServices() []string {
-	services := make([]string, len(p.Services))
+	services := make([]string, 0, len(p.Services))
 	for service := range p.Services {
 		services = append(services, service)
 	}

--- a/terraformutils/providers_mapping_test.go
+++ b/terraformutils/providers_mapping_test.go
@@ -109,11 +109,15 @@ func TestGetServices(t *testing.T) {
 	pm.AddServiceToProvider("ec2")
 
 	services := pm.GetServices()
+	if len(services) != 2 {
+		t.Fatalf("expected 2 services, got %d: %v", len(services), services)
+	}
 	found := map[string]bool{}
 	for _, s := range services {
-		if s != "" {
-			found[s] = true
+		if s == "" {
+			t.Fatalf("GetServices returned empty service: %v", services)
 		}
+		found[s] = true
 	}
 	if !found["vpc"] || !found["ec2"] {
 		t.Errorf("GetServices missing expected services, got %v", services)
@@ -311,21 +315,15 @@ func TestGetServicesSorted(t *testing.T) {
 	pm.AddServiceToProvider("vpc")
 
 	services := pm.GetServices()
-	nonEmpty := []string{}
-	for _, s := range services {
-		if s != "" {
-			nonEmpty = append(nonEmpty, s)
-		}
-	}
-	sort.Strings(nonEmpty)
+	sort.Strings(services)
 
 	want := []string{"ec2", "s3", "vpc"}
-	if len(nonEmpty) != len(want) {
-		t.Fatalf("expected %d services, got %d: %v", len(want), len(nonEmpty), nonEmpty)
+	if len(services) != len(want) {
+		t.Fatalf("expected %d services, got %d: %v", len(want), len(services), services)
 	}
 	for i, s := range want {
-		if nonEmpty[i] != s {
-			t.Errorf("sorted service[%d] = %q, want %q", i, nonEmpty[i], s)
+		if services[i] != s {
+			t.Errorf("sorted service[%d] = %q, want %q", i, services[i], s)
 		}
 	}
 }


### PR DESCRIPTION
## Summary

- Fix provider service listing to avoid leading empty service names.
- Tighten provider mapping tests so empty service entries are not filtered away.
- Preserve existing service membership behavior while returning only registered services.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix provider service listing in `terraformutils` to omit empty service names and return only registered services. Tightens tests to assert non-empty entries.

- **Bug Fixes**
  - Build services slice with length 0 and capacity `len(p.Services)` in `ProvidersMapping.GetServices` to prevent leading empty names.
  - Update tests to fail on empty strings, check expected counts, and sort the full list without filtering.

<sup>Written for commit 8b8b810d8e8198dc10fb07e25f8218f669eab0c8. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

