### PR TITLE
aws(accessanalyzer): add archive rule imports

### DIFF
--- a/docs/aws.md
+++ b/docs/aws.md
@@ -35,6 +35,7 @@ terraformer import aws --resources=sg --regions=us-east-1
 
 *   `accessanalyzer`
     * `aws_accessanalyzer_analyzer`
+    * `aws_accessanalyzer_archive_rule`
 *   `acm`
     * `aws_acm_certificate`
 *   `alb` (supports ALB and NLB)

--- a/providers/aws/accessanalyzer.go
+++ b/providers/aws/accessanalyzer.go
@@ -4,12 +4,22 @@ package aws
 
 import (
 	"context"
+	"errors"
+	"strings"
 
 	"github.com/aws/aws-sdk-go-v2/service/accessanalyzer"
+	accessanalyzertypes "github.com/aws/aws-sdk-go-v2/service/accessanalyzer/types"
 	"github.com/chenrui333/terraformer/terraformutils"
 )
 
 var accessanalyzerAllowEmptyValues = []string{"tags."}
+
+const (
+	accessAnalyzerAnalyzerResourceType    = "aws_accessanalyzer_analyzer"
+	accessAnalyzerArchiveRuleResourceType = "aws_accessanalyzer_archive_rule"
+	accessAnalyzerArchiveRuleIDSeparator  = "/"
+	accessAnalyzerResourceNameSeparator   = ":"
+)
 
 type AccessAnalyzerGenerator struct {
 	AWSService
@@ -29,15 +39,84 @@ func (g *AccessAnalyzerGenerator) InitResources() error {
 			return e
 		}
 		for _, analyzer := range page.Analyzers {
-			resourceName := *analyzer.Name
-			resources = append(resources, terraformutils.NewSimpleResource(
-				resourceName,
-				resourceName,
-				"aws_accessanalyzer_analyzer",
-				"aws",
-				accessanalyzerAllowEmptyValues))
+			analyzerName := StringValue(analyzer.Name)
+			if analyzerName == "" {
+				continue
+			}
+			resources = append(resources, newAccessAnalyzerAnalyzerResource(analyzerName))
+			archiveRuleResources, err := accessAnalyzerArchiveRuleResources(svc, analyzerName)
+			if err != nil {
+				if accessAnalyzerResourceNotFound(err) {
+					continue
+				}
+				return err
+			}
+			resources = append(resources, archiveRuleResources...)
 		}
 	}
 	g.Resources = resources
 	return nil
+}
+
+func accessAnalyzerArchiveRuleResources(svc *accessanalyzer.Client, analyzerName string) ([]terraformutils.Resource, error) {
+	p := accessanalyzer.NewListArchiveRulesPaginator(svc, &accessanalyzer.ListArchiveRulesInput{
+		AnalyzerName: &analyzerName,
+	})
+	var resources []terraformutils.Resource
+	for p.HasMorePages() {
+		page, err := p.NextPage(context.TODO())
+		if err != nil {
+			return nil, err
+		}
+		for _, rule := range page.ArchiveRules {
+			ruleName := StringValue(rule.RuleName)
+			if ruleName == "" {
+				continue
+			}
+			resources = append(resources, newAccessAnalyzerArchiveRuleResource(analyzerName, ruleName))
+		}
+	}
+	return resources, nil
+}
+
+func newAccessAnalyzerAnalyzerResource(analyzerName string) terraformutils.Resource {
+	return terraformutils.NewResource(
+		analyzerName,
+		accessAnalyzerResourceName(analyzerName),
+		accessAnalyzerAnalyzerResourceType,
+		"aws",
+		map[string]string{
+			"analyzer_name": analyzerName,
+		},
+		accessanalyzerAllowEmptyValues,
+		map[string]interface{}{},
+	)
+}
+
+func newAccessAnalyzerArchiveRuleResource(analyzerName, ruleName string) terraformutils.Resource {
+	return terraformutils.NewResource(
+		accessAnalyzerArchiveRuleResourceID(analyzerName, ruleName),
+		accessAnalyzerResourceName(analyzerName, ruleName),
+		accessAnalyzerArchiveRuleResourceType,
+		"aws",
+		map[string]string{
+			"analyzer_name": analyzerName,
+			"rule_name":     ruleName,
+		},
+		accessanalyzerAllowEmptyValues,
+		map[string]interface{}{},
+	)
+}
+
+func accessAnalyzerArchiveRuleResourceID(analyzerName, ruleName string) string {
+	return strings.Join([]string{analyzerName, ruleName}, accessAnalyzerArchiveRuleIDSeparator)
+}
+
+func accessAnalyzerResourceName(parts ...string) string {
+	return strings.Join(parts, accessAnalyzerResourceNameSeparator)
+}
+
+func accessAnalyzerResourceNotFound(err error) bool {
+	var notFound *accessanalyzertypes.ResourceNotFoundException
+	return errors.As(err, &notFound)
 }

