### PR TITLE
chore(deps): enable conservative Renovate automerge

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -20,10 +20,14 @@
   "timezone": "America/New_York",
   "packageRules": [
     {
-      "description": "Keep GitHub Actions updates together and allow safe automerge.",
+      "description": "Keep GitHub Actions updates together.",
       "matchManagers": ["github-actions"],
       "groupName": "GitHub Actions",
-      "groupSlug": "github-actions",
+      "groupSlug": "github-actions"
+    },
+    {
+      "description": "Allow conservative automerge for GitHub Actions patch and digest updates after release cooldown.",
+      "matchManagers": ["github-actions"],
       "automerge": true,
       "automergeType": "pr",
       "matchUpdateTypes": ["patch", "digest"]

--- a/renovate.json
+++ b/renovate.json
@@ -9,8 +9,9 @@
   "enabledManagers": ["github-actions", "gomod"],
   "internalChecksFilter": "strict",
   "labels": ["dependencies"],
-  "minimumReleaseAge": "2 days",
-  "platformAutomerge": false,
+  "minimumReleaseAge": "7 days",
+  "platformAutomerge": true,
+  "automergeStrategy": "squash",
   "prConcurrentLimit": 8,
   "prHourlyLimit": 2,
   "rebaseWhen": "conflicted",
@@ -25,12 +26,19 @@
       "groupSlug": "github-actions",
       "automerge": true,
       "automergeType": "pr",
-      "matchUpdateTypes": ["minor", "patch", "digest"]
+      "matchUpdateTypes": ["patch", "digest"]
     },
     {
       "description": "Run go mod tidy after Go module updates.",
       "matchManagers": ["gomod"],
       "postUpdateOptions": ["gomodTidy"]
+    },
+    {
+      "description": "Allow conservative automerge for Go patch and digest updates after release cooldown.",
+      "matchManagers": ["gomod"],
+      "matchUpdateTypes": ["patch", "digest"],
+      "automerge": true,
+      "automergeType": "pr"
     },
     {
       "description": "Do not auto-bump the Go directive; handle Go version changes manually.",
@@ -54,7 +62,8 @@
       ],
       "groupName": "terraform core dependencies",
       "groupSlug": "go-terraform-core",
-      "dependencyDashboardApproval": true
+      "dependencyDashboardApproval": true,
+      "automerge": false
     },
     {
       "description": "AWS provider dependency family.",


### PR DESCRIPTION
Summary:
- Enable Renovate platform PR automerge with squash merges.
- Increase the release-age cooldown to 7 days.
- Limit automerge to patch and digest updates, while keeping Terraform core updates manual.

Notes:
- GitHub repository auto-merge should be enabled after this config lands on main.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enable conservative Renovate automerge with squash and a 7‑day release-age cooldown. Only patch/digest updates for `github-actions` and `gomod` auto-merge; Terraform core remains manual.

- **Migration**
  - After merging to main, enable GitHub repository auto-merge in repo settings.

<sup>Written for commit fa878608bc5feea60d57e6e33f85e0078e250f0f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated dependency automation: extended cooldown before automerge, enabled platform-level automerge, and switched default merge behavior to squash.
  * Narrowed automerge to safer update types for GitHub Actions and added a conservative automerge rule for Go module patch/digest updates after cooldown.
  * Disabled automerge for core Terraform dependencies while keeping dashboard approval required.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/chenrui333/terraformer/pull/355)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->