### PR TITLE
fix(auth0): guard resource fields

### DIFF
--- a/providers/auth0/action.go
+++ b/providers/auth0/action.go
@@ -17,19 +17,25 @@ type ActionGenerator struct {
 	Auth0Service
 }
 
-func (g ActionGenerator) createResources(actions []*management.Action) []terraformutils.Resource {
+func (g ActionGenerator) createResources(actions []*management.Action) ([]terraformutils.Resource, error) {
 	resources := []terraformutils.Resource{}
 	for _, action := range actions {
-		resourceName := *action.ID
+		if action == nil {
+			return nil, auth0MissingResource("auth0_action")
+		}
+		resourceName, err := auth0RequiredString("auth0_action", "id", action.ID)
+		if err != nil {
+			return nil, err
+		}
 		resources = append(resources, terraformutils.NewSimpleResource(
 			resourceName,
-			resourceName+"_"+*action.Name,
+			auth0ResourceName(action.Name, resourceName),
 			"auth0_action",
 			"auth0",
 			ActionAllowEmptyValues,
 		))
 	}
-	return resources
+	return resources, nil
 }
 
 func (g *ActionGenerator) InitResources() error {
@@ -53,6 +59,10 @@ func (g *ActionGenerator) InitResources() error {
 		page++
 	}
 
-	g.Resources = g.createResources(list)
+	resources, err := g.createResources(list)
+	if err != nil {
+		return err
+	}
+	g.Resources = resources
 	return nil
 }

--- a/providers/auth0/auth0_resource_test.go
+++ b/providers/auth0/auth0_resource_test.go
@@ -1,0 +1,284 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package auth0
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/auth0/go-auth0/management"
+	"github.com/chenrui333/terraformer/terraformutils"
+)
+
+func auth0StringPtr(value string) *string {
+	return &value
+}
+
+func TestAuth0CreateResourcesFallsBackToIDName(t *testing.T) {
+	tests := []struct {
+		name     string
+		create   func() ([]terraformutils.Resource, error)
+		wantID   string
+		wantName string
+		wantType string
+	}{
+		{
+			name: "action",
+			create: func() ([]terraformutils.Resource, error) {
+				return (ActionGenerator{}).createResources([]*management.Action{{ID: auth0StringPtr("action-id")}})
+			},
+			wantID:   "action-id",
+			wantName: "action-id",
+			wantType: "auth0_action",
+		},
+		{
+			name: "client",
+			create: func() ([]terraformutils.Resource, error) {
+				return (ClientGenerator{}).createResources([]*management.Client{{ClientID: auth0StringPtr("client-id")}})
+			},
+			wantID:   "client-id",
+			wantName: "client-id",
+			wantType: "auth0_client",
+		},
+		{
+			name: "client grant",
+			create: func() ([]terraformutils.Resource, error) {
+				return (ClientGrantGenerator{}).createResources([]*management.ClientGrant{{ID: auth0StringPtr("grant-id")}})
+			},
+			wantID:   "grant-id",
+			wantName: "grant-id",
+			wantType: "auth0_client_grant",
+		},
+		{
+			name: "custom domain",
+			create: func() ([]terraformutils.Resource, error) {
+				return (CustomDomainGenerator{}).createResources([]*management.CustomDomain{{ID: auth0StringPtr("domain-id")}})
+			},
+			wantID:   "domain-id",
+			wantName: "domain-id",
+			wantType: "auth0_custom_domain",
+		},
+		{
+			name: "email",
+			create: func() ([]terraformutils.Resource, error) {
+				return (EmailGenerator{}).createResources(&management.EmailProvider{Name: auth0StringPtr("smtp")})
+			},
+			wantID:   "smtp",
+			wantName: "smtp",
+			wantType: "auth0_email",
+		},
+		{
+			name: "hook",
+			create: func() ([]terraformutils.Resource, error) {
+				return (HookGenerator{}).createResources([]*management.Hook{{ID: auth0StringPtr("hook-id")}})
+			},
+			wantID:   "hook-id",
+			wantName: "hook-id",
+			wantType: "auth0_hook",
+		},
+		{
+			name: "log stream",
+			create: func() ([]terraformutils.Resource, error) {
+				return (LogStreamGenerator{}).createResources([]*management.LogStream{{ID: auth0StringPtr("stream-id")}})
+			},
+			wantID:   "stream-id",
+			wantName: "stream-id",
+			wantType: "auth0_log_stream",
+		},
+		{
+			name: "resource server",
+			create: func() ([]terraformutils.Resource, error) {
+				return (ResourceServerGenerator{}).createResources([]*management.ResourceServer{{ID: auth0StringPtr("server-id")}})
+			},
+			wantID:   "server-id",
+			wantName: "server-id",
+			wantType: "auth0_resource_server",
+		},
+		{
+			name: "role",
+			create: func() ([]terraformutils.Resource, error) {
+				return (RoleGenerator{}).createResources([]*management.Role{{ID: auth0StringPtr("role-id")}})
+			},
+			wantID:   "role-id",
+			wantName: "role-id",
+			wantType: "auth0_role",
+		},
+		{
+			name: "rule",
+			create: func() ([]terraformutils.Resource, error) {
+				return (RuleGenerator{}).createResources([]*management.Rule{{ID: auth0StringPtr("rule-id")}})
+			},
+			wantID:   "rule-id",
+			wantName: "rule-id",
+			wantType: "auth0_rule",
+		},
+		{
+			name: "trigger binding",
+			create: func() ([]terraformutils.Resource, error) {
+				return (TriggerBindingGenerator{}).createResources(map[string]*management.ActionBinding{
+					"binding-id": {
+						ID:        auth0StringPtr("binding-id"),
+						TriggerID: auth0StringPtr("post-login"),
+					},
+				})
+			},
+			wantID:   "post-login",
+			wantName: "binding-id",
+			wantType: "auth0_trigger_binding",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			resources, err := tt.create()
+			if err != nil {
+				t.Fatalf("expected no error: %v", err)
+			}
+			if len(resources) != 1 {
+				t.Fatalf("resources len = %d, want 1", len(resources))
+			}
+			resource := resources[0]
+			if resource.InstanceState.ID != tt.wantID {
+				t.Fatalf("resource ID = %q, want %q", resource.InstanceState.ID, tt.wantID)
+			}
+			if resource.ResourceName != terraformutils.TfSanitize(tt.wantName) {
+				t.Fatalf("resource name = %q, want %q", resource.ResourceName, terraformutils.TfSanitize(tt.wantName))
+			}
+			if resource.InstanceInfo.Type != tt.wantType {
+				t.Fatalf("resource type = %q, want %q", resource.InstanceInfo.Type, tt.wantType)
+			}
+		})
+	}
+}
+
+func TestAuth0CreateResourcesIncludesDisplayNameWhenAvailable(t *testing.T) {
+	resources, err := (ActionGenerator{}).createResources([]*management.Action{{
+		ID:   auth0StringPtr("action-id"),
+		Name: auth0StringPtr("display-name"),
+	}})
+	if err != nil {
+		t.Fatalf("expected no error: %v", err)
+	}
+	if len(resources) != 1 {
+		t.Fatalf("resources len = %d, want 1", len(resources))
+	}
+	if resources[0].ResourceName != terraformutils.TfSanitize("action-id_display-name") {
+		t.Fatalf("resource name = %q, want id/display name", resources[0].ResourceName)
+	}
+}
+
+func TestAuth0CreateResourcesRequiresIDs(t *testing.T) {
+	tests := []struct {
+		name    string
+		create  func() ([]terraformutils.Resource, error)
+		wantErr string
+	}{
+		{
+			name: "action nil resource",
+			create: func() ([]terraformutils.Resource, error) {
+				return (ActionGenerator{}).createResources([]*management.Action{nil})
+			},
+			wantErr: "resource is nil",
+		},
+		{
+			name: "action id",
+			create: func() ([]terraformutils.Resource, error) {
+				return (ActionGenerator{}).createResources([]*management.Action{{}})
+			},
+			wantErr: "missing id",
+		},
+		{
+			name: "client id",
+			create: func() ([]terraformutils.Resource, error) {
+				return (ClientGenerator{}).createResources([]*management.Client{{}})
+			},
+			wantErr: "missing client_id",
+		},
+		{
+			name: "client grant id",
+			create: func() ([]terraformutils.Resource, error) {
+				return (ClientGrantGenerator{}).createResources([]*management.ClientGrant{{}})
+			},
+			wantErr: "missing id",
+		},
+		{
+			name: "custom domain id",
+			create: func() ([]terraformutils.Resource, error) {
+				return (CustomDomainGenerator{}).createResources([]*management.CustomDomain{{}})
+			},
+			wantErr: "missing id",
+		},
+		{
+			name: "email name",
+			create: func() ([]terraformutils.Resource, error) {
+				return (EmailGenerator{}).createResources(&management.EmailProvider{})
+			},
+			wantErr: "missing name",
+		},
+		{
+			name: "hook id",
+			create: func() ([]terraformutils.Resource, error) {
+				return (HookGenerator{}).createResources([]*management.Hook{{}})
+			},
+			wantErr: "missing id",
+		},
+		{
+			name: "log stream id",
+			create: func() ([]terraformutils.Resource, error) {
+				return (LogStreamGenerator{}).createResources([]*management.LogStream{{}})
+			},
+			wantErr: "missing id",
+		},
+		{
+			name: "resource server id",
+			create: func() ([]terraformutils.Resource, error) {
+				return (ResourceServerGenerator{}).createResources([]*management.ResourceServer{{}})
+			},
+			wantErr: "missing id",
+		},
+		{
+			name: "role id",
+			create: func() ([]terraformutils.Resource, error) {
+				return (RoleGenerator{}).createResources([]*management.Role{{}})
+			},
+			wantErr: "missing id",
+		},
+		{
+			name: "rule id",
+			create: func() ([]terraformutils.Resource, error) {
+				return (RuleGenerator{}).createResources([]*management.Rule{{}})
+			},
+			wantErr: "missing id",
+		},
+		{
+			name: "trigger binding id",
+			create: func() ([]terraformutils.Resource, error) {
+				return (TriggerBindingGenerator{}).createResources(map[string]*management.ActionBinding{
+					"binding": {TriggerID: auth0StringPtr("post-login")},
+				})
+			},
+			wantErr: "missing id",
+		},
+		{
+			name: "trigger binding trigger id",
+			create: func() ([]terraformutils.Resource, error) {
+				return (TriggerBindingGenerator{}).createResources(map[string]*management.ActionBinding{
+					"binding": {ID: auth0StringPtr("binding-id")},
+				})
+			},
+			wantErr: "missing trigger_id",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := tt.create()
+			if err == nil {
+				t.Fatal("expected missing Auth0 field error")
+			}
+			if !strings.Contains(err.Error(), tt.wantErr) {
+				t.Fatalf("error = %q, want %q", err, tt.wantErr)
+			}
+		})
+	}
+}

