### PR TITLE
fix(providers): surface ignored parse errors

### DIFF
--- a/providers/aws/aws_provider.go
+++ b/providers/aws/aws_provider.go
@@ -184,12 +184,15 @@ func (p *AWSProvider) Init(args []string) error {
 
 	region := args[0]
 	profile := args[1]
+	enableSharedConfig, err := awsSDKLoadConfigEnabled()
+	if err != nil {
+		return err
+	}
 	if err := clearAWSEnvConfig(region == NoRegion); err != nil {
 		return err
 	}
 
 	// Terraformer accepts region and profile configuration, so we must detect what env variables to adjust to make Go SDK rely on them. AWS_SDK_LOAD_CONFIG here must be checked to determine correct variable to set.
-	enableSharedConfig, _ := strconv.ParseBool(os.Getenv("AWS_SDK_LOAD_CONFIG"))
 	if region != GlobalRegion && region != NoRegion {
 		envVar := "AWS_REGION"
 		if enableSharedConfig {
@@ -213,6 +216,18 @@ func (p *AWSProvider) Init(args []string) error {
 	p.region = region
 	p.profile = profile
 	return nil
+}
+
+func awsSDKLoadConfigEnabled() (bool, error) {
+	value := os.Getenv("AWS_SDK_LOAD_CONFIG")
+	if value == "" {
+		return false, nil
+	}
+	enabled, err := strconv.ParseBool(value)
+	if err != nil {
+		return false, errors.Wrap(err, "parse AWS_SDK_LOAD_CONFIG")
+	}
+	return enabled, nil
 }
 
 func clearAWSEnvConfig(preserveRegion bool) error {

--- a/providers/aws/aws_provider_init_test.go
+++ b/providers/aws/aws_provider_init_test.go
@@ -64,3 +64,47 @@ func TestAWSProviderInitPreservesAmbientRegionForNoRegion(t *testing.T) {
 		t.Fatalf("AWS_DEFAULT_PROFILE = %q, want unset", value)
 	}
 }
+
+func TestAWSProviderInitRejectsInvalidSDKLoadConfig(t *testing.T) {
+	t.Setenv("AWS_SDK_LOAD_CONFIG", "not-bool")
+	t.Setenv("AWS_REGION", "old-region")
+	var provider AWSProvider
+
+	err := provider.Init([]string{MainRegionPublicPartition, "default"})
+	if err == nil {
+		t.Fatal("expected invalid AWS_SDK_LOAD_CONFIG error")
+	}
+	if !strings.Contains(err.Error(), "AWS_SDK_LOAD_CONFIG") {
+		t.Fatalf("Init error = %q, want AWS_SDK_LOAD_CONFIG context", err)
+	}
+	if provider.region != "" {
+		t.Fatalf("region = %q, want empty after failed init", provider.region)
+	}
+	if provider.profile != "" {
+		t.Fatalf("profile = %q, want empty after failed init", provider.profile)
+	}
+	if got := os.Getenv("AWS_REGION"); got != "old-region" {
+		t.Fatalf("AWS_REGION = %q, want old-region after failed init", got)
+	}
+}
+
+func TestAWSProviderInitUsesSharedConfigEnvVars(t *testing.T) {
+	t.Setenv("AWS_SDK_LOAD_CONFIG", "true")
+	var provider AWSProvider
+
+	if err := provider.Init([]string{MainRegionPublicPartition, "ops"}); err != nil {
+		t.Fatalf("expected Init to succeed: %v", err)
+	}
+	if got := os.Getenv("AWS_DEFAULT_REGION"); got != MainRegionPublicPartition {
+		t.Fatalf("AWS_DEFAULT_REGION = %q, want %q", got, MainRegionPublicPartition)
+	}
+	if got := os.Getenv("AWS_DEFAULT_PROFILE"); got != "ops" {
+		t.Fatalf("AWS_DEFAULT_PROFILE = %q, want ops", got)
+	}
+	if value, ok := os.LookupEnv("AWS_REGION"); ok {
+		t.Fatalf("AWS_REGION = %q, want unset", value)
+	}
+	if value, ok := os.LookupEnv("AWS_PROFILE"); ok {
+		t.Fatalf("AWS_PROFILE = %q, want unset", value)
+	}
+}

--- a/providers/aws/aws_provider_init_test.go
+++ b/providers/aws/aws_provider_init_test.go
@@ -90,6 +90,8 @@ func TestAWSProviderInitRejectsInvalidSDKLoadConfig(t *testing.T) {
 
 func TestAWSProviderInitUsesSharedConfigEnvVars(t *testing.T) {
 	t.Setenv("AWS_SDK_LOAD_CONFIG", "true")
+	t.Setenv("AWS_REGION", "old-region")
+	t.Setenv("AWS_PROFILE", "old-profile")
 	var provider AWSProvider
 
 	if err := provider.Init([]string{MainRegionPublicPartition, "ops"}); err != nil {

--- a/providers/aws/ecs.go
+++ b/providers/aws/ecs.go
@@ -178,9 +178,15 @@ func ecsTaskDefinitionRevision(taskDefinitionArn string) (string, int, error) {
 	if definitionWithFamily == "" || revisionValue == "" {
 		return "", 0, fmt.Errorf("parse ecs task definition %q: missing family or revision", taskDefinitionArn)
 	}
+	if arnLastSegment(definitionWithFamily, "/") == "" {
+		return "", 0, fmt.Errorf("parse ecs task definition %q: missing family", taskDefinitionArn)
+	}
 	revision, err := strconv.Atoi(revisionValue)
 	if err != nil {
 		return "", 0, fmt.Errorf("parse ecs task definition revision for %q: %w", taskDefinitionArn, err)
+	}
+	if revision <= 0 {
+		return "", 0, fmt.Errorf("parse ecs task definition %q: revision must be positive", taskDefinitionArn)
 	}
 	return definitionWithFamily, revision, nil
 }

--- a/providers/aws/ecs.go
+++ b/providers/aws/ecs.go
@@ -134,9 +134,10 @@ func (g *EcsGenerator) InitResources() error {
 			return fmt.Errorf("list ecs task definitions: %w", e)
 		}
 		for _, taskDefinitionArn := range taskDefinitionsNextPage.TaskDefinitionArns {
-			arnParts := strings.Split(taskDefinitionArn, ":")
-			definitionWithFamily := arnParts[len(arnParts)-2]
-			revision, _ := strconv.Atoi(arnParts[len(arnParts)-1])
+			definitionWithFamily, revision, err := ecsTaskDefinitionRevision(taskDefinitionArn)
+			if err != nil {
+				return err
+			}
 
 			// fetch only latest revision of task definitions
 			if val, ok := taskDefinitionsMap[definitionWithFamily]; !ok || val.AdditionalFields["revision"].(int) < revision {
@@ -165,6 +166,23 @@ func (g *EcsGenerator) InitResources() error {
 	}
 
 	return nil
+}
+
+func ecsTaskDefinitionRevision(taskDefinitionArn string) (string, int, error) {
+	arnParts := strings.Split(taskDefinitionArn, ":")
+	if len(arnParts) < 2 {
+		return "", 0, fmt.Errorf("parse ecs task definition %q: missing revision", taskDefinitionArn)
+	}
+	definitionWithFamily := arnParts[len(arnParts)-2]
+	revisionValue := arnParts[len(arnParts)-1]
+	if definitionWithFamily == "" || revisionValue == "" {
+		return "", 0, fmt.Errorf("parse ecs task definition %q: missing family or revision", taskDefinitionArn)
+	}
+	revision, err := strconv.Atoi(revisionValue)
+	if err != nil {
+		return "", 0, fmt.Errorf("parse ecs task definition revision for %q: %w", taskDefinitionArn, err)
+	}
+	return definitionWithFamily, revision, nil
 }
 
 func ecsServiceDetails(output *ecs.DescribeServicesOutput, serviceName string) (ecstypes.Service, error) {

--- a/providers/aws/ecs_test.go
+++ b/providers/aws/ecs_test.go
@@ -88,6 +88,16 @@ func TestEcsTaskDefinitionRevision(t *testing.T) {
 			arn:     "arn:aws:ecs:us-east-1:123456789012:task-definition/example:not-a-number",
 			wantErr: "parse ecs task definition revision",
 		},
+		{
+			name:    "empty family",
+			arn:     "arn:aws:ecs:us-east-1:123456789012:task-definition/:1",
+			wantErr: "missing family",
+		},
+		{
+			name:    "zero revision",
+			arn:     "arn:aws:ecs:us-east-1:123456789012:task-definition/example:0",
+			wantErr: "revision must be positive",
+		},
 	}
 
 	for _, tt := range tests {

--- a/providers/aws/ecs_test.go
+++ b/providers/aws/ecs_test.go
@@ -64,6 +64,57 @@ func TestEcsResourceName(t *testing.T) {
 	}
 }
 
+func TestEcsTaskDefinitionRevision(t *testing.T) {
+	tests := []struct {
+		name           string
+		arn            string
+		wantDefinition string
+		wantRevision   int
+		wantErr        string
+	}{
+		{
+			name:           "valid",
+			arn:            "arn:aws:ecs:us-east-1:123456789012:task-definition/example:42",
+			wantDefinition: "task-definition/example",
+			wantRevision:   42,
+		},
+		{
+			name:    "missing revision",
+			arn:     "task-definition/example",
+			wantErr: "missing revision",
+		},
+		{
+			name:    "non numeric revision",
+			arn:     "arn:aws:ecs:us-east-1:123456789012:task-definition/example:not-a-number",
+			wantErr: "parse ecs task definition revision",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			definition, revision, err := ecsTaskDefinitionRevision(tt.arn)
+			if tt.wantErr != "" {
+				if err == nil {
+					t.Fatal("expected error")
+				}
+				if !strings.Contains(err.Error(), tt.wantErr) {
+					t.Fatalf("error = %q, want %q", err, tt.wantErr)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("expected no error: %v", err)
+			}
+			if definition != tt.wantDefinition {
+				t.Fatalf("definition = %q, want %q", definition, tt.wantDefinition)
+			}
+			if revision != tt.wantRevision {
+				t.Fatalf("revision = %d, want %d", revision, tt.wantRevision)
+			}
+		})
+	}
+}
+
 func TestEcsCapacityProviderImportable(t *testing.T) {
 	tests := []struct {
 		name             string

--- a/providers/honeycombio/honeycomb_provider_test.go
+++ b/providers/honeycombio/honeycomb_provider_test.go
@@ -52,3 +52,27 @@ func TestHoneycombProviderInitUsesDefaultAPIURL(t *testing.T) {
 		t.Fatalf("datasets = %v, want [dataset]", provider.datasets)
 	}
 }
+
+func TestHoneycombDebugEnabledRejectsInvalidValue(t *testing.T) {
+	t.Setenv("HONEYCOMBIO_DEBUG", "sometimes")
+
+	_, err := honeycombDebugEnabled()
+	if err == nil {
+		t.Fatal("expected invalid HONEYCOMBIO_DEBUG error")
+	}
+	if !strings.Contains(err.Error(), "HONEYCOMBIO_DEBUG") {
+		t.Fatalf("error = %q, want HONEYCOMBIO_DEBUG context", err)
+	}
+}
+
+func TestHoneycombDebugEnabledParsesValue(t *testing.T) {
+	t.Setenv("HONEYCOMBIO_DEBUG", "true")
+
+	enabled, err := honeycombDebugEnabled()
+	if err != nil {
+		t.Fatalf("expected no error: %v", err)
+	}
+	if !enabled {
+		t.Fatal("enabled = false, want true")
+	}
+}

--- a/providers/honeycombio/honeycomb_service.go
+++ b/providers/honeycombio/honeycomb_service.go
@@ -18,7 +18,10 @@ type HoneycombService struct {
 }
 
 func (s *HoneycombService) newClient() (*hnyclient.Client, error) {
-	enableDebug, _ := strconv.ParseBool(os.Getenv("HONEYCOMBIO_DEBUG"))
+	enableDebug, err := honeycombDebugEnabled()
+	if err != nil {
+		return nil, err
+	}
 
 	client, err := hnyclient.NewClientWithConfig(&hnyclient.Config{
 		APIKey:    s.GetArgs()["api_key"].(string),
@@ -64,6 +67,18 @@ func (s *HoneycombService) newClient() (*hnyclient.Client, error) {
 	}
 
 	return client, nil
+}
+
+func honeycombDebugEnabled() (bool, error) {
+	value := os.Getenv("HONEYCOMBIO_DEBUG")
+	if value == "" {
+		return false, nil
+	}
+	enabled, err := strconv.ParseBool(value)
+	if err != nil {
+		return false, fmt.Errorf("parse HONEYCOMBIO_DEBUG: %w", err)
+	}
+	return enabled, nil
 }
 
 func (s *HoneycombService) isClassicEnvironment() bool {

--- a/providers/okta/okta_provider_test.go
+++ b/providers/okta/okta_provider_test.go
@@ -2,7 +2,12 @@
 
 package okta
 
-import "testing"
+import (
+	"strings"
+	"testing"
+
+	oktasdk "github.com/okta/okta-sdk-golang/v2/okta"
+)
 
 func TestOktaProviderInitClearsStateOnMissingAPIToken(t *testing.T) {
 	provider := &OktaProvider{}
@@ -23,5 +28,43 @@ func TestOktaProviderInitClearsStateOnMissingAPIToken(t *testing.T) {
 	}
 	if provider.orgName != "" || provider.baseURL != "" || provider.apiToken != "" {
 		t.Fatalf("expected stale provider state to be cleared, got orgName=%q baseURL=%q apiToken=%q", provider.orgName, provider.baseURL, provider.apiToken)
+	}
+}
+
+func TestGetUserTypeSchemaID(t *testing.T) {
+	userType := &oktasdk.UserType{
+		Id: "custom",
+		Links: map[string]interface{}{
+			"schema": map[string]interface{}{
+				"href": "https://example.okta.com/api/v1/meta/schemas/user/custom",
+			},
+		},
+	}
+
+	schemaID, err := getUserTypeSchemaID(userType)
+	if err != nil {
+		t.Fatalf("expected no error: %v", err)
+	}
+	if schemaID != "custom" {
+		t.Fatalf("schemaID = %q, want custom", schemaID)
+	}
+}
+
+func TestGetUserTypeSchemaIDReturnsParseError(t *testing.T) {
+	userType := &oktasdk.UserType{
+		Id: "custom",
+		Links: map[string]interface{}{
+			"schema": map[string]interface{}{
+				"href": "https://example.okta.com/%zz",
+			},
+		},
+	}
+
+	_, err := getUserTypeSchemaID(userType)
+	if err == nil {
+		t.Fatal("expected schema link parse error")
+	}
+	if !strings.Contains(err.Error(), "schema link") {
+		t.Fatalf("error = %q, want schema link context", err)
 	}
 }

--- a/providers/okta/okta_provider_test.go
+++ b/providers/okta/okta_provider_test.go
@@ -68,3 +68,41 @@ func TestGetUserTypeSchemaIDReturnsParseError(t *testing.T) {
 		t.Fatalf("error = %q, want schema link context", err)
 	}
 }
+
+func TestGetUserTypeSchemaIDRejectsUnexpectedPath(t *testing.T) {
+	userType := &oktasdk.UserType{
+		Id: "custom",
+		Links: map[string]interface{}{
+			"schema": map[string]interface{}{
+				"href": "https://example.okta.com/api/v1/users/custom",
+			},
+		},
+	}
+
+	_, err := getUserTypeSchemaID(userType)
+	if err == nil {
+		t.Fatal("expected unexpected schema path error")
+	}
+	if !strings.Contains(err.Error(), "unexpected path") {
+		t.Fatalf("error = %q, want unexpected path context", err)
+	}
+}
+
+func TestGetUserTypeSchemaIDRejectsMissingSchemaID(t *testing.T) {
+	userType := &oktasdk.UserType{
+		Id: "custom",
+		Links: map[string]interface{}{
+			"schema": map[string]interface{}{
+				"href": "https://example.okta.com/api/v1/meta/schemas/user/",
+			},
+		},
+	}
+
+	_, err := getUserTypeSchemaID(userType)
+	if err == nil {
+		t.Fatal("expected missing schema ID error")
+	}
+	if !strings.Contains(err.Error(), "missing schema ID") {
+		t.Fatalf("error = %q, want missing schema ID context", err)
+	}
+}

--- a/providers/okta/okta_provider_test.go
+++ b/providers/okta/okta_provider_test.go
@@ -50,6 +50,94 @@ func TestGetUserTypeSchemaID(t *testing.T) {
 	}
 }
 
+func TestGetUserTypeSchemaIDAllowsMissingLinkFields(t *testing.T) {
+	tests := []struct {
+		name     string
+		userType *oktasdk.UserType
+	}{
+		{
+			name:     "links missing",
+			userType: &oktasdk.UserType{Id: "custom"},
+		},
+		{
+			name: "schema missing",
+			userType: &oktasdk.UserType{
+				Id:    "custom",
+				Links: map[string]interface{}{},
+			},
+		},
+		{
+			name: "href missing",
+			userType: &oktasdk.UserType{
+				Id: "custom",
+				Links: map[string]interface{}{
+					"schema": map[string]interface{}{},
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			schemaID, err := getUserTypeSchemaID(tt.userType)
+			if err != nil {
+				t.Fatalf("expected no error: %v", err)
+			}
+			if schemaID != "" {
+				t.Fatalf("schemaID = %q, want empty", schemaID)
+			}
+		})
+	}
+}
+
+func TestGetUserTypeSchemaIDRejectsMalformedLinkFields(t *testing.T) {
+	tests := []struct {
+		name     string
+		userType *oktasdk.UserType
+		wantErr  string
+	}{
+		{
+			name:     "links wrong type",
+			userType: &oktasdk.UserType{Id: "custom", Links: "bad-links"},
+			wantErr:  "links has type",
+		},
+		{
+			name: "schema wrong type",
+			userType: &oktasdk.UserType{
+				Id: "custom",
+				Links: map[string]interface{}{
+					"schema": "bad-schema",
+				},
+			},
+			wantErr: "schema has type",
+		},
+		{
+			name: "href wrong type",
+			userType: &oktasdk.UserType{
+				Id: "custom",
+				Links: map[string]interface{}{
+					"schema": map[string]interface{}{
+						"href": 123,
+					},
+				},
+			},
+			wantErr: "href has type",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := getUserTypeSchemaID(tt.userType)
+			if err == nil {
+				t.Fatal("expected malformed schema link error")
+			}
+			if !strings.Contains(err.Error(), tt.wantErr) {
+				t.Fatalf("error = %q, want %q", err, tt.wantErr)
+			}
+		})
+	}
+}
+
 func TestGetUserTypeSchemaIDReturnsParseError(t *testing.T) {
 	userType := &oktasdk.UserType{
 		Id: "custom",

--- a/providers/okta/user_schema.go
+++ b/providers/okta/user_schema.go
@@ -12,6 +12,8 @@ import (
 	"github.com/okta/okta-sdk-golang/v2/okta"
 )
 
+const oktaUserSchemaPathPrefix = "/api/v1/meta/schemas/user/"
+
 type UserSchemaPropertyGenerator struct {
 	OktaService
 }
@@ -115,7 +117,15 @@ func getUserTypeSchemaID(ut *okta.UserType) (string, error) {
 				if err != nil {
 					return "", fmt.Errorf("parse Okta user type %q schema link: %w", ut.Id, err)
 				}
-				return strings.TrimPrefix(u.EscapedPath(), "/api/v1/meta/schemas/user/"), nil
+				path := u.EscapedPath()
+				if !strings.HasPrefix(path, oktaUserSchemaPathPrefix) {
+					return "", fmt.Errorf("parse Okta user type %q schema link %q: unexpected path %q", ut.Id, href, path)
+				}
+				schemaID := strings.TrimPrefix(path, oktaUserSchemaPathPrefix)
+				if schemaID == "" {
+					return "", fmt.Errorf("parse Okta user type %q schema link %q: missing schema ID", ut.Id, href)
+				}
+				return schemaID, nil
 			}
 		}
 	}

--- a/providers/okta/user_schema.go
+++ b/providers/okta/user_schema.go
@@ -4,6 +4,7 @@ package okta
 
 import (
 	"context"
+	"fmt"
 	"net/url"
 	"strings"
 
@@ -62,7 +63,10 @@ func (g *UserSchemaPropertyGenerator) InitResources() error {
 	}
 
 	for _, userType := range userTypes {
-		schemaID := getUserTypeSchemaID(userType)
+		schemaID, err := getUserTypeSchemaID(userType)
+		if err != nil {
+			return err
+		}
 		if schemaID != "" {
 			schema, _, err := client.UserSchema.GetUserSchema(ctx, schemaID)
 			if err != nil {
@@ -100,17 +104,20 @@ func getUserTypes(ctx context.Context, client *okta.Client) ([]*okta.UserType, e
 	return output, nil
 }
 
-func getUserTypeSchemaID(ut *okta.UserType) string {
+func getUserTypeSchemaID(ut *okta.UserType) (string, error) {
 	fm, ok := ut.Links.(map[string]interface{})
 	if ok {
 		sm, ok := fm["schema"].(map[string]interface{})
 		if ok {
 			href, ok := sm["href"].(string)
 			if ok {
-				u, _ := url.Parse(href)
-				return strings.TrimPrefix(u.EscapedPath(), "/api/v1/meta/schemas/user/")
+				u, err := url.Parse(href)
+				if err != nil {
+					return "", fmt.Errorf("parse Okta user type %q schema link: %w", ut.Id, err)
+				}
+				return strings.TrimPrefix(u.EscapedPath(), "/api/v1/meta/schemas/user/"), nil
 			}
 		}
 	}
-	return ""
+	return "", nil
 }

--- a/providers/okta/user_schema.go
+++ b/providers/okta/user_schema.go
@@ -108,26 +108,39 @@ func getUserTypes(ctx context.Context, client *okta.Client) ([]*okta.UserType, e
 
 func getUserTypeSchemaID(ut *okta.UserType) (string, error) {
 	fm, ok := ut.Links.(map[string]interface{})
-	if ok {
-		sm, ok := fm["schema"].(map[string]interface{})
-		if ok {
-			href, ok := sm["href"].(string)
-			if ok {
-				u, err := url.Parse(href)
-				if err != nil {
-					return "", fmt.Errorf("parse Okta user type %q schema link: %w", ut.Id, err)
-				}
-				path := u.EscapedPath()
-				if !strings.HasPrefix(path, oktaUserSchemaPathPrefix) {
-					return "", fmt.Errorf("parse Okta user type %q schema link %q: unexpected path %q", ut.Id, href, path)
-				}
-				schemaID := strings.TrimPrefix(path, oktaUserSchemaPathPrefix)
-				if schemaID == "" {
-					return "", fmt.Errorf("parse Okta user type %q schema link %q: missing schema ID", ut.Id, href)
-				}
-				return schemaID, nil
-			}
+	if !ok {
+		if ut.Links == nil {
+			return "", nil
 		}
+		return "", fmt.Errorf("parse Okta user type %q schema link: links has type %T, want map[string]interface{}", ut.Id, ut.Links)
 	}
-	return "", nil
+	schemaValue, ok := fm["schema"]
+	if !ok {
+		return "", nil
+	}
+	sm, ok := schemaValue.(map[string]interface{})
+	if !ok {
+		return "", fmt.Errorf("parse Okta user type %q schema link: schema has type %T, want map[string]interface{}", ut.Id, schemaValue)
+	}
+	hrefValue, ok := sm["href"]
+	if !ok {
+		return "", nil
+	}
+	href, ok := hrefValue.(string)
+	if !ok {
+		return "", fmt.Errorf("parse Okta user type %q schema link: href has type %T, want string", ut.Id, hrefValue)
+	}
+	u, err := url.Parse(href)
+	if err != nil {
+		return "", fmt.Errorf("parse Okta user type %q schema link: %w", ut.Id, err)
+	}
+	path := u.EscapedPath()
+	if !strings.HasPrefix(path, oktaUserSchemaPathPrefix) {
+		return "", fmt.Errorf("parse Okta user type %q schema link %q: unexpected path %q", ut.Id, href, path)
+	}
+	schemaID := strings.TrimPrefix(path, oktaUserSchemaPathPrefix)
+	if schemaID == "" {
+		return "", fmt.Errorf("parse Okta user type %q schema link %q: missing schema ID", ut.Id, href)
+	}
+	return schemaID, nil
 }

--- a/providers/tencentcloud/cos.go
+++ b/providers/tencentcloud/cos.go
@@ -22,7 +22,10 @@ func (g *CosGenerator) InitResources() error {
 	region := args["region"].(string)
 	credential := args["credential"].(common.Credential)
 	requestURL := fmt.Sprintf("https://cos.%s.myqcloud.com", region)
-	u, _ := url.Parse(requestURL)
+	u, err := url.Parse(requestURL)
+	if err != nil {
+		return fmt.Errorf("parse Tencent COS service URL: %w", err)
+	}
 	uri := &cos.BaseURL{ServiceURL: u}
 	client := cos.NewClient(uri, &http.Client{
 		Transport: &cos.AuthorizationTransport{

--- a/providers/tencentcloud/cos_test.go
+++ b/providers/tencentcloud/cos_test.go
@@ -1,0 +1,32 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package tencentcloud
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/chenrui333/terraformer/terraformutils"
+	"github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common"
+)
+
+func TestCosInitResourcesReturnsServiceURLParseError(t *testing.T) {
+	generator := &CosGenerator{
+		TencentCloudService: TencentCloudService{
+			Service: terraformutils.Service{
+				Args: map[string]interface{}{
+					"region":     "bad\nregion",
+					"credential": common.Credential{},
+				},
+			},
+		},
+	}
+
+	err := generator.InitResources()
+	if err == nil {
+		t.Fatal("expected COS service URL parse error")
+	}
+	if !strings.Contains(err.Error(), "parse Tencent COS service URL") {
+		t.Fatalf("error = %q, want COS service URL parse context", err)
+	}
+}


### PR DESCRIPTION
Summary

- Return explicit errors for invalid AWS_SDK_LOAD_CONFIG and HONEYCOMBIO_DEBUG values instead of silently using false.
- Validate ECS task definition revisions, Okta user schema links, and Tencent COS service URLs before continuing.
- Add regression coverage for malformed config/API-data parsing paths.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Surface ignored parse errors and tighten validation in provider setup. Invalid env flags, ECS task ARNs (positive revision), Okta user schema links, and Tencent COS URLs now return clear errors; AWS shared-config envs handled correctly; tests added.

- **Bug Fixes**
  - `providers/aws`: validate `AWS_SDK_LOAD_CONFIG` and fail early; keep env unchanged on init failure; when shared config is enabled, set `AWS_DEFAULT_REGION`/`AWS_DEFAULT_PROFILE` and unset `AWS_REGION`/`AWS_PROFILE`; strictly parse ECS task definition revisions (family present, numeric and positive).
  - `providers/honeycombio`: validate `HONEYCOMBIO_DEBUG` before enabling debug.
  - `providers/okta`: parse and validate user type schema links; reject malformed link fields and unexpected paths; allow missing link fields; propagate parse errors.
  - `providers/tencentcloud`: validate COS service URL and surface parse errors.

<sup>Written for commit 35ace069a1c6fe3e6d3eeec44ed810650e1f9952. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved parsing and validation for AWS shared-config/env, Honeycomb debug flag, ECS task-definition identifiers, Okta schema links, and Tencent COS service URLs so invalid values produce clear errors instead of being ignored.

* **Tests**
  * Added tests for valid/invalid env values, ECS ARN parsing, Okta schema link handling, and Tencent COS URL parsing to prevent regressions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->