### PR TITLE
fix(opal): guard resource fields

### DIFF
--- a/providers/opal/group.go
+++ b/providers/opal/group.go
@@ -5,10 +5,33 @@ import (
 	"fmt"
 
 	"github.com/chenrui333/terraformer/terraformutils"
+	opalsdk "github.com/opalsecurity/opal-go"
 )
 
 type GroupGenerator struct {
 	OpalService
+}
+
+func (g *GroupGenerator) createResources(groups []opalsdk.Group, countByName map[string]int) ([]terraformutils.Resource, error) {
+	resources := []terraformutils.Resource{}
+
+	for _, group := range groups {
+		resourceID, err := opalRequiredString("opal_group", "group_id", group.GroupId)
+		if err != nil {
+			return nil, err
+		}
+		name := opalUniqueResourceName(opalResourceDisplayName(group.Name, resourceID), countByName)
+
+		resources = append(resources, terraformutils.NewSimpleResource(
+			resourceID,
+			name,
+			"opal_group",
+			"opal",
+			[]string{},
+		))
+	}
+
+	return resources, nil
 }
 
 func (g *GroupGenerator) InitResources() error {
@@ -25,23 +48,11 @@ func (g *GroupGenerator) InitResources() error {
 	countByName := make(map[string]int)
 
 	for {
-		for _, group := range groups.Results {
-			name := normalizeResourceName(*group.Name)
-			if count, ok := countByName[name]; ok {
-				countByName[name] = count + 1
-				name = normalizeResourceName(fmt.Sprintf("%s_%d", *group.Name, count+1))
-			} else {
-				countByName[name] = 1
-			}
-
-			g.Resources = append(g.Resources, terraformutils.NewSimpleResource(
-				group.GroupId,
-				name,
-				"opal_group",
-				"opal",
-				[]string{},
-			))
+		resources, err := g.createResources(groups.Results, countByName)
+		if err != nil {
+			return err
 		}
+		g.Resources = append(g.Resources, resources...)
 
 		if !groups.HasNext() || groups.Next == nil {
 			break

--- a/providers/opal/helpers.go
+++ b/providers/opal/helpers.go
@@ -35,12 +35,29 @@ func opalResourceDisplayName(name *string, fallback string) string {
 
 func opalUniqueResourceName(name string, countByName map[string]int) string {
 	normalizedName := normalizeResourceName(name)
-	if count, ok := countByName[normalizedName]; ok {
-		countByName[normalizedName] = count + 1
-		return normalizeResourceName(fmt.Sprintf("%s_%d", name, count+1))
+	if _, ok := countByName[normalizedName]; !ok {
+		countByName[normalizedName] = 1
+		return normalizedName
 	}
-	countByName[normalizedName] = 1
-	return normalizedName
+	next := countByName[normalizedName] + 1
+	for {
+		candidate := normalizeResourceName(fmt.Sprintf("%s_%d", name, next))
+		if _, exists := countByName[candidate]; !exists {
+			countByName[normalizedName] = next
+			countByName[candidate] = 1
+			return candidate
+		}
+		next++
+	}
+}
+
+func opalUniqueResourceNameWithSuffix(name, suffix string, countByName map[string]int) string {
+	normalizedName := normalizeResourceName(name)
+	if _, ok := countByName[normalizedName]; !ok {
+		countByName[normalizedName] = 1
+		return normalizedName
+	}
+	return opalUniqueResourceName(fmt.Sprintf("%s_%s", name, suffix), countByName)
 }
 
 func normalizeResourceName(s string) string {

--- a/providers/opal/helpers.go
+++ b/providers/opal/helpers.go
@@ -3,6 +3,7 @@
 package opal
 
 import (
+	"fmt"
 	"strings"
 	"unicode"
 
@@ -10,6 +11,37 @@ import (
 	"golang.org/x/text/transform"
 	"golang.org/x/text/unicode/norm"
 )
+
+func opalRequiredString(resourceType, field, value string) (string, error) {
+	if value == "" {
+		return "", fmt.Errorf("%s resource is missing %s", resourceType, field)
+	}
+	return value, nil
+}
+
+func opalRequiredStringPtr(resourceType, field string, value *string) (string, error) {
+	if value == nil || *value == "" {
+		return "", fmt.Errorf("%s resource is missing %s", resourceType, field)
+	}
+	return *value, nil
+}
+
+func opalResourceDisplayName(name *string, fallback string) string {
+	if name != nil && *name != "" {
+		return *name
+	}
+	return fallback
+}
+
+func opalUniqueResourceName(name string, countByName map[string]int) string {
+	normalizedName := normalizeResourceName(name)
+	if count, ok := countByName[normalizedName]; ok {
+		countByName[normalizedName] = count + 1
+		return normalizeResourceName(fmt.Sprintf("%s_%d", name, count+1))
+	}
+	countByName[normalizedName] = 1
+	return normalizedName
+}
 
 func normalizeResourceName(s string) string {
 	normalize := precis.NewIdentifier(

--- a/providers/opal/message_channel.go
+++ b/providers/opal/message_channel.go
@@ -5,10 +5,34 @@ import (
 	"fmt"
 
 	"github.com/chenrui333/terraformer/terraformutils"
+	opalsdk "github.com/opalsecurity/opal-go"
 )
 
 type MessageChannelGenerator struct {
 	OpalService
+}
+
+func (g *MessageChannelGenerator) createResources(messageChannels []opalsdk.MessageChannel) ([]terraformutils.Resource, error) {
+	resources := []terraformutils.Resource{}
+	countByName := make(map[string]int)
+
+	for _, channel := range messageChannels {
+		resourceID, err := opalRequiredString("opal_message_channel", "message_channel_id", channel.MessageChannelId)
+		if err != nil {
+			return nil, err
+		}
+		name := opalUniqueResourceName(opalResourceDisplayName(channel.Name, resourceID), countByName)
+
+		resources = append(resources, terraformutils.NewSimpleResource(
+			resourceID,
+			name,
+			"opal_message_channel",
+			"opal",
+			[]string{},
+		))
+	}
+
+	return resources, nil
 }
 
 func (g *MessageChannelGenerator) InitResources() error {
@@ -22,25 +46,11 @@ func (g *MessageChannelGenerator) InitResources() error {
 		return fmt.Errorf("unable to list opal message channels: %w", err)
 	}
 
-	countByName := make(map[string]int)
-
-	for _, channel := range messageChannels.Channels {
-		name := normalizeResourceName(*channel.Name)
-		if count, ok := countByName[name]; ok {
-			countByName[name] = count + 1
-			name = normalizeResourceName(fmt.Sprintf("%s_%d", *channel.Name, count+1))
-		} else {
-			countByName[name] = 1
-		}
-
-		g.Resources = append(g.Resources, terraformutils.NewSimpleResource(
-			channel.MessageChannelId,
-			name,
-			"opal_message_channel",
-			"opal",
-			[]string{},
-		))
+	resources, err := g.createResources(messageChannels.Channels)
+	if err != nil {
+		return err
 	}
+	g.Resources = append(g.Resources, resources...)
 
 	return nil
 }

--- a/providers/opal/on_call_schedule.go
+++ b/providers/opal/on_call_schedule.go
@@ -5,10 +5,34 @@ import (
 	"fmt"
 
 	"github.com/chenrui333/terraformer/terraformutils"
+	opalsdk "github.com/opalsecurity/opal-go"
 )
 
 type OnCallScheduleGenerator struct {
 	OpalService
+}
+
+func (g *OnCallScheduleGenerator) createResources(onCallSchedules []opalsdk.OnCallSchedule) ([]terraformutils.Resource, error) {
+	resources := []terraformutils.Resource{}
+	countByName := make(map[string]int)
+
+	for _, onCallSchedule := range onCallSchedules {
+		resourceID, err := opalRequiredStringPtr("opal_on_call_schedule", "on_call_schedule_id", onCallSchedule.OnCallScheduleId)
+		if err != nil {
+			return nil, err
+		}
+		name := opalUniqueResourceName(opalResourceDisplayName(onCallSchedule.Name, resourceID), countByName)
+
+		resources = append(resources, terraformutils.NewSimpleResource(
+			resourceID,
+			name,
+			"opal_on_call_schedule",
+			"opal",
+			[]string{},
+		))
+	}
+
+	return resources, nil
 }
 
 func (g *OnCallScheduleGenerator) InitResources() error {
@@ -22,25 +46,11 @@ func (g *OnCallScheduleGenerator) InitResources() error {
 		return fmt.Errorf("unable to list opal on call schedules: %w", err)
 	}
 
-	countByName := make(map[string]int)
-
-	for _, onCallSchedule := range onCallSchedules.OnCallSchedules {
-		name := normalizeResourceName(*onCallSchedule.Name)
-		if count, ok := countByName[name]; ok {
-			countByName[name] = count + 1
-			name = normalizeResourceName(fmt.Sprintf("%s_%d", *onCallSchedule.Name, count+1))
-		} else {
-			countByName[name] = 1
-		}
-
-		g.Resources = append(g.Resources, terraformutils.NewSimpleResource(
-			*onCallSchedule.OnCallScheduleId,
-			name,
-			"opal_on_call_schedule",
-			"opal",
-			[]string{},
-		))
+	resources, err := g.createResources(onCallSchedules.OnCallSchedules)
+	if err != nil {
+		return err
 	}
+	g.Resources = append(g.Resources, resources...)
 
 	return nil
 }

--- a/providers/opal/owner.go
+++ b/providers/opal/owner.go
@@ -5,10 +5,33 @@ import (
 	"fmt"
 
 	"github.com/chenrui333/terraformer/terraformutils"
+	opalsdk "github.com/opalsecurity/opal-go"
 )
 
 type OwnerGenerator struct {
 	OpalService
+}
+
+func (g *OwnerGenerator) createResources(owners []opalsdk.Owner, countByName map[string]int) ([]terraformutils.Resource, error) {
+	resources := []terraformutils.Resource{}
+
+	for _, owner := range owners {
+		resourceID, err := opalRequiredString("opal_owner", "owner_id", owner.OwnerId)
+		if err != nil {
+			return nil, err
+		}
+		name := opalUniqueResourceName(opalResourceDisplayName(owner.Name, resourceID), countByName)
+
+		resources = append(resources, terraformutils.NewSimpleResource(
+			resourceID,
+			name,
+			"opal_owner",
+			"opal",
+			[]string{},
+		))
+	}
+
+	return resources, nil
 }
 
 func (g *OwnerGenerator) InitResources() error {
@@ -25,23 +48,11 @@ func (g *OwnerGenerator) InitResources() error {
 	countByName := make(map[string]int)
 
 	for {
-		for _, owner := range owners.Results {
-			name := normalizeResourceName(*owner.Name)
-			if count, ok := countByName[name]; ok {
-				countByName[name] = count + 1
-				name = normalizeResourceName(fmt.Sprintf("%s_%d", *owner.Name, count+1))
-			} else {
-				countByName[name] = 1
-			}
-
-			g.Resources = append(g.Resources, terraformutils.NewSimpleResource(
-				owner.OwnerId,
-				name,
-				"opal_owner",
-				"opal",
-				[]string{},
-			))
+		resources, err := g.createResources(owners.Results, countByName)
+		if err != nil {
+			return err
 		}
+		g.Resources = append(g.Resources, resources...)
 
 		if !owners.HasNext() || owners.Next == nil {
 			break

--- a/providers/opal/resource.go
+++ b/providers/opal/resource.go
@@ -5,11 +5,75 @@ import (
 	"fmt"
 
 	"github.com/chenrui333/terraformer/terraformutils"
-	"github.com/opalsecurity/opal-go"
+	opalsdk "github.com/opalsecurity/opal-go"
 )
 
 type ResourceGenerator struct {
 	OpalService
+}
+
+func opalResourceNameSuffix(resourceID string) string {
+	if len(resourceID) > 8 {
+		return resourceID[:8]
+	}
+	return resourceID
+}
+
+func (g *ResourceGenerator) createResources(opalResources []*opalsdk.Resource) ([]terraformutils.Resource, error) {
+	resources := []terraformutils.Resource{}
+	opalResourceByID := make(map[string]*opalsdk.Resource)
+	for _, resource := range opalResources {
+		if resource == nil {
+			return nil, fmt.Errorf("opal_resource resource is nil")
+		}
+		resourceID, err := opalRequiredString("opal_resource", "resource_id", resource.ResourceId)
+		if err != nil {
+			return nil, err
+		}
+		opalResourceByID[resourceID] = resource
+	}
+
+	seenNames := make(map[string]bool)
+	for _, resource := range opalResources {
+		resourceID, err := opalRequiredString("opal_resource", "resource_id", resource.ResourceId)
+		if err != nil {
+			return nil, err
+		}
+		tfname := opalResourceDisplayName(resource.Name, resourceID)
+		if resource.ResourceType != nil &&
+			*resource.ResourceType == opalsdk.RESOURCETYPEENUM_AWS_SSO_PERMISSION_SET &&
+			resource.ParentResourceId != nil {
+			parentResourceID, err := opalRequiredStringPtr("opal_resource", "parent_resource_id", resource.ParentResourceId)
+			if err != nil {
+				return nil, err
+			}
+			parentAccount, ok := opalResourceByID[parentResourceID]
+			if !ok {
+				return nil, fmt.Errorf("could not find account for permission set %q: parent resource %q", resourceID, parentResourceID)
+			}
+			parentID, err := opalRequiredString("opal_resource parent", "resource_id", parentAccount.ResourceId)
+			if err != nil {
+				return nil, err
+			}
+			tfname = fmt.Sprintf("%s_%s", opalResourceDisplayName(parentAccount.Name, parentID), tfname)
+		}
+
+		if seenNames[tfname] {
+			tfname = tfname + "_" + opalResourceNameSuffix(resourceID)
+		} else {
+			seenNames[tfname] = true
+		}
+
+		resources = append(resources, terraformutils.NewSimpleResource(
+			resourceID,
+			normalizeResourceName(tfname),
+			"opal_resource",
+			"opal",
+			[]string{},
+		))
+	}
+
+	return resources, nil
 }
 
 func (g *ResourceGenerator) InitResources() error {
@@ -23,7 +87,7 @@ func (g *ResourceGenerator) InitResources() error {
 		return fmt.Errorf("unable to list opal resources: %w", err)
 	}
 
-	var opalResources []*opal.Resource
+	var opalResources []*opalsdk.Resource
 	for {
 		for _, resource := range resources.Results {
 			resourceRef := resource
@@ -40,39 +104,11 @@ func (g *ResourceGenerator) InitResources() error {
 		}
 	}
 
-	opalResourceByID := make(map[string]*opal.Resource)
-	for _, resource := range opalResources {
-		opalResourceByID[resource.ResourceId] = resource
+	resourcesList, err := g.createResources(opalResources)
+	if err != nil {
+		return err
 	}
-
-	seenNames := make(map[string]bool)
-	for _, resource := range opalResources {
-		tfname := *resource.Name
-		if resource.ResourceType != nil &&
-			*resource.ResourceType == opal.RESOURCETYPEENUM_AWS_SSO_PERMISSION_SET &&
-			resource.ParentResourceId != nil {
-			parentAccount, ok := opalResourceByID[*resource.ParentResourceId]
-			if !ok {
-				return fmt.Errorf("could not find account for permission set: %#v", resource)
-			}
-			tfname = fmt.Sprintf("%s_%s", *parentAccount.Name, *resource.Name)
-		}
-
-		if seenNames[tfname] {
-			tfname = tfname + "_" + resource.ResourceId[:8]
-		} else {
-			seenNames[tfname] = true
-		}
-
-		tfname = normalizeResourceName(tfname)
-		g.Resources = append(g.Resources, terraformutils.NewSimpleResource(
-			resource.ResourceId,
-			tfname,
-			"opal_resource",
-			"opal",
-			[]string{},
-		))
-	}
+	g.Resources = append(g.Resources, resourcesList...)
 
 	return nil
 }

--- a/providers/opal/resource.go
+++ b/providers/opal/resource.go
@@ -33,7 +33,7 @@ func (g *ResourceGenerator) createResources(opalResources []*opalsdk.Resource) (
 		opalResourceByID[resourceID] = resource
 	}
 
-	seenNames := make(map[string]bool)
+	seenNames := make(map[string]int)
 	for _, resource := range opalResources {
 		resourceID, err := opalRequiredString("opal_resource", "resource_id", resource.ResourceId)
 		if err != nil {
@@ -58,15 +58,11 @@ func (g *ResourceGenerator) createResources(opalResources []*opalsdk.Resource) (
 			tfname = fmt.Sprintf("%s_%s", opalResourceDisplayName(parentAccount.Name, parentID), tfname)
 		}
 
-		if seenNames[tfname] {
-			tfname = tfname + "_" + opalResourceNameSuffix(resourceID)
-		} else {
-			seenNames[tfname] = true
-		}
+		tfname = opalUniqueResourceNameWithSuffix(tfname, opalResourceNameSuffix(resourceID), seenNames)
 
 		resources = append(resources, terraformutils.NewSimpleResource(
 			resourceID,
-			normalizeResourceName(tfname),
+			tfname,
 			"opal_resource",
 			"opal",
 			[]string{},

--- a/providers/opal/resource.go
+++ b/providers/opal/resource.go
@@ -41,8 +41,7 @@ func (g *ResourceGenerator) createResources(opalResources []*opalsdk.Resource) (
 		}
 		tfname := opalResourceDisplayName(resource.Name, resourceID)
 		if resource.ResourceType != nil &&
-			*resource.ResourceType == opalsdk.RESOURCETYPEENUM_AWS_SSO_PERMISSION_SET &&
-			resource.ParentResourceId != nil {
+			*resource.ResourceType == opalsdk.RESOURCETYPEENUM_AWS_SSO_PERMISSION_SET {
 			parentResourceID, err := opalRequiredStringPtr("opal_resource", "parent_resource_id", resource.ParentResourceId)
 			if err != nil {
 				return nil, err

--- a/providers/opal/resource_fields_test.go
+++ b/providers/opal/resource_fields_test.go
@@ -158,6 +158,17 @@ func TestOpalCreateResourcesRequiresIDs(t *testing.T) {
 			},
 			wantErr: "missing resource_id",
 		},
+		{
+			name: "permission set parent resource id",
+			create: func() ([]terraformutils.Resource, error) {
+				resourceType := opalsdk.RESOURCETYPEENUM_AWS_SSO_PERMISSION_SET
+				return (&ResourceGenerator{}).createResources([]*opalsdk.Resource{{
+					ResourceId:   "permission-set-id",
+					ResourceType: &resourceType,
+				}})
+			},
+			wantErr: "missing parent_resource_id",
+		},
 	}
 
 	for _, tt := range tests {

--- a/providers/opal/resource_fields_test.go
+++ b/providers/opal/resource_fields_test.go
@@ -194,6 +194,24 @@ func TestOpalUniqueResourceNameDeduplicatesFallbackNames(t *testing.T) {
 	}
 }
 
+func TestOpalUniqueResourceNameAvoidsGeneratedNameCollision(t *testing.T) {
+	resources, err := (&GroupGenerator{}).createResources([]opalsdk.Group{
+		{GroupId: "first-group", Name: opalStringPtr("Engineering")},
+		{GroupId: "second-group", Name: opalStringPtr("Engineering 2")},
+		{GroupId: "third-group", Name: opalStringPtr("Engineering")},
+	}, map[string]int{})
+	if err != nil {
+		t.Fatalf("expected no error: %v", err)
+	}
+	if len(resources) != 3 {
+		t.Fatalf("resources len = %d, want 3", len(resources))
+	}
+	wantName := terraformutils.TfSanitize("engineering_3")
+	if resources[2].ResourceName != wantName {
+		t.Fatalf("third resource name = %q, want %q", resources[2].ResourceName, wantName)
+	}
+}
+
 func TestOpalResourcePermissionSetUsesParentFallbackName(t *testing.T) {
 	resourceType := opalsdk.RESOURCETYPEENUM_AWS_SSO_PERMISSION_SET
 	resources, err := (&ResourceGenerator{}).createResources([]*opalsdk.Resource{
@@ -214,6 +232,23 @@ func TestOpalResourcePermissionSetUsesParentFallbackName(t *testing.T) {
 	wantName := terraformutils.TfSanitize("account_id_admin_access")
 	if resources[1].ResourceName != wantName {
 		t.Fatalf("permission set name = %q, want %q", resources[1].ResourceName, wantName)
+	}
+}
+
+func TestOpalResourceDeduplicatesAfterNormalization(t *testing.T) {
+	resources, err := (&ResourceGenerator{}).createResources([]*opalsdk.Resource{
+		{ResourceId: "abc", Name: opalStringPtr("Shared Name")},
+		{ResourceId: "def", Name: opalStringPtr("Shared-Name")},
+	})
+	if err != nil {
+		t.Fatalf("expected no error: %v", err)
+	}
+	if len(resources) != 2 {
+		t.Fatalf("resources len = %d, want 2", len(resources))
+	}
+	wantName := terraformutils.TfSanitize("shared_name_def")
+	if resources[1].ResourceName != wantName {
+		t.Fatalf("second resource name = %q, want %q", resources[1].ResourceName, wantName)
 	}
 }
 

--- a/providers/opal/resource_fields_test.go
+++ b/providers/opal/resource_fields_test.go
@@ -1,0 +1,235 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package opal
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/chenrui333/terraformer/terraformutils"
+	opalsdk "github.com/opalsecurity/opal-go"
+)
+
+func opalStringPtr(value string) *string {
+	return &value
+}
+
+func TestOpalCreateResourcesFallsBackToIDName(t *testing.T) {
+	tests := []struct {
+		name     string
+		create   func() ([]terraformutils.Resource, error)
+		wantID   string
+		wantName string
+		wantType string
+	}{
+		{
+			name: "group",
+			create: func() ([]terraformutils.Resource, error) {
+				return (&GroupGenerator{}).createResources([]opalsdk.Group{{GroupId: "group-id"}}, map[string]int{})
+			},
+			wantID:   "group-id",
+			wantName: "group_id",
+			wantType: "opal_group",
+		},
+		{
+			name: "message channel",
+			create: func() ([]terraformutils.Resource, error) {
+				return (&MessageChannelGenerator{}).createResources([]opalsdk.MessageChannel{{MessageChannelId: "channel-id"}})
+			},
+			wantID:   "channel-id",
+			wantName: "channel_id",
+			wantType: "opal_message_channel",
+		},
+		{
+			name: "on call schedule",
+			create: func() ([]terraformutils.Resource, error) {
+				return (&OnCallScheduleGenerator{}).createResources([]opalsdk.OnCallSchedule{{OnCallScheduleId: opalStringPtr("schedule-id")}})
+			},
+			wantID:   "schedule-id",
+			wantName: "schedule_id",
+			wantType: "opal_on_call_schedule",
+		},
+		{
+			name: "owner",
+			create: func() ([]terraformutils.Resource, error) {
+				return (&OwnerGenerator{}).createResources([]opalsdk.Owner{{OwnerId: "owner-id"}}, map[string]int{})
+			},
+			wantID:   "owner-id",
+			wantName: "owner_id",
+			wantType: "opal_owner",
+		},
+		{
+			name: "resource",
+			create: func() ([]terraformutils.Resource, error) {
+				return (&ResourceGenerator{}).createResources([]*opalsdk.Resource{{ResourceId: "resource-id"}})
+			},
+			wantID:   "resource-id",
+			wantName: "resource_id",
+			wantType: "opal_resource",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			resources, err := tt.create()
+			if err != nil {
+				t.Fatalf("expected no error: %v", err)
+			}
+			if len(resources) != 1 {
+				t.Fatalf("resources len = %d, want 1", len(resources))
+			}
+			resource := resources[0]
+			if resource.InstanceState.ID != tt.wantID {
+				t.Fatalf("resource ID = %q, want %q", resource.InstanceState.ID, tt.wantID)
+			}
+			wantName := terraformutils.TfSanitize(tt.wantName)
+			if resource.ResourceName != wantName {
+				t.Fatalf("resource name = %q, want %q", resource.ResourceName, wantName)
+			}
+			if resource.InstanceInfo.Type != tt.wantType {
+				t.Fatalf("resource type = %q, want %q", resource.InstanceInfo.Type, tt.wantType)
+			}
+		})
+	}
+}
+
+func TestOpalCreateResourcesIncludesDisplayNameWhenAvailable(t *testing.T) {
+	resources, err := (&GroupGenerator{}).createResources([]opalsdk.Group{{
+		GroupId: "group-id",
+		Name:    opalStringPtr("Engineering Team"),
+	}}, map[string]int{})
+	if err != nil {
+		t.Fatalf("expected no error: %v", err)
+	}
+	if len(resources) != 1 {
+		t.Fatalf("resources len = %d, want 1", len(resources))
+	}
+	wantName := terraformutils.TfSanitize("engineering_team")
+	if resources[0].ResourceName != wantName {
+		t.Fatalf("resource name = %q, want %q", resources[0].ResourceName, wantName)
+	}
+}
+
+func TestOpalCreateResourcesRequiresIDs(t *testing.T) {
+	tests := []struct {
+		name    string
+		create  func() ([]terraformutils.Resource, error)
+		wantErr string
+	}{
+		{
+			name: "group id",
+			create: func() ([]terraformutils.Resource, error) {
+				return (&GroupGenerator{}).createResources([]opalsdk.Group{{}}, map[string]int{})
+			},
+			wantErr: "missing group_id",
+		},
+		{
+			name: "message channel id",
+			create: func() ([]terraformutils.Resource, error) {
+				return (&MessageChannelGenerator{}).createResources([]opalsdk.MessageChannel{{}})
+			},
+			wantErr: "missing message_channel_id",
+		},
+		{
+			name: "on call schedule id",
+			create: func() ([]terraformutils.Resource, error) {
+				return (&OnCallScheduleGenerator{}).createResources([]opalsdk.OnCallSchedule{{}})
+			},
+			wantErr: "missing on_call_schedule_id",
+		},
+		{
+			name: "owner id",
+			create: func() ([]terraformutils.Resource, error) {
+				return (&OwnerGenerator{}).createResources([]opalsdk.Owner{{}}, map[string]int{})
+			},
+			wantErr: "missing owner_id",
+		},
+		{
+			name: "resource nil",
+			create: func() ([]terraformutils.Resource, error) {
+				return (&ResourceGenerator{}).createResources([]*opalsdk.Resource{nil})
+			},
+			wantErr: "resource is nil",
+		},
+		{
+			name: "resource id",
+			create: func() ([]terraformutils.Resource, error) {
+				return (&ResourceGenerator{}).createResources([]*opalsdk.Resource{{}})
+			},
+			wantErr: "missing resource_id",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := tt.create()
+			if err == nil {
+				t.Fatal("expected missing Opal field error")
+			}
+			if !strings.Contains(err.Error(), tt.wantErr) {
+				t.Fatalf("error = %q, want %q", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestOpalUniqueResourceNameDeduplicatesFallbackNames(t *testing.T) {
+	resources, err := (&GroupGenerator{}).createResources([]opalsdk.Group{
+		{GroupId: "first-group", Name: opalStringPtr("Engineering")},
+		{GroupId: "second-group", Name: opalStringPtr("Engineering")},
+	}, map[string]int{})
+	if err != nil {
+		t.Fatalf("expected no error: %v", err)
+	}
+	if len(resources) != 2 {
+		t.Fatalf("resources len = %d, want 2", len(resources))
+	}
+	wantFirstName := terraformutils.TfSanitize("engineering")
+	if resources[0].ResourceName != wantFirstName {
+		t.Fatalf("first resource name = %q, want %q", resources[0].ResourceName, wantFirstName)
+	}
+	wantSecondName := terraformutils.TfSanitize("engineering_2")
+	if resources[1].ResourceName != wantSecondName {
+		t.Fatalf("second resource name = %q, want %q", resources[1].ResourceName, wantSecondName)
+	}
+}
+
+func TestOpalResourcePermissionSetUsesParentFallbackName(t *testing.T) {
+	resourceType := opalsdk.RESOURCETYPEENUM_AWS_SSO_PERMISSION_SET
+	resources, err := (&ResourceGenerator{}).createResources([]*opalsdk.Resource{
+		{ResourceId: "account-id"},
+		{
+			ResourceId:       "permission-set-id",
+			Name:             opalStringPtr("Admin Access"),
+			ResourceType:     &resourceType,
+			ParentResourceId: opalStringPtr("account-id"),
+		},
+	})
+	if err != nil {
+		t.Fatalf("expected no error: %v", err)
+	}
+	if len(resources) != 2 {
+		t.Fatalf("resources len = %d, want 2", len(resources))
+	}
+	wantName := terraformutils.TfSanitize("account_id_admin_access")
+	if resources[1].ResourceName != wantName {
+		t.Fatalf("permission set name = %q, want %q", resources[1].ResourceName, wantName)
+	}
+}
+
+func TestOpalResourceDuplicateNameUsesShortIDSuffix(t *testing.T) {
+	resources, err := (&ResourceGenerator{}).createResources([]*opalsdk.Resource{
+		{ResourceId: "abc", Name: opalStringPtr("Shared")},
+		{ResourceId: "def", Name: opalStringPtr("Shared")},
+	})
+	if err != nil {
+		t.Fatalf("expected no error: %v", err)
+	}
+	if len(resources) != 2 {
+		t.Fatalf("resources len = %d, want 2", len(resources))
+	}
+	wantName := terraformutils.TfSanitize("shared_def")
+	if resources[1].ResourceName != wantName {
+		t.Fatalf("second resource name = %q, want %q", resources[1].ResourceName, wantName)
+	}
+}


### PR DESCRIPTION
Summary

- Guard Opal resource construction against missing required IDs from SDK payloads.
- Fall back to stable ID-based Terraform names when optional display names are absent.
- Add regression coverage for malformed Opal resource fields, duplicate names, and permission-set parent naming.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hardened Opal Terraform resource generation to validate required IDs, handle missing names, and prevent name collisions after normalization. Also enforce and prefix AWS SSO permission-set names with their parent account.

- **Bug Fixes**
  - Validate IDs for opal_group, opal_owner, opal_message_channel, opal_on_call_schedule, and opal_resource; error on missing fields and nil resources.
  - Fall back to ID-based names when display names are missing; de-dupe after normalization (numeric suffix for most, short ID suffix for opal_resource).
  - For AWS SSO permission sets, prefix names with the parent account and fail when parent_resource_id is missing or the parent account is not found.

- **Refactors**
  - Centralized validation and naming in helpers (opalRequiredString, opalRequiredStringPtr, opalResourceDisplayName, opalUniqueResourceName, opalUniqueResourceNameWithSuffix).
  - Moved resource creation into createResources across generators; added regression tests in providers/opal/resource_fields_test.go.

<sup>Written for commit 2ac1111f5115aaa43814b0acc233c630f4479984. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved OPAL resource creation and naming across providers, with stronger validation and deterministic name deduplication to reduce collisions and surface missing required fields earlier.

* **Tests**
  * Added comprehensive tests for resource field validation, fallback-to-ID naming, deterministic name generation, deduplication, and collision-resolution behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->