### PR TITLE
fix(providers): wrap environment mutation errors

### DIFF
--- a/providers/aws/aws_provider.go
+++ b/providers/aws/aws_provider.go
@@ -3,7 +3,6 @@
 package aws
 
 import (
-	"fmt"
 	"os"
 	"strconv"
 
@@ -196,8 +195,8 @@ func (p *AWSProvider) Init(args []string) error {
 		if enableSharedConfig {
 			envVar = "AWS_DEFAULT_REGION"
 		}
-		if err := os.Setenv(envVar, region); err != nil {
-			return fmt.Errorf("failed to set env %s=%q: %w", envVar, region, err)
+		if err := terraformutils.SetEnv(envVar, region); err != nil {
+			return err
 		}
 	}
 
@@ -207,8 +206,8 @@ func (p *AWSProvider) Init(args []string) error {
 			envVar = "AWS_DEFAULT_PROFILE"
 		}
 
-		if err := os.Setenv(envVar, profile); err != nil {
-			return fmt.Errorf("failed to set env %s=%q: %w", envVar, profile, err)
+		if err := terraformutils.SetEnv(envVar, profile); err != nil {
+			return err
 		}
 	}
 	p.region = region
@@ -222,8 +221,8 @@ func clearAWSEnvConfig(preserveRegion bool) error {
 		keys = append(keys, "AWS_REGION", "AWS_DEFAULT_REGION")
 	}
 	for _, key := range keys {
-		if err := os.Unsetenv(key); err != nil {
-			return fmt.Errorf("failed to unset env %s: %w", key, err)
+		if err := terraformutils.UnsetEnv(key); err != nil {
+			return err
 		}
 	}
 	return nil

--- a/providers/aws/aws_service.go
+++ b/providers/aws/aws_service.go
@@ -48,11 +48,17 @@ func (s *AWSService) generateConfig() (aws.Config, error) {
 	// terraform cannot ask for MFA token, so we need to pass STS session token, which might contain credentials with MFA requirement
 	accessKey := os.Getenv("AWS_SECRET_ACCESS_KEY")
 	if accessKey == "" {
-		os.Setenv("AWS_ACCESS_KEY_ID", creds.AccessKeyID)
-		os.Setenv("AWS_SECRET_ACCESS_KEY", creds.SecretAccessKey)
+		if err := terraformutils.SetEnv("AWS_ACCESS_KEY_ID", creds.AccessKeyID); err != nil {
+			return baseConfig, err
+		}
+		if err := terraformutils.SetEnv("AWS_SECRET_ACCESS_KEY", creds.SecretAccessKey); err != nil {
+			return baseConfig, err
+		}
 
 		if creds.SessionToken != "" {
-			os.Setenv("AWS_SESSION_TOKEN", creds.SessionToken)
+			if err := terraformutils.SetEnv("AWS_SESSION_TOKEN", creds.SessionToken); err != nil {
+				return baseConfig, err
+			}
 		}
 	}
 	configCache = &baseConfig
@@ -65,7 +71,9 @@ func (s *AWSService) buildBaseConfig() (aws.Config, error) {
 		loadOptions = append(loadOptions, config.WithSharedConfigProfile(s.GetArgs()["profile"].(string)))
 	}
 	if s.GetArgs()["region"].(string) != "" {
-		os.Setenv("AWS_REGION", s.GetArgs()["region"].(string))
+		if err := terraformutils.SetEnv("AWS_REGION", s.GetArgs()["region"].(string)); err != nil {
+			return aws.Config{}, err
+		}
 	}
 	loadOptions = append(loadOptions, config.WithAssumeRoleCredentialOptions(func(options *stscreds.AssumeRoleOptions) {
 		options.TokenProvider = stscreds.StdinTokenProvider

--- a/providers/aws/aws_service_test.go
+++ b/providers/aws/aws_service_test.go
@@ -18,7 +18,11 @@ func TestAWSServiceBuildBaseConfigReturnsRegionEnvError(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected region env error")
 	}
-	if msg := err.Error(); !strings.Contains(msg, `failed to set env AWS_REGION="bad\x00region"`) {
+	msg := err.Error()
+	if !strings.Contains(msg, "failed to set env AWS_REGION") {
 		t.Fatalf("buildBaseConfig error = %q, want AWS_REGION context", msg)
+	}
+	if strings.Contains(msg, "bad") {
+		t.Fatalf("buildBaseConfig error = %q, want env value redacted", msg)
 	}
 }

--- a/providers/aws/aws_service_test.go
+++ b/providers/aws/aws_service_test.go
@@ -8,10 +8,11 @@ import (
 )
 
 func TestAWSServiceBuildBaseConfigReturnsRegionEnvError(t *testing.T) {
+	const probe = "REDACT_PROBE_AWS_REGION"
 	service := &AWSService{}
 	service.SetArgs(map[string]interface{}{
 		"profile": "",
-		"region":  "bad\x00region",
+		"region":  probe + "\x00region",
 	})
 
 	_, err := service.buildBaseConfig()
@@ -22,7 +23,7 @@ func TestAWSServiceBuildBaseConfigReturnsRegionEnvError(t *testing.T) {
 	if !strings.Contains(msg, "failed to set env AWS_REGION") {
 		t.Fatalf("buildBaseConfig error = %q, want AWS_REGION context", msg)
 	}
-	if strings.Contains(msg, "bad") {
+	if strings.Contains(msg, probe) {
 		t.Fatalf("buildBaseConfig error = %q, want env value redacted", msg)
 	}
 }

--- a/providers/aws/aws_service_test.go
+++ b/providers/aws/aws_service_test.go
@@ -1,0 +1,24 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package aws
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestAWSServiceBuildBaseConfigReturnsRegionEnvError(t *testing.T) {
+	service := &AWSService{}
+	service.SetArgs(map[string]interface{}{
+		"profile": "",
+		"region":  "bad\x00region",
+	})
+
+	_, err := service.buildBaseConfig()
+	if err == nil {
+		t.Fatal("expected region env error")
+	}
+	if msg := err.Error(); !strings.Contains(msg, `failed to set env AWS_REGION="bad\x00region"`) {
+		t.Fatalf("buildBaseConfig error = %q, want AWS_REGION context", msg)
+	}
+}

--- a/providers/gmailfilter/gmailfilter_provider.go
+++ b/providers/gmailfilter/gmailfilter_provider.go
@@ -19,12 +19,16 @@ func (p *GmailfilterProvider) Init(args []string) error {
 	credentials := os.Getenv("GOOGLE_CREDENTIALS")
 	if len(args) > 0 && args[0] != "" {
 		credentials = args[0]
-		os.Setenv("GOOGLE_CREDENTIALS", credentials)
+		if err := terraformutils.SetEnv("GOOGLE_CREDENTIALS", credentials); err != nil {
+			return err
+		}
 	}
 	email := os.Getenv("IMPERSONATED_USER_EMAIL")
 	if len(args) > 1 && args[1] != "" {
 		email = args[1]
-		os.Setenv("IMPERSONATED_USER_EMAIL", email)
+		if err := terraformutils.SetEnv("IMPERSONATED_USER_EMAIL", email); err != nil {
+			return err
+		}
 	}
 
 	p.credentials = credentials

--- a/providers/gmailfilter/gmailfilter_provider_test.go
+++ b/providers/gmailfilter/gmailfilter_provider_test.go
@@ -8,9 +8,10 @@ import (
 )
 
 func TestGmailfilterProviderInitReturnsCredentialEnvError(t *testing.T) {
+	const probe = "REDACT_PROBE_GMAIL_CREDENTIALS"
 	var provider GmailfilterProvider
 
-	err := provider.Init([]string{"bad\x00credentials"})
+	err := provider.Init([]string{probe + "\x00credentials"})
 	if err == nil {
 		t.Fatal("expected credentials env error")
 	}
@@ -18,15 +19,16 @@ func TestGmailfilterProviderInitReturnsCredentialEnvError(t *testing.T) {
 	if !strings.Contains(msg, "failed to set env GOOGLE_CREDENTIALS") {
 		t.Fatalf("Init error = %q, want GOOGLE_CREDENTIALS context", msg)
 	}
-	if strings.Contains(msg, "credentials") {
+	if strings.Contains(msg, probe) {
 		t.Fatalf("Init error = %q, want credentials value redacted", msg)
 	}
 }
 
 func TestGmailfilterProviderInitReturnsImpersonatedUserEnvError(t *testing.T) {
+	const probe = "REDACT_PROBE_GMAIL_USER"
 	var provider GmailfilterProvider
 
-	err := provider.Init([]string{"credentials", "bad\x00email"})
+	err := provider.Init([]string{"credentials", probe + "\x00email"})
 	if err == nil {
 		t.Fatal("expected impersonated user env error")
 	}
@@ -34,7 +36,7 @@ func TestGmailfilterProviderInitReturnsImpersonatedUserEnvError(t *testing.T) {
 	if !strings.Contains(msg, "failed to set env IMPERSONATED_USER_EMAIL") {
 		t.Fatalf("Init error = %q, want IMPERSONATED_USER_EMAIL context", msg)
 	}
-	if strings.Contains(msg, "email") {
+	if strings.Contains(msg, probe) {
 		t.Fatalf("Init error = %q, want email value redacted", msg)
 	}
 }

--- a/providers/gmailfilter/gmailfilter_provider_test.go
+++ b/providers/gmailfilter/gmailfilter_provider_test.go
@@ -1,0 +1,32 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package gmailfilter
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestGmailfilterProviderInitReturnsCredentialEnvError(t *testing.T) {
+	var provider GmailfilterProvider
+
+	err := provider.Init([]string{"bad\x00credentials"})
+	if err == nil {
+		t.Fatal("expected credentials env error")
+	}
+	if msg := err.Error(); !strings.Contains(msg, `failed to set env GOOGLE_CREDENTIALS="bad\x00credentials"`) {
+		t.Fatalf("Init error = %q, want GOOGLE_CREDENTIALS context", msg)
+	}
+}
+
+func TestGmailfilterProviderInitReturnsImpersonatedUserEnvError(t *testing.T) {
+	var provider GmailfilterProvider
+
+	err := provider.Init([]string{"credentials", "bad\x00email"})
+	if err == nil {
+		t.Fatal("expected impersonated user env error")
+	}
+	if msg := err.Error(); !strings.Contains(msg, `failed to set env IMPERSONATED_USER_EMAIL="bad\x00email"`) {
+		t.Fatalf("Init error = %q, want IMPERSONATED_USER_EMAIL context", msg)
+	}
+}

--- a/providers/gmailfilter/gmailfilter_provider_test.go
+++ b/providers/gmailfilter/gmailfilter_provider_test.go
@@ -14,8 +14,12 @@ func TestGmailfilterProviderInitReturnsCredentialEnvError(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected credentials env error")
 	}
-	if msg := err.Error(); !strings.Contains(msg, `failed to set env GOOGLE_CREDENTIALS="bad\x00credentials"`) {
+	msg := err.Error()
+	if !strings.Contains(msg, "failed to set env GOOGLE_CREDENTIALS") {
 		t.Fatalf("Init error = %q, want GOOGLE_CREDENTIALS context", msg)
+	}
+	if strings.Contains(msg, "credentials") {
+		t.Fatalf("Init error = %q, want credentials value redacted", msg)
 	}
 }
 
@@ -26,7 +30,11 @@ func TestGmailfilterProviderInitReturnsImpersonatedUserEnvError(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected impersonated user env error")
 	}
-	if msg := err.Error(); !strings.Contains(msg, `failed to set env IMPERSONATED_USER_EMAIL="bad\x00email"`) {
+	msg := err.Error()
+	if !strings.Contains(msg, "failed to set env IMPERSONATED_USER_EMAIL") {
 		t.Fatalf("Init error = %q, want IMPERSONATED_USER_EMAIL context", msg)
+	}
+	if strings.Contains(msg, "email") {
+		t.Fatalf("Init error = %q, want email value redacted", msg)
 	}
 }

--- a/providers/ibm/ibm_provider.go
+++ b/providers/ibm/ibm_provider.go
@@ -33,7 +33,7 @@ func (p *IBMProvider) Init(args []string) error {
 	p.ResourceGroup = ""
 	p.Region = ""
 	p.VPC = ""
-	if err := os.Unsetenv("IC_REGION"); err != nil {
+	if err := terraformutils.UnsetEnv("IC_REGION"); err != nil {
 		return err
 	}
 
@@ -47,7 +47,7 @@ func (p *IBMProvider) Init(args []string) error {
 	if region == NoRegion {
 		region = DefaultRegion
 	}
-	if err := os.Setenv("IC_REGION", region); err != nil {
+	if err := terraformutils.SetEnv("IC_REGION", region); err != nil {
 		return err
 	}
 	p.ResourceGroup = resourceGroup

--- a/providers/ibm/ibm_provider_test.go
+++ b/providers/ibm/ibm_provider_test.go
@@ -5,6 +5,7 @@ package ibm
 import (
 	"errors"
 	"os"
+	"strings"
 	"testing"
 )
 
@@ -48,6 +49,18 @@ func TestProviderInitRequiresArgs(t *testing.T) {
 	}
 	if value, ok := os.LookupEnv("IC_REGION"); ok {
 		t.Fatalf("IC_REGION = %q, want unset after failed init", value)
+	}
+}
+
+func TestProviderInitReturnsRegionEnvError(t *testing.T) {
+	provider := &IBMProvider{}
+
+	err := provider.Init([]string{"resource-group", "bad\x00region", "vpc"})
+	if err == nil {
+		t.Fatal("expected region env error")
+	}
+	if !strings.Contains(err.Error(), `failed to set env IC_REGION="bad\x00region"`) {
+		t.Fatalf("Init error = %q, want IC_REGION context", err)
 	}
 }
 

--- a/providers/ibm/ibm_provider_test.go
+++ b/providers/ibm/ibm_provider_test.go
@@ -53,9 +53,10 @@ func TestProviderInitRequiresArgs(t *testing.T) {
 }
 
 func TestProviderInitReturnsRegionEnvError(t *testing.T) {
+	const probe = "REDACT_PROBE_IBM_REGION"
 	provider := &IBMProvider{}
 
-	err := provider.Init([]string{"resource-group", "bad\x00region", "vpc"})
+	err := provider.Init([]string{"resource-group", probe + "\x00region", "vpc"})
 	if err == nil {
 		t.Fatal("expected region env error")
 	}
@@ -63,7 +64,7 @@ func TestProviderInitReturnsRegionEnvError(t *testing.T) {
 	if !strings.Contains(msg, "failed to set env IC_REGION") {
 		t.Fatalf("Init error = %q, want IC_REGION context", err)
 	}
-	if strings.Contains(msg, "bad") {
+	if strings.Contains(msg, probe) {
 		t.Fatalf("Init error = %q, want env value redacted", err)
 	}
 }

--- a/providers/ibm/ibm_provider_test.go
+++ b/providers/ibm/ibm_provider_test.go
@@ -59,8 +59,12 @@ func TestProviderInitReturnsRegionEnvError(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected region env error")
 	}
-	if !strings.Contains(err.Error(), `failed to set env IC_REGION="bad\x00region"`) {
+	msg := err.Error()
+	if !strings.Contains(msg, "failed to set env IC_REGION") {
 		t.Fatalf("Init error = %q, want IC_REGION context", err)
+	}
+	if strings.Contains(msg, "bad") {
+		t.Fatalf("Init error = %q, want env value redacted", err)
 	}
 }
 

--- a/providers/openstack/openstack_provider.go
+++ b/providers/openstack/openstack_provider.go
@@ -3,8 +3,6 @@
 package openstack
 
 import (
-	"os"
-
 	"github.com/chenrui333/terraformer/terraformutils"
 	"github.com/pkg/errors"
 )
@@ -31,7 +29,7 @@ func (p OpenStackProvider) GetProviderData(_ ...string) map[string]interface{} {
 // check projectName in env params
 func (p *OpenStackProvider) Init(args []string) error {
 	p.region = ""
-	if err := os.Unsetenv("OS_REGION_NAME"); err != nil {
+	if err := terraformutils.UnsetEnv("OS_REGION_NAME"); err != nil {
 		return err
 	}
 
@@ -41,7 +39,7 @@ func (p *OpenStackProvider) Init(args []string) error {
 
 	region := args[0]
 	// terraform work with env param OS_REGION_NAME
-	if err := os.Setenv("OS_REGION_NAME", region); err != nil {
+	if err := terraformutils.SetEnv("OS_REGION_NAME", region); err != nil {
 		return err
 	}
 	p.region = region

--- a/providers/openstack/openstack_provider_test.go
+++ b/providers/openstack/openstack_provider_test.go
@@ -34,7 +34,11 @@ func TestOpenStackProviderInitReturnsRegionEnvError(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected region env error")
 	}
-	if !strings.Contains(err.Error(), `failed to set env OS_REGION_NAME="bad\x00region"`) {
+	msg := err.Error()
+	if !strings.Contains(msg, "failed to set env OS_REGION_NAME") {
 		t.Fatalf("Init error = %q, want OS_REGION_NAME context", err)
+	}
+	if strings.Contains(msg, "bad") {
+		t.Fatalf("Init error = %q, want env value redacted", err)
 	}
 }

--- a/providers/openstack/openstack_provider_test.go
+++ b/providers/openstack/openstack_provider_test.go
@@ -28,9 +28,10 @@ func TestOpenStackProviderInitRequiresRegion(t *testing.T) {
 }
 
 func TestOpenStackProviderInitReturnsRegionEnvError(t *testing.T) {
+	const probe = "REDACT_PROBE_OPENSTACK_REGION"
 	var provider OpenStackProvider
 
-	err := provider.Init([]string{"bad\x00region"})
+	err := provider.Init([]string{probe + "\x00region"})
 	if err == nil {
 		t.Fatal("expected region env error")
 	}
@@ -38,7 +39,7 @@ func TestOpenStackProviderInitReturnsRegionEnvError(t *testing.T) {
 	if !strings.Contains(msg, "failed to set env OS_REGION_NAME") {
 		t.Fatalf("Init error = %q, want OS_REGION_NAME context", err)
 	}
-	if strings.Contains(msg, "bad") {
+	if strings.Contains(msg, probe) {
 		t.Fatalf("Init error = %q, want env value redacted", err)
 	}
 }

--- a/providers/openstack/openstack_provider_test.go
+++ b/providers/openstack/openstack_provider_test.go
@@ -26,3 +26,15 @@ func TestOpenStackProviderInitRequiresRegion(t *testing.T) {
 		t.Fatalf("OS_REGION_NAME = %q, want unset after failed init", value)
 	}
 }
+
+func TestOpenStackProviderInitReturnsRegionEnvError(t *testing.T) {
+	var provider OpenStackProvider
+
+	err := provider.Init([]string{"bad\x00region"})
+	if err == nil {
+		t.Fatal("expected region env error")
+	}
+	if !strings.Contains(err.Error(), `failed to set env OS_REGION_NAME="bad\x00region"`) {
+		t.Fatalf("Init error = %q, want OS_REGION_NAME context", err)
+	}
+}

--- a/terraformutils/env.go
+++ b/terraformutils/env.go
@@ -9,7 +9,7 @@ import (
 
 func SetEnv(key, value string) error {
 	if err := os.Setenv(key, value); err != nil {
-		return fmt.Errorf("failed to set env %s=%q: %w", key, value, err)
+		return fmt.Errorf("failed to set env %s: %w", key, err)
 	}
 	return nil
 }

--- a/terraformutils/env.go
+++ b/terraformutils/env.go
@@ -1,0 +1,22 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package terraformutils
+
+import (
+	"fmt"
+	"os"
+)
+
+func SetEnv(key, value string) error {
+	if err := os.Setenv(key, value); err != nil {
+		return fmt.Errorf("failed to set env %s=%q: %w", key, value, err)
+	}
+	return nil
+}
+
+func UnsetEnv(key string) error {
+	if err := os.Unsetenv(key); err != nil {
+		return fmt.Errorf("failed to unset env %s: %w", key, err)
+	}
+	return nil
+}

--- a/terraformutils/env_test.go
+++ b/terraformutils/env_test.go
@@ -1,0 +1,18 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package terraformutils
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestSetEnvWrapsMutationError(t *testing.T) {
+	err := SetEnv("BAD=KEY", "value")
+	if err == nil {
+		t.Fatal("expected SetEnv to fail")
+	}
+	if msg := err.Error(); !strings.Contains(msg, "failed to set env BAD=KEY=\"value\"") {
+		t.Fatalf("error = %q, want env key and value context", msg)
+	}
+}

--- a/terraformutils/env_test.go
+++ b/terraformutils/env_test.go
@@ -12,7 +12,11 @@ func TestSetEnvWrapsMutationError(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected SetEnv to fail")
 	}
-	if msg := err.Error(); !strings.Contains(msg, "failed to set env BAD=KEY=\"value\"") {
-		t.Fatalf("error = %q, want env key and value context", msg)
+	msg := err.Error()
+	if !strings.Contains(msg, "failed to set env BAD=KEY") {
+		t.Fatalf("error = %q, want env key context", msg)
+	}
+	if strings.Contains(msg, "value") {
+		t.Fatalf("error = %q, want env value redacted", msg)
 	}
 }


### PR DESCRIPTION
Summary

- Add shared terraformutils helpers that wrap environment variable mutation errors with key/value context.
- Use the helpers across AWS, Gmail Filter, IBM, and OpenStack provider env setup.
- Return AWS service env setup failures instead of silently ignoring them, with regression coverage for invalid env values.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Standardized env var handling with `terraformutils.SetEnv` and `terraformutils.UnsetEnv` to return key-scoped errors and redact values. Applied across AWS (provider and service), Gmail Filter, IBM, and OpenStack; AWS now returns env setup failures instead of silently ignoring them.

- **Bug Fixes**
  - AWS provider and service now return env setup errors for `AWS_REGION`, profile, and credential vars; messages include key context and redact values.
  - Gmail Filter (`GOOGLE_CREDENTIALS`, `IMPERSONATED_USER_EMAIL`), IBM (`IC_REGION`), and OpenStack (`OS_REGION_NAME`) init now surface env mutation errors; tests cover invalid inputs and use unique redaction probes per provider.

- **Refactors**
  - Replaced direct `os.Setenv`/`os.Unsetenv` with `terraformutils` helpers across providers and AWS service.

<sup>Written for commit a02654be08b669358190321e45db889fa95db6dd. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Standardized environment-variable handling across providers to improve error propagation and robustness.

* **Tests**
  * Added tests for environment operation failures and to verify error messages redact sensitive values.

* **Chores**
  * Introduced centralized helpers for setting/unsetting environment variables and replaced direct OS env mutations for consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->