### PR TITLE
fix(providers): clear required init state before validation

### DIFF
--- a/providers/alicloud/alicloud_provider.go
+++ b/providers/alicloud/alicloud_provider.go
@@ -77,6 +77,9 @@ func (p AliCloudProvider) GetProviderData(_ ...string) map[string]interface{} {
 
 // Init Loads up command line arguments in the provider
 func (p *AliCloudProvider) Init(args []string) error {
+	p.region = ""
+	p.profile = ""
+
 	if len(args) < 2 {
 		return errors.New("alicloud: expected 2 init args (region, profile)")
 	}

--- a/providers/alicloud/alicloud_provider_test.go
+++ b/providers/alicloud/alicloud_provider_test.go
@@ -8,7 +8,10 @@ import (
 )
 
 func TestAliCloudProviderInitRequiresArgs(t *testing.T) {
-	var provider AliCloudProvider
+	provider := AliCloudProvider{
+		region:  "cn-hangzhou",
+		profile: "old-profile",
+	}
 
 	err := provider.Init([]string{"cn-hangzhou"})
 	if err == nil {
@@ -16,5 +19,11 @@ func TestAliCloudProviderInitRequiresArgs(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "expected 2 init args") {
 		t.Fatalf("Init error = %q, want missing AliCloud args", err)
+	}
+	if provider.region != "" {
+		t.Fatalf("region = %q, want empty after failed init", provider.region)
+	}
+	if provider.profile != "" {
+		t.Fatalf("profile = %q, want empty after failed init", provider.profile)
 	}
 }

--- a/providers/aws/aws_provider.go
+++ b/providers/aws/aws_provider.go
@@ -172,6 +172,9 @@ func (p *AWSProvider) GetBasicConfig() cty.Value {
 
 // check projectName in env params
 func (p *AWSProvider) Init(args []string) error {
+	p.region = ""
+	p.profile = ""
+
 	if len(args) < 2 {
 		return errors.New("aws: expected 2 init args (region, profile)")
 	}

--- a/providers/aws/aws_provider.go
+++ b/providers/aws/aws_provider.go
@@ -174,16 +174,19 @@ func (p *AWSProvider) GetBasicConfig() cty.Value {
 func (p *AWSProvider) Init(args []string) error {
 	p.region = ""
 	p.profile = ""
-	if err := clearAWSEnvConfig(); err != nil {
-		return err
-	}
 
 	if len(args) < 2 {
+		if err := clearAWSEnvConfig(false); err != nil {
+			return err
+		}
 		return errors.New("aws: expected 2 init args (region, profile)")
 	}
 
 	region := args[0]
 	profile := args[1]
+	if err := clearAWSEnvConfig(region == NoRegion); err != nil {
+		return err
+	}
 
 	// Terraformer accepts region and profile configuration, so we must detect what env variables to adjust to make Go SDK rely on them. AWS_SDK_LOAD_CONFIG here must be checked to determine correct variable to set.
 	enableSharedConfig, _ := strconv.ParseBool(os.Getenv("AWS_SDK_LOAD_CONFIG"))
@@ -214,8 +217,12 @@ func (p *AWSProvider) Init(args []string) error {
 	return nil
 }
 
-func clearAWSEnvConfig() error {
-	for _, key := range []string{"AWS_REGION", "AWS_DEFAULT_REGION", "AWS_PROFILE", "AWS_DEFAULT_PROFILE"} {
+func clearAWSEnvConfig(preserveRegion bool) error {
+	keys := []string{"AWS_PROFILE", "AWS_DEFAULT_PROFILE"}
+	if !preserveRegion {
+		keys = append(keys, "AWS_REGION", "AWS_DEFAULT_REGION")
+	}
+	for _, key := range keys {
 		if err := os.Unsetenv(key); err != nil {
 			return err
 		}

--- a/providers/aws/aws_provider.go
+++ b/providers/aws/aws_provider.go
@@ -3,6 +3,7 @@
 package aws
 
 import (
+	"fmt"
 	"os"
 	"strconv"
 
@@ -190,15 +191,13 @@ func (p *AWSProvider) Init(args []string) error {
 
 	// Terraformer accepts region and profile configuration, so we must detect what env variables to adjust to make Go SDK rely on them. AWS_SDK_LOAD_CONFIG here must be checked to determine correct variable to set.
 	enableSharedConfig, _ := strconv.ParseBool(os.Getenv("AWS_SDK_LOAD_CONFIG"))
-	var err error
 	if region != GlobalRegion && region != NoRegion {
+		envVar := "AWS_REGION"
 		if enableSharedConfig {
-			err = os.Setenv("AWS_DEFAULT_REGION", region)
-		} else {
-			err = os.Setenv("AWS_REGION", region)
+			envVar = "AWS_DEFAULT_REGION"
 		}
-		if err != nil {
-			return err
+		if err := os.Setenv(envVar, region); err != nil {
+			return fmt.Errorf("failed to set env %s=%q: %w", envVar, region, err)
 		}
 	}
 
@@ -209,7 +208,7 @@ func (p *AWSProvider) Init(args []string) error {
 		}
 
 		if err := os.Setenv(envVar, profile); err != nil {
-			return err
+			return fmt.Errorf("failed to set env %s=%q: %w", envVar, profile, err)
 		}
 	}
 	p.region = region
@@ -224,7 +223,7 @@ func clearAWSEnvConfig(preserveRegion bool) error {
 	}
 	for _, key := range keys {
 		if err := os.Unsetenv(key); err != nil {
-			return err
+			return fmt.Errorf("failed to unset env %s: %w", key, err)
 		}
 	}
 	return nil

--- a/providers/aws/aws_provider.go
+++ b/providers/aws/aws_provider.go
@@ -174,35 +174,49 @@ func (p *AWSProvider) GetBasicConfig() cty.Value {
 func (p *AWSProvider) Init(args []string) error {
 	p.region = ""
 	p.profile = ""
+	if err := clearAWSEnvConfig(); err != nil {
+		return err
+	}
 
 	if len(args) < 2 {
 		return errors.New("aws: expected 2 init args (region, profile)")
 	}
 
-	p.region = args[0]
-	p.profile = args[1]
+	region := args[0]
+	profile := args[1]
 
 	// Terraformer accepts region and profile configuration, so we must detect what env variables to adjust to make Go SDK rely on them. AWS_SDK_LOAD_CONFIG here must be checked to determine correct variable to set.
 	enableSharedConfig, _ := strconv.ParseBool(os.Getenv("AWS_SDK_LOAD_CONFIG"))
 	var err error
-	if p.region != GlobalRegion && p.region != NoRegion {
+	if region != GlobalRegion && region != NoRegion {
 		if enableSharedConfig {
-			err = os.Setenv("AWS_DEFAULT_REGION", p.region)
+			err = os.Setenv("AWS_DEFAULT_REGION", region)
 		} else {
-			err = os.Setenv("AWS_REGION", p.region)
+			err = os.Setenv("AWS_REGION", region)
 		}
 		if err != nil {
 			return err
 		}
 	}
 
-	if p.profile != "" && p.profile != "default" {
+	if profile != "" && profile != "default" {
 		envVar := "AWS_PROFILE"
 		if enableSharedConfig {
 			envVar = "AWS_DEFAULT_PROFILE"
 		}
 
-		if err := os.Setenv(envVar, p.profile); err != nil {
+		if err := os.Setenv(envVar, profile); err != nil {
+			return err
+		}
+	}
+	p.region = region
+	p.profile = profile
+	return nil
+}
+
+func clearAWSEnvConfig() error {
+	for _, key := range []string{"AWS_REGION", "AWS_DEFAULT_REGION", "AWS_PROFILE", "AWS_DEFAULT_PROFILE"} {
+		if err := os.Unsetenv(key); err != nil {
 			return err
 		}
 	}

--- a/providers/aws/aws_provider_init_test.go
+++ b/providers/aws/aws_provider_init_test.go
@@ -8,7 +8,10 @@ import (
 )
 
 func TestAWSProviderInitRequiresArgs(t *testing.T) {
-	var provider AWSProvider
+	provider := AWSProvider{
+		region:  MainRegionPublicPartition,
+		profile: "old-profile",
+	}
 
 	err := provider.Init([]string{MainRegionPublicPartition})
 	if err == nil {
@@ -16,5 +19,11 @@ func TestAWSProviderInitRequiresArgs(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "expected 2 init args") {
 		t.Fatalf("Init error = %q, want missing AWS args", err)
+	}
+	if provider.region != "" {
+		t.Fatalf("region = %q, want empty after failed init", provider.region)
+	}
+	if provider.profile != "" {
+		t.Fatalf("profile = %q, want empty after failed init", provider.profile)
 	}
 }

--- a/providers/aws/aws_provider_init_test.go
+++ b/providers/aws/aws_provider_init_test.go
@@ -37,3 +37,30 @@ func TestAWSProviderInitRequiresArgs(t *testing.T) {
 		}
 	}
 }
+
+func TestAWSProviderInitPreservesAmbientRegionForNoRegion(t *testing.T) {
+	t.Setenv("AWS_REGION", "env-region")
+	t.Setenv("AWS_DEFAULT_REGION", "env-default-region")
+	t.Setenv("AWS_PROFILE", "old-profile")
+	t.Setenv("AWS_DEFAULT_PROFILE", "old-default-profile")
+	var provider AWSProvider
+
+	if err := provider.Init([]string{NoRegion, "default"}); err != nil {
+		t.Fatalf("expected Init to succeed: %v", err)
+	}
+	if provider.region != NoRegion {
+		t.Fatalf("region = %q, want NoRegion", provider.region)
+	}
+	if got := os.Getenv("AWS_REGION"); got != "env-region" {
+		t.Fatalf("AWS_REGION = %q, want env-region", got)
+	}
+	if got := os.Getenv("AWS_DEFAULT_REGION"); got != "env-default-region" {
+		t.Fatalf("AWS_DEFAULT_REGION = %q, want env-default-region", got)
+	}
+	if value, ok := os.LookupEnv("AWS_PROFILE"); ok {
+		t.Fatalf("AWS_PROFILE = %q, want unset", value)
+	}
+	if value, ok := os.LookupEnv("AWS_DEFAULT_PROFILE"); ok {
+		t.Fatalf("AWS_DEFAULT_PROFILE = %q, want unset", value)
+	}
+}

--- a/providers/aws/aws_provider_init_test.go
+++ b/providers/aws/aws_provider_init_test.go
@@ -3,11 +3,16 @@
 package aws
 
 import (
+	"os"
 	"strings"
 	"testing"
 )
 
 func TestAWSProviderInitRequiresArgs(t *testing.T) {
+	t.Setenv("AWS_REGION", "old-region")
+	t.Setenv("AWS_DEFAULT_REGION", "old-default-region")
+	t.Setenv("AWS_PROFILE", "old-profile")
+	t.Setenv("AWS_DEFAULT_PROFILE", "old-default-profile")
 	provider := AWSProvider{
 		region:  MainRegionPublicPartition,
 		profile: "old-profile",
@@ -25,5 +30,10 @@ func TestAWSProviderInitRequiresArgs(t *testing.T) {
 	}
 	if provider.profile != "" {
 		t.Fatalf("profile = %q, want empty after failed init", provider.profile)
+	}
+	for _, key := range []string{"AWS_REGION", "AWS_DEFAULT_REGION", "AWS_PROFILE", "AWS_DEFAULT_PROFILE"} {
+		if value, ok := os.LookupEnv(key); ok {
+			t.Fatalf("%s = %q, want unset after failed init", key, value)
+		}
 	}
 }

--- a/providers/azure/azure_provider.go
+++ b/providers/azure/azure_provider.go
@@ -539,21 +539,24 @@ func (p *AzureProvider) Init(args []string) error {
 		return errors.New("azure: expected 1 init arg (resource group)")
 	}
 
-	err := p.setEnvConfig()
+	staged := &AzureProvider{}
+	err := staged.setEnvConfig()
 	if err != nil {
 		return err
 	}
 
-	clientOptions, err := p.getClientOptions()
+	clientOptions, err := staged.getClientOptions()
 	if err != nil {
 		return err
 	}
+	staged.clientOptions = clientOptions
+
+	credential, err := staged.getTokenCredential()
+	if err != nil {
+		return err
+	}
+	p.config = staged.config
 	p.clientOptions = clientOptions
-
-	credential, err := p.getTokenCredential()
-	if err != nil {
-		return err
-	}
 	p.credential = credential
 	p.resourceGroup = args[0]
 

--- a/providers/azure/azure_provider.go
+++ b/providers/azure/azure_provider.go
@@ -530,6 +530,11 @@ func discoverCloudConfig(metadataHost, environment string) (cloud.Configuration,
 }
 
 func (p *AzureProvider) Init(args []string) error {
+	p.config = providerConfig{}
+	p.credential = nil
+	p.clientOptions = nil
+	p.resourceGroup = ""
+
 	if len(args) < 1 {
 		return errors.New("azure: expected 1 init arg (resource group)")
 	}

--- a/providers/azure/azure_provider_test.go
+++ b/providers/azure/azure_provider_test.go
@@ -5,6 +5,8 @@ package azure
 import (
 	"strings"
 	"testing"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
 )
 
 func TestAzureProviderInitRequiresResourceGroupArg(t *testing.T) {
@@ -27,5 +29,45 @@ func TestAzureProviderInitRequiresResourceGroupArg(t *testing.T) {
 	}
 	if provider.config.SubscriptionID != "" {
 		t.Fatalf("SubscriptionID = %q, want empty after failed init", provider.config.SubscriptionID)
+	}
+}
+
+func TestAzureProviderInitClearsStateOnLaterInitError(t *testing.T) {
+	t.Setenv("ARM_SUBSCRIPTION_ID", "subscription-id")
+	t.Setenv("ARM_CLIENT_ID", "client-id")
+	t.Setenv("ARM_TENANT_ID", "tenant-id")
+	t.Setenv("ARM_CLIENT_CERTIFICATE_PATH", t.TempDir()+"/missing.pem")
+
+	provider := AzureProvider{
+		config: providerConfig{
+			SubscriptionID:       "old-subscription",
+			UseClientCertificate: true,
+		},
+		credential:    &stubTokenCredential{},
+		clientOptions: &arm.ClientOptions{},
+		resourceGroup: "old-resource-group",
+	}
+
+	err := provider.Init([]string{"resource-group"})
+	if err == nil {
+		t.Fatal("expected client certificate error")
+	}
+	if !strings.Contains(err.Error(), "reading client certificate") {
+		t.Fatalf("Init error = %q, want client certificate read error", err)
+	}
+	if provider.resourceGroup != "" {
+		t.Fatalf("resourceGroup = %q, want empty after failed init", provider.resourceGroup)
+	}
+	if provider.config.SubscriptionID != "" {
+		t.Fatalf("SubscriptionID = %q, want empty after failed init", provider.config.SubscriptionID)
+	}
+	if provider.config.UseClientCertificate {
+		t.Fatal("UseClientCertificate = true, want false after failed init")
+	}
+	if provider.credential != nil {
+		t.Fatalf("credential = %T, want nil after failed init", provider.credential)
+	}
+	if provider.clientOptions != nil {
+		t.Fatal("clientOptions should be nil after failed init")
 	}
 }

--- a/providers/azure/azure_provider_test.go
+++ b/providers/azure/azure_provider_test.go
@@ -8,7 +8,12 @@ import (
 )
 
 func TestAzureProviderInitRequiresResourceGroupArg(t *testing.T) {
-	var provider AzureProvider
+	provider := AzureProvider{
+		config: providerConfig{
+			SubscriptionID: "old-subscription",
+		},
+		resourceGroup: "old-resource-group",
+	}
 
 	err := provider.Init(nil)
 	if err == nil {
@@ -16,5 +21,11 @@ func TestAzureProviderInitRequiresResourceGroupArg(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "expected 1 init arg") {
 		t.Fatalf("Init error = %q, want missing resource group arg", err)
+	}
+	if provider.resourceGroup != "" {
+		t.Fatalf("resourceGroup = %q, want empty after failed init", provider.resourceGroup)
+	}
+	if provider.config.SubscriptionID != "" {
+		t.Fatalf("SubscriptionID = %q, want empty after failed init", provider.config.SubscriptionID)
 	}
 }

--- a/providers/commercetools/commercetools_provider.go
+++ b/providers/commercetools/commercetools_provider.go
@@ -27,6 +27,13 @@ func (p CommercetoolsProvider) GetProviderData(_ ...string) map[string]interface
 
 // Init CommerectoolsProvider
 func (p *CommercetoolsProvider) Init(args []string) error {
+	p.clientID = ""
+	p.clientScope = ""
+	p.clientSecret = ""
+	p.projectKey = ""
+	p.baseURL = ""
+	p.tokenURL = ""
+
 	if len(args) < 6 {
 		return errors.New("commercetools: client id, client scope, client secret, project key, base URL, and token URL are required")
 	}

--- a/providers/commercetools/commercetools_provider_test.go
+++ b/providers/commercetools/commercetools_provider_test.go
@@ -8,7 +8,14 @@ import (
 )
 
 func TestCommercetoolsProviderInitRequiresArgs(t *testing.T) {
-	var provider CommercetoolsProvider
+	provider := CommercetoolsProvider{
+		clientID:     "old-client-id",
+		clientScope:  "old-scope",
+		clientSecret: "old-secret",
+		projectKey:   "old-project",
+		baseURL:      "https://old-api.example.com",
+		tokenURL:     "https://old-auth.example.com",
+	}
 
 	err := provider.Init([]string{"client-id", "scope", "secret", "project", "https://api.example.com"})
 	if err == nil {
@@ -16,6 +23,10 @@ func TestCommercetoolsProviderInitRequiresArgs(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "client id, client scope, client secret, project key, base URL, and token URL are required") {
 		t.Fatalf("Init error = %q, want missing Commercetools args", err)
+	}
+	if provider.clientID != "" || provider.clientScope != "" || provider.clientSecret != "" ||
+		provider.projectKey != "" || provider.baseURL != "" || provider.tokenURL != "" {
+		t.Fatalf("provider state was not cleared after failed init: %#v", provider)
 	}
 }
 

--- a/providers/gcp/gcp_provider.go
+++ b/providers/gcp/gcp_provider.go
@@ -57,6 +57,10 @@ func getRegion(project, regionName string) (*compute.Region, error) {
 
 // check projectName in env params
 func (p *GCPProvider) Init(args []string) error {
+	p.projectName = ""
+	p.region = compute.Region{}
+	p.providerType = ""
+
 	if len(args) == 0 {
 		return errors.New("gcp region must be provided")
 	}
@@ -68,16 +72,14 @@ func (p *GCPProvider) Init(args []string) error {
 	if projectName == "" {
 		return errors.New("google cloud project name must be set")
 	}
-	p.projectName = projectName
 	region, err := getRegion(projectName, args[0])
 	if err != nil {
 		return err
 	}
+	p.projectName = projectName
 	p.region = *region
 	if len(args) > 2 {
 		p.providerType = args[2]
-	} else {
-		p.providerType = ""
 	}
 	return nil
 }

--- a/providers/gcp/gcp_provider_test.go
+++ b/providers/gcp/gcp_provider_test.go
@@ -15,13 +15,26 @@ import (
 func TestGCPProviderInitRequiresRegion(t *testing.T) {
 	t.Setenv("GOOGLE_CLOUD_PROJECT", "test-project")
 
-	provider := GCPProvider{}
+	provider := GCPProvider{
+		projectName:  "old-project",
+		region:       compute.Region{Name: "old-region"},
+		providerType: "beta",
+	}
 	err := provider.Init(nil)
 	if err == nil {
 		t.Fatal("expected missing region error")
 	}
 	if !strings.Contains(err.Error(), "gcp region must be provided") {
 		t.Fatalf("Init error = %q, want missing region", err)
+	}
+	if provider.projectName != "" {
+		t.Fatalf("projectName = %q, want empty after failed init", provider.projectName)
+	}
+	if provider.region.Name != "" {
+		t.Fatalf("region.Name = %q, want empty after failed init", provider.region.Name)
+	}
+	if provider.providerType != "" {
+		t.Fatalf("providerType = %q, want empty after failed init", provider.providerType)
 	}
 }
 
@@ -71,7 +84,11 @@ func TestGCPProviderInitReturnsNonGlobalRegionLookupError(t *testing.T) {
 		return newTestComputeService(ctx, t, server.URL+"/"), nil
 	}
 
-	provider := GCPProvider{}
+	provider := GCPProvider{
+		projectName:  "old-project",
+		region:       compute.Region{Name: "old-region"},
+		providerType: "beta",
+	}
 	err := provider.Init([]string{"us-west1"})
 	if err == nil {
 		t.Fatal("expected region lookup error")
@@ -79,5 +96,14 @@ func TestGCPProviderInitReturnsNonGlobalRegionLookupError(t *testing.T) {
 	want := `get GCP region "us-west1" for project "test-project"`
 	if !strings.Contains(err.Error(), want) {
 		t.Fatalf("Init error = %q, want it to contain %q", err, want)
+	}
+	if provider.projectName != "" {
+		t.Fatalf("projectName = %q, want empty after failed region lookup", provider.projectName)
+	}
+	if provider.region.Name != "" {
+		t.Fatalf("region.Name = %q, want empty after failed region lookup", provider.region.Name)
+	}
+	if provider.providerType != "" {
+		t.Fatalf("providerType = %q, want empty after failed region lookup", provider.providerType)
 	}
 }

--- a/providers/ibm/ibm_provider.go
+++ b/providers/ibm/ibm_provider.go
@@ -30,6 +30,10 @@ type IBMProvider struct { //nolint
 }
 
 func (p *IBMProvider) Init(args []string) error {
+	p.ResourceGroup = ""
+	p.Region = ""
+	p.VPC = ""
+
 	if len(args) < 3 {
 		return errors.New("ibm: expected 3 init args (resource group, region, vpc)")
 	}

--- a/providers/ibm/ibm_provider.go
+++ b/providers/ibm/ibm_provider.go
@@ -33,25 +33,26 @@ func (p *IBMProvider) Init(args []string) error {
 	p.ResourceGroup = ""
 	p.Region = ""
 	p.VPC = ""
+	if err := os.Unsetenv("IC_REGION"); err != nil {
+		return err
+	}
 
 	if len(args) < 3 {
 		return errors.New("ibm: expected 3 init args (resource group, region, vpc)")
 	}
 
-	p.ResourceGroup = args[0]
-	p.Region = args[1]
-	p.VPC = args[2]
-
-	var err error
-	if p.Region != NoRegion {
-		err = os.Setenv("IC_REGION", p.Region)
-	} else {
-		p.Region = DefaultRegion
-		err = os.Setenv("IC_REGION", DefaultRegion)
+	resourceGroup := args[0]
+	region := args[1]
+	vpc := args[2]
+	if region == NoRegion {
+		region = DefaultRegion
 	}
-	if err != nil {
+	if err := os.Setenv("IC_REGION", region); err != nil {
 		return err
 	}
+	p.ResourceGroup = resourceGroup
+	p.Region = region
+	p.VPC = vpc
 	return nil
 }
 

--- a/providers/ibm/ibm_provider_test.go
+++ b/providers/ibm/ibm_provider_test.go
@@ -4,6 +4,7 @@ package ibm
 
 import (
 	"errors"
+	"os"
 	"testing"
 )
 
@@ -23,6 +24,7 @@ func TestProviderInitDoesNotRequireAPIKey(t *testing.T) {
 }
 
 func TestProviderInitRequiresArgs(t *testing.T) {
+	t.Setenv("IC_REGION", "old-region")
 	provider := &IBMProvider{
 		ResourceGroup: "old-resource-group",
 		Region:        "old-region",
@@ -43,6 +45,9 @@ func TestProviderInitRequiresArgs(t *testing.T) {
 	}
 	if provider.VPC != "" {
 		t.Fatalf("VPC = %q, want empty after failed init", provider.VPC)
+	}
+	if value, ok := os.LookupEnv("IC_REGION"); ok {
+		t.Fatalf("IC_REGION = %q, want unset after failed init", value)
 	}
 }
 

--- a/providers/ibm/ibm_provider_test.go
+++ b/providers/ibm/ibm_provider_test.go
@@ -23,13 +23,26 @@ func TestProviderInitDoesNotRequireAPIKey(t *testing.T) {
 }
 
 func TestProviderInitRequiresArgs(t *testing.T) {
-	provider := &IBMProvider{}
+	provider := &IBMProvider{
+		ResourceGroup: "old-resource-group",
+		Region:        "old-region",
+		VPC:           "old-vpc",
+	}
 	err := provider.Init([]string{"", ""})
 	if err == nil {
 		t.Fatal("expected missing args error")
 	}
 	if err.Error() != "ibm: expected 3 init args (resource group, region, vpc)" {
 		t.Fatalf("Init error = %q, want missing IBM args", err)
+	}
+	if provider.ResourceGroup != "" {
+		t.Fatalf("ResourceGroup = %q, want empty after failed init", provider.ResourceGroup)
+	}
+	if provider.Region != "" {
+		t.Fatalf("Region = %q, want empty after failed init", provider.Region)
+	}
+	if provider.VPC != "" {
+		t.Fatalf("VPC = %q, want empty after failed init", provider.VPC)
 	}
 }
 

--- a/providers/keycloak/keycloak_provider.go
+++ b/providers/keycloak/keycloak_provider.go
@@ -35,6 +35,17 @@ func getArg(arg string) string {
 }
 
 func (p *KeycloakProvider) Init(args []string) error {
+	p.url = ""
+	p.basePath = ""
+	p.clientID = ""
+	p.clientSecret = ""
+	p.realm = ""
+	p.clientTimeout = 0
+	p.caCert = ""
+	p.tlsInsecureSkipVerify = false
+	p.redHatSSO = false
+	p.target = ""
+
 	if len(args) < keycloakInitArgCount {
 		return fmt.Errorf("keycloak: expected %d init args, got %d", keycloakInitArgCount, len(args))
 	}

--- a/providers/keycloak/keycloak_provider_test.go
+++ b/providers/keycloak/keycloak_provider_test.go
@@ -23,7 +23,18 @@ func validKeycloakInitArgs() []string {
 }
 
 func TestKeycloakProviderInitRequiresArgs(t *testing.T) {
-	var provider KeycloakProvider
+	provider := KeycloakProvider{
+		url:                   "https://old.example.com",
+		basePath:              "/old",
+		clientID:              "old-client",
+		clientSecret:          "old-secret",
+		realm:                 "old-realm",
+		clientTimeout:         99,
+		caCert:                "old-cert",
+		tlsInsecureSkipVerify: true,
+		redHatSSO:             true,
+		target:                "old-target",
+	}
 
 	err := provider.Init(validKeycloakInitArgs()[:9])
 	if err == nil {
@@ -32,10 +43,11 @@ func TestKeycloakProviderInitRequiresArgs(t *testing.T) {
 	if !strings.Contains(err.Error(), "expected 10 init args") {
 		t.Fatalf("expected init arg count error, got %q", err)
 	}
+	assertKeycloakProviderCleared(t, provider)
 }
 
 func TestKeycloakProviderInitReturnsClientTimeoutError(t *testing.T) {
-	var provider KeycloakProvider
+	provider := KeycloakProvider{url: "https://old.example.com", clientTimeout: 30}
 	args := validKeycloakInitArgs()
 	args[5] = "slow"
 
@@ -46,10 +58,11 @@ func TestKeycloakProviderInitReturnsClientTimeoutError(t *testing.T) {
 	if !strings.Contains(err.Error(), "invalid client timeout") {
 		t.Fatalf("expected client timeout error, got %q", err)
 	}
+	assertKeycloakProviderCleared(t, provider)
 }
 
 func TestKeycloakProviderInitReturnsTLSBoolError(t *testing.T) {
-	var provider KeycloakProvider
+	provider := KeycloakProvider{url: "https://old.example.com", tlsInsecureSkipVerify: true}
 	args := validKeycloakInitArgs()
 	args[7] = "sometimes"
 
@@ -60,10 +73,11 @@ func TestKeycloakProviderInitReturnsTLSBoolError(t *testing.T) {
 	if !strings.Contains(err.Error(), "invalid tls insecure skip verify") {
 		t.Fatalf("expected TLS bool error, got %q", err)
 	}
+	assertKeycloakProviderCleared(t, provider)
 }
 
 func TestKeycloakProviderInitReturnsRedHatSSOBoolError(t *testing.T) {
-	var provider KeycloakProvider
+	provider := KeycloakProvider{url: "https://old.example.com", redHatSSO: true}
 	args := validKeycloakInitArgs()
 	args[8] = "maybe"
 
@@ -74,6 +88,7 @@ func TestKeycloakProviderInitReturnsRedHatSSOBoolError(t *testing.T) {
 	if !strings.Contains(err.Error(), "invalid red hat sso") {
 		t.Fatalf("expected Red Hat SSO bool error, got %q", err)
 	}
+	assertKeycloakProviderCleared(t, provider)
 }
 
 func TestKeycloakProviderInitStoresArgs(t *testing.T) {
@@ -99,5 +114,16 @@ func TestKeycloakProviderInitStoresArgs(t *testing.T) {
 	}
 	if provider.target != "" {
 		t.Fatalf("target = %q, want empty", provider.target)
+	}
+}
+
+func assertKeycloakProviderCleared(t *testing.T, provider KeycloakProvider) {
+	t.Helper()
+
+	if provider.url != "" || provider.basePath != "" || provider.clientID != "" ||
+		provider.clientSecret != "" || provider.realm != "" || provider.clientTimeout != 0 ||
+		provider.caCert != "" || provider.tlsInsecureSkipVerify || provider.redHatSSO ||
+		provider.target != "" {
+		t.Fatalf("provider state was not cleared after failed init: %#v", provider)
 	}
 }

--- a/providers/logzio/logzio_provider.go
+++ b/providers/logzio/logzio_provider.go
@@ -40,6 +40,9 @@ func (p *LogzioProvider) GetConfig() cty.Value {
 
 // Init LogzioProvider with API apiToken
 func (p *LogzioProvider) Init(args []string) error {
+	p.apiToken = ""
+	p.baseURL = ""
+
 	if len(args) < 2 {
 		return errors.New("logzio: api token and base URL are required")
 	}

--- a/providers/logzio/logzio_provider_test.go
+++ b/providers/logzio/logzio_provider_test.go
@@ -8,10 +8,19 @@ import (
 )
 
 func TestLogzioProviderInitRequiresArgs(t *testing.T) {
-	var provider LogzioProvider
+	provider := LogzioProvider{
+		apiToken: "old-token",
+		baseURL:  "https://old.example.com",
+	}
 
 	if err := provider.Init([]string{"token"}); err == nil {
 		t.Fatal("expected missing base URL error")
+	}
+	if provider.apiToken != "" {
+		t.Fatalf("apiToken = %q, want empty after failed init", provider.apiToken)
+	}
+	if provider.baseURL != "" {
+		t.Fatalf("baseURL = %q, want empty after failed init", provider.baseURL)
 	}
 }
 

--- a/providers/openstack/openstack_provider.go
+++ b/providers/openstack/openstack_provider.go
@@ -31,17 +31,20 @@ func (p OpenStackProvider) GetProviderData(_ ...string) map[string]interface{} {
 // check projectName in env params
 func (p *OpenStackProvider) Init(args []string) error {
 	p.region = ""
+	if err := os.Unsetenv("OS_REGION_NAME"); err != nil {
+		return err
+	}
 
 	if len(args) < 1 {
 		return errors.New("openstack: expected 1 init arg (region)")
 	}
 
-	p.region = args[0]
+	region := args[0]
 	// terraform work with env param OS_REGION_NAME
-	err := os.Setenv("OS_REGION_NAME", p.region)
-	if err != nil {
+	if err := os.Setenv("OS_REGION_NAME", region); err != nil {
 		return err
 	}
+	p.region = region
 	return nil
 }
 

--- a/providers/openstack/openstack_provider.go
+++ b/providers/openstack/openstack_provider.go
@@ -30,6 +30,8 @@ func (p OpenStackProvider) GetProviderData(_ ...string) map[string]interface{} {
 
 // check projectName in env params
 func (p *OpenStackProvider) Init(args []string) error {
+	p.region = ""
+
 	if len(args) < 1 {
 		return errors.New("openstack: expected 1 init arg (region)")
 	}

--- a/providers/openstack/openstack_provider_test.go
+++ b/providers/openstack/openstack_provider_test.go
@@ -8,7 +8,7 @@ import (
 )
 
 func TestOpenStackProviderInitRequiresRegion(t *testing.T) {
-	var provider OpenStackProvider
+	provider := OpenStackProvider{region: "old-region"}
 
 	err := provider.Init(nil)
 	if err == nil {
@@ -16,5 +16,8 @@ func TestOpenStackProviderInitRequiresRegion(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "expected 1 init arg") {
 		t.Fatalf("Init error = %q, want missing region", err)
+	}
+	if provider.region != "" {
+		t.Fatalf("region = %q, want empty after failed init", provider.region)
 	}
 }

--- a/providers/openstack/openstack_provider_test.go
+++ b/providers/openstack/openstack_provider_test.go
@@ -3,11 +3,13 @@
 package openstack
 
 import (
+	"os"
 	"strings"
 	"testing"
 )
 
 func TestOpenStackProviderInitRequiresRegion(t *testing.T) {
+	t.Setenv("OS_REGION_NAME", "old-region")
 	provider := OpenStackProvider{region: "old-region"}
 
 	err := provider.Init(nil)
@@ -19,5 +21,8 @@ func TestOpenStackProviderInitRequiresRegion(t *testing.T) {
 	}
 	if provider.region != "" {
 		t.Fatalf("region = %q, want empty after failed init", provider.region)
+	}
+	if value, ok := os.LookupEnv("OS_REGION_NAME"); ok {
+		t.Fatalf("OS_REGION_NAME = %q, want unset after failed init", value)
 	}
 }

--- a/providers/panos/panos_provider.go
+++ b/providers/panos/panos_provider.go
@@ -15,6 +15,8 @@ type PanosProvider struct { //nolint
 }
 
 func (p *PanosProvider) Init(args []string) error {
+	p.vsys = ""
+
 	if len(args) < 1 {
 		return errors.New("panos: vsys is required")
 	}

--- a/providers/panos/panos_provider_test.go
+++ b/providers/panos/panos_provider_test.go
@@ -8,7 +8,7 @@ import (
 )
 
 func TestPanosProviderInitRequiresArgs(t *testing.T) {
-	var provider PanosProvider
+	provider := PanosProvider{vsys: "old-vsys"}
 
 	err := provider.Init(nil)
 	if err == nil {
@@ -16,6 +16,9 @@ func TestPanosProviderInitRequiresArgs(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "vsys is required") {
 		t.Fatalf("Init error = %q, want missing PAN-OS args", err)
+	}
+	if provider.vsys != "" {
+		t.Fatalf("vsys = %q, want empty after failed init", provider.vsys)
 	}
 }
 

--- a/providers/rabbitmq/rabbitmq_provider.go
+++ b/providers/rabbitmq/rabbitmq_provider.go
@@ -17,6 +17,10 @@ type RBTProvider struct {
 }
 
 func (p *RBTProvider) Init(args []string) error {
+	p.endpoint = ""
+	p.username = ""
+	p.password = ""
+
 	if len(args) < 3 {
 		return errors.New("rabbitmq: endpoint, username, and password are required")
 	}

--- a/providers/rabbitmq/rabbitmq_provider_test.go
+++ b/providers/rabbitmq/rabbitmq_provider_test.go
@@ -8,7 +8,11 @@ import (
 )
 
 func TestRBTProviderInitRequiresArgs(t *testing.T) {
-	var provider RBTProvider
+	provider := RBTProvider{
+		endpoint: "https://old.example.com",
+		username: "old-user",
+		password: "old-password",
+	}
 
 	err := provider.Init([]string{"https://rabbitmq.example.com", "guest"})
 	if err == nil {
@@ -16,6 +20,15 @@ func TestRBTProviderInitRequiresArgs(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "endpoint, username, and password are required") {
 		t.Fatalf("Init error = %q, want missing RabbitMQ args", err)
+	}
+	if provider.endpoint != "" {
+		t.Fatalf("endpoint = %q, want empty after failed init", provider.endpoint)
+	}
+	if provider.username != "" {
+		t.Fatalf("username = %q, want empty after failed init", provider.username)
+	}
+	if provider.password != "" {
+		t.Fatalf("password = %q, want empty after failed init", provider.password)
 	}
 }
 

--- a/providers/tencentcloud/tencentcloud_provider.go
+++ b/providers/tencentcloud/tencentcloud_provider.go
@@ -52,6 +52,9 @@ func (p *TencentCloudProvider) GetSource() string {
 }
 
 func (p *TencentCloudProvider) Init(args []string) error {
+	p.region = ""
+	p.credential = common.Credential{}
+
 	if len(args) < 1 {
 		return errors.New("tencentcloud: expected 1 init arg (region)")
 	}

--- a/providers/tencentcloud/tencentcloud_provider_test.go
+++ b/providers/tencentcloud/tencentcloud_provider_test.go
@@ -5,10 +5,17 @@ package tencentcloud
 import (
 	"strings"
 	"testing"
+
+	"github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common"
 )
 
 func TestTencentCloudProviderInitRequiresRegion(t *testing.T) {
-	var provider TencentCloudProvider
+	provider := TencentCloudProvider{
+		region: "old-region",
+		credential: common.Credential{
+			SecretId: "old-secret-id",
+		},
+	}
 
 	err := provider.Init(nil)
 	if err == nil {
@@ -16,5 +23,11 @@ func TestTencentCloudProviderInitRequiresRegion(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "expected 1 init arg") {
 		t.Fatalf("Init error = %q, want missing region", err)
+	}
+	if provider.region != "" {
+		t.Fatalf("region = %q, want empty after failed init", provider.region)
+	}
+	if provider.credential.SecretId != "" {
+		t.Fatalf("credential.SecretId = %q, want empty after failed init", provider.credential.SecretId)
 	}
 }


### PR DESCRIPTION
## Summary

- Clear stale init state before required-argument validation across AWS, Azure, GCP, AliCloud, IBM, OpenStack, PAN-OS, RabbitMQ, Logz.io, Commercetools, Keycloak, and TencentCloud.
- Avoid leaving old partial provider config behind when repeated Init calls fail early.
- Expand provider init regression tests to assert stale values are cleared on missing args and parse failures.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevent stale provider and env config by clearing required init fields and related env vars before validation. For `azure`, stage init values and only commit after credentials/options succeed; for `aws`, preserve ambient region with `NoRegion` and wrap env mutation errors with clear context.

- **Bug Fixes**
  - Clear init state before validation in `alicloud`, `aws`, `azure`, `gcp`, `ibm`, `openstack`, `panos`, `rabbitmq`, `logzio`, `commercetools`, `keycloak`, `tencentcloud`; reset env vars for `aws` (`AWS_REGION`, `AWS_DEFAULT_REGION`, `AWS_PROFILE`, `AWS_DEFAULT_PROFILE`), `ibm` (`IC_REGION`), and `openstack` (`OS_REGION_NAME`)—`aws` now preserves ambient region when `NoRegion` is used.
  - Improve `aws` init errors by wrapping env set/unset failures with the variable name; expand tests to assert provider/env reset and AWS `NoRegion` behavior.

<sup>Written for commit a3180a208895565fa8b595fcab07a959a39778fa. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  - Provider initialization now clears prior in-memory state and related environment settings at the start, preventing stale configuration or environment variables from persisting after failed or partial initializations across many cloud and service providers.

* **Tests**
  - Tests updated and expanded to verify provider state and relevant environment variables are cleared on initialization failure; new tests also cover preservation of ambient settings where intended.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->