### PR TITLE
fix(providers): guard sdk resource fields

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -192,7 +192,7 @@ require (
 	github.com/golang/snappy v1.0.0 // indirect
 	github.com/google/go-querystring v1.2.0 // indirect
 	github.com/google/jsonapi v1.0.0 // indirect
-	github.com/google/uuid v1.6.0 // indirect
+	github.com/google/uuid v1.6.0
 	github.com/googleapis/gax-go/v2 v2.22.0 // indirect
 	github.com/gorilla/websocket v1.5.4-0.20250319132907-e064f32e3674 // indirect
 	github.com/hashicorp/errwrap v1.1.0 // indirect

--- a/providers/azuread/app_role_assignment.go
+++ b/providers/azuread/app_role_assignment.go
@@ -47,7 +47,7 @@ func (az *AppRoleAssignmentServiceGenerator) listResources() ([]msgraph.AppRoleA
 			continue
 		}
 		for _, assignment := range *appRoleAssignments {
-			if *assignment.PrincipalType != "ServicePrincipal" {
+			if assignment.PrincipalType == nil || *assignment.PrincipalType != "ServicePrincipal" {
 				continue
 			}
 			if assignment.Id != nil {
@@ -59,10 +59,22 @@ func (az *AppRoleAssignmentServiceGenerator) listResources() ([]msgraph.AppRoleA
 	return resources, nil
 }
 
-func (az *AppRoleAssignmentServiceGenerator) appendResource(resource *msgraph.AppRoleAssignment) {
+func (az *AppRoleAssignmentServiceGenerator) appendResource(resource *msgraph.AppRoleAssignment) error {
+	if resource == nil {
+		return fmt.Errorf("azuread_app_role_assignment resource is nil")
+	}
 	// {objectId}/{type}/{subId}
-	id := fmt.Sprintf("%s/appRoleAssignment/%s", *resource.PrincipalId, *resource.Id)
-	az.appendSimpleResource(id, *resource.PrincipalDisplayName+"-"+id, "azuread_app_role_assignment")
+	principalID, err := azureADRequiredString("azuread_app_role_assignment", "principalId", resource.PrincipalId)
+	if err != nil {
+		return err
+	}
+	assignmentID, err := azureADRequiredString("azuread_app_role_assignment", "id", resource.Id)
+	if err != nil {
+		return err
+	}
+	id := fmt.Sprintf("%s/appRoleAssignment/%s", principalID, assignmentID)
+	az.appendSimpleResource(id, azureADQualifiedResourceName(resource.PrincipalDisplayName, id), "azuread_app_role_assignment")
+	return nil
 }
 
 func (az *AppRoleAssignmentServiceGenerator) InitResources() error {
@@ -71,8 +83,10 @@ func (az *AppRoleAssignmentServiceGenerator) InitResources() error {
 		return err
 	}
 	for _, resource := range resources {
-		log.Println(*resource.PrincipalDisplayName)
-		az.appendResource(&resource)
+		log.Println(azureADResourceName(resource.PrincipalDisplayName, azureADStringValue(resource.PrincipalId)))
+		if err := az.appendResource(&resource); err != nil {
+			return err
+		}
 	}
 	return nil
 }

--- a/providers/azuread/application.go
+++ b/providers/azuread/application.go
@@ -3,6 +3,7 @@ package azuread
 
 import (
 	"context"
+	"fmt"
 	"log"
 
 	"github.com/hashicorp/go-azure-sdk/sdk/odata"
@@ -34,9 +35,16 @@ func (az *ApplicationServiceGenerator) listResources() ([]msgraph.Application, e
 	return resources, nil
 }
 
-func (az *ApplicationServiceGenerator) appendResource(resource *msgraph.Application) {
-	id := resource.ID()
-	az.appendSimpleResource(*id, *resource.DisplayName, "azuread_application")
+func (az *ApplicationServiceGenerator) appendResource(resource *msgraph.Application) error {
+	if resource == nil {
+		return fmt.Errorf("azuread_application resource is nil")
+	}
+	id, err := azureADRequiredString("azuread_application", "id", resource.ID())
+	if err != nil {
+		return err
+	}
+	az.appendSimpleResource(id, azureADResourceName(resource.DisplayName, id), "azuread_application")
+	return nil
 }
 
 func (az *ApplicationServiceGenerator) InitResources() error {
@@ -45,8 +53,10 @@ func (az *ApplicationServiceGenerator) InitResources() error {
 		return err
 	}
 	for _, resource := range resources {
-		log.Println(*resource.DisplayName)
-		az.appendResource(&resource)
+		log.Println(azureADResourceName(resource.DisplayName, azureADStringValue(resource.ID())))
+		if err := az.appendResource(&resource); err != nil {
+			return err
+		}
 	}
 	return nil
 }

--- a/providers/azuread/azuread_resource_test.go
+++ b/providers/azuread/azuread_resource_test.go
@@ -1,0 +1,184 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package azuread
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/chenrui333/terraformer/terraformutils"
+	"github.com/manicminer/hamilton/msgraph"
+)
+
+func stringPtr(value string) *string {
+	return &value
+}
+
+func TestAzureADAppendResourceFallsBackToIDName(t *testing.T) {
+	tests := []struct {
+		name     string
+		append   func() ([]terraformutils.Resource, error)
+		wantID   string
+		wantName string
+		wantType string
+	}{
+		{
+			name: "application",
+			append: func() ([]terraformutils.Resource, error) {
+				generator := &ApplicationServiceGenerator{}
+				err := generator.appendResource(&msgraph.Application{
+					DirectoryObject: msgraph.DirectoryObject{Id: stringPtr("application-id")},
+				})
+				return generator.Resources, err
+			},
+			wantID:   "application-id",
+			wantName: "application-id",
+			wantType: "azuread_application",
+		},
+		{
+			name: "group",
+			append: func() ([]terraformutils.Resource, error) {
+				generator := &GroupServiceGenerator{}
+				err := generator.appendResource(&msgraph.Group{
+					DirectoryObject: msgraph.DirectoryObject{Id: stringPtr("group-id")},
+				})
+				return generator.Resources, err
+			},
+			wantID:   "group-id",
+			wantName: "group-id",
+			wantType: "azuread_group",
+		},
+		{
+			name: "service principal",
+			append: func() ([]terraformutils.Resource, error) {
+				generator := &ServicePrincipalServiceGenerator{}
+				err := generator.appendResource(&msgraph.ServicePrincipal{
+					DirectoryObject: msgraph.DirectoryObject{Id: stringPtr("principal-id")},
+				})
+				return generator.Resources, err
+			},
+			wantID:   "principal-id",
+			wantName: "principal-id",
+			wantType: "azuread_service_principal",
+		},
+		{
+			name: "user",
+			append: func() ([]terraformutils.Resource, error) {
+				generator := &UserServiceGenerator{}
+				err := generator.appendResource(&msgraph.User{
+					DirectoryObject: msgraph.DirectoryObject{Id: stringPtr("user-id")},
+				})
+				return generator.Resources, err
+			},
+			wantID:   "user-id",
+			wantName: "user-id",
+			wantType: "azuread_user",
+		},
+		{
+			name: "app role assignment",
+			append: func() ([]terraformutils.Resource, error) {
+				generator := &AppRoleAssignmentServiceGenerator{}
+				err := generator.appendResource(&msgraph.AppRoleAssignment{
+					Id:          stringPtr("assignment-id"),
+					PrincipalId: stringPtr("principal-id"),
+				})
+				return generator.Resources, err
+			},
+			wantID:   "principal-id/appRoleAssignment/assignment-id",
+			wantName: "principal-id/appRoleAssignment/assignment-id",
+			wantType: "azuread_app_role_assignment",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			resources, err := tt.append()
+			if err != nil {
+				t.Fatalf("expected no error: %v", err)
+			}
+			if len(resources) != 1 {
+				t.Fatalf("resources len = %d, want 1", len(resources))
+			}
+			resource := resources[0]
+			if resource.InstanceState.ID != tt.wantID {
+				t.Fatalf("resource ID = %q, want %q", resource.InstanceState.ID, tt.wantID)
+			}
+			if resource.ResourceName != terraformutils.TfSanitize(tt.wantName) {
+				t.Fatalf("resource name = %q, want %q", resource.ResourceName, terraformutils.TfSanitize(tt.wantName))
+			}
+			if resource.InstanceInfo.Type != tt.wantType {
+				t.Fatalf("resource type = %q, want %q", resource.InstanceInfo.Type, tt.wantType)
+			}
+		})
+	}
+}
+
+func TestAzureADAppendResourceRequiresImportIDs(t *testing.T) {
+	tests := []struct {
+		name    string
+		append  func() error
+		wantErr string
+	}{
+		{
+			name: "application nil resource",
+			append: func() error {
+				return (&ApplicationServiceGenerator{}).appendResource(nil)
+			},
+			wantErr: "resource is nil",
+		},
+		{
+			name: "application id",
+			append: func() error {
+				return (&ApplicationServiceGenerator{}).appendResource(&msgraph.Application{})
+			},
+			wantErr: "missing id",
+		},
+		{
+			name: "group id",
+			append: func() error {
+				return (&GroupServiceGenerator{}).appendResource(&msgraph.Group{})
+			},
+			wantErr: "missing id",
+		},
+		{
+			name: "service principal id",
+			append: func() error {
+				return (&ServicePrincipalServiceGenerator{}).appendResource(&msgraph.ServicePrincipal{})
+			},
+			wantErr: "missing id",
+		},
+		{
+			name: "user id",
+			append: func() error {
+				return (&UserServiceGenerator{}).appendResource(&msgraph.User{})
+			},
+			wantErr: "missing id",
+		},
+		{
+			name: "app role principal id",
+			append: func() error {
+				return (&AppRoleAssignmentServiceGenerator{}).appendResource(&msgraph.AppRoleAssignment{Id: stringPtr("assignment-id")})
+			},
+			wantErr: "missing principalId",
+		},
+		{
+			name: "app role assignment id",
+			append: func() error {
+				return (&AppRoleAssignmentServiceGenerator{}).appendResource(&msgraph.AppRoleAssignment{PrincipalId: stringPtr("principal-id")})
+			},
+			wantErr: "missing id",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.append()
+			if err == nil {
+				t.Fatal("expected missing import ID error")
+			}
+			if !strings.Contains(err.Error(), tt.wantErr) {
+				t.Fatalf("error = %q, want %q", err, tt.wantErr)
+			}
+		})
+	}
+}

--- a/providers/azuread/azuread_service.go
+++ b/providers/azuread/azuread_service.go
@@ -4,6 +4,7 @@ package azuread
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/chenrui333/terraformer/terraformutils"
 	"github.com/hashicorp/go-azure-sdk/sdk/auth"
@@ -110,4 +111,33 @@ func (az *AzureADService) appendSimpleResource(id string, resourceName string, r
 		"id": id,
 	}, []string{}, map[string]interface{}{})
 	az.Resources = append(az.Resources, newResource)
+}
+
+func azureADRequiredString(resourceType, field string, value *string) (string, error) {
+	if value == nil || *value == "" {
+		return "", fmt.Errorf("%s resource is missing %s", resourceType, field)
+	}
+	return *value, nil
+}
+
+func azureADStringValue(value *string) string {
+	if value == nil {
+		return ""
+	}
+	return *value
+}
+
+func azureADResourceName(displayName *string, fallback string) string {
+	if displayName != nil && *displayName != "" {
+		return *displayName
+	}
+	return fallback
+}
+
+func azureADQualifiedResourceName(displayName *string, id string) string {
+	name := azureADResourceName(displayName, id)
+	if name == id {
+		return id
+	}
+	return name + "-" + id
 }

--- a/providers/azuread/group.go
+++ b/providers/azuread/group.go
@@ -3,6 +3,7 @@ package azuread
 
 import (
 	"context"
+	"fmt"
 	"log"
 
 	"github.com/hashicorp/go-azure-sdk/sdk/odata"
@@ -34,9 +35,16 @@ func (az *GroupServiceGenerator) listResources() ([]msgraph.Group, error) {
 	return resources, nil
 }
 
-func (az *GroupServiceGenerator) appendResource(resource *msgraph.Group) {
-	id := resource.ID()
-	az.appendSimpleResource(*id, *resource.DisplayName+"-"+*id, "azuread_group")
+func (az *GroupServiceGenerator) appendResource(resource *msgraph.Group) error {
+	if resource == nil {
+		return fmt.Errorf("azuread_group resource is nil")
+	}
+	id, err := azureADRequiredString("azuread_group", "id", resource.ID())
+	if err != nil {
+		return err
+	}
+	az.appendSimpleResource(id, azureADQualifiedResourceName(resource.DisplayName, id), "azuread_group")
+	return nil
 }
 
 func (az *GroupServiceGenerator) InitResources() error {
@@ -45,8 +53,10 @@ func (az *GroupServiceGenerator) InitResources() error {
 		return err
 	}
 	for _, resource := range resources {
-		log.Println(*resource.DisplayName)
-		az.appendResource(&resource)
+		log.Println(azureADResourceName(resource.DisplayName, azureADStringValue(resource.ID())))
+		if err := az.appendResource(&resource); err != nil {
+			return err
+		}
 	}
 	return nil
 }

--- a/providers/azuread/service_principal.go
+++ b/providers/azuread/service_principal.go
@@ -3,6 +3,7 @@ package azuread
 
 import (
 	"context"
+	"fmt"
 	"log"
 
 	"github.com/hashicorp/go-azure-sdk/sdk/odata"
@@ -34,9 +35,16 @@ func (az *ServicePrincipalServiceGenerator) listResources() ([]msgraph.ServicePr
 	return resources, nil
 }
 
-func (az *ServicePrincipalServiceGenerator) appendResource(resource *msgraph.ServicePrincipal) {
-	id := resource.ID()
-	az.appendSimpleResource(*id, *resource.DisplayName+"-"+*id, "azuread_service_principal")
+func (az *ServicePrincipalServiceGenerator) appendResource(resource *msgraph.ServicePrincipal) error {
+	if resource == nil {
+		return fmt.Errorf("azuread_service_principal resource is nil")
+	}
+	id, err := azureADRequiredString("azuread_service_principal", "id", resource.ID())
+	if err != nil {
+		return err
+	}
+	az.appendSimpleResource(id, azureADQualifiedResourceName(resource.DisplayName, id), "azuread_service_principal")
+	return nil
 }
 
 func (az *ServicePrincipalServiceGenerator) InitResources() error {
@@ -45,8 +53,10 @@ func (az *ServicePrincipalServiceGenerator) InitResources() error {
 		return err
 	}
 	for _, resource := range resources {
-		log.Println(*resource.DisplayName)
-		az.appendResource(&resource)
+		log.Println(azureADResourceName(resource.DisplayName, azureADStringValue(resource.ID())))
+		if err := az.appendResource(&resource); err != nil {
+			return err
+		}
 	}
 	return nil
 }

--- a/providers/azuread/user.go
+++ b/providers/azuread/user.go
@@ -3,6 +3,7 @@ package azuread
 
 import (
 	"context"
+	"fmt"
 	"log"
 
 	"github.com/hashicorp/go-azure-sdk/sdk/odata"
@@ -34,9 +35,16 @@ func (az *UserServiceGenerator) listResources() ([]msgraph.User, error) {
 	return resources, nil
 }
 
-func (az *UserServiceGenerator) appendResource(resource *msgraph.User) {
-	id := resource.ID()
-	az.appendSimpleResource(*id, *resource.DisplayName, "azuread_user")
+func (az *UserServiceGenerator) appendResource(resource *msgraph.User) error {
+	if resource == nil {
+		return fmt.Errorf("azuread_user resource is nil")
+	}
+	id, err := azureADRequiredString("azuread_user", "id", resource.ID())
+	if err != nil {
+		return err
+	}
+	az.appendSimpleResource(id, azureADResourceName(resource.DisplayName, id), "azuread_user")
+	return nil
 }
 
 func (az *UserServiceGenerator) InitResources() error {
@@ -45,8 +53,10 @@ func (az *UserServiceGenerator) InitResources() error {
 		return err
 	}
 	for _, resource := range resources {
-		log.Println(*resource.DisplayName)
-		az.appendResource(&resource)
+		log.Println(azureADResourceName(resource.DisplayName, azureADStringValue(resource.ID())))
+		if err := az.appendResource(&resource); err != nil {
+			return err
+		}
 	}
 	return nil
 }

--- a/providers/azuredevops/azuredevops_resource_test.go
+++ b/providers/azuredevops/azuredevops_resource_test.go
@@ -1,0 +1,123 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package azuredevops
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/chenrui333/terraformer/terraformutils"
+	"github.com/google/uuid"
+	"github.com/microsoft/azure-devops-go-api/azuredevops/core"
+	"github.com/microsoft/azure-devops-go-api/azuredevops/git"
+)
+
+func uuidPtr(value string) *uuid.UUID {
+	parsed := uuid.MustParse(value)
+	return &parsed
+}
+
+func TestAzureDevOpsAppendResourceFallsBackToIDName(t *testing.T) {
+	tests := []struct {
+		name     string
+		append   func() ([]terraformutils.Resource, error)
+		wantID   string
+		wantType string
+	}{
+		{
+			name: "project",
+			append: func() ([]terraformutils.Resource, error) {
+				generator := &ProjectGenerator{}
+				err := generator.appendResource(&core.TeamProjectReference{
+					Id: uuidPtr("11111111-1111-1111-1111-111111111111"),
+				})
+				return generator.Resources, err
+			},
+			wantID:   "11111111-1111-1111-1111-111111111111",
+			wantType: "azuredevops_project",
+		},
+		{
+			name: "git repository",
+			append: func() ([]terraformutils.Resource, error) {
+				generator := &GitRepositoryGenerator{}
+				err := generator.appendResource(&git.GitRepository{
+					Id: uuidPtr("22222222-2222-2222-2222-222222222222"),
+				})
+				return generator.Resources, err
+			},
+			wantID:   "22222222-2222-2222-2222-222222222222",
+			wantType: "azuredevops_git_repository",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			resources, err := tt.append()
+			if err != nil {
+				t.Fatalf("expected no error: %v", err)
+			}
+			if len(resources) != 1 {
+				t.Fatalf("resources len = %d, want 1", len(resources))
+			}
+			resource := resources[0]
+			if resource.InstanceState.ID != tt.wantID {
+				t.Fatalf("resource ID = %q, want %q", resource.InstanceState.ID, tt.wantID)
+			}
+			if resource.ResourceName != terraformutils.TfSanitize(tt.wantID) {
+				t.Fatalf("resource name = %q, want %q", resource.ResourceName, terraformutils.TfSanitize(tt.wantID))
+			}
+			if resource.InstanceInfo.Type != tt.wantType {
+				t.Fatalf("resource type = %q, want %q", resource.InstanceInfo.Type, tt.wantType)
+			}
+		})
+	}
+}
+
+func TestAzureDevOpsAppendResourceRequiresIDs(t *testing.T) {
+	tests := []struct {
+		name    string
+		append  func() error
+		wantErr string
+	}{
+		{
+			name: "project nil resource",
+			append: func() error {
+				return (&ProjectGenerator{}).appendResource(nil)
+			},
+			wantErr: "resource is nil",
+		},
+		{
+			name: "project id",
+			append: func() error {
+				return (&ProjectGenerator{}).appendResource(&core.TeamProjectReference{})
+			},
+			wantErr: "missing id",
+		},
+		{
+			name: "git repository nil resource",
+			append: func() error {
+				return (&GitRepositoryGenerator{}).appendResource(nil)
+			},
+			wantErr: "resource is nil",
+		},
+		{
+			name: "git repository id",
+			append: func() error {
+				return (&GitRepositoryGenerator{}).appendResource(&git.GitRepository{})
+			},
+			wantErr: "missing id",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.append()
+			if err == nil {
+				t.Fatal("expected missing import ID error")
+			}
+			if !strings.Contains(err.Error(), tt.wantErr) {
+				t.Fatalf("error = %q, want %q", err, tt.wantErr)
+			}
+		})
+	}
+}

--- a/providers/azuredevops/azuredevops_service.go
+++ b/providers/azuredevops/azuredevops_service.go
@@ -5,7 +5,9 @@ package azuredevops
 
 import (
 	"context"
+	"fmt"
 
+	"github.com/google/uuid"
 	"github.com/microsoft/azure-devops-go-api/azuredevops"
 	"github.com/microsoft/azure-devops-go-api/azuredevops/core"
 	"github.com/microsoft/azure-devops-go-api/azuredevops/git"
@@ -63,4 +65,18 @@ func (az *AzureDevOpsService) getGitClient() (git.Client, error) {
 func (az *AzureDevOpsService) appendSimpleResource(id string, resourceName string, resourceType string) {
 	newResource := terraformutils.NewSimpleResource(id, resourceName, resourceType, az.ProviderName, []string{})
 	az.Resources = append(az.Resources, newResource)
+}
+
+func azureDevOpsRequiredUUID(resourceType, field string, value *uuid.UUID) (string, error) {
+	if value == nil || *value == uuid.Nil {
+		return "", fmt.Errorf("%s resource is missing %s", resourceType, field)
+	}
+	return value.String(), nil
+}
+
+func azureDevOpsResourceName(name *string, fallback string) string {
+	if name != nil && *name != "" {
+		return *name
+	}
+	return fallback
 }

--- a/providers/azuredevops/git_repository.go
+++ b/providers/azuredevops/git_repository.go
@@ -2,6 +2,7 @@ package azuredevops
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/microsoft/azure-devops-go-api/azuredevops/git"
 )
@@ -23,9 +24,16 @@ func (az *GitRepositoryGenerator) listResources() ([]git.GitRepository, error) {
 	return *resources, nil
 }
 
-func (az *GitRepositoryGenerator) appendResource(resource *git.GitRepository) {
-	id := *resource.Id
-	az.appendSimpleResource(id.String(), *resource.Name, "azuredevops_git_repository")
+func (az *GitRepositoryGenerator) appendResource(resource *git.GitRepository) error {
+	if resource == nil {
+		return fmt.Errorf("azuredevops_git_repository resource is nil")
+	}
+	id, err := azureDevOpsRequiredUUID("azuredevops_git_repository", "id", resource.Id)
+	if err != nil {
+		return err
+	}
+	az.appendSimpleResource(id, azureDevOpsResourceName(resource.Name, id), "azuredevops_git_repository")
+	return nil
 }
 
 func (az *GitRepositoryGenerator) InitResources() error {
@@ -34,7 +42,9 @@ func (az *GitRepositoryGenerator) InitResources() error {
 		return err
 	}
 	for _, resource := range resources {
-		az.appendResource(&resource)
+		if err := az.appendResource(&resource); err != nil {
+			return err
+		}
 	}
 	return nil
 }

--- a/providers/azuredevops/project.go
+++ b/providers/azuredevops/project.go
@@ -2,6 +2,7 @@ package azuredevops
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/microsoft/azure-devops-go-api/azuredevops/core"
 )
@@ -33,9 +34,16 @@ func (az *ProjectGenerator) listResources() ([]core.TeamProjectReference, error)
 	return nil, err
 }
 
-func (az *ProjectGenerator) appendResource(resource *core.TeamProjectReference) {
-	id := *resource.Id
-	az.appendSimpleResource(id.String(), *resource.Name, "azuredevops_project")
+func (az *ProjectGenerator) appendResource(resource *core.TeamProjectReference) error {
+	if resource == nil {
+		return fmt.Errorf("azuredevops_project resource is nil")
+	}
+	id, err := azureDevOpsRequiredUUID("azuredevops_project", "id", resource.Id)
+	if err != nil {
+		return err
+	}
+	az.appendSimpleResource(id, azureDevOpsResourceName(resource.Name, id), "azuredevops_project")
+	return nil
 }
 
 func (az *ProjectGenerator) InitResources() error {
@@ -44,7 +52,9 @@ func (az *ProjectGenerator) InitResources() error {
 		return err
 	}
 	for _, resource := range resources {
-		az.appendResource(&resource)
+		if err := az.appendResource(&resource); err != nil {
+			return err
+		}
 	}
 	return nil
 }


### PR DESCRIPTION
Summary

- Guard AzureAD resource construction against nil or empty SDK IDs and use ID fallback names when display names are absent.
- Guard Azure DevOps project and repository construction against nil or empty SDK IDs and missing names.
- Add focused regression coverage for fallback names and missing required import IDs.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hardened `azuread` and `azuredevops` providers by validating SDK IDs and falling back to ID-based names to avoid crashes and unnamed resources. Promoted `github.com/google/uuid` to a direct dependency for UUID validation.

- **Bug Fixes**
  - `azuread`: `application`, `group`, `service_principal`, `user`, and `app_role_assignment` now validate required IDs, guard nil `PrincipalType`, and use ID fallbacks when display names are missing.
  - `azuredevops`: `project` and `git_repository` now validate UUID IDs and use ID fallbacks when names are missing.
  - Append methods return errors on invalid SDK objects; init loops stop on error to avoid partial state.
  - Added tests in `providers/azuread/azuread_resource_test.go` and `providers/azuredevops/azuredevops_resource_test.go`.

- **Dependencies**
  - Promoted `github.com/google/uuid` v1.6.0 to a direct dependency.

<sup>Written for commit 64649f9e0cf31c360804250ae1e1b680e0090dc2. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved input validation and error propagation across Azure AD and Azure DevOps resource generators to prevent panics and handle missing identifiers more safely.
  * Resource naming and ID generation now use validated values to avoid crashes and improve error clarity.

* **Tests**
  * Added unit tests covering resource generation, naming fallbacks, and error cases for Azure and Azure DevOps providers.

* **Chores**
  * Minor dependency manifest adjustment.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->