### PR TITLE
fix(providers): reset init state before fallback

### DIFF
--- a/providers/heroku/heroku_provider.go
+++ b/providers/heroku/heroku_provider.go
@@ -16,6 +16,9 @@ type HerokuProvider struct { //nolint
 
 // Init the Provider for imports. args are defined in cmd/provider_cmd_heroku.go
 func (p *HerokuProvider) Init(args []string) error {
+	p.apiKey = ""
+	p.team = ""
+
 	if len(args) > 0 {
 		p.apiKey = args[0]
 	}

--- a/providers/heroku/heroku_provider_test.go
+++ b/providers/heroku/heroku_provider_test.go
@@ -1,0 +1,22 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package heroku
+
+import "testing"
+
+func TestHerokuProviderInitClearsStateWhenArgsOmitted(t *testing.T) {
+	provider := HerokuProvider{
+		apiKey: "old-key",
+		team:   "old-team",
+	}
+
+	if err := provider.Init(nil); err != nil {
+		t.Fatalf("expected Init to succeed: %v", err)
+	}
+	if provider.apiKey != "" {
+		t.Fatalf("apiKey = %q, want empty", provider.apiKey)
+	}
+	if provider.team != "" {
+		t.Fatalf("team = %q, want empty", provider.team)
+	}
+}

--- a/providers/mackerel/mackerel_provider.go
+++ b/providers/mackerel/mackerel_provider.go
@@ -19,15 +19,17 @@ type MackerelProvider struct { //nolint
 
 // Init check env params and initialize API Client
 func (p *MackerelProvider) Init(args []string) error {
+	p.apiKey = ""
+	p.mackerelClient = nil
+
+	apiKey := os.Getenv("MACKEREL_API_KEY")
 	if len(args) > 0 && args[0] != "" {
-		p.apiKey = args[0]
-	} else {
-		if apiKey := os.Getenv("MACKEREL_API_KEY"); apiKey != "" {
-			p.apiKey = apiKey
-		} else {
-			return errors.New("api-key requirement")
-		}
+		apiKey = args[0]
 	}
+	if apiKey == "" {
+		return errors.New("api-key requirement")
+	}
+	p.apiKey = apiKey
 	// Initialize the Mackerel API client
 	p.mackerelClient = mackerel.NewClient(p.apiKey)
 	return nil

--- a/providers/mackerel/mackerel_provider_test.go
+++ b/providers/mackerel/mackerel_provider_test.go
@@ -5,6 +5,8 @@ package mackerel
 import (
 	"strings"
 	"testing"
+
+	mackerelapi "github.com/mackerelio/mackerel-client-go"
 )
 
 func TestMackerelProviderInitReturnsMissingAPIKeyWithNoArgs(t *testing.T) {
@@ -17,6 +19,25 @@ func TestMackerelProviderInitReturnsMissingAPIKeyWithNoArgs(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "api-key requirement") {
 		t.Fatalf("expected missing API key error, got %q", err)
+	}
+}
+
+func TestMackerelProviderInitClearsStateOnMissingAPIKey(t *testing.T) {
+	t.Setenv("MACKEREL_API_KEY", "")
+	provider := MackerelProvider{
+		apiKey:         "old-key",
+		mackerelClient: mackerelapi.NewClient("old-key"),
+	}
+
+	err := provider.Init(nil)
+	if err == nil {
+		t.Fatal("expected missing API key error")
+	}
+	if provider.apiKey != "" {
+		t.Fatalf("apiKey = %q, want empty", provider.apiKey)
+	}
+	if provider.mackerelClient != nil {
+		t.Fatal("mackerelClient should be nil after failed init")
 	}
 }
 

--- a/providers/octopusdeploy/octopusdeploy_provider.go
+++ b/providers/octopusdeploy/octopusdeploy_provider.go
@@ -15,26 +15,27 @@ type OctopusDeployProvider struct { //nolint
 }
 
 func (p *OctopusDeployProvider) Init(args []string) error {
+	p.address = ""
+	p.apiKey = ""
+
+	address := os.Getenv("OCTOPUS_CLI_SERVER")
 	if len(args) > 0 && args[0] != "" {
-		p.address = args[0]
-	} else {
-		if address := os.Getenv("OCTOPUS_CLI_SERVER"); address != "" {
-			p.address = address
-		} else {
-			return errors.New("server requirement")
-		}
+		address = args[0]
+	}
+	if address == "" {
+		return errors.New("server requirement")
 	}
 
+	apiKey := os.Getenv("OCTOPUS_CLI_API_KEY")
 	if len(args) > 1 && args[1] != "" {
-		p.apiKey = args[1]
-	} else {
-		if apiKey := os.Getenv("OCTOPUS_CLI_API_KEY"); apiKey != "" {
-			p.apiKey = apiKey
-		} else {
-			return errors.New("api-key requirement")
-		}
+		apiKey = args[1]
+	}
+	if apiKey == "" {
+		return errors.New("api-key requirement")
 	}
 
+	p.address = address
+	p.apiKey = apiKey
 	return nil
 }
 

--- a/providers/octopusdeploy/octopusdeploy_provider_test.go
+++ b/providers/octopusdeploy/octopusdeploy_provider_test.go
@@ -21,6 +21,26 @@ func TestOctopusDeployProviderInitReturnsMissingServerWithNoArgs(t *testing.T) {
 	}
 }
 
+func TestOctopusDeployProviderInitClearsStateOnMissingServer(t *testing.T) {
+	t.Setenv("OCTOPUS_CLI_SERVER", "")
+	t.Setenv("OCTOPUS_CLI_API_KEY", "")
+	provider := OctopusDeployProvider{
+		address: "https://old.example.com",
+		apiKey:  "old-key",
+	}
+
+	err := provider.Init(nil)
+	if err == nil {
+		t.Fatal("expected missing server error")
+	}
+	if provider.address != "" {
+		t.Fatalf("address = %q, want empty", provider.address)
+	}
+	if provider.apiKey != "" {
+		t.Fatalf("apiKey = %q, want empty", provider.apiKey)
+	}
+}
+
 func TestOctopusDeployProviderInitUsesEnvCredentials(t *testing.T) {
 	t.Setenv("OCTOPUS_CLI_SERVER", "https://octopus.example.com")
 	t.Setenv("OCTOPUS_CLI_API_KEY", "env-key")

--- a/providers/pagerduty/pagerduty_provider.go
+++ b/providers/pagerduty/pagerduty_provider.go
@@ -16,8 +16,10 @@ type PagerDutyProvider struct { //nolint
 }
 
 func (p *PagerDutyProvider) Init(args []string) error {
+	p.token = ""
+
 	if token := os.Getenv("PAGERDUTY_TOKEN"); token != "" {
-		p.token = os.Getenv("PAGERDUTY_TOKEN")
+		p.token = token
 	}
 	if len(args) > 0 && args[0] != "" {
 		p.token = args[0]

--- a/providers/pagerduty/pagerduty_provider_test.go
+++ b/providers/pagerduty/pagerduty_provider_test.go
@@ -1,0 +1,17 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package pagerduty
+
+import "testing"
+
+func TestPagerDutyProviderInitClearsTokenWhenEnvAndArgOmitted(t *testing.T) {
+	t.Setenv("PAGERDUTY_TOKEN", "")
+	provider := PagerDutyProvider{token: "old-token"}
+
+	if err := provider.Init(nil); err != nil {
+		t.Fatalf("expected Init to succeed: %v", err)
+	}
+	if provider.token != "" {
+		t.Fatalf("token = %q, want empty", provider.token)
+	}
+}

--- a/providers/vault/vault_provider.go
+++ b/providers/vault/vault_provider.go
@@ -16,12 +16,15 @@ type Provider struct {
 }
 
 func (p *Provider) Init(args []string) error {
+	p.address = ""
+	p.token = ""
+
 	if address := os.Getenv("VAULT_ADDR"); address != "" {
-		p.address = os.Getenv("VAULT_ADDR")
+		p.address = address
 	}
 
 	if token := os.Getenv("VAULT_TOKEN"); token != "" {
-		p.token = os.Getenv("VAULT_TOKEN")
+		p.token = token
 	}
 
 	if len(args) > 0 && args[0] != "" {

--- a/providers/vault/vault_provider_test.go
+++ b/providers/vault/vault_provider_test.go
@@ -1,0 +1,22 @@
+package vault
+
+import "testing"
+
+func TestProviderInitClearsStateWhenArgsAndEnvOmitted(t *testing.T) {
+	t.Setenv("VAULT_ADDR", "")
+	t.Setenv("VAULT_TOKEN", "")
+	provider := Provider{
+		address: "https://old-vault.example.com",
+		token:   "old-token",
+	}
+
+	if err := provider.Init(nil); err != nil {
+		t.Fatalf("expected Init to succeed: %v", err)
+	}
+	if provider.address != "" {
+		t.Fatalf("address = %q, want empty", provider.address)
+	}
+	if provider.token != "" {
+		t.Fatalf("token = %q, want empty", provider.token)
+	}
+}

--- a/providers/yandex/yandex_provider.go
+++ b/providers/yandex/yandex_provider.go
@@ -21,6 +21,10 @@ type YandexProvider struct { //nolint
 }
 
 func (p *YandexProvider) Init(args []string) error {
+	p.token = ""
+	p.saKeyFileOrContent = ""
+	p.folderID = ""
+
 	if ycToken, ok := os.LookupEnv("YC_TOKEN"); ok {
 		p.token = ycToken
 	}
@@ -29,14 +33,13 @@ func (p *YandexProvider) Init(args []string) error {
 		p.saKeyFileOrContent = saKeyFileOrContent
 	}
 
-	if len(args) > 0 {
+	if len(args) > 0 && args[0] != "" {
 		//  first args is target folder ID
 		p.folderID = args[0]
+	} else if folderID := os.Getenv("YC_FOLDER_ID"); folderID != "" {
+		p.folderID = folderID
 	} else {
-		if os.Getenv("YC_FOLDER_ID") == "" {
-			return errors.New("set YC_FOLDER_ID env var")
-		}
-		p.folderID = os.Getenv("YC_FOLDER_ID")
+		return errors.New("set YC_FOLDER_ID env var")
 	}
 
 	return nil

--- a/providers/yandex/yandex_provider_test.go
+++ b/providers/yandex/yandex_provider_test.go
@@ -1,0 +1,56 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package yandex
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestYandexProviderInitClearsStateOnMissingFolderID(t *testing.T) {
+	t.Setenv("YC_TOKEN", "")
+	t.Setenv("YC_SERVICE_ACCOUNT_KEY_FILE", "")
+	t.Setenv("YC_FOLDER_ID", "")
+	provider := YandexProvider{
+		token:              "old-token",
+		saKeyFileOrContent: "old-key",
+		folderID:           "old-folder",
+	}
+
+	err := provider.Init(nil)
+	if err == nil {
+		t.Fatal("expected missing folder ID error")
+	}
+	if !strings.Contains(err.Error(), "set YC_FOLDER_ID env var") {
+		t.Fatalf("expected folder ID error, got %q", err)
+	}
+	if provider.token != "" {
+		t.Fatalf("token = %q, want empty", provider.token)
+	}
+	if provider.saKeyFileOrContent != "" {
+		t.Fatalf("saKeyFileOrContent = %q, want empty", provider.saKeyFileOrContent)
+	}
+	if provider.folderID != "" {
+		t.Fatalf("folderID = %q, want empty", provider.folderID)
+	}
+}
+
+func TestYandexProviderInitUsesEnvFolderIDWhenArgEmpty(t *testing.T) {
+	t.Setenv("YC_TOKEN", "env-token")
+	t.Setenv("YC_SERVICE_ACCOUNT_KEY_FILE", "env-key")
+	t.Setenv("YC_FOLDER_ID", "env-folder")
+	var provider YandexProvider
+
+	if err := provider.Init([]string{""}); err != nil {
+		t.Fatalf("expected Init to succeed: %v", err)
+	}
+	if provider.folderID != "env-folder" {
+		t.Fatalf("folderID = %q, want env-folder", provider.folderID)
+	}
+	if provider.token != "env-token" {
+		t.Fatalf("token = %q, want env-token", provider.token)
+	}
+	if provider.saKeyFileOrContent != "env-key" {
+		t.Fatalf("saKeyFileOrContent = %q, want env-key", provider.saKeyFileOrContent)
+	}
+}


### PR DESCRIPTION
## Summary

- Reset provider init state before reading optional args or environment fallbacks for Vault, Heroku, PagerDuty, Yandex, Mackerel, and Octopus Deploy.
- Avoid leaving partial credentials/config behind when required fallback values are missing.
- Add regression coverage for repeated init and missing-fallback paths across the touched providers.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reset provider init state before applying args or env fallbacks across `vault`, `heroku`, `pagerduty`, `yandex`, `mackerel`, and `octopusdeploy`. This prevents stale credentials/config after repeated init or when required fallbacks are missing, with added regression tests.

- **Bug Fixes**
  - Clear internal fields (address, tokens, API keys, clients) at the start of Init to avoid partial state.
  - Validate required inputs and return clear errors when missing: `MACKEREL_API_KEY`, `OCTOPUS_CLI_SERVER`, `OCTOPUS_CLI_API_KEY`, `YC_FOLDER_ID`.
  - Keep precedence predictable: args override env; `yandex` now uses `YC_FOLDER_ID` when the arg is empty.

<sup>Written for commit f4f76dfbd08371b99fd1fb58d495498f37a6c623. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved provider initialization across Heroku, Mackerel, OctopusDeploy, PagerDuty, Vault, and Yandex. Providers now properly clear their configuration state during initialization when optional parameters are omitted, preventing stale settings from persisting across re-initializations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->