### PR TITLE
fix(providers): stage optional init state until success

### DIFF
--- a/providers/datadog/datadog_provider.go
+++ b/providers/datadog/datadog_provider.go
@@ -28,6 +28,13 @@ type DatadogProvider struct { //nolint
 
 // Init check env params and initialize API Client
 func (p *DatadogProvider) Init(args []string) error {
+	p.apiKey = ""
+	p.appKey = ""
+	p.apiURL = ""
+	p.validate = false
+	p.auth = nil
+	p.datadogClient = nil
+
 	apiKeyArg := optionalInitArg(args, 0)
 	appKeyArg := optionalInitArg(args, 1)
 	apiURLArg := optionalInitArg(args, 2)

--- a/providers/datadog/datadog_provider_test.go
+++ b/providers/datadog/datadog_provider_test.go
@@ -67,6 +67,45 @@ func TestDatadogProviderInitReturnsCredentialErrorForShortArgs(t *testing.T) {
 	}
 }
 
+func TestDatadogProviderInitClearsStateOnValidateError(t *testing.T) {
+	t.Setenv("DATADOG_API_KEY", "env-api-key")
+	t.Setenv("DATADOG_APP_KEY", "env-app-key")
+	t.Setenv("DATADOG_HOST", "https://old.example.com")
+	t.Setenv("DATADOG_VALIDATE", "not-bool")
+	provider := DatadogProvider{
+		apiKey:   "old-api-key",
+		appKey:   "old-app-key",
+		apiURL:   "https://stale.example.com",
+		validate: true,
+	}
+
+	err := provider.Init(nil)
+	if err == nil {
+		t.Fatal("expected invalid validate error")
+	}
+	if !strings.Contains(err.Error(), "invalid DATADOG_VALIDATE") {
+		t.Fatalf("Init error = %q, want validate parse error", err)
+	}
+	if provider.apiKey != "" {
+		t.Fatalf("apiKey = %q, want empty after failed init", provider.apiKey)
+	}
+	if provider.appKey != "" {
+		t.Fatalf("appKey = %q, want empty after failed init", provider.appKey)
+	}
+	if provider.apiURL != "" {
+		t.Fatalf("apiURL = %q, want empty after failed init", provider.apiURL)
+	}
+	if provider.validate {
+		t.Fatal("validate = true, want false after failed init")
+	}
+	if provider.auth != nil {
+		t.Fatal("auth is set, want nil after failed init")
+	}
+	if provider.datadogClient != nil {
+		t.Fatal("datadogClient is set, want nil after failed init")
+	}
+}
+
 func TestDatadogProviderAPMRetentionFilterConnections(t *testing.T) {
 	connections := DatadogProvider{}.GetResourceConnections()
 

--- a/providers/github/github_errors_test.go
+++ b/providers/github/github_errors_test.go
@@ -28,7 +28,14 @@ func TestCreateMembershipsResourcesReturnsListError(t *testing.T) {
 }
 
 func TestGithubProviderInitRequiresOwner(t *testing.T) {
-	var provider GithubProvider
+	provider := GithubProvider{
+		owner:          "old-owner",
+		token:          "old-token",
+		baseURL:        "https://github.example.com/api/v3/",
+		appID:          123,
+		installationID: 456,
+		pem:            "old-pem",
+	}
 
 	err := provider.Init(nil)
 	if err == nil {
@@ -36,6 +43,18 @@ func TestGithubProviderInitRequiresOwner(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "owner is required") {
 		t.Fatalf("Init error = %q, want missing owner", err)
+	}
+	if provider.owner != "" {
+		t.Fatalf("owner = %q, want empty after failed init", provider.owner)
+	}
+	if provider.token != "" {
+		t.Fatalf("token = %q, want empty after failed init", provider.token)
+	}
+	if provider.baseURL != githubDefaultURL {
+		t.Fatalf("baseURL = %q, want %q after failed init", provider.baseURL, githubDefaultURL)
+	}
+	if provider.appID != 0 || provider.installationID != 0 || provider.pem != "" {
+		t.Fatalf("app auth = (%d, %d, %q), want cleared after failed init", provider.appID, provider.installationID, provider.pem)
 	}
 }
 
@@ -62,7 +81,14 @@ func TestGithubProviderInitReturnsTokenErrorForEmptyTokenArgWithoutEnv(t *testin
 	t.Setenv("GITHUB_APP_ID", "")
 	t.Setenv("GITHUB_APP_INSTALLATION_ID", "")
 	t.Setenv("GITHUB_APP_PEM_FILE", "")
-	var provider GithubProvider
+	provider := GithubProvider{
+		owner:          "old-owner",
+		token:          "old-token",
+		baseURL:        "https://github.example.com/api/v3/",
+		appID:          123,
+		installationID: 456,
+		pem:            "old-pem",
+	}
 
 	err := provider.Init([]string{"test-org", "", ""})
 	if err == nil {
@@ -70,6 +96,18 @@ func TestGithubProviderInitReturnsTokenErrorForEmptyTokenArgWithoutEnv(t *testin
 	}
 	if !strings.Contains(err.Error(), "token requirement") {
 		t.Fatalf("Init error = %q, want token requirement", err)
+	}
+	if provider.owner != "" {
+		t.Fatalf("owner = %q, want empty after failed init", provider.owner)
+	}
+	if provider.token != "" {
+		t.Fatalf("token = %q, want empty after failed init", provider.token)
+	}
+	if provider.baseURL != githubDefaultURL {
+		t.Fatalf("baseURL = %q, want %q after failed init", provider.baseURL, githubDefaultURL)
+	}
+	if provider.appID != 0 || provider.installationID != 0 || provider.pem != "" {
+		t.Fatalf("app auth = (%d, %d, %q), want cleared after failed init", provider.appID, provider.installationID, provider.pem)
 	}
 }
 

--- a/providers/github/github_provider.go
+++ b/providers/github/github_provider.go
@@ -60,47 +60,58 @@ func (p *GithubProvider) GetConfig() cty.Value {
 
 // Init GithubProvider with owner
 func (p *GithubProvider) Init(args []string) error {
-	if len(args) < 1 || args[0] == "" {
-		return errors.New("github: owner is required")
-	}
-
-	p.owner = args[0]
+	p.owner = ""
 	p.token = ""
 	p.baseURL = githubDefaultURL
 	p.appID = 0
 	p.installationID = 0
 	p.pem = ""
 
+	if len(args) < 1 || args[0] == "" {
+		return errors.New("github: owner is required")
+	}
+
+	owner := args[0]
+	token := ""
+	baseURL := githubDefaultURL
+	var appID int64
+	var installationID int64
+	pem := ""
 	if appIDValue := os.Getenv("GITHUB_APP_ID"); appIDValue != "" {
-		appID, err := strconv.ParseInt(appIDValue, 10, 64)
+		parsedAppID, err := strconv.ParseInt(appIDValue, 10, 64)
 		if err != nil {
 			return err
 		}
-		p.appID = appID
+		appID = parsedAppID
 	}
 	if installationIDValue := os.Getenv("GITHUB_APP_INSTALLATION_ID"); installationIDValue != "" {
-		installationID, err := strconv.ParseInt(installationIDValue, 10, 64)
+		parsedInstallationID, err := strconv.ParseInt(installationIDValue, 10, 64)
 		if err != nil {
 			return err
 		}
-		p.installationID = installationID
+		installationID = parsedInstallationID
 	}
-	if pem := os.Getenv("GITHUB_APP_PEM_FILE"); pem != "" {
-		p.pem = strings.ReplaceAll(pem, `\n`, "\n")
+	if pemValue := os.Getenv("GITHUB_APP_PEM_FILE"); pemValue != "" {
+		pem = strings.ReplaceAll(pemValue, `\n`, "\n")
 	}
 
 	if len(args) > 1 && args[1] != "" {
-		p.token = args[1]
+		token = args[1]
 	} else {
-		token := os.Getenv("GITHUB_TOKEN")
-		if token == "" && (p.appID == 0 || p.installationID == 0 || p.pem == "") {
+		token = os.Getenv("GITHUB_TOKEN")
+		if token == "" && (appID == 0 || installationID == 0 || pem == "") {
 			return errors.New("token requirement")
 		}
-		p.token = token
 	}
 	if len(args) > 2 && args[2] != "" {
-		p.baseURL = args[2]
+		baseURL = args[2]
 	}
+	p.owner = owner
+	p.token = token
+	p.baseURL = baseURL
+	p.appID = appID
+	p.installationID = installationID
+	p.pem = pem
 	return nil
 }
 

--- a/providers/gitlab/gitlab_errors_test.go
+++ b/providers/gitlab/gitlab_errors_test.go
@@ -76,7 +76,11 @@ func TestGitLabProviderInitUsesEnvTokenForEmptyTokenArg(t *testing.T) {
 
 func TestGitLabProviderInitReturnsTokenErrorForEmptyTokenArgWithoutEnv(t *testing.T) {
 	t.Setenv("GITLAB_TOKEN", "")
-	var provider GitLabProvider
+	provider := GitLabProvider{
+		group:   "old-group",
+		token:   "old-token",
+		baseURL: "https://gitlab.example.com/api/v4/",
+	}
 
 	err := provider.Init([]string{"test-group", "", ""})
 	if err == nil {
@@ -84,6 +88,15 @@ func TestGitLabProviderInitReturnsTokenErrorForEmptyTokenArgWithoutEnv(t *testin
 	}
 	if !strings.Contains(err.Error(), "token requirement") {
 		t.Fatalf("Init error = %q, want token requirement", err)
+	}
+	if provider.group != "" {
+		t.Fatalf("group = %q, want empty after failed init", provider.group)
+	}
+	if provider.token != "" {
+		t.Fatalf("token = %q, want empty after failed init", provider.token)
+	}
+	if provider.baseURL != gitLabDefaultURL {
+		t.Fatalf("baseURL = %q, want %q after failed init", provider.baseURL, gitLabDefaultURL)
 	}
 }
 

--- a/providers/gitlab/gitlab_provider.go
+++ b/providers/gitlab/gitlab_provider.go
@@ -51,19 +51,23 @@ func (p *GitLabProvider) Init(args []string) error {
 		return errors.New("gitlab: group is required")
 	}
 
-	p.group = args[0]
+	group := args[0]
+	token := ""
+	baseURL := gitLabDefaultURL
 	if len(args) > 1 && args[1] != "" {
-		p.token = args[1]
+		token = args[1]
 	} else {
-		token := os.Getenv("GITLAB_TOKEN")
+		token = os.Getenv("GITLAB_TOKEN")
 		if token == "" {
 			return errors.New("token requirement")
 		}
-		p.token = token
 	}
 	if len(args) > 2 && args[2] != "" {
-		p.baseURL = args[2]
+		baseURL = args[2]
 	}
+	p.group = group
+	p.token = token
+	p.baseURL = baseURL
 	return nil
 }
 

--- a/providers/gmailfilter/gmailfilter_provider.go
+++ b/providers/gmailfilter/gmailfilter_provider.go
@@ -16,25 +16,41 @@ type GmailfilterProvider struct { //nolint
 }
 
 func (p *GmailfilterProvider) Init(args []string) error {
-	credentials := os.Getenv("GOOGLE_CREDENTIALS")
+	p.credentials = ""
+	p.impersonatedUserEmail = ""
+
+	previousCredentials, hadPreviousCredentials := os.LookupEnv("GOOGLE_CREDENTIALS")
+	credentials := previousCredentials
 	if len(args) > 0 && args[0] != "" {
-		credentials = args[0]
-		if err := terraformutils.SetEnv("GOOGLE_CREDENTIALS", credentials); err != nil {
+		if err := terraformutils.SetEnv("GOOGLE_CREDENTIALS", args[0]); err != nil {
 			return err
 		}
+		credentials = args[0]
 	}
 	email := os.Getenv("IMPERSONATED_USER_EMAIL")
 	if len(args) > 1 && args[1] != "" {
-		email = args[1]
-		if err := terraformutils.SetEnv("IMPERSONATED_USER_EMAIL", email); err != nil {
+		if err := terraformutils.SetEnv("IMPERSONATED_USER_EMAIL", args[1]); err != nil {
+			if len(args) > 0 && args[0] != "" {
+				if restoreErr := restoreEnv("GOOGLE_CREDENTIALS", previousCredentials, hadPreviousCredentials); restoreErr != nil {
+					return errors.Join(err, restoreErr)
+				}
+			}
 			return err
 		}
+		email = args[1]
 	}
 
 	p.credentials = credentials
 	p.impersonatedUserEmail = email
 
 	return nil
+}
+
+func restoreEnv(key, previousValue string, hadPreviousValue bool) error {
+	if hadPreviousValue {
+		return terraformutils.SetEnv(key, previousValue)
+	}
+	return terraformutils.UnsetEnv(key)
 }
 
 func (p *GmailfilterProvider) GetName() string {

--- a/providers/gmailfilter/gmailfilter_provider_test.go
+++ b/providers/gmailfilter/gmailfilter_provider_test.go
@@ -3,13 +3,17 @@
 package gmailfilter
 
 import (
+	"os"
 	"strings"
 	"testing"
 )
 
 func TestGmailfilterProviderInitReturnsCredentialEnvError(t *testing.T) {
 	const probe = "REDACT_PROBE_GMAIL_CREDENTIALS"
-	var provider GmailfilterProvider
+	provider := GmailfilterProvider{
+		credentials:           "old-credentials",
+		impersonatedUserEmail: "old@example.com",
+	}
 
 	err := provider.Init([]string{probe + "\x00credentials"})
 	if err == nil {
@@ -22,11 +26,21 @@ func TestGmailfilterProviderInitReturnsCredentialEnvError(t *testing.T) {
 	if strings.Contains(msg, probe) {
 		t.Fatalf("Init error = %q, want credentials value redacted", msg)
 	}
+	if provider.credentials != "" {
+		t.Fatalf("credentials = %q, want empty after failed init", provider.credentials)
+	}
+	if provider.impersonatedUserEmail != "" {
+		t.Fatalf("impersonatedUserEmail = %q, want empty after failed init", provider.impersonatedUserEmail)
+	}
 }
 
 func TestGmailfilterProviderInitReturnsImpersonatedUserEnvError(t *testing.T) {
 	const probe = "REDACT_PROBE_GMAIL_USER"
-	var provider GmailfilterProvider
+	t.Setenv("GOOGLE_CREDENTIALS", "previous-credentials")
+	provider := GmailfilterProvider{
+		credentials:           "old-credentials",
+		impersonatedUserEmail: "old@example.com",
+	}
 
 	err := provider.Init([]string{"credentials", probe + "\x00email"})
 	if err == nil {
@@ -38,5 +52,14 @@ func TestGmailfilterProviderInitReturnsImpersonatedUserEnvError(t *testing.T) {
 	}
 	if strings.Contains(msg, probe) {
 		t.Fatalf("Init error = %q, want email value redacted", msg)
+	}
+	if provider.credentials != "" {
+		t.Fatalf("credentials = %q, want empty after failed init", provider.credentials)
+	}
+	if provider.impersonatedUserEmail != "" {
+		t.Fatalf("impersonatedUserEmail = %q, want empty after failed init", provider.impersonatedUserEmail)
+	}
+	if got := os.Getenv("GOOGLE_CREDENTIALS"); got != "previous-credentials" {
+		t.Fatalf("GOOGLE_CREDENTIALS = %q, want previous-credentials after failed init", got)
 	}
 }

--- a/providers/honeycombio/honeycomb_provider.go
+++ b/providers/honeycombio/honeycomb_provider.go
@@ -70,15 +70,20 @@ func (p HoneycombProvider) GetResourceConnections() map[string]map[string][]stri
 	}
 }
 func (p *HoneycombProvider) Init(args []string) error {
-	p.apiKey = os.Getenv("HONEYCOMB_API_KEY")
-	if p.apiKey == "" {
+	p.apiKey = ""
+	p.apiURL = ""
+	p.datasets = nil
+
+	apiKey := os.Getenv("HONEYCOMB_API_KEY")
+	if apiKey == "" {
 		return errors.New("the Honeycomb API key must be set via `HONEYCOMB_API_KEY` env var")
 	}
-	p.apiURL = os.Getenv("HONEYCOMB_API_URL")
-	if p.apiURL == "" {
-		p.apiURL = honeycombDefaultURL
+	apiURL := os.Getenv("HONEYCOMB_API_URL")
+	if apiURL == "" {
+		apiURL = honeycombDefaultURL
 	}
-	// datasets are the only argument
+	p.apiKey = apiKey
+	p.apiURL = apiURL
 	p.datasets = args
 
 	return nil

--- a/providers/honeycombio/honeycomb_provider_test.go
+++ b/providers/honeycombio/honeycomb_provider_test.go
@@ -1,0 +1,54 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package honeycombio
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestHoneycombProviderInitClearsStateOnMissingAPIKey(t *testing.T) {
+	t.Setenv("HONEYCOMB_API_KEY", "")
+	t.Setenv("HONEYCOMB_API_URL", "https://api.eu1.honeycomb.io")
+	provider := HoneycombProvider{
+		apiKey:   "old-key",
+		apiURL:   "https://old.example.com",
+		datasets: []string{"old-dataset"},
+	}
+
+	err := provider.Init([]string{"dataset"})
+	if err == nil {
+		t.Fatal("expected missing API key error")
+	}
+	if !strings.Contains(err.Error(), "HONEYCOMB_API_KEY") {
+		t.Fatalf("Init error = %q, want API key requirement", err)
+	}
+	if provider.apiKey != "" {
+		t.Fatalf("apiKey = %q, want empty after failed init", provider.apiKey)
+	}
+	if provider.apiURL != "" {
+		t.Fatalf("apiURL = %q, want empty after failed init", provider.apiURL)
+	}
+	if provider.datasets != nil {
+		t.Fatalf("datasets = %v, want nil after failed init", provider.datasets)
+	}
+}
+
+func TestHoneycombProviderInitUsesDefaultAPIURL(t *testing.T) {
+	t.Setenv("HONEYCOMB_API_KEY", "api-key")
+	t.Setenv("HONEYCOMB_API_URL", "")
+	var provider HoneycombProvider
+
+	if err := provider.Init([]string{"dataset"}); err != nil {
+		t.Fatalf("expected Init to succeed: %v", err)
+	}
+	if provider.apiKey != "api-key" {
+		t.Fatalf("apiKey = %q, want api-key", provider.apiKey)
+	}
+	if provider.apiURL != honeycombDefaultURL {
+		t.Fatalf("apiURL = %q, want %q", provider.apiURL, honeycombDefaultURL)
+	}
+	if len(provider.datasets) != 1 || provider.datasets[0] != "dataset" {
+		t.Fatalf("datasets = %v, want [dataset]", provider.datasets)
+	}
+}

--- a/providers/newrelic/newrelic_provider.go
+++ b/providers/newrelic/newrelic_provider.go
@@ -19,6 +19,10 @@ type NewRelicProvider struct { //nolint
 }
 
 func (p *NewRelicProvider) Init(args []string) error {
+	p.APIKey = ""
+	p.accountID = 0
+	p.Region = ""
+
 	apiKey := os.Getenv("NEW_RELIC_API_KEY")
 	accountID := 0
 	accountIDSet := false
@@ -45,15 +49,15 @@ func (p *NewRelicProvider) Init(args []string) error {
 	if len(args) > 2 && args[2] != "" {
 		region = args[2]
 	}
-	p.APIKey = apiKey
-	p.accountID = accountID
-	p.Region = region
 	if !accountIDSet {
 		return errors.New("newrelic: account id is required")
 	}
 	if accountID <= 0 {
 		return errors.New("newrelic: account id must be greater than 0")
 	}
+	p.APIKey = apiKey
+	p.accountID = accountID
+	p.Region = region
 	return nil
 }
 

--- a/providers/newrelic/newrelic_provider_test.go
+++ b/providers/newrelic/newrelic_provider_test.go
@@ -88,7 +88,31 @@ func TestNewRelicProviderInitReturnsMissingAccountIDError(t *testing.T) {
 	if provider.accountID != 0 {
 		t.Fatalf("accountID = %d, want 0", provider.accountID)
 	}
-	if provider.Region != "US" {
-		t.Fatalf("Region = %q, want US", provider.Region)
+	if provider.Region != "" {
+		t.Fatalf("Region = %q, want empty", provider.Region)
+	}
+}
+
+func TestNewRelicProviderInitClearsStateOnInvalidAccountID(t *testing.T) {
+	t.Setenv("NEW_RELIC_API_KEY", "env-key")
+	t.Setenv("NEW_RELIC_ACCOUNT_ID", "")
+	provider := NewRelicProvider{
+		APIKey:    "old-key",
+		accountID: 123,
+		Region:    "EU",
+	}
+
+	err := provider.Init([]string{"api-key", "not-a-number", "US"})
+	if err == nil {
+		t.Fatal("expected invalid account ID error")
+	}
+	if provider.APIKey != "" {
+		t.Fatalf("APIKey = %q, want empty after failed init", provider.APIKey)
+	}
+	if provider.accountID != 0 {
+		t.Fatalf("accountID = %d, want 0 after failed init", provider.accountID)
+	}
+	if provider.Region != "" {
+		t.Fatalf("Region = %q, want empty after failed init", provider.Region)
 	}
 }

--- a/providers/yandex/yandex_provider.go
+++ b/providers/yandex/yandex_provider.go
@@ -25,22 +25,28 @@ func (p *YandexProvider) Init(args []string) error {
 	p.saKeyFileOrContent = ""
 	p.folderID = ""
 
+	token := ""
+	saKeyFileOrContent := ""
+	folderID := ""
 	if ycToken, ok := os.LookupEnv("YC_TOKEN"); ok {
-		p.token = ycToken
+		token = ycToken
 	}
 
-	if saKeyFileOrContent, ok := os.LookupEnv("YC_SERVICE_ACCOUNT_KEY_FILE"); ok {
-		p.saKeyFileOrContent = saKeyFileOrContent
+	if envSaKeyFileOrContent, ok := os.LookupEnv("YC_SERVICE_ACCOUNT_KEY_FILE"); ok {
+		saKeyFileOrContent = envSaKeyFileOrContent
 	}
 
 	if len(args) > 0 && args[0] != "" {
 		//  first args is target folder ID
-		p.folderID = args[0]
-	} else if folderID := os.Getenv("YC_FOLDER_ID"); folderID != "" {
-		p.folderID = folderID
+		folderID = args[0]
+	} else if envFolderID := os.Getenv("YC_FOLDER_ID"); envFolderID != "" {
+		folderID = envFolderID
 	} else {
 		return errors.New("set YC_FOLDER_ID env var")
 	}
+	p.token = token
+	p.saKeyFileOrContent = saKeyFileOrContent
+	p.folderID = folderID
 
 	return nil
 }

--- a/providers/yandex/yandex_provider_test.go
+++ b/providers/yandex/yandex_provider_test.go
@@ -8,8 +8,8 @@ import (
 )
 
 func TestYandexProviderInitClearsStateOnMissingFolderID(t *testing.T) {
-	t.Setenv("YC_TOKEN", "")
-	t.Setenv("YC_SERVICE_ACCOUNT_KEY_FILE", "")
+	t.Setenv("YC_TOKEN", "env-token")
+	t.Setenv("YC_SERVICE_ACCOUNT_KEY_FILE", "env-key")
 	t.Setenv("YC_FOLDER_ID", "")
 	provider := YandexProvider{
 		token:              "old-token",


### PR DESCRIPTION
Summary

- Clear optional/env-backed provider init state before validation and publish fields only after Init succeeds.
- Stage GitHub, GitLab, Gmail Filter, Honeycomb, New Relic, Yandex, and Datadog init values to avoid partial provider state after later failures.
- Restore Gmail Filter credential env when a later impersonated-user env mutation fails.
- Add focused failed re-init regression coverage across the touched providers.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents stale provider state after failed Init by committing optional and env-backed values only on success. Adds safeguards for `gmailfilter` env mutations and regression tests across providers.

- **Bug Fixes**
  - `gmailfilter`: restore previous `GOOGLE_CREDENTIALS` if `IMPERSONATED_USER_EMAIL` update fails; redact sensitive values in errors.
  - Apply defaults only after validation (e.g., `github` base URL, `honeycombio` API URL).
  - Added focused re-init regression tests to verify state clearing and error handling across `datadog`, `github`, `gitlab`, `gmailfilter`, `honeycombio`, `newrelic`, and `yandex`.

<sup>Written for commit 6eee08c008944e8b686d7b5e2ffc85bab9c29af4. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed an issue where providers could be left in a partially initialized state if initialization failed. All provider configurations now properly reset to default values when initialization encounters errors.

* **Tests**
  * Added and updated provider initialization tests to verify state is properly cleared on initialization failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->