--- a/providers/auth0/auth0_service.go
+++ b/providers/auth0/auth0_service.go
@@ -37,3 +37,21 @@ func (s *Auth0Service) generateClient() (*management.Management, error) {
 
 	return newManagementClient(s.Args["domain"].(string), s.Args["client_id"].(string), s.Args["client_secret"].(string))
 }
+
+func auth0MissingResource(resourceType string) error {
+	return fmt.Errorf("%s resource is nil", resourceType)
+}
+
+func auth0RequiredString(resourceType, field string, value *string) (string, error) {
+	if value == nil || *value == "" {
+		return "", fmt.Errorf("%s resource is missing %s", resourceType, field)
+	}
+	return *value, nil
+}
+
+func auth0ResourceName(name *string, fallback string) string {
+	if name != nil && *name != "" && *name != fallback {
+		return fallback + "_" + *name
+	}
+	return fallback
+}

--- a/providers/auth0/client.go
+++ b/providers/auth0/client.go
@@ -17,19 +17,25 @@ type ClientGenerator struct {
 	Auth0Service
 }
 
-func (g ClientGenerator) createResources(clients []*management.Client) []terraformutils.Resource {
+func (g ClientGenerator) createResources(clients []*management.Client) ([]terraformutils.Resource, error) {
 	resources := []terraformutils.Resource{}
 	for _, client := range clients {
-		resourceName := *client.ClientID
+		if client == nil {
+			return nil, auth0MissingResource("auth0_client")
+		}
+		resourceName, err := auth0RequiredString("auth0_client", "client_id", client.ClientID)
+		if err != nil {
+			return nil, err
+		}
 		resources = append(resources, terraformutils.NewSimpleResource(
 			resourceName,
-			resourceName+"_"+*client.Name,
+			auth0ResourceName(client.Name, resourceName),
 			"auth0_client",
 			"auth0",
 			ClientAllowEmptyValues,
 		))
 	}
-	return resources
+	return resources, nil
 }
 
 func (g *ClientGenerator) InitResources() error {
@@ -53,6 +59,10 @@ func (g *ClientGenerator) InitResources() error {
 		page++
 	}
 
-	g.Resources = g.createResources(list)
+	resources, err := g.createResources(list)
+	if err != nil {
+		return err
+	}
+	g.Resources = resources
 	return nil
 }

--- a/providers/auth0/client_grant.go
+++ b/providers/auth0/client_grant.go
@@ -17,19 +17,25 @@ type ClientGrantGenerator struct {
 	Auth0Service
 }
 
-func (g ClientGrantGenerator) createResources(clientGrantGrants []*management.ClientGrant) []terraformutils.Resource {
+func (g ClientGrantGenerator) createResources(clientGrantGrants []*management.ClientGrant) ([]terraformutils.Resource, error) {
 	resources := []terraformutils.Resource{}
 	for _, clientGrant := range clientGrantGrants {
-		resourceName := *clientGrant.ID
+		if clientGrant == nil {
+			return nil, auth0MissingResource("auth0_client_grant")
+		}
+		resourceName, err := auth0RequiredString("auth0_client_grant", "id", clientGrant.ID)
+		if err != nil {
+			return nil, err
+		}
 		resources = append(resources, terraformutils.NewSimpleResource(
 			resourceName,
-			resourceName+"_"+*clientGrant.ClientID,
+			auth0ResourceName(clientGrant.ClientID, resourceName),
 			"auth0_client_grant",
 			"auth0",
 			ClientGrantAllowEmptyValues,
 		))
 	}
-	return resources
+	return resources, nil
 }
 
 func (g *ClientGrantGenerator) InitResources() error {
@@ -53,6 +59,10 @@ func (g *ClientGrantGenerator) InitResources() error {
 		page++
 	}
 
-	g.Resources = g.createResources(list)
+	resources, err := g.createResources(list)
+	if err != nil {
+		return err
+	}
+	g.Resources = resources
 	return nil
 }

--- a/providers/auth0/custom_domain.go
+++ b/providers/auth0/custom_domain.go
@@ -17,19 +17,25 @@ type CustomDomainGenerator struct {
 	Auth0Service
 }
 
-func (g CustomDomainGenerator) createResources(customDomains []*management.CustomDomain) []terraformutils.Resource {
+func (g CustomDomainGenerator) createResources(customDomains []*management.CustomDomain) ([]terraformutils.Resource, error) {
 	resources := []terraformutils.Resource{}
-	for _, CustomDomain := range customDomains {
-		resourceName := *CustomDomain.ID
+	for _, customDomain := range customDomains {
+		if customDomain == nil {
+			return nil, auth0MissingResource("auth0_custom_domain")
+		}
+		resourceName, err := auth0RequiredString("auth0_custom_domain", "id", customDomain.ID)
+		if err != nil {
+			return nil, err
+		}
 		resources = append(resources, terraformutils.NewSimpleResource(
 			resourceName,
-			resourceName+"_"+*CustomDomain.Domain,
+			auth0ResourceName(customDomain.Domain, resourceName),
 			"auth0_custom_domain",
 			"auth0",
 			CustomDomainAllowEmptyValues,
 		))
 	}
-	return resources
+	return resources, nil
 }
 
 func (g *CustomDomainGenerator) InitResources() error {
@@ -43,6 +49,10 @@ func (g *CustomDomainGenerator) InitResources() error {
 		return err
 	}
 
-	g.Resources = g.createResources(list)
+	resources, err := g.createResources(list)
+	if err != nil {
+		return err
+	}
+	g.Resources = resources
 	return nil
 }

--- a/providers/auth0/email.go
+++ b/providers/auth0/email.go
@@ -17,9 +17,15 @@ type EmailGenerator struct {
 	Auth0Service
 }
 
-func (g EmailGenerator) createResources(email *management.EmailProvider) []terraformutils.Resource {
+func (g EmailGenerator) createResources(email *management.EmailProvider) ([]terraformutils.Resource, error) {
 	resources := []terraformutils.Resource{}
-	resourceName := *email.Name
+	if email == nil {
+		return nil, auth0MissingResource("auth0_email")
+	}
+	resourceName, err := auth0RequiredString("auth0_email", "name", email.Name)
+	if err != nil {
+		return nil, err
+	}
 	resources = append(resources, terraformutils.NewSimpleResource(
 		resourceName,
 		resourceName,
@@ -27,7 +33,7 @@ func (g EmailGenerator) createResources(email *management.EmailProvider) []terra
 		"auth0",
 		EmailAllowEmptyValues,
 	))
-	return resources
+	return resources, nil
 }
 
 func (g *EmailGenerator) InitResources() error {
@@ -40,6 +46,10 @@ func (g *EmailGenerator) InitResources() error {
 	if err != nil {
 		return err
 	}
-	g.Resources = g.createResources(email)
+	resources, err := g.createResources(email)
+	if err != nil {
+		return err
+	}
+	g.Resources = resources
 	return nil
 }

--- a/providers/auth0/hook.go
+++ b/providers/auth0/hook.go
@@ -17,19 +17,25 @@ type HookGenerator struct {
 	Auth0Service
 }
 
-func (g HookGenerator) createResources(hooks []*management.Hook) []terraformutils.Resource {
+func (g HookGenerator) createResources(hooks []*management.Hook) ([]terraformutils.Resource, error) {
 	resources := []terraformutils.Resource{}
 	for _, hook := range hooks {
-		resourceName := *hook.ID
+		if hook == nil {
+			return nil, auth0MissingResource("auth0_hook")
+		}
+		resourceName, err := auth0RequiredString("auth0_hook", "id", hook.ID)
+		if err != nil {
+			return nil, err
+		}
 		resources = append(resources, terraformutils.NewSimpleResource(
 			resourceName,
-			resourceName+"_"+*hook.Name,
+			auth0ResourceName(hook.Name, resourceName),
 			"auth0_hook",
 			"auth0",
 			HookAllowEmptyValues,
 		))
 	}
-	return resources
+	return resources, nil
 }
 
 func (g *HookGenerator) InitResources() error {
@@ -53,6 +59,10 @@ func (g *HookGenerator) InitResources() error {
 		page++
 	}
 
-	g.Resources = g.createResources(list)
+	resources, err := g.createResources(list)
+	if err != nil {
+		return err
+	}
+	g.Resources = resources
 	return nil
 }

--- a/providers/auth0/log_stream.go
+++ b/providers/auth0/log_stream.go
@@ -17,19 +17,25 @@ type LogStreamGenerator struct {
 	Auth0Service
 }
 
-func (g LogStreamGenerator) createResources(logStreams []*management.LogStream) []terraformutils.Resource {
+func (g LogStreamGenerator) createResources(logStreams []*management.LogStream) ([]terraformutils.Resource, error) {
 	resources := []terraformutils.Resource{}
-	for _, LogStream := range logStreams {
-		resourceName := *LogStream.ID
+	for _, logStream := range logStreams {
+		if logStream == nil {
+			return nil, auth0MissingResource("auth0_log_stream")
+		}
+		resourceName, err := auth0RequiredString("auth0_log_stream", "id", logStream.ID)
+		if err != nil {
+			return nil, err
+		}
 		resources = append(resources, terraformutils.NewSimpleResource(
 			resourceName,
-			resourceName+"_"+*LogStream.Name,
+			auth0ResourceName(logStream.Name, resourceName),
 			"auth0_log_stream",
 			"auth0",
 			LogStreamAllowEmptyValues,
 		))
 	}
-	return resources
+	return resources, nil
 }
 
 func (g *LogStreamGenerator) InitResources() error {
@@ -43,6 +49,10 @@ func (g *LogStreamGenerator) InitResources() error {
 		return err
 	}
 
-	g.Resources = g.createResources(list)
+	resources, err := g.createResources(list)
+	if err != nil {
+		return err
+	}
+	g.Resources = resources
 	return nil
 }

--- a/providers/auth0/resource_server.go
+++ b/providers/auth0/resource_server.go
@@ -17,19 +17,25 @@ type ResourceServerGenerator struct {
 	Auth0Service
 }
 
-func (g ResourceServerGenerator) createResources(resourceServers []*management.ResourceServer) []terraformutils.Resource {
+func (g ResourceServerGenerator) createResources(resourceServers []*management.ResourceServer) ([]terraformutils.Resource, error) {
 	resources := []terraformutils.Resource{}
 	for _, resourceServer := range resourceServers {
-		resourceName := *resourceServer.ID
+		if resourceServer == nil {
+			return nil, auth0MissingResource("auth0_resource_server")
+		}
+		resourceName, err := auth0RequiredString("auth0_resource_server", "id", resourceServer.ID)
+		if err != nil {
+			return nil, err
+		}
 		resources = append(resources, terraformutils.NewSimpleResource(
 			resourceName,
-			resourceName+"_"+*resourceServer.Name,
+			auth0ResourceName(resourceServer.Name, resourceName),
 			"auth0_resource_server",
 			"auth0",
 			ResourceServerAllowEmptyValues,
 		))
 	}
-	return resources
+	return resources, nil
 }
 
 func (g *ResourceServerGenerator) InitResources() error {
@@ -53,6 +59,10 @@ func (g *ResourceServerGenerator) InitResources() error {
 		page++
 	}
 
-	g.Resources = g.createResources(list)
+	resources, err := g.createResources(list)
+	if err != nil {
+		return err
+	}
+	g.Resources = resources
 	return nil
 }

--- a/providers/auth0/role.go
+++ b/providers/auth0/role.go
@@ -17,19 +17,25 @@ type RoleGenerator struct {
 	Auth0Service
 }
 
-func (g RoleGenerator) createResources(roles []*management.Role) []terraformutils.Resource {
+func (g RoleGenerator) createResources(roles []*management.Role) ([]terraformutils.Resource, error) {
 	resources := []terraformutils.Resource{}
 	for _, role := range roles {
-		resourceName := *role.ID
+		if role == nil {
+			return nil, auth0MissingResource("auth0_role")
+		}
+		resourceName, err := auth0RequiredString("auth0_role", "id", role.ID)
+		if err != nil {
+			return nil, err
+		}
 		resources = append(resources, terraformutils.NewSimpleResource(
 			resourceName,
-			resourceName+"_"+*role.Name,
+			auth0ResourceName(role.Name, resourceName),
 			"auth0_role",
 			"auth0",
 			RoleAllowEmptyValues,
 		))
 	}
-	return resources
+	return resources, nil
 }
 
 func (g *RoleGenerator) InitResources() error {
@@ -53,6 +59,10 @@ func (g *RoleGenerator) InitResources() error {
 		page++
 	}
 
-	g.Resources = g.createResources(list)
+	resources, err := g.createResources(list)
+	if err != nil {
+		return err
+	}
+	g.Resources = resources
 	return nil
 }

--- a/providers/auth0/rule.go
+++ b/providers/auth0/rule.go
@@ -17,19 +17,25 @@ type RuleGenerator struct {
 	Auth0Service
 }
 
-func (g RuleGenerator) createResources(rules []*management.Rule) []terraformutils.Resource {
+func (g RuleGenerator) createResources(rules []*management.Rule) ([]terraformutils.Resource, error) {
 	resources := []terraformutils.Resource{}
 	for _, rule := range rules {
-		resourceName := *rule.ID
+		if rule == nil {
+			return nil, auth0MissingResource("auth0_rule")
+		}
+		resourceName, err := auth0RequiredString("auth0_rule", "id", rule.ID)
+		if err != nil {
+			return nil, err
+		}
 		resources = append(resources, terraformutils.NewSimpleResource(
 			resourceName,
-			resourceName+"_"+*rule.Name,
+			auth0ResourceName(rule.Name, resourceName),
 			"auth0_rule",
 			"auth0",
 			RuleAllowEmptyValues,
 		))
 	}
-	return resources
+	return resources, nil
 }
 
 func (g *RuleGenerator) InitResources() error {
@@ -53,6 +59,10 @@ func (g *RuleGenerator) InitResources() error {
 		page++
 	}
 
-	g.Resources = g.createResources(list)
+	resources, err := g.createResources(list)
+	if err != nil {
+		return err
+	}
+	g.Resources = resources
 	return nil
 }

--- a/providers/auth0/trigger_binding.go
+++ b/providers/auth0/trigger_binding.go
@@ -17,24 +17,34 @@ type TriggerBindingGenerator struct {
 	Auth0Service
 }
 
-func (g TriggerBindingGenerator) createResources(bindings map[string]*management.ActionBinding) []terraformutils.Resource {
+func (g TriggerBindingGenerator) createResources(bindings map[string]*management.ActionBinding) ([]terraformutils.Resource, error) {
 	resources := []terraformutils.Resource{}
 
 	for _, binding := range bindings {
-		resourceName := *binding.TriggerID
+		if binding == nil {
+			return nil, auth0MissingResource("auth0_trigger_binding")
+		}
+		resourceID, err := auth0RequiredString("auth0_trigger_binding", "trigger_id", binding.TriggerID)
+		if err != nil {
+			return nil, err
+		}
+		resourceName, err := auth0RequiredString("auth0_trigger_binding", "id", binding.ID)
+		if err != nil {
+			return nil, err
+		}
 		resources = append(resources, terraformutils.NewResource(
+			resourceID,
 			resourceName,
-			*binding.ID,
 			"auth0_trigger_binding",
 			"auth0",
 			map[string]string{},
 			TriggerBindingAllowEmptyValues,
 			map[string]interface{}{
-				"trigger": *binding.TriggerID,
+				"trigger": resourceID,
 			},
 		))
 	}
-	return resources
+	return resources, nil
 }
 
 func (g *TriggerBindingGenerator) InitResources() error {
@@ -51,15 +61,29 @@ func (g *TriggerBindingGenerator) InitResources() error {
 	}
 
 	for _, trigger := range t.Triggers {
+		if trigger == nil {
+			return auth0MissingResource("auth0_trigger_binding trigger")
+		}
+		triggerID, err := auth0RequiredString("auth0_trigger_binding", "trigger_id", trigger.ID)
+		if err != nil {
+			return err
+		}
 		var page int
 		for {
-			l, err := m.Action.Bindings(ctx, *trigger.ID, management.Page(page))
+			l, err := m.Action.Bindings(ctx, triggerID, management.Page(page))
 			if err != nil {
 				return err
 			}
 			for _, binding := range l.Bindings {
-				if _, ok := bindings[*binding.ID]; !ok {
-					bindings[*binding.ID] = binding
+				if binding == nil {
+					return auth0MissingResource("auth0_trigger_binding")
+				}
+				bindingID, err := auth0RequiredString("auth0_trigger_binding", "id", binding.ID)
+				if err != nil {
+					return err
+				}
+				if _, ok := bindings[bindingID]; !ok {
+					bindings[bindingID] = binding
 				}
 			}
 			if !l.HasNext() {
@@ -69,6 +93,10 @@ func (g *TriggerBindingGenerator) InitResources() error {
 		}
 	}
 
-	g.Resources = g.createResources(bindings)
+	resources, err := g.createResources(bindings)
+	if err != nil {
+		return err
+	}
+	g.Resources = resources
 	return nil
 }


### PR DESCRIPTION
Summary

- Guard Auth0 resource construction against nil SDK resources and missing required IDs.
- Use stable ID-based Terraform names when optional display names are absent.
- Add regression coverage for malformed Auth0 Management API payloads.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hardened Auth0 resource generation by validating nil SDK objects and required IDs, and using ID-first Terraform resource names when display names are missing. Prevents panics from malformed Management API payloads and makes resource naming consistent.

- **Bug Fixes**
  - Guard all generators (`auth0_action`, `auth0_client`, `auth0_client_grant`, `auth0_custom_domain`, `auth0_email`, `auth0_hook`, `auth0_log_stream`, `auth0_resource_server`, `auth0_role`, `auth0_rule`, `auth0_trigger_binding`) against nil resources and missing IDs.
  - Use shared helpers for required field checks and names, appending display names only when present and different.
  - Validate `trigger_binding` `trigger_id` and `id`, set instance ID to the trigger ID, and keep a consistent `trigger` attribute.
  - Add regression tests for missing fields and name fallback in `providers/auth0/auth0_resource_test.go`.

<sup>Written for commit 673970d623f509a895ad34bf0c777b4196b7d064. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Enhanced validation and error handling across Auth0 resource generators to properly detect and report missing or invalid fields before resource creation.

* **Tests**
  * Added comprehensive test coverage for Auth0 resource generation, validating required fields, fallback naming behavior, and display name inclusion for resource identification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->