### PR TITLE
refactor(cmd): share provider generator registry

### DIFF
--- a/cmd/import_test.go
+++ b/cmd/import_test.go
@@ -184,11 +184,13 @@ func TestPlanReplayCoversAllImportProviders(t *testing.T) {
 
 	importers := providerImporterSubcommands()
 	if len(generators) != len(importers) {
-		t.Errorf("providerGenerators has %d entries but providerImporterSubcommands has %d — "+
+		t.Errorf("providerGenerators has %d entries but providerImporterSubcommands has %d; "+
 			"every importer needs a matching generator for plan replay",
 			len(generators), len(importers))
 	}
 
+	importerNames := map[string]bool{}
+	matchedGenerators := map[string]bool{}
 	for name, genFn := range generators {
 		t.Run("generator/"+name, func(t *testing.T) {
 			prov := genFn()
@@ -198,16 +200,34 @@ func TestPlanReplayCoversAllImportProviders(t *testing.T) {
 		})
 	}
 
-	seen := map[string]bool{}
 	for _, fn := range importers {
 		options := ImportOptions{}
 		cmd := fn(options)
 		name := cmd.Use
 		t.Run("importer/"+name, func(t *testing.T) {
-			if seen[name] {
+			if importerNames[name] {
 				t.Errorf("duplicate import subcommand %q", name)
 			}
-			seen[name] = true
+			importerNames[name] = true
+			providerName := planReplayProviderName(name)
+			if _, ok := generators[providerName]; !ok {
+				t.Errorf("import subcommand %q maps to missing provider generator %q for plan replay", name, providerName)
+			}
+			matchedGenerators[providerName] = true
 		})
+	}
+	for name := range generators {
+		if !matchedGenerators[name] {
+			t.Errorf("provider generator %q has no import subcommand", name)
+		}
+	}
+}
+
+func planReplayProviderName(importCommand string) string {
+	switch importCommand {
+	case "azure":
+		return "azurerm"
+	default:
+		return importCommand
 	}
 }

--- a/cmd/provider_registry_compat_test.go
+++ b/cmd/provider_registry_compat_test.go
@@ -81,52 +81,7 @@ func TestProviderRegistryCompatibility(t *testing.T) {
 // provider GetName values that Terraformer uses during imports.
 func registryAuditProviderSources() map[string]string {
 	providers := map[string]string{}
-	for _, providerGen := range []func() terraformutils.ProviderGenerator{
-		newGoogleProvider,
-		newAWSProvider,
-		newAzureProvider,
-		newAliCloudProvider,
-		newIbmProvider,
-		newDigitalOceanProvider,
-		newEquinixMetalProvider,
-		newFastlyProvider,
-		newHerokuProvider,
-		newLaunchDarklyProvider,
-		newLinodeProvider,
-		newNs1Provider,
-		newOpenStackProvider,
-		newTencentCloudProvider,
-		newVultrProvider,
-		newYandexProvider,
-		newIonosCloudProvider,
-		newKubernetesProvider,
-		newOctopusDeployProvider,
-		newRabbitMQProvider,
-		newMyrasecProvider,
-		newCloudflareProvider,
-		newPanosProvider,
-		newAzureDevOpsProvider,
-		newAzureADProvider,
-		newGitHubProvider,
-		newGitLabProvider,
-		newDataDogProvider,
-		newNewRelicProvider,
-		newMackerelProvider,
-		newGrafanaProvider,
-		newPagerDutyProvider,
-		newOpsgenieProvider,
-		newHoneycombioProvider,
-		newOpalProvider,
-		newKeycloakProvider,
-		newLogzioProvider,
-		newCommercetoolsProvider,
-		newMikrotikProvider,
-		newXenorchestraProvider,
-		newGmailfilterProvider,
-		newVaultProvider,
-		newOktaProvider,
-		newAuth0Provider,
-	} {
+	for _, providerGen := range providerGeneratorConstructors() {
 		provider := providerGen()
 		providers[provider.GetName()] = terraformutils.ProviderSource(provider.GetName())
 	}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -81,9 +81,8 @@ func providerImporterSubcommands() []func(options ImportOptions) *cobra.Command 
 	}
 }
 
-func providerGenerators() map[string]func() terraformutils.ProviderGenerator {
-	list := make(map[string]func() terraformutils.ProviderGenerator)
-	for _, providerGen := range []func() terraformutils.ProviderGenerator{
+func providerGeneratorConstructors() []func() terraformutils.ProviderGenerator {
+	return []func() terraformutils.ProviderGenerator{
 		// Major Cloud
 		newGoogleProvider,
 		newAWSProvider,
@@ -135,7 +134,12 @@ func providerGenerators() map[string]func() terraformutils.ProviderGenerator {
 		newVaultProvider,
 		newOktaProvider,
 		newAuth0Provider,
-	} {
+	}
+}
+
+func providerGenerators() map[string]func() terraformutils.ProviderGenerator {
+	list := make(map[string]func() terraformutils.ProviderGenerator)
+	for _, providerGen := range providerGeneratorConstructors() {
 		list[providerGen().GetName()] = providerGen
 	}
 	return list


### PR DESCRIPTION
## Summary

- Share the provider generator constructor list instead of duplicating it in the registry compatibility audit.
- Tighten the plan replay coverage test to verify exact importer-to-provider mappings.
- Keep Azure's `azure` command to `azurerm` provider mapping explicit in the test coverage.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Share a single provider generator registry and tighten plan replay coverage to enforce exact importer-to-provider mappings. This removes duplicated lists and keeps Azure’s `azure` command mapped explicitly to the `azurerm` provider.

- **Refactors**
  - Introduced `providerGeneratorConstructors()` and derive `providerGenerators()` from it.
  - Switched the registry compatibility audit to use the shared constructors list.
  - Tightened the plan replay test to enforce unique importers, require a generator for each importer, and assert `azure` -> `azurerm` mapping.

<sup>Written for commit 914e509630cf37cc86e298b8499172b4e230033c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced test coverage to verify complete consistency between provider generators and import subcommands, detecting missing or orphaned provider mappings.

* **Refactor**
  * Simplified provider registration by centralizing provider constructor definitions to reduce code duplication.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->