### PR TITLE
feat(kubernetes): enforce native manifest policy

### DIFF
--- a/docs/kubernetes.md
+++ b/docs/kubernetes.md
@@ -11,6 +11,7 @@ Terraformer discovers Kubernetes API resources from the active cluster and impor
 Discovered CRDs, other untyped API extensions, and selected native APIs without a first-class Terraform Kubernetes provider type can be imported through `kubernetes_manifest` when the API resource is manageable and the installed provider supports that resource.
 Manifest-backed resources use a group/version-qualified resource selector such as `example.com/v1/widgets`, `apps/v1/replicasets`, `v1/podtemplates`, or `admissionregistration.k8s.io/v1/validatingadmissionpolicybindings` to avoid collisions between API resources that share the same plural name.
 For selected native manifest-backed resources, beta and alpha variants are supported when the cluster advertises them and they satisfy the required management verbs. For example, use selectors like `certificates.k8s.io/v1beta1/clustertrustbundles`, `scheduling.k8s.io/v1alpha2/workloads`, or `storagemigration.k8s.io/v1alpha1/storageversionmigrations` on clusters that still serve those versions.
+Native Kubernetes API groups only use `kubernetes_manifest` when the resource kind is explicitly selected for manifest-backed import; unselected native kinds are skipped instead of falling through the generic CRD import path.
 Terraformer intentionally skips `PodCertificateRequest` (`podcertificaterequests`) even when served, because kubelets generate these runtime certificate request objects and their specs include pod, node, service account, and proof material that should not become Terraform-owned configuration.
 Terraformer also skips native runtime or controller-generated APIs such as `ResourceSlice`, `PodScheduling`/`PodSchedulingContext`, `IPAddress`, `PodGroup`, `ControllerRevision`, `LeaseCandidate`, `CSINode`, `CSIStorageCapacity`, and `VolumeAttachment`, even when an older served version is not recognized by the pinned typed client.
 When `labels` or `annotations` are selected with full resource imports, Terraformer keeps the full resource import and skips overlapping metadata-only resources to avoid duplicate Terraform ownership of the same object metadata.
@@ -142,6 +143,22 @@ Common supported resources include:
 *   `resource.k8s.io/v1alpha3/resourceclaims`
     * `kubernetes_manifest`
 *   `resource.k8s.io/v1alpha3/resourceclaimtemplates`
+    * `kubernetes_manifest`
+*   `resource.k8s.io/v1alpha2/resourceclasses`
+    * `kubernetes_manifest`
+*   `resource.k8s.io/v1alpha2/resourceclassparameters`
+    * `kubernetes_manifest`
+*   `resource.k8s.io/v1alpha2/resourceclaims`
+    * `kubernetes_manifest`
+*   `resource.k8s.io/v1alpha2/resourceclaimparameters`
+    * `kubernetes_manifest`
+*   `resource.k8s.io/v1alpha2/resourceclaimtemplates`
+    * `kubernetes_manifest`
+*   `resource.k8s.io/v1alpha1/resourceclasses`
+    * `kubernetes_manifest`
+*   `resource.k8s.io/v1alpha1/resourceclaims`
+    * `kubernetes_manifest`
+*   `resource.k8s.io/v1alpha1/resourceclaimtemplates`
     * `kubernetes_manifest`
 *   `resourcequotas`
     * `kubernetes_resource_quota_v1`

--- a/docs/kubernetes.md
+++ b/docs/kubernetes.md
@@ -8,10 +8,11 @@ Example:
 ```
 
 Terraformer discovers Kubernetes API resources from the active cluster and imports resources that are available through either the typed Kubernetes client or an explicit dynamic-client import path, and the installed Terraform Kubernetes provider schema.
+This provider's native Kubernetes resource policy is scoped to Kubernetes 1.33 through 1.35; historical alpha APIs that only existed before that support window are not added as native manifest selectors.
 Discovered CRDs, other untyped API extensions, and selected native APIs without a first-class Terraform Kubernetes provider type can be imported through `kubernetes_manifest` when the API resource is manageable and the installed provider supports that resource.
 Manifest-backed resources use a group/version-qualified resource selector such as `example.com/v1/widgets`, `apps/v1/replicasets`, `v1/podtemplates`, or `admissionregistration.k8s.io/v1/validatingadmissionpolicybindings` to avoid collisions between API resources that share the same plural name.
 For selected native manifest-backed resources, beta and alpha variants are supported when the cluster advertises them and they satisfy the required management verbs. For example, use selectors like `certificates.k8s.io/v1beta1/clustertrustbundles`, `scheduling.k8s.io/v1alpha2/workloads`, or `storagemigration.k8s.io/v1alpha1/storageversionmigrations` on clusters that still serve those versions.
-Native Kubernetes API groups only use `kubernetes_manifest` when the resource kind is explicitly selected for manifest-backed import; unselected native kinds are skipped instead of falling through the generic CRD import path.
+Native Kubernetes API groups only use `kubernetes_manifest` when the resource kind is explicitly selected for manifest-backed import; unselected native kinds are skipped instead of falling through the generic CRD import path. Run with `--verbose` to log native API resources skipped by this policy or by generated-resource safeguards.
 Terraformer intentionally skips `PodCertificateRequest` (`podcertificaterequests`) even when served, because kubelets generate these runtime certificate request objects and their specs include pod, node, service account, and proof material that should not become Terraform-owned configuration.
 Terraformer also skips native runtime or controller-generated APIs such as `ResourceSlice`, `PodScheduling`/`PodSchedulingContext`, `IPAddress`, `PodGroup`, `ControllerRevision`, `LeaseCandidate`, `CSINode`, `CSIStorageCapacity`, and `VolumeAttachment`, even when an older served version is not recognized by the pinned typed client.
 When `labels` or `annotations` are selected with full resource imports, Terraformer keeps the full resource import and skips overlapping metadata-only resources to avoid duplicate Terraform ownership of the same object metadata.
@@ -143,22 +144,6 @@ Common supported resources include:
 *   `resource.k8s.io/v1alpha3/resourceclaims`
     * `kubernetes_manifest`
 *   `resource.k8s.io/v1alpha3/resourceclaimtemplates`
-    * `kubernetes_manifest`
-*   `resource.k8s.io/v1alpha2/resourceclasses`
-    * `kubernetes_manifest`
-*   `resource.k8s.io/v1alpha2/resourceclassparameters`
-    * `kubernetes_manifest`
-*   `resource.k8s.io/v1alpha2/resourceclaims`
-    * `kubernetes_manifest`
-*   `resource.k8s.io/v1alpha2/resourceclaimparameters`
-    * `kubernetes_manifest`
-*   `resource.k8s.io/v1alpha2/resourceclaimtemplates`
-    * `kubernetes_manifest`
-*   `resource.k8s.io/v1alpha1/resourceclasses`
-    * `kubernetes_manifest`
-*   `resource.k8s.io/v1alpha1/resourceclaims`
-    * `kubernetes_manifest`
-*   `resource.k8s.io/v1alpha1/resourceclaimtemplates`
     * `kubernetes_manifest`
 *   `resourcequotas`
     * `kubernetes_resource_quota_v1`

--- a/providers/kubernetes/kind.go
+++ b/providers/kubernetes/kind.go
@@ -54,9 +54,15 @@ func (k *Kind) InitResources() error {
 }
 
 func (k *Kind) initTypedResources(clientset kubernetes.Interface) error {
-	group := reflect.ValueOf(clientset).MethodByName(
-		extractClientSetFuncGroupName(k.Group, k.Version)).Call(
-		[]reflect.Value{})[0]
+	groupMethod := reflect.ValueOf(clientset).MethodByName(extractClientSetFuncGroupName(k.Group, k.Version))
+	if !groupMethod.IsValid() {
+		return fmt.Errorf("kubernetes: typed client group %s is not supported", kubernetesResourceLogName(k.Group, k.Version, k.Name))
+	}
+	groupValues := groupMethod.Call([]reflect.Value{})
+	if len(groupValues) == 0 || !groupValues[0].IsValid() {
+		return fmt.Errorf("kubernetes: typed client group %s is not supported", kubernetesResourceLogName(k.Group, k.Version, k.Name))
+	}
+	group := groupValues[0]
 
 	param := []reflect.Value{}
 	namespace := ""
@@ -64,7 +70,15 @@ func (k *Kind) initTypedResources(clientset kubernetes.Interface) error {
 		param = append(param, reflect.ValueOf(namespace))
 	}
 
-	resource := group.MethodByName(extractClientSetFuncTypeName(k.Name)).Call(param)[0]
+	resourceMethod := group.MethodByName(extractClientSetFuncTypeName(k.Name))
+	if !resourceMethod.IsValid() {
+		return fmt.Errorf("kubernetes: typed client resource %s is not supported", kubernetesResourceLogName(k.Group, k.Version, k.Name))
+	}
+	resourceValues := resourceMethod.Call(param)
+	if len(resourceValues) == 0 || !resourceValues[0].IsValid() {
+		return fmt.Errorf("kubernetes: typed client resource %s is not supported", kubernetesResourceLogName(k.Group, k.Version, k.Name))
+	}
+	resource := resourceValues[0]
 
 	results := resource.MethodByName("List").Call([]reflect.Value{reflect.ValueOf(context.Background()),
 		reflect.ValueOf(metav1.ListOptions{})})

--- a/providers/kubernetes/kind_test.go
+++ b/providers/kubernetes/kind_test.go
@@ -3,6 +3,7 @@
 package kubernetes
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/chenrui333/terraformer/terraformutils"
@@ -12,7 +13,39 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	dynamicfake "k8s.io/client-go/dynamic/fake"
+	"k8s.io/client-go/kubernetes/fake"
 )
+
+func TestInitTypedResourcesUnsupportedGroup(t *testing.T) {
+	kind := &Kind{
+		Group:   "example.com",
+		Version: "v1",
+		Name:    "Widget",
+	}
+
+	err := kind.initTypedResources(fake.NewSimpleClientset())
+	if err == nil {
+		t.Fatal("initTypedResources() error = nil, want error")
+	}
+	if !strings.Contains(err.Error(), "typed client group example.com/v1/Widget is not supported") {
+		t.Fatalf("initTypedResources() error = %q, want unsupported group error", err)
+	}
+}
+
+func TestInitTypedResourcesUnsupportedResource(t *testing.T) {
+	kind := &Kind{
+		Version: "v1",
+		Name:    "NotAResource",
+	}
+
+	err := kind.initTypedResources(fake.NewSimpleClientset())
+	if err == nil {
+		t.Fatal("initTypedResources() error = nil, want error")
+	}
+	if !strings.Contains(err.Error(), "typed client resource v1/NotAResource is not supported") {
+		t.Fatalf("initTypedResources() error = %q, want unsupported resource error", err)
+	}
+}
 
 func TestInitDynamicResources(t *testing.T) {
 	gvr := schema.GroupVersionResource{

--- a/providers/kubernetes/kubernetes_provider.go
+++ b/providers/kubernetes/kubernetes_provider.go
@@ -123,6 +123,11 @@ func (p *KubernetesProvider) GetSupportedService() map[string]terraformutils.Ser
 			}
 			terraformResourceName, useDynamicClient, ok := selectImportResourceName(clientset, gv.Group, gv.Version, resource, hasResourceType)
 			if !ok {
+				if p.verbose == "true" {
+					if reason := importSkipPolicyReason(clientset, gv.Group, gv.Version, resource, hasResourceType); reason != "" {
+						log.Printf("kubernetes: skipping %s (%s): %s", kubernetesResourceLogName(gv.Group, gv.Version, resource.Name), resource.Kind, reason)
+					}
+				}
 				continue
 			}
 

--- a/providers/kubernetes/utils.go
+++ b/providers/kubernetes/utils.go
@@ -131,14 +131,6 @@ var nativeManifestResources = map[kubernetesResourceID]struct{}{
 	{group: "resource.k8s.io", version: "v1alpha3", kind: "DeviceTaintRule"}:                               {},
 	{group: "resource.k8s.io", version: "v1alpha3", kind: "ResourceClaim"}:                                 {},
 	{group: "resource.k8s.io", version: "v1alpha3", kind: "ResourceClaimTemplate"}:                         {},
-	{group: "resource.k8s.io", version: "v1alpha2", kind: "ResourceClass"}:                                 {},
-	{group: "resource.k8s.io", version: "v1alpha2", kind: "ResourceClassParameters"}:                       {},
-	{group: "resource.k8s.io", version: "v1alpha2", kind: "ResourceClaim"}:                                 {},
-	{group: "resource.k8s.io", version: "v1alpha2", kind: "ResourceClaimParameters"}:                       {},
-	{group: "resource.k8s.io", version: "v1alpha2", kind: "ResourceClaimTemplate"}:                         {},
-	{group: "resource.k8s.io", version: "v1alpha1", kind: "ResourceClass"}:                                 {},
-	{group: "resource.k8s.io", version: "v1alpha1", kind: "ResourceClaim"}:                                 {},
-	{group: "resource.k8s.io", version: "v1alpha1", kind: "ResourceClaimTemplate"}:                         {},
 	{group: "scheduling.k8s.io", version: "v1alpha2", kind: "Workload"}:                                    {},
 	{group: "scheduling.k8s.io", version: "v1alpha1", kind: "Workload"}:                                    {},
 	{group: "storage.k8s.io", version: "v1", kind: "VolumeAttributesClass"}:                                {},
@@ -311,6 +303,37 @@ func selectImportResourceName(
 		return "", false, false
 	}
 	return manifestTerraformResourceName, true, true
+}
+
+func importSkipPolicyReason(
+	clientset kubernetes.Interface,
+	group string,
+	version string,
+	resource metav1.APIResource,
+	hasResourceType func(string) bool,
+) string {
+	if skipsImportResource(group, version, resource.Kind) {
+		return "runtime/controller-generated native API is not importable as Terraform-managed configuration"
+	}
+	if !isNativeAPIGroup(group) {
+		return ""
+	}
+	if supportsNativeManifestResource(group, version, resource.Kind) ||
+		supportsTypedClientResource(clientset, group, version, resource.Kind) ||
+		supportsDynamicClientResource(group, version, resource.Kind) {
+		return ""
+	}
+	if !supportsManifestResource(resource, hasResourceType) {
+		return ""
+	}
+	return "native API is outside the explicit manifest import policy"
+}
+
+func kubernetesResourceLogName(group, version, resourceName string) string {
+	if group == "" {
+		return version + "/" + resourceName
+	}
+	return group + "/" + version + "/" + resourceName
 }
 
 func supportsDynamicClientResource(group, version, kind string) bool {

--- a/providers/kubernetes/utils.go
+++ b/providers/kubernetes/utils.go
@@ -131,6 +131,14 @@ var nativeManifestResources = map[kubernetesResourceID]struct{}{
 	{group: "resource.k8s.io", version: "v1alpha3", kind: "DeviceTaintRule"}:                               {},
 	{group: "resource.k8s.io", version: "v1alpha3", kind: "ResourceClaim"}:                                 {},
 	{group: "resource.k8s.io", version: "v1alpha3", kind: "ResourceClaimTemplate"}:                         {},
+	{group: "resource.k8s.io", version: "v1alpha2", kind: "ResourceClass"}:                                 {},
+	{group: "resource.k8s.io", version: "v1alpha2", kind: "ResourceClassParameters"}:                       {},
+	{group: "resource.k8s.io", version: "v1alpha2", kind: "ResourceClaim"}:                                 {},
+	{group: "resource.k8s.io", version: "v1alpha2", kind: "ResourceClaimParameters"}:                       {},
+	{group: "resource.k8s.io", version: "v1alpha2", kind: "ResourceClaimTemplate"}:                         {},
+	{group: "resource.k8s.io", version: "v1alpha1", kind: "ResourceClass"}:                                 {},
+	{group: "resource.k8s.io", version: "v1alpha1", kind: "ResourceClaim"}:                                 {},
+	{group: "resource.k8s.io", version: "v1alpha1", kind: "ResourceClaimTemplate"}:                         {},
 	{group: "scheduling.k8s.io", version: "v1alpha2", kind: "Workload"}:                                    {},
 	{group: "scheduling.k8s.io", version: "v1alpha1", kind: "Workload"}:                                    {},
 	{group: "storage.k8s.io", version: "v1", kind: "VolumeAttributesClass"}:                                {},
@@ -206,8 +214,13 @@ var typedClientSetAPIGroups = map[string]struct{}{
 	"storage.k8s.io":               {},
 }
 
+func isNativeAPIGroup(group string) bool {
+	_, ok := typedClientSetAPIGroups[group]
+	return ok
+}
+
 func extractClientSetFuncGroupName(group, version string) string {
-	if _, ok := typedClientSetAPIGroups[group]; !ok {
+	if !isNativeAPIGroup(group) {
 		return ""
 	}
 
@@ -275,7 +288,8 @@ func selectImportResourceName(
 		if supportsDynamicClientResource(group, version, resource.Kind) {
 			return terraformResourceName, true, true
 		}
-		if supportsManifestResource(resource, hasResourceType) {
+		if supportsManifestResource(resource, hasResourceType) &&
+			(supportsNativeManifestResource(group, version, resource.Kind) || !isNativeAPIGroup(group)) {
 			return manifestTerraformResourceName, true, true
 		}
 		return "", false, false
@@ -288,6 +302,9 @@ func selectImportResourceName(
 		return manifestTerraformResourceName, true, true
 	}
 	if supportsTypedClientResource(clientset, group, version, resource.Kind) {
+		return "", false, false
+	}
+	if isNativeAPIGroup(group) {
 		return "", false, false
 	}
 	if !supportsManifestResource(resource, hasResourceType) {

--- a/providers/kubernetes/utils_test.go
+++ b/providers/kubernetes/utils_test.go
@@ -664,7 +664,7 @@ func TestSelectImportResourceName(t *testing.T) {
 			wantOK:      true,
 		},
 		{
-			name:    "falls back to manifest for legacy dynamic resource class",
+			name:    "skips legacy dynamic resource allocation resource outside supported policy",
 			group:   "resource.k8s.io",
 			version: "v1alpha2",
 			resource: metav1.APIResource{
@@ -675,43 +675,7 @@ func TestSelectImportResourceName(t *testing.T) {
 			supportedTypes: map[string]struct{}{
 				manifestTerraformResourceName: {},
 			},
-			want:        manifestTerraformResourceName,
-			wantDynamic: true,
-			wantOK:      true,
-		},
-		{
-			name:    "falls back to manifest for legacy dynamic resource parameters",
-			group:   "resource.k8s.io",
-			version: "v1alpha2",
-			resource: metav1.APIResource{
-				Name:       "resourceclaimparameters",
-				Kind:       "ResourceClaimParameters",
-				Namespaced: true,
-				Verbs:      manageableVerbs,
-			},
-			supportedTypes: map[string]struct{}{
-				manifestTerraformResourceName: {},
-			},
-			want:        manifestTerraformResourceName,
-			wantDynamic: true,
-			wantOK:      true,
-		},
-		{
-			name:    "falls back to manifest for original dynamic resource claim template",
-			group:   "resource.k8s.io",
-			version: "v1alpha1",
-			resource: metav1.APIResource{
-				Name:       "resourceclaimtemplates",
-				Kind:       "ResourceClaimTemplate",
-				Namespaced: true,
-				Verbs:      manageableVerbs,
-			},
-			supportedTypes: map[string]struct{}{
-				manifestTerraformResourceName: {},
-			},
-			want:        manifestTerraformResourceName,
-			wantDynamic: true,
-			wantOK:      true,
+			wantOK: false,
 		},
 		{
 			name:    "falls back to manifest for cluster trust bundle",
@@ -1152,6 +1116,89 @@ func TestIsNativeAPIGroup(t *testing.T) {
 	}
 }
 
+func TestImportSkipPolicyReason(t *testing.T) {
+	clientset := fake.NewSimpleClientset()
+	manageableVerbs := []string{"create", "delete", "get", "list", "patch", "update"}
+	hasManifestType := func(name string) bool {
+		return name == manifestTerraformResourceName
+	}
+
+	tests := []struct {
+		name     string
+		group    string
+		version  string
+		resource metav1.APIResource
+		want     string
+	}{
+		{
+			name:    "generated native API",
+			group:   "resource.k8s.io",
+			version: "v1",
+			resource: metav1.APIResource{
+				Name:  "resourceslices",
+				Kind:  "ResourceSlice",
+				Verbs: manageableVerbs,
+			},
+			want: "runtime/controller-generated native API is not importable as Terraform-managed configuration",
+		},
+		{
+			name:    "legacy native API outside supported manifest policy",
+			group:   "resource.k8s.io",
+			version: "v1alpha2",
+			resource: metav1.APIResource{
+				Name:  "resourceclasses",
+				Kind:  "ResourceClass",
+				Verbs: manageableVerbs,
+			},
+			want: "native API is outside the explicit manifest import policy",
+		},
+		{
+			name:    "custom resource keeps generic manifest fallback",
+			group:   "example.com",
+			version: "v1",
+			resource: metav1.APIResource{
+				Name:  "widgets",
+				Kind:  "Widget",
+				Verbs: manageableVerbs,
+			},
+		},
+		{
+			name:    "allowlisted native manifest resource",
+			group:   "resource.k8s.io",
+			version: "v1",
+			resource: metav1.APIResource{
+				Name:       "resourceclaims",
+				Kind:       "ResourceClaim",
+				Namespaced: true,
+				Verbs:      manageableVerbs,
+			},
+		},
+		{
+			name:    "native resource without manifest type",
+			group:   "resource.k8s.io",
+			version: "v1alpha2",
+			resource: metav1.APIResource{
+				Name:  "resourceclasses",
+				Kind:  "ResourceClass",
+				Verbs: manageableVerbs,
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			hasResourceType := hasManifestType
+			if tt.name == "native resource without manifest type" {
+				hasResourceType = func(string) bool { return false }
+			}
+			got := importSkipPolicyReason(clientset, tt.group, tt.version, tt.resource, hasResourceType)
+			if got != tt.want {
+				t.Fatalf("importSkipPolicyReason() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
 func TestSupportsNativeManifestResource(t *testing.T) {
 	tests := []struct {
 		name    string
@@ -1177,14 +1224,7 @@ func TestSupportsNativeManifestResource(t *testing.T) {
 		{name: "device taint rule alpha", group: "resource.k8s.io", version: "v1alpha3", kind: "DeviceTaintRule", want: true},
 		{name: "resource claim alpha", group: "resource.k8s.io", version: "v1alpha3", kind: "ResourceClaim", want: true},
 		{name: "resource claim template alpha", group: "resource.k8s.io", version: "v1alpha3", kind: "ResourceClaimTemplate", want: true},
-		{name: "legacy resource class alpha", group: "resource.k8s.io", version: "v1alpha2", kind: "ResourceClass", want: true},
-		{name: "legacy resource class parameters alpha", group: "resource.k8s.io", version: "v1alpha2", kind: "ResourceClassParameters", want: true},
-		{name: "legacy resource claim alpha", group: "resource.k8s.io", version: "v1alpha2", kind: "ResourceClaim", want: true},
-		{name: "legacy resource claim parameters alpha", group: "resource.k8s.io", version: "v1alpha2", kind: "ResourceClaimParameters", want: true},
-		{name: "legacy resource claim template alpha", group: "resource.k8s.io", version: "v1alpha2", kind: "ResourceClaimTemplate", want: true},
-		{name: "original resource class alpha", group: "resource.k8s.io", version: "v1alpha1", kind: "ResourceClass", want: true},
-		{name: "original resource claim alpha", group: "resource.k8s.io", version: "v1alpha1", kind: "ResourceClaim", want: true},
-		{name: "original resource claim template alpha", group: "resource.k8s.io", version: "v1alpha1", kind: "ResourceClaimTemplate", want: true},
+		{name: "legacy resource class is outside supported policy", group: "resource.k8s.io", version: "v1alpha2", kind: "ResourceClass", want: false},
 		{name: "scheduling workload preferred alpha", group: "scheduling.k8s.io", version: "v1alpha2", kind: "Workload", want: true},
 		{name: "scheduling workload alpha", group: "scheduling.k8s.io", version: "v1alpha1", kind: "Workload", want: true},
 		{name: "volume attributes class v1", group: "storage.k8s.io", version: "v1", kind: "VolumeAttributesClass", want: true},

--- a/providers/kubernetes/utils_test.go
+++ b/providers/kubernetes/utils_test.go
@@ -519,6 +519,20 @@ func TestSelectImportResourceName(t *testing.T) {
 			wantOK:      true,
 		},
 		{
+			name:    "skips unallowlisted native API group instead of generic manifest fallback",
+			group:   "events.k8s.io",
+			version: "v1beta1",
+			resource: metav1.APIResource{
+				Name:  "events",
+				Kind:  "Event",
+				Verbs: manageableVerbs,
+			},
+			supportedTypes: map[string]struct{}{
+				manifestTerraformResourceName: {},
+			},
+			wantOK: false,
+		},
+		{
 			name:    "falls back to manifest for native admission policy binding",
 			group:   "admissionregistration.k8s.io",
 			version: "v1",
@@ -639,6 +653,56 @@ func TestSelectImportResourceName(t *testing.T) {
 			resource: metav1.APIResource{
 				Name:       "resourceclaims",
 				Kind:       "ResourceClaim",
+				Namespaced: true,
+				Verbs:      manageableVerbs,
+			},
+			supportedTypes: map[string]struct{}{
+				manifestTerraformResourceName: {},
+			},
+			want:        manifestTerraformResourceName,
+			wantDynamic: true,
+			wantOK:      true,
+		},
+		{
+			name:    "falls back to manifest for legacy dynamic resource class",
+			group:   "resource.k8s.io",
+			version: "v1alpha2",
+			resource: metav1.APIResource{
+				Name:  "resourceclasses",
+				Kind:  "ResourceClass",
+				Verbs: manageableVerbs,
+			},
+			supportedTypes: map[string]struct{}{
+				manifestTerraformResourceName: {},
+			},
+			want:        manifestTerraformResourceName,
+			wantDynamic: true,
+			wantOK:      true,
+		},
+		{
+			name:    "falls back to manifest for legacy dynamic resource parameters",
+			group:   "resource.k8s.io",
+			version: "v1alpha2",
+			resource: metav1.APIResource{
+				Name:       "resourceclaimparameters",
+				Kind:       "ResourceClaimParameters",
+				Namespaced: true,
+				Verbs:      manageableVerbs,
+			},
+			supportedTypes: map[string]struct{}{
+				manifestTerraformResourceName: {},
+			},
+			want:        manifestTerraformResourceName,
+			wantDynamic: true,
+			wantOK:      true,
+		},
+		{
+			name:    "falls back to manifest for original dynamic resource claim template",
+			group:   "resource.k8s.io",
+			version: "v1alpha1",
+			resource: metav1.APIResource{
+				Name:       "resourceclaimtemplates",
+				Kind:       "ResourceClaimTemplate",
 				Namespaced: true,
 				Verbs:      manageableVerbs,
 			},
@@ -1066,6 +1130,28 @@ func TestSupportsDynamicClientResource(t *testing.T) {
 	}
 }
 
+func TestIsNativeAPIGroup(t *testing.T) {
+	tests := []struct {
+		name  string
+		group string
+		want  bool
+	}{
+		{name: "core", want: true},
+		{name: "resource API", group: "resource.k8s.io", want: true},
+		{name: "custom group sharing native prefix", group: "apps.example.com", want: false},
+		{name: "custom group", group: "example.com", want: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := isNativeAPIGroup(tt.group)
+			if got != tt.want {
+				t.Fatalf("isNativeAPIGroup(%q) = %t, want %t", tt.group, got, tt.want)
+			}
+		})
+	}
+}
+
 func TestSupportsNativeManifestResource(t *testing.T) {
 	tests := []struct {
 		name    string
@@ -1091,6 +1177,14 @@ func TestSupportsNativeManifestResource(t *testing.T) {
 		{name: "device taint rule alpha", group: "resource.k8s.io", version: "v1alpha3", kind: "DeviceTaintRule", want: true},
 		{name: "resource claim alpha", group: "resource.k8s.io", version: "v1alpha3", kind: "ResourceClaim", want: true},
 		{name: "resource claim template alpha", group: "resource.k8s.io", version: "v1alpha3", kind: "ResourceClaimTemplate", want: true},
+		{name: "legacy resource class alpha", group: "resource.k8s.io", version: "v1alpha2", kind: "ResourceClass", want: true},
+		{name: "legacy resource class parameters alpha", group: "resource.k8s.io", version: "v1alpha2", kind: "ResourceClassParameters", want: true},
+		{name: "legacy resource claim alpha", group: "resource.k8s.io", version: "v1alpha2", kind: "ResourceClaim", want: true},
+		{name: "legacy resource claim parameters alpha", group: "resource.k8s.io", version: "v1alpha2", kind: "ResourceClaimParameters", want: true},
+		{name: "legacy resource claim template alpha", group: "resource.k8s.io", version: "v1alpha2", kind: "ResourceClaimTemplate", want: true},
+		{name: "original resource class alpha", group: "resource.k8s.io", version: "v1alpha1", kind: "ResourceClass", want: true},
+		{name: "original resource claim alpha", group: "resource.k8s.io", version: "v1alpha1", kind: "ResourceClaim", want: true},
+		{name: "original resource claim template alpha", group: "resource.k8s.io", version: "v1alpha1", kind: "ResourceClaimTemplate", want: true},
 		{name: "scheduling workload preferred alpha", group: "scheduling.k8s.io", version: "v1alpha2", kind: "Workload", want: true},
 		{name: "scheduling workload alpha", group: "scheduling.k8s.io", version: "v1alpha1", kind: "Workload", want: true},
 		{name: "volume attributes class v1", group: "storage.k8s.io", version: "v1", kind: "VolumeAttributesClass", want: true},
@@ -1103,6 +1197,8 @@ func TestSupportsNativeManifestResource(t *testing.T) {
 		{name: "token review is not manifest-backed", group: "authentication.k8s.io", version: "v1", kind: "TokenReview", want: false},
 		{name: "pod certificate request is kubelet-generated", group: "certificates.k8s.io", version: "v1beta1", kind: "PodCertificateRequest", want: false},
 		{name: "resource slice is generated by drivers", group: "resource.k8s.io", version: "v1", kind: "ResourceSlice", want: false},
+		{name: "pod scheduling context is generated scheduling state", group: "resource.k8s.io", version: "v1alpha2", kind: "PodSchedulingContext", want: false},
+		{name: "pod scheduling is generated scheduling state", group: "resource.k8s.io", version: "v1alpha1", kind: "PodScheduling", want: false},
 		{name: "volume attachment is controller-managed", group: "storage.k8s.io", version: "v1", kind: "VolumeAttachment", want: false},
 		{name: "ip address is allocator-managed", group: "networking.k8s.io", version: "v1", kind: "IPAddress", want: false},
 		{name: "custom resource is handled by general manifest fallback", group: "example.com", version: "v1", kind: "Widget", want: false},


### PR DESCRIPTION
Summary
- gate kubernetes_manifest fallback for native Kubernetes API groups to explicit manifest selectors
- keep CRD and custom-resource manifest fallback unchanged
- document the Kubernetes 1.33-1.35 native resource policy and --verbose skip logging
- log generated or out-of-policy native API skips when verbose mode is enabled

Notes
- pre-1.33 historical alpha APIs are intentionally not added as native manifest selectors


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified native Kubernetes import policy: applies to Kubernetes 1.33–1.35 and excludes historical alpha APIs; documented stricter native-group import rules and verbose logging for skipped resources.

* **Improvements**
  * Refined import selection to skip unallowlisted native API kinds and restrict when manifest-backed imports are used; expanded supported resource coverage for certain resource types.

* **Tests**
  * Added/expanded tests validating native-group detection, manifest-backed decisions, and skip-reason behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->