--- a/providers/aws/accessanalyzer_test.go
+++ b/providers/aws/accessanalyzer_test.go
@@ -1,0 +1,64 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package aws
+
+import (
+	"errors"
+	"testing"
+
+	accessanalyzertypes "github.com/aws/aws-sdk-go-v2/service/accessanalyzer/types"
+)
+
+func TestAccessAnalyzerArchiveRuleResourceID(t *testing.T) {
+	got := accessAnalyzerArchiveRuleResourceID("account-analyzer", "archive-public")
+	want := "account-analyzer/archive-public"
+	if got != want {
+		t.Fatalf("archive rule resource ID = %q, want %q", got, want)
+	}
+}
+
+func TestAccessAnalyzerArchiveRuleResource(t *testing.T) {
+	resource := newAccessAnalyzerArchiveRuleResource("account-analyzer", "archive-public")
+
+	if got, want := resource.InstanceState.ID, "account-analyzer/archive-public"; got != want {
+		t.Fatalf("resource ID = %q, want %q", got, want)
+	}
+	if got, want := resource.InstanceInfo.Type, accessAnalyzerArchiveRuleResourceType; got != want {
+		t.Fatalf("resource type = %q, want %q", got, want)
+	}
+	if got, want := resource.InstanceState.Attributes["analyzer_name"], "account-analyzer"; got != want {
+		t.Fatalf("analyzer_name = %q, want %q", got, want)
+	}
+	if got, want := resource.InstanceState.Attributes["rule_name"], "archive-public"; got != want {
+		t.Fatalf("rule_name = %q, want %q", got, want)
+	}
+}
+
+func TestAccessAnalyzerResourceNamesDoNotCollapseJoinedParts(t *testing.T) {
+	left := newAccessAnalyzerArchiveRuleResource("a_b", "c")
+	right := newAccessAnalyzerArchiveRuleResource("a", "b_c")
+	if left.ResourceName == right.ResourceName {
+		t.Fatalf("archive rule resource names collide: %q", left.ResourceName)
+	}
+}
+
+func TestAccessAnalyzerResourceNotFound(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{name: "nil", want: false},
+		{name: "resource not found", err: &accessanalyzertypes.ResourceNotFoundException{}, want: true},
+		{name: "wrapped resource not found", err: errors.Join(errors.New("lookup failed"), &accessanalyzertypes.ResourceNotFoundException{}), want: true},
+		{name: "generic", err: errors.New("boom"), want: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := accessAnalyzerResourceNotFound(tt.err); got != tt.want {
+				t.Fatalf("accessAnalyzerResourceNotFound(%v) = %t, want %t", tt.err, got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Summary:
- add Access Analyzer archive rule discovery from each analyzer
- seed archive rule import IDs as analyzer_name/rule_name
- document aws_accessanalyzer_archive_rule support

References:
- #338


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds import support for Access Analyzer archive rules so we can generate `aws_accessanalyzer_archive_rule` resources per analyzer. Also standardizes IDs and names to avoid collisions.

- **New Features**
  - Discover archive rules for each analyzer using `ListArchiveRules`.
  - Import `aws_accessanalyzer_archive_rule` with IDs formatted as `analyzer_name/rule_name`.
  - Add helpers to build stable resource names (`:`) and IDs (`/`), preventing name collisions.
  - Skip gracefully when the analyzer or rules are not found.
  - Document `aws_accessanalyzer_archive_rule` in `docs/aws.md`.
  - Add unit tests for ID formatting, resource construction, name uniqueness, and not-found detection.

<sup>Written for commit 9375f87bd476e7da411263f8d44e0df0c11853e4. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * AWS Access Analyzer now supports archive rule resource discovery and management

* **Tests**
  * Added unit tests for archive rule resource handling and error scenarios

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/chenrui333/terraformer/pull/388)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->