### PR TITLE
aws: add provider gap inventory and skip-list scaffolding

### DIFF
--- a/docs/aws-gap-inventory.md
+++ b/docs/aws-gap-inventory.md
@@ -1,0 +1,84 @@
+# AWS Provider Gap Inventory
+
+Use the AWS gap inventory tool to compare Terraformer AWS resource coverage with
+the Terraform AWS provider schema and docs/aws.md.
+
+The tool is read-only. It does not call AWS APIs and does not change Terraformer
+import behavior.
+
+## Generate Provider Schema Input
+
+Create a temporary Terraform configuration that only installs the AWS provider:
+
+~~~hcl
+terraform {
+  required_providers {
+    aws = {
+      source = "hashicorp/aws"
+    }
+  }
+}
+~~~
+
+Then generate the provider schema JSON:
+
+~~~bash
+terraform init
+terraform providers schema -json > aws-provider-schema.json
+~~~
+
+## Run The Inventory
+
+From the repository root:
+
+~~~bash
+go run ./tools/aws-gap-inventory \
+  -provider-schema aws-provider-schema.json \
+  -docs docs/aws.md \
+  -aws-dir providers/aws \
+  -skip-list providers/aws/unsupported_resources.json \
+  -format markdown
+~~~
+
+Use -format json when another script needs structured output.
+
+If -provider-schema is omitted, the tool still audits docs/aws.md against
+resource types detected in providers/aws/*.go, but it cannot report Terraform
+AWS provider gaps.
+
+## Skip-List Format
+
+Resources that cannot be imported safely should be recorded in
+providers/aws/unsupported_resources.json instead of being added as misleading
+Terraformer support.
+
+~~~json
+{
+  "version": 1,
+  "resources": [
+    {
+      "resource": "aws_example_resource",
+      "service_family": "example",
+      "reason": "AWS does not expose a list API with enough parent context for safe discovery.",
+      "evidence": "Checked Terraform AWS provider schema and AWS service API reference.",
+      "status": "unsafe-discovery",
+      "references": [
+        "https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/example_resource"
+      ]
+    }
+  ]
+}
+~~~
+
+Supported statuses:
+
+- needs-research
+- not-importable
+- unsupported
+- unsafe-discovery
+- deferred
+
+The provider schema lists resource types, not importer contracts. Before adding
+an AWS resource importer, still verify the Terraform AWS provider read/import ID
+shape, AWS list and describe APIs, pagination, region or global behavior,
+generated address uniqueness, filter behavior, and unsupported or deleted states.

--- a/docs/aws.md
+++ b/docs/aws.md
@@ -33,6 +33,8 @@ terraformer import aws --resources=sg --regions=us-east-1
 
 #### Supported services
 
+For AWS provider gap audits and unsupported-resource skip-list maintenance, see [aws-gap-inventory.md](aws-gap-inventory.md).
+
 *   `accessanalyzer`
     * `aws_accessanalyzer_analyzer`
     * `aws_accessanalyzer_archive_rule`
@@ -165,6 +167,7 @@ terraformer import aws --resources=sg --regions=us-east-1
 *   `codebuild`
     * `aws_codebuild_project`
 *   `codecommit`
+    * `aws_codecommit_approval_rule_template`
     * `aws_codecommit_repository`
 *   `codedeploy`
     * `aws_codedeploy_app`
@@ -204,6 +207,11 @@ terraformer import aws --resources=sg --regions=us-east-1
     * `aws_docdb_cluster_instance`
     * `aws_docdb_cluster_parameter_group`
     * `aws_docdb_subnet_group`
+*   `dx`
+    * `aws_dx_connection`
+    * `aws_dx_gateway`
+    * `aws_dx_private_virtual_interface`
+    * `aws_dx_public_virtual_interface`
 *   `dynamodb`
     * `aws_dynamodb_contributor_insights`
     * `aws_dynamodb_kinesis_streaming_destination`
@@ -307,6 +315,10 @@ terraformer import aws --resources=sg --regions=us-east-1
     * `aws_iam_user_group_membership`
     * `aws_iam_user_policy`
     * `aws_iam_user_policy_attachment`
+*   `identitystore`
+    * `aws_identitystore_group`
+    * `aws_identitystore_group_membership`
+    * `aws_identitystore_user`
 *   `igw`
     * `aws_internet_gateway`
 *   `iot`
@@ -361,6 +373,7 @@ terraformer import aws --resources=sg --regions=us-east-1
     * `aws_msk_single_scram_secret_association`
     * `aws_msk_vpc_connection`
 *   `nacl`
+    * `aws_default_network_acl`
     * `aws_network_acl`
 *   `nat`
     * `aws_nat_gateway`
@@ -370,7 +383,6 @@ terraformer import aws --resources=sg --regions=us-east-1
     * `aws_opsworks_instance`
     * `aws_opsworks_java_app_layer`
     * `aws_opsworks_php_app_layer`
-    * `aws_opsworks_rds_db_instance`
     * `aws_opsworks_stack`
     * `aws_opsworks_static_web_layer`
     * `aws_opsworks_user_profile`
@@ -389,13 +401,13 @@ terraformer import aws --resources=sg --regions=us-east-1
     * `aws_db_proxy_default_target_group`
     * `aws_db_proxy_endpoint`
     * `aws_db_proxy_target`
-    * `aws_db_cluster`
     * `aws_db_cluster_snapshot`
     * `aws_db_parameter_group`
     * `aws_db_snapshot`
     * `aws_db_subnet_group`
     * `aws_db_option_group`
     * `aws_db_event_subscription`
+    * `aws_rds_cluster`
     * `aws_rds_cluster_endpoint`
     * `aws_rds_cluster_parameter_group`
     * `aws_rds_global_cluster`
@@ -481,6 +493,7 @@ terraformer import aws --resources=sg --regions=us-east-1
 *   `swf`
     * `aws_swf_domain`
 *   `transit_gateway`
+    * `aws_ec2_transit_gateway`
     * `aws_ec2_transit_gateway_route_table`
     * `aws_ec2_transit_gateway_vpc_attachment`
 *   `vpc`

--- a/providers/aws/unsupported_resources.json
+++ b/providers/aws/unsupported_resources.json
@@ -1,0 +1,16 @@
+{
+  "version": 1,
+  "resources": [
+    {
+      "resource": "aws_cloudwatch_event_connection",
+      "service_family": "cloudwatch",
+      "reason": "EventBridge connection credentials are write-only secrets; Terraformer cannot discover the required auth_parameters values from EventBridge APIs.",
+      "evidence": "Terraform AWS provider marks auth_parameters as required and reuses prior state for sensitive values during Read; EventBridge DescribeConnection does not return the secret values needed to seed an imported resource.",
+      "status": "unsupported",
+      "references": [
+        "https://github.com/chenrui333/terraformer/issues/338",
+        "https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_event_connection"
+      ]
+    }
+  ]
+}

--- a/tools/aws-gap-inventory/inventory.go
+++ b/tools/aws-gap-inventory/inventory.go
@@ -31,6 +31,11 @@ var (
 		"unsupported":      true,
 		"unsafe-discovery": true,
 	}
+	resourceServiceOverrides = map[string]map[string][]string{
+		"wafv2.go": {
+			"aws_wafv2_web_acl_association": {"wafv2_regional"},
+		},
+	}
 )
 
 type options struct {
@@ -83,13 +88,62 @@ type skipListEntry struct {
 	References    []string `json:"references,omitempty"`
 }
 
+type resourceFamilySet map[string]map[string]bool
+
+func newResourceFamilySet() resourceFamilySet {
+	return resourceFamilySet{}
+}
+
+func (s resourceFamilySet) add(resource string, serviceFamily string) {
+	if s[resource] == nil {
+		s[resource] = map[string]bool{}
+	}
+	s[resource][serviceFamily] = true
+}
+
+func (s resourceFamilySet) has(resource string, serviceFamily string) bool {
+	return s[resource][serviceFamily]
+}
+
+func (s resourceFamilySet) hasResource(resource string) bool {
+	return len(s[resource]) > 0
+}
+
+func (s resourceFamilySet) records() []resourceRecord {
+	records := []resourceRecord{}
+	for resource, serviceFamilies := range s {
+		for serviceFamily := range serviceFamilies {
+			records = append(records, resourceRecord{Resource: resource, ServiceFamily: serviceFamily})
+		}
+	}
+	sortRecords(records)
+	return records
+}
+
+func (s resourceFamilySet) resourceSet() map[string]bool {
+	resources := map[string]bool{}
+	for resource := range s {
+		resources[resource] = true
+	}
+	return resources
+}
+
+func (s resourceFamilySet) serviceFamilies(resource string) []string {
+	serviceFamilies := []string{}
+	for serviceFamily := range s[resource] {
+		serviceFamilies = append(serviceFamilies, serviceFamily)
+	}
+	sort.Strings(serviceFamilies)
+	return serviceFamilies
+}
+
 func buildInventory(opts options) (inventory, error) {
 	docsResources, err := parseDocsResources(opts.docsPath)
 	if err != nil {
 		return inventory{}, err
 	}
 
-	terraformerResources, err := scanTerraformerResources(opts.awsDir, docsResources)
+	terraformerResources, err := scanTerraformerResources(opts.awsDir)
 	if err != nil {
 		return inventory{}, err
 	}
@@ -109,8 +163,8 @@ func buildInventory(opts options) (inventory, error) {
 
 	inv := inventory{
 		ProviderResources:    providerResources,
-		TerraformerResources: recordsFromMap(terraformerResources),
-		DocsResources:        recordsFromMap(docsResources),
+		TerraformerResources: terraformerResources.records(),
+		DocsResources:        docsResources.records(),
 		SkippedResources:     skippedResources,
 		DocsAudit:            compareDocs(terraformerResources, docsResources),
 	}
@@ -118,14 +172,14 @@ func buildInventory(opts options) (inventory, error) {
 	return inv, nil
 }
 
-func parseDocsResources(path string) (map[string]string, error) {
+func parseDocsResources(path string) (resourceFamilySet, error) {
 	file, err := os.Open(path)
 	if err != nil {
 		return nil, fmt.Errorf("open docs: %w", err)
 	}
 	defer file.Close()
 
-	resources := map[string]string{}
+	resources := newResourceFamilySet()
 	service := ""
 	scanner := bufio.NewScanner(file)
 	for scanner.Scan() {
@@ -135,7 +189,7 @@ func parseDocsResources(path string) (map[string]string, error) {
 			continue
 		}
 		if match := docsResourceRe.FindStringSubmatch(line); len(match) == 2 && service != "" {
-			resources[match[1]] = service
+			resources.add(match[1], service)
 		}
 	}
 	if err := scanner.Err(); err != nil {
@@ -144,13 +198,13 @@ func parseDocsResources(path string) (map[string]string, error) {
 	return resources, nil
 }
 
-func scanTerraformerResources(awsDir string, docsResources map[string]string) (map[string]string, error) {
+func scanTerraformerResources(awsDir string) (resourceFamilySet, error) {
 	serviceByFile, err := servicesByFile(awsDir)
 	if err != nil {
 		return nil, err
 	}
 
-	resources := map[string]string{}
+	resources := newResourceFamilySet()
 	err = filepath.WalkDir(awsDir, func(path string, d os.DirEntry, err error) error {
 		if err != nil {
 			return err
@@ -168,9 +222,9 @@ func scanTerraformerResources(awsDir string, docsResources map[string]string) (m
 			return fmt.Errorf("parse %s: %w", path, err)
 		}
 
-		serviceFamily := serviceByFile[path]
-		if serviceFamily == "" {
-			serviceFamily = fallbackServiceFamily(path)
+		serviceFamilies := serviceByFile[path]
+		if len(serviceFamilies) == 0 {
+			serviceFamilies = []string{fallbackServiceFamily(path)}
 		}
 		ast.Inspect(file, func(node ast.Node) bool {
 			literal, ok := node.(*ast.BasicLit)
@@ -181,11 +235,9 @@ func scanTerraformerResources(awsDir string, docsResources map[string]string) (m
 			if err != nil || !awsResourceRe.MatchString(value) {
 				return true
 			}
-			if docsFamily := docsResources[value]; docsFamily != "" {
-				resources[value] = docsFamily
-				return true
+			for _, family := range resourceServices(path, value, serviceFamilies) {
+				resources.add(value, family)
 			}
-			resources[value] = serviceFamily
 			return true
 		})
 		return nil
@@ -196,7 +248,7 @@ func scanTerraformerResources(awsDir string, docsResources map[string]string) (m
 	return resources, nil
 }
 
-func servicesByFile(awsDir string) (map[string]string, error) {
+func servicesByFile(awsDir string) (map[string][]string, error) {
 	providerPath := filepath.Join(awsDir, "aws_provider.go")
 	fileSet := token.NewFileSet()
 	file, err := parser.ParseFile(fileSet, providerPath, nil, 0)
@@ -204,7 +256,7 @@ func servicesByFile(awsDir string) (map[string]string, error) {
 		return nil, fmt.Errorf("parse aws provider: %w", err)
 	}
 
-	serviceByGenerator := map[string]string{}
+	serviceByGenerator := map[string][]string{}
 	ast.Inspect(file, func(node ast.Node) bool {
 		kv, ok := node.(*ast.KeyValueExpr)
 		if !ok {
@@ -219,12 +271,12 @@ func servicesByFile(awsDir string) (map[string]string, error) {
 			return true
 		}
 		for _, generator := range generatorNames(kv.Value) {
-			serviceByGenerator[generator] = service
+			serviceByGenerator[generator] = appendStringUnique(serviceByGenerator[generator], service)
 		}
 		return true
 	})
 
-	serviceByFile := map[string]string{}
+	serviceByFile := map[string][]string{}
 	err = filepath.WalkDir(awsDir, func(path string, d os.DirEntry, err error) error {
 		if err != nil {
 			return err
@@ -238,19 +290,22 @@ func servicesByFile(awsDir string) (map[string]string, error) {
 			return fmt.Errorf("parse %s: %w", path, err)
 		}
 		for _, declaration := range file.Decls {
-			genericDeclaration, ok := declaration.(*ast.GenDecl)
-			if !ok || genericDeclaration.Tok != token.TYPE {
-				continue
-			}
-			for _, spec := range genericDeclaration.Specs {
-				typeSpec, ok := spec.(*ast.TypeSpec)
-				if !ok {
+			switch declaration := declaration.(type) {
+			case *ast.GenDecl:
+				if declaration.Tok != token.TYPE {
 					continue
 				}
-				if service := serviceByGenerator[typeSpec.Name.Name]; service != "" {
-					serviceByFile[path] = service
-					return nil
+				for _, spec := range declaration.Specs {
+					typeSpec, ok := spec.(*ast.TypeSpec)
+					if !ok {
+						continue
+					}
+					serviceByFile[path] = appendStringsUnique(serviceByFile[path], serviceByGenerator[typeSpec.Name.Name]...)
 				}
+			case *ast.FuncDecl:
+				serviceByFile[path] = appendStringsUnique(serviceByFile[path], serviceByGenerator[declaration.Name.Name]...)
+			default:
+				continue
 			}
 		}
 		return nil
@@ -279,9 +334,36 @@ func generatorNames(expr ast.Expr) []string {
 	return names
 }
 
+func resourceServices(path string, resource string, serviceFamilies []string) []string {
+	if overrides := resourceServiceOverrides[filepath.Base(path)]; len(overrides) > 0 {
+		if services := overrides[resource]; len(services) > 0 {
+			return services
+		}
+	}
+	return serviceFamilies
+}
+
+func appendStringsUnique(values []string, additions ...string) []string {
+	for _, addition := range additions {
+		values = appendStringUnique(values, addition)
+	}
+	return values
+}
+
+func appendStringUnique(values []string, addition string) []string {
+	if addition == "" {
+		return values
+	}
+	for _, value := range values {
+		if value == addition {
+			return values
+		}
+	}
+	return append(values, addition)
+}
+
 func fallbackServiceFamily(path string) string {
-	base := strings.TrimSuffix(filepath.Base(path), ".go")
-	return strings.ReplaceAll(base, "_", "-")
+	return strings.TrimSuffix(filepath.Base(path), ".go")
 }
 
 func parseProviderSchema(path string) ([]string, error) {
@@ -352,16 +434,16 @@ func readSkipList(path string) ([]skipListEntry, error) {
 	return list.Resources, nil
 }
 
-func compareDocs(terraformerResources, docsResources map[string]string) docsAudit {
+func compareDocs(terraformerResources, docsResources resourceFamilySet) docsAudit {
 	audit := docsAudit{}
-	for resource, service := range docsResources {
-		if _, ok := terraformerResources[resource]; !ok {
-			audit.DocumentedButNotDetected = append(audit.DocumentedButNotDetected, resourceRecord{Resource: resource, ServiceFamily: service})
+	for _, record := range docsResources.records() {
+		if !terraformerResources.has(record.Resource, record.ServiceFamily) {
+			audit.DocumentedButNotDetected = append(audit.DocumentedButNotDetected, record)
 		}
 	}
-	for resource, service := range terraformerResources {
-		if _, ok := docsResources[resource]; !ok {
-			audit.DetectedButNotDocumented = append(audit.DetectedButNotDocumented, resourceRecord{Resource: resource, ServiceFamily: service})
+	for _, record := range terraformerResources.records() {
+		if !docsResources.has(record.Resource, record.ServiceFamily) {
+			audit.DetectedButNotDocumented = append(audit.DetectedButNotDocumented, record)
 		}
 	}
 	sortRecords(audit.DocumentedButNotDetected)
@@ -369,27 +451,25 @@ func compareDocs(terraformerResources, docsResources map[string]string) docsAudi
 	return audit
 }
 
-func groupFamilies(providerResources []string, terraformerResources, docsResources map[string]string, skippedResources []skipListEntry) []familyInventory {
-	terraformerSet := map[string]bool{}
-	for resource := range terraformerResources {
-		terraformerSet[resource] = true
-	}
+func groupFamilies(providerResources []string, terraformerResources, docsResources resourceFamilySet, skippedResources []skipListEntry) []familyInventory {
+	terraformerSet := terraformerResources.resourceSet()
 	skipSet := map[string]skipListEntry{}
 	for _, resource := range skippedResources {
 		skipSet[resource.Resource] = resource
 	}
 
 	families := map[string]*familyInventory{}
-	for resource, service := range terraformerResources {
-		family := familyEntry(families, service)
-		family.TerraformerResources = append(family.TerraformerResources, resource)
+	for _, record := range terraformerResources.records() {
+		family := familyEntry(families, record.ServiceFamily)
+		family.TerraformerResources = append(family.TerraformerResources, record.Resource)
 	}
 	for _, resource := range providerResources {
-		service := serviceFamily(resource, docsResources, terraformerResources, skipSet)
-		family := familyEntry(families, service)
-		family.ProviderResources = append(family.ProviderResources, resource)
-		if !terraformerSet[resource] && skipSet[resource].Resource == "" {
-			family.ProviderGaps = append(family.ProviderGaps, resource)
+		for _, service := range serviceFamilies(resource, docsResources, terraformerResources, skipSet) {
+			family := familyEntry(families, service)
+			family.ProviderResources = append(family.ProviderResources, resource)
+			if !terraformerSet[resource] && skipSet[resource].Resource == "" {
+				family.ProviderGaps = append(family.ProviderGaps, resource)
+			}
 		}
 	}
 	for _, resource := range skippedResources {
@@ -423,17 +503,17 @@ func familyEntry(families map[string]*familyInventory, service string) *familyIn
 	return families[service]
 }
 
-func serviceFamily(resource string, docsResources, terraformerResources map[string]string, skipSet map[string]skipListEntry) string {
-	if service := docsResources[resource]; service != "" {
-		return service
+func serviceFamilies(resource string, docsResources, terraformerResources resourceFamilySet, skipSet map[string]skipListEntry) []string {
+	if services := terraformerResources.serviceFamilies(resource); len(services) > 0 {
+		return services
 	}
-	if service := terraformerResources[resource]; service != "" {
-		return service
+	if services := docsResources.serviceFamilies(resource); len(services) > 0 {
+		return services
 	}
 	if skip := skipSet[resource]; skip.ServiceFamily != "" {
-		return skip.ServiceFamily
+		return []string{skip.ServiceFamily}
 	}
-	return guessAWSService(resource)
+	return []string{guessAWSService(resource)}
 }
 
 func guessAWSService(resource string) string {

--- a/tools/aws-gap-inventory/inventory.go
+++ b/tools/aws-gap-inventory/inventory.go
@@ -1,0 +1,612 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"io"
+	"os"
+	"path/filepath"
+	"regexp"
+	"sort"
+	"strings"
+)
+
+const awsProviderAddress = "registry.terraform.io/hashicorp/aws"
+
+var (
+	docsServiceRe   = regexp.MustCompile("^\\*\\s+`([^`]+)`")
+	docsResourceRe  = regexp.MustCompile("^\\s+\\*\\s+`(aws_[^`]+)`")
+	awsResourceRe   = regexp.MustCompile("^aws_[a-z0-9_]+$")
+	validSkipStatus = map[string]bool{
+		"deferred":         true,
+		"needs-research":   true,
+		"not-importable":   true,
+		"unsupported":      true,
+		"unsafe-discovery": true,
+	}
+)
+
+type options struct {
+	awsDir         string
+	docsPath       string
+	format         string
+	providerSchema string
+	skipListPath   string
+}
+
+type inventory struct {
+	ProviderResources    []string          `json:"provider_resources,omitempty"`
+	TerraformerResources []resourceRecord  `json:"terraformer_resources"`
+	DocsResources        []resourceRecord  `json:"docs_resources"`
+	SkippedResources     []skipListEntry   `json:"skipped_resources"`
+	Families             []familyInventory `json:"families"`
+	DocsAudit            docsAudit         `json:"docs_audit"`
+}
+
+type resourceRecord struct {
+	Resource      string `json:"resource"`
+	ServiceFamily string `json:"service_family"`
+}
+
+type familyInventory struct {
+	ServiceFamily        string          `json:"service_family"`
+	ProviderResources    []string        `json:"provider_resources,omitempty"`
+	TerraformerResources []string        `json:"terraformer_resources"`
+	SkippedResources     []skipListEntry `json:"skipped_resources,omitempty"`
+	ProviderGaps         []string        `json:"provider_gaps,omitempty"`
+}
+
+type docsAudit struct {
+	DocumentedButNotDetected []resourceRecord `json:"documented_but_not_detected"`
+	DetectedButNotDocumented []resourceRecord `json:"detected_but_not_documented"`
+}
+
+type skipList struct {
+	Version   int             `json:"version"`
+	Resources []skipListEntry `json:"resources"`
+}
+
+type skipListEntry struct {
+	Resource      string   `json:"resource"`
+	ServiceFamily string   `json:"service_family"`
+	Reason        string   `json:"reason"`
+	Evidence      string   `json:"evidence,omitempty"`
+	SourceNotes   string   `json:"source_notes,omitempty"`
+	Status        string   `json:"status"`
+	References    []string `json:"references,omitempty"`
+}
+
+func buildInventory(opts options) (inventory, error) {
+	docsResources, err := parseDocsResources(opts.docsPath)
+	if err != nil {
+		return inventory{}, err
+	}
+
+	terraformerResources, err := scanTerraformerResources(opts.awsDir, docsResources)
+	if err != nil {
+		return inventory{}, err
+	}
+
+	skippedResources, err := readSkipList(opts.skipListPath)
+	if err != nil {
+		return inventory{}, err
+	}
+
+	var providerResources []string
+	if opts.providerSchema != "" {
+		providerResources, err = parseProviderSchema(opts.providerSchema)
+		if err != nil {
+			return inventory{}, err
+		}
+	}
+
+	inv := inventory{
+		ProviderResources:    providerResources,
+		TerraformerResources: recordsFromMap(terraformerResources),
+		DocsResources:        recordsFromMap(docsResources),
+		SkippedResources:     skippedResources,
+		DocsAudit:            compareDocs(terraformerResources, docsResources),
+	}
+	inv.Families = groupFamilies(providerResources, terraformerResources, docsResources, skippedResources)
+	return inv, nil
+}
+
+func parseDocsResources(path string) (map[string]string, error) {
+	file, err := os.Open(path)
+	if err != nil {
+		return nil, fmt.Errorf("open docs: %w", err)
+	}
+	defer file.Close()
+
+	resources := map[string]string{}
+	service := ""
+	scanner := bufio.NewScanner(file)
+	for scanner.Scan() {
+		line := scanner.Text()
+		if match := docsServiceRe.FindStringSubmatch(line); len(match) == 2 {
+			service = match[1]
+			continue
+		}
+		if match := docsResourceRe.FindStringSubmatch(line); len(match) == 2 && service != "" {
+			resources[match[1]] = service
+		}
+	}
+	if err := scanner.Err(); err != nil {
+		return nil, fmt.Errorf("scan docs: %w", err)
+	}
+	return resources, nil
+}
+
+func scanTerraformerResources(awsDir string, docsResources map[string]string) (map[string]string, error) {
+	serviceByFile, err := servicesByFile(awsDir)
+	if err != nil {
+		return nil, err
+	}
+
+	resources := map[string]string{}
+	err = filepath.WalkDir(awsDir, func(path string, d os.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.IsDir() || !strings.HasSuffix(path, ".go") || strings.HasSuffix(path, "_test.go") {
+			return nil
+		}
+		if filepath.Base(path) == "aws_provider.go" {
+			return nil
+		}
+
+		fileSet := token.NewFileSet()
+		file, err := parser.ParseFile(fileSet, path, nil, 0)
+		if err != nil {
+			return fmt.Errorf("parse %s: %w", path, err)
+		}
+
+		serviceFamily := serviceByFile[path]
+		if serviceFamily == "" {
+			serviceFamily = fallbackServiceFamily(path)
+		}
+		ast.Inspect(file, func(node ast.Node) bool {
+			literal, ok := node.(*ast.BasicLit)
+			if !ok || literal.Kind != token.STRING {
+				return true
+			}
+			value, err := unquote(literal.Value)
+			if err != nil || !awsResourceRe.MatchString(value) {
+				return true
+			}
+			if docsFamily := docsResources[value]; docsFamily != "" {
+				resources[value] = docsFamily
+				return true
+			}
+			resources[value] = serviceFamily
+			return true
+		})
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	return resources, nil
+}
+
+func servicesByFile(awsDir string) (map[string]string, error) {
+	providerPath := filepath.Join(awsDir, "aws_provider.go")
+	fileSet := token.NewFileSet()
+	file, err := parser.ParseFile(fileSet, providerPath, nil, 0)
+	if err != nil {
+		return nil, fmt.Errorf("parse aws provider: %w", err)
+	}
+
+	serviceByGenerator := map[string]string{}
+	ast.Inspect(file, func(node ast.Node) bool {
+		kv, ok := node.(*ast.KeyValueExpr)
+		if !ok {
+			return true
+		}
+		key, ok := kv.Key.(*ast.BasicLit)
+		if !ok || key.Kind != token.STRING {
+			return true
+		}
+		service, err := unquote(key.Value)
+		if err != nil {
+			return true
+		}
+		for _, generator := range generatorNames(kv.Value) {
+			serviceByGenerator[generator] = service
+		}
+		return true
+	})
+
+	serviceByFile := map[string]string{}
+	err = filepath.WalkDir(awsDir, func(path string, d os.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.IsDir() || !strings.HasSuffix(path, ".go") || strings.HasSuffix(path, "_test.go") || filepath.Base(path) == "aws_provider.go" {
+			return nil
+		}
+		fileSet := token.NewFileSet()
+		file, err := parser.ParseFile(fileSet, path, nil, parser.SkipObjectResolution)
+		if err != nil {
+			return fmt.Errorf("parse %s: %w", path, err)
+		}
+		for _, declaration := range file.Decls {
+			genericDeclaration, ok := declaration.(*ast.GenDecl)
+			if !ok || genericDeclaration.Tok != token.TYPE {
+				continue
+			}
+			for _, spec := range genericDeclaration.Specs {
+				typeSpec, ok := spec.(*ast.TypeSpec)
+				if !ok {
+					continue
+				}
+				if service := serviceByGenerator[typeSpec.Name.Name]; service != "" {
+					serviceByFile[path] = service
+					return nil
+				}
+			}
+		}
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	return serviceByFile, nil
+}
+
+func generatorNames(expr ast.Expr) []string {
+	var names []string
+	ast.Inspect(expr, func(node ast.Node) bool {
+		switch value := node.(type) {
+		case *ast.CompositeLit:
+			if ident, ok := value.Type.(*ast.Ident); ok && strings.HasSuffix(ident.Name, "Generator") {
+				names = append(names, ident.Name)
+			}
+		case *ast.CallExpr:
+			if ident, ok := value.Fun.(*ast.Ident); ok && strings.HasPrefix(ident.Name, "New") && strings.HasSuffix(ident.Name, "Generator") {
+				names = append(names, ident.Name)
+			}
+		}
+		return true
+	})
+	return names
+}
+
+func fallbackServiceFamily(path string) string {
+	base := strings.TrimSuffix(filepath.Base(path), ".go")
+	return strings.ReplaceAll(base, "_", "-")
+}
+
+func parseProviderSchema(path string) ([]string, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("read provider schema: %w", err)
+	}
+
+	var schema struct {
+		ProviderSchemas map[string]struct {
+			ResourceSchemas map[string]json.RawMessage `json:"resource_schemas"`
+		} `json:"provider_schemas"`
+	}
+	if err := json.Unmarshal(data, &schema); err != nil {
+		return nil, fmt.Errorf("decode provider schema: %w", err)
+	}
+
+	resourceSet := map[string]bool{}
+	for providerAddress, provider := range schema.ProviderSchemas {
+		if providerAddress != awsProviderAddress && !strings.HasSuffix(providerAddress, "/aws") {
+			continue
+		}
+		for resource := range provider.ResourceSchemas {
+			if awsResourceRe.MatchString(resource) {
+				resourceSet[resource] = true
+			}
+		}
+	}
+	resources := keys(resourceSet)
+	if len(resources) == 0 {
+		return nil, fmt.Errorf("provider schema %s did not contain AWS resource schemas", path)
+	}
+	return resources, nil
+}
+
+func readSkipList(path string) ([]skipListEntry, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("read skip-list: %w", err)
+	}
+	var list skipList
+	if err := json.Unmarshal(data, &list); err != nil {
+		return nil, fmt.Errorf("decode skip-list: %w", err)
+	}
+	if list.Version != 1 {
+		return nil, fmt.Errorf("unsupported skip-list version %d", list.Version)
+	}
+	for i, entry := range list.Resources {
+		if entry.Resource == "" || entry.ServiceFamily == "" || entry.Reason == "" || entry.Status == "" {
+			return nil, fmt.Errorf("skip-list resource %d is missing a required field", i)
+		}
+		if entry.Evidence == "" && entry.SourceNotes == "" {
+			return nil, fmt.Errorf("skip-list resource %q requires evidence or source_notes", entry.Resource)
+		}
+		if !awsResourceRe.MatchString(entry.Resource) {
+			return nil, fmt.Errorf("skip-list resource %d has invalid resource %q", i, entry.Resource)
+		}
+		if !validSkipStatus[entry.Status] {
+			return nil, fmt.Errorf("skip-list resource %q has invalid status %q", entry.Resource, entry.Status)
+		}
+	}
+	sort.Slice(list.Resources, func(i, j int) bool {
+		if list.Resources[i].ServiceFamily == list.Resources[j].ServiceFamily {
+			return list.Resources[i].Resource < list.Resources[j].Resource
+		}
+		return list.Resources[i].ServiceFamily < list.Resources[j].ServiceFamily
+	})
+	return list.Resources, nil
+}
+
+func compareDocs(terraformerResources, docsResources map[string]string) docsAudit {
+	audit := docsAudit{}
+	for resource, service := range docsResources {
+		if _, ok := terraformerResources[resource]; !ok {
+			audit.DocumentedButNotDetected = append(audit.DocumentedButNotDetected, resourceRecord{Resource: resource, ServiceFamily: service})
+		}
+	}
+	for resource, service := range terraformerResources {
+		if _, ok := docsResources[resource]; !ok {
+			audit.DetectedButNotDocumented = append(audit.DetectedButNotDocumented, resourceRecord{Resource: resource, ServiceFamily: service})
+		}
+	}
+	sortRecords(audit.DocumentedButNotDetected)
+	sortRecords(audit.DetectedButNotDocumented)
+	return audit
+}
+
+func groupFamilies(providerResources []string, terraformerResources, docsResources map[string]string, skippedResources []skipListEntry) []familyInventory {
+	terraformerSet := map[string]bool{}
+	for resource := range terraformerResources {
+		terraformerSet[resource] = true
+	}
+	skipSet := map[string]skipListEntry{}
+	for _, resource := range skippedResources {
+		skipSet[resource.Resource] = resource
+	}
+
+	families := map[string]*familyInventory{}
+	for resource, service := range terraformerResources {
+		family := familyEntry(families, service)
+		family.TerraformerResources = append(family.TerraformerResources, resource)
+	}
+	for _, resource := range providerResources {
+		service := serviceFamily(resource, docsResources, terraformerResources, skipSet)
+		family := familyEntry(families, service)
+		family.ProviderResources = append(family.ProviderResources, resource)
+		if !terraformerSet[resource] && skipSet[resource].Resource == "" {
+			family.ProviderGaps = append(family.ProviderGaps, resource)
+		}
+	}
+	for _, resource := range skippedResources {
+		family := familyEntry(families, resource.ServiceFamily)
+		family.SkippedResources = append(family.SkippedResources, resource)
+	}
+
+	result := make([]familyInventory, 0, len(families))
+	for _, family := range families {
+		sort.Strings(family.ProviderResources)
+		sort.Strings(family.TerraformerResources)
+		sort.Strings(family.ProviderGaps)
+		sort.Slice(family.SkippedResources, func(i, j int) bool {
+			return family.SkippedResources[i].Resource < family.SkippedResources[j].Resource
+		})
+		result = append(result, *family)
+	}
+	sort.Slice(result, func(i, j int) bool {
+		return result[i].ServiceFamily < result[j].ServiceFamily
+	})
+	return result
+}
+
+func familyEntry(families map[string]*familyInventory, service string) *familyInventory {
+	if service == "" {
+		service = "unknown"
+	}
+	if _, ok := families[service]; !ok {
+		families[service] = &familyInventory{ServiceFamily: service}
+	}
+	return families[service]
+}
+
+func serviceFamily(resource string, docsResources, terraformerResources map[string]string, skipSet map[string]skipListEntry) string {
+	if service := docsResources[resource]; service != "" {
+		return service
+	}
+	if service := terraformerResources[resource]; service != "" {
+		return service
+	}
+	if skip := skipSet[resource]; skip.ServiceFamily != "" {
+		return skip.ServiceFamily
+	}
+	return guessAWSService(resource)
+}
+
+func guessAWSService(resource string) string {
+	name := strings.TrimPrefix(resource, "aws_")
+	parts := strings.Split(name, "_")
+	if len(parts) == 0 || parts[0] == "" {
+		return "unknown"
+	}
+	if len(parts) >= 2 {
+		switch parts[0] + "_" + parts[1] {
+		case "cloudwatch_log":
+			return "logs"
+		case "ec2_transit":
+			return "transit_gateway"
+		case "elastic_beanstalk":
+			return "elastic_beanstalk"
+		case "kinesis_firehose":
+			return "firehose"
+		case "network_acl":
+			return "nacl"
+		case "nat_gateway":
+			return "nat"
+		case "sfn_activity", "sfn_state":
+			return "sfn"
+		}
+	}
+	switch parts[0] {
+	case "lb":
+		return "alb"
+	case "volume":
+		return "ebs"
+	case "instance":
+		return "ec2_instance"
+	case "internet":
+		return "igw"
+	case "main":
+		return "route_table"
+	case "organizations":
+		return "organization"
+	case "route53":
+		return "route53"
+	case "route":
+		return "route_table"
+	case "vpn":
+		return "vpn_connection"
+	}
+	return parts[0]
+}
+
+func writeJSON(writer io.Writer, inv inventory) error {
+	encoder := json.NewEncoder(writer)
+	encoder.SetIndent("", "  ")
+	return encoder.Encode(inv)
+}
+
+func writeMarkdown(writer io.Writer, inv inventory, providerSchema string) error {
+	var buffer bytes.Buffer
+	buffer.WriteString("# AWS Provider Gap Inventory\n\n")
+	buffer.WriteString("| Source | Count |\n")
+	buffer.WriteString("| --- | ---: |\n")
+	buffer.WriteString(fmt.Sprintf("| Terraformer detected resources | %d |\n", len(inv.TerraformerResources)))
+	buffer.WriteString(fmt.Sprintf("| docs/aws.md resources | %d |\n", len(inv.DocsResources)))
+	if providerSchema == "" {
+		buffer.WriteString("| Terraform AWS provider resources | not supplied |\n")
+	} else {
+		buffer.WriteString(fmt.Sprintf("| Terraform AWS provider resources | %d |\n", len(inv.ProviderResources)))
+	}
+	buffer.WriteString(fmt.Sprintf("| Skip-list resources | %d |\n\n", len(inv.SkippedResources)))
+
+	buffer.WriteString("## Docs Audit\n\n")
+	writeRecordList(&buffer, "Documented in docs/aws.md but not detected in AWS provider code", inv.DocsAudit.DocumentedButNotDetected)
+	writeRecordList(&buffer, "Detected in AWS provider code but missing from docs/aws.md", inv.DocsAudit.DetectedButNotDocumented)
+
+	buffer.WriteString("## Service Families\n\n")
+	buffer.WriteString("| Service family | Provider | Terraformer | Skipped | Gap |\n")
+	buffer.WriteString("| --- | ---: | ---: | ---: | ---: |\n")
+	for _, family := range inv.Families {
+		providerCount := "-"
+		gapCount := "-"
+		if providerSchema != "" {
+			providerCount = fmt.Sprintf("%d", len(family.ProviderResources))
+			gapCount = fmt.Sprintf("%d", len(family.ProviderGaps))
+		}
+		buffer.WriteString(fmt.Sprintf("| %s | %s | %d | %d | %s |\n",
+			family.ServiceFamily,
+			providerCount,
+			len(family.TerraformerResources),
+			len(family.SkippedResources),
+			gapCount,
+		))
+	}
+	buffer.WriteString("\n")
+
+	for _, family := range inv.Families {
+		buffer.WriteString(fmt.Sprintf("### %s\n\n", family.ServiceFamily))
+		writeStringList(&buffer, "Terraformer resources", family.TerraformerResources)
+		if providerSchema != "" {
+			writeStringList(&buffer, "Terraform provider gaps", family.ProviderGaps)
+		}
+		writeSkipList(&buffer, family.SkippedResources)
+	}
+
+	_, err := writer.Write(buffer.Bytes())
+	return err
+}
+
+func writeRecordList(buffer *bytes.Buffer, title string, records []resourceRecord) {
+	buffer.WriteString(fmt.Sprintf("### %s\n\n", title))
+	if len(records) == 0 {
+		buffer.WriteString("_None._\n\n")
+		return
+	}
+	for _, record := range records {
+		buffer.WriteString(fmt.Sprintf("- `%s` (%s)\n", record.Resource, record.ServiceFamily))
+	}
+	buffer.WriteString("\n")
+}
+
+func writeStringList(buffer *bytes.Buffer, title string, values []string) {
+	buffer.WriteString(fmt.Sprintf("#### %s\n\n", title))
+	if len(values) == 0 {
+		buffer.WriteString("_None._\n\n")
+		return
+	}
+	for _, value := range values {
+		buffer.WriteString(fmt.Sprintf("- `%s`\n", value))
+	}
+	buffer.WriteString("\n")
+}
+
+func writeSkipList(buffer *bytes.Buffer, values []skipListEntry) {
+	buffer.WriteString("#### Skipped resources\n\n")
+	if len(values) == 0 {
+		buffer.WriteString("_None._\n\n")
+		return
+	}
+	for _, value := range values {
+		buffer.WriteString(fmt.Sprintf("- `%s` (%s): %s\n", value.Resource, value.Status, value.Reason))
+	}
+	buffer.WriteString("\n")
+}
+
+func recordsFromMap(resources map[string]string) []resourceRecord {
+	records := make([]resourceRecord, 0, len(resources))
+	for resource, service := range resources {
+		records = append(records, resourceRecord{Resource: resource, ServiceFamily: service})
+	}
+	sortRecords(records)
+	return records
+}
+
+func sortRecords(records []resourceRecord) {
+	sort.Slice(records, func(i, j int) bool {
+		if records[i].ServiceFamily == records[j].ServiceFamily {
+			return records[i].Resource < records[j].Resource
+		}
+		return records[i].ServiceFamily < records[j].ServiceFamily
+	})
+}
+
+func keys(values map[string]bool) []string {
+	keys := make([]string, 0, len(values))
+	for key := range values {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	return keys
+}
+
+func unquote(value string) (string, error) {
+	var out string
+	if err := json.Unmarshal([]byte(value), &out); err != nil {
+		return "", err
+	}
+	return out, nil
+}

--- a/tools/aws-gap-inventory/inventory_test.go
+++ b/tools/aws-gap-inventory/inventory_test.go
@@ -1,0 +1,176 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package main
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestBuildInventoryReportsProviderGapsAndDocsDrift(t *testing.T) {
+	root := t.TempDir()
+	awsDir := filepath.Join(root, "providers", "aws")
+	if err := os.MkdirAll(awsDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	writeFile(t, filepath.Join(awsDir, "aws_provider.go"),
+		"package aws\n\n"+
+			"func (p *AWSProvider) GetSupportedService() map[string]terraformutils.ServiceGenerator {\n"+
+			"\treturn map[string]terraformutils.ServiceGenerator{\n"+
+			"\t\t\"example\": &AwsFacade{service: &ExampleGenerator{}},\n"+
+			"\t}\n"+
+			"}\n")
+	writeFile(t, filepath.Join(awsDir, "example.go"),
+		"package aws\n\n"+
+			"type ExampleGenerator struct{}\n\n"+
+			"func (g *ExampleGenerator) InitResources() {\n"+
+			"\tterraformutils.NewSimpleResource(\"id\", \"name\", \"aws_example_supported\", \"aws\", nil)\n"+
+			"\tterraformutils.NewSimpleResource(\"id\", \"name\", \"aws_example_undocumented\", \"aws\", nil)\n"+
+			"}\n")
+
+	tick := string(rune(96))
+	docsPath := filepath.Join(root, "docs", "aws.md")
+	writeFile(t, docsPath,
+		"#### Supported services\n\n"+
+			"*   "+tick+"example"+tick+"\n"+
+			"    * "+tick+"aws_example_supported"+tick+"\n"+
+			"    * "+tick+"aws_example_documented_only"+tick+"\n")
+
+	skipListPath := filepath.Join(awsDir, "unsupported_resources.json")
+	writeFile(t, skipListPath,
+		"{\n"+
+			"  \"version\": 1,\n"+
+			"  \"resources\": [\n"+
+			"    {\n"+
+			"      \"resource\": \"aws_example_skipped\",\n"+
+			"      \"service_family\": \"example\",\n"+
+			"      \"reason\": \"Discovery requires parent context not available yet.\",\n"+
+			"      \"evidence\": \"Terraform AWS provider schema check.\",\n"+
+			"      \"status\": \"unsupported\"\n"+
+			"    }\n"+
+			"  ]\n"+
+			"}\n")
+
+	providerSchemaPath := filepath.Join(root, "schema.json")
+	writeFile(t, providerSchemaPath,
+		"{\n"+
+			"  \"provider_schemas\": {\n"+
+			"    \"registry.terraform.io/hashicorp/aws\": {\n"+
+			"      \"resource_schemas\": {\n"+
+			"        \"aws_example_supported\": {},\n"+
+			"        \"aws_example_missing\": {},\n"+
+			"        \"aws_example_skipped\": {}\n"+
+			"      }\n"+
+			"    }\n"+
+			"  }\n"+
+			"}\n")
+
+	inv, err := buildInventory(options{
+		awsDir:         awsDir,
+		docsPath:       docsPath,
+		providerSchema: providerSchemaPath,
+		skipListPath:   skipListPath,
+	})
+	if err != nil {
+		t.Fatalf("buildInventory() error = %v", err)
+	}
+
+	assertRecords(t, inv.DocsAudit.DocumentedButNotDetected, []resourceRecord{
+		{Resource: "aws_example_documented_only", ServiceFamily: "example"},
+	})
+	assertRecords(t, inv.DocsAudit.DetectedButNotDocumented, []resourceRecord{
+		{Resource: "aws_example_undocumented", ServiceFamily: "example"},
+	})
+	if len(inv.Families) != 1 {
+		t.Fatalf("families len = %d, want 1", len(inv.Families))
+	}
+	family := inv.Families[0]
+	assertStrings(t, family.ProviderGaps, []string{"aws_example_missing"})
+	if len(family.SkippedResources) != 1 || family.SkippedResources[0].Resource != "aws_example_skipped" {
+		t.Fatalf("skipped resources = %#v, want aws_example_skipped", family.SkippedResources)
+	}
+}
+
+func TestReadSkipListValidatesRequiredFields(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "unsupported_resources.json")
+	writeFile(t, path,
+		"{\n"+
+			"  \"version\": 1,\n"+
+			"  \"resources\": [\n"+
+			"    {\n"+
+			"      \"resource\": \"aws_example_missing_status\",\n"+
+			"      \"service_family\": \"example\",\n"+
+			"      \"reason\": \"Missing status should fail.\",\n"+
+			"      \"source_notes\": \"test\"\n"+
+			"    }\n"+
+			"  ]\n"+
+			"}\n")
+
+	_, err := readSkipList(path)
+	if err == nil {
+		t.Fatal("readSkipList() error = nil, want validation error")
+	}
+	if !strings.Contains(err.Error(), "missing a required field") {
+		t.Fatalf("readSkipList() error = %q, want required field error", err)
+	}
+}
+
+func TestWriteMarkdownOmitsProviderCountsWithoutSchema(t *testing.T) {
+	var output bytes.Buffer
+	err := writeMarkdown(&output, inventory{
+		TerraformerResources: []resourceRecord{{Resource: "aws_example_supported", ServiceFamily: "example"}},
+		Families: []familyInventory{
+			{
+				ServiceFamily:        "example",
+				TerraformerResources: []string{"aws_example_supported"},
+			},
+		},
+	}, "")
+	if err != nil {
+		t.Fatalf("writeMarkdown() error = %v", err)
+	}
+	if !strings.Contains(output.String(), "| Terraform AWS provider resources | not supplied |") {
+		t.Fatalf("markdown output did not note missing provider schema:\n%s", output.String())
+	}
+	if strings.Contains(output.String(), "Terraform provider gaps") {
+		t.Fatalf("markdown output included provider gap section without schema:\n%s", output.String())
+	}
+}
+
+func writeFile(t *testing.T, path string, contents string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, []byte(contents), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func assertRecords(t *testing.T, got []resourceRecord, want []resourceRecord) {
+	t.Helper()
+	if len(got) != len(want) {
+		t.Fatalf("records len = %d, want %d: %#v", len(got), len(want), got)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("records[%d] = %#v, want %#v", i, got[i], want[i])
+		}
+	}
+}
+
+func assertStrings(t *testing.T, got []string, want []string) {
+	t.Helper()
+	if len(got) != len(want) {
+		t.Fatalf("strings len = %d, want %d: %#v", len(got), len(want), got)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("strings[%d] = %q, want %q", i, got[i], want[i])
+		}
+	}
+}

--- a/tools/aws-gap-inventory/inventory_test.go
+++ b/tools/aws-gap-inventory/inventory_test.go
@@ -119,6 +119,64 @@ func TestReadSkipListValidatesRequiredFields(t *testing.T) {
 	}
 }
 
+func TestBuildInventoryPreservesDuplicateDocsResourceFamilies(t *testing.T) {
+	root := t.TempDir()
+	awsDir := filepath.Join(root, "providers", "aws")
+	if err := os.MkdirAll(awsDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	writeFile(t, filepath.Join(awsDir, "aws_provider.go"),
+		"package aws\n\n"+
+			"func (p *AWSProvider) GetSupportedService() map[string]terraformutils.ServiceGenerator {\n"+
+			"\treturn map[string]terraformutils.ServiceGenerator{\n"+
+			"\t\t\"wafv2_cloudfront\": &AwsFacade{service: NewWafv2CloudfrontGenerator()},\n"+
+			"\t\t\"wafv2_regional\": &AwsFacade{service: NewWafv2RegionalGenerator()},\n"+
+			"\t}\n"+
+			"}\n")
+	writeFile(t, filepath.Join(awsDir, "wafv2.go"),
+		"package aws\n\n"+
+			"type Wafv2Generator struct{}\n\n"+
+			"func NewWafv2CloudfrontGenerator() *Wafv2Generator { return &Wafv2Generator{} }\n"+
+			"func NewWafv2RegionalGenerator() *Wafv2Generator { return &Wafv2Generator{} }\n"+
+			"func (g *Wafv2Generator) InitResources() {\n"+
+			"\t_ = \"aws_wafv2_web_acl\"\n"+
+			"\t_ = \"aws_wafv2_web_acl_association\"\n"+
+			"}\n")
+
+	tick := string(rune(96))
+	docsPath := filepath.Join(root, "docs", "aws.md")
+	writeFile(t, docsPath,
+		"#### Supported services\n\n"+
+			"*   "+tick+"wafv2_cloudfront"+tick+"\n"+
+			"    * "+tick+"aws_wafv2_web_acl"+tick+"\n"+
+			"*   "+tick+"wafv2_regional"+tick+"\n"+
+			"    * "+tick+"aws_wafv2_web_acl"+tick+"\n"+
+			"    * "+tick+"aws_wafv2_web_acl_association"+tick+"\n")
+	skipListPath := filepath.Join(awsDir, "unsupported_resources.json")
+	writeFile(t, skipListPath, "{\n  \"version\": 1,\n  \"resources\": []\n}\n")
+
+	inv, err := buildInventory(options{
+		awsDir:       awsDir,
+		docsPath:     docsPath,
+		skipListPath: skipListPath,
+	})
+	if err != nil {
+		t.Fatalf("buildInventory() error = %v", err)
+	}
+	assertRecords(t, inv.DocsAudit.DocumentedButNotDetected, nil)
+	assertRecords(t, inv.DocsAudit.DetectedButNotDocumented, nil)
+	assertStrings(t, familyByName(t, inv, "wafv2_cloudfront").TerraformerResources, []string{"aws_wafv2_web_acl"})
+	assertStrings(t, familyByName(t, inv, "wafv2_regional").TerraformerResources, []string{"aws_wafv2_web_acl", "aws_wafv2_web_acl_association"})
+}
+
+func TestFallbackServiceFamilyPreservesUnderscores(t *testing.T) {
+	got := fallbackServiceFamily(filepath.Join("providers", "aws", "transit_gateway.go"))
+	if got != "transit_gateway" {
+		t.Fatalf("fallbackServiceFamily() = %q, want transit_gateway", got)
+	}
+}
+
 func TestWriteMarkdownOmitsProviderCountsWithoutSchema(t *testing.T) {
 	var output bytes.Buffer
 	err := writeMarkdown(&output, inventory{
@@ -139,6 +197,17 @@ func TestWriteMarkdownOmitsProviderCountsWithoutSchema(t *testing.T) {
 	if strings.Contains(output.String(), "Terraform provider gaps") {
 		t.Fatalf("markdown output included provider gap section without schema:\n%s", output.String())
 	}
+}
+
+func familyByName(t *testing.T, inv inventory, name string) familyInventory {
+	t.Helper()
+	for _, family := range inv.Families {
+		if family.ServiceFamily == name {
+			return family
+		}
+	}
+	t.Fatalf("family %q not found in %#v", name, inv.Families)
+	return familyInventory{}
 }
 
 func writeFile(t *testing.T, path string, contents string) {

--- a/tools/aws-gap-inventory/main.go
+++ b/tools/aws-gap-inventory/main.go
@@ -1,0 +1,38 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package main
+
+import (
+	"flag"
+	"fmt"
+	"os"
+)
+
+func main() {
+	opts := options{}
+	flag.StringVar(&opts.awsDir, "aws-dir", "providers/aws", "path to the Terraformer AWS provider source directory")
+	flag.StringVar(&opts.docsPath, "docs", "docs/aws.md", "path to the AWS provider docs")
+	flag.StringVar(&opts.format, "format", "markdown", "output format: markdown or json")
+	flag.StringVar(&opts.providerSchema, "provider-schema", "", "optional Terraform AWS provider schema JSON from terraform providers schema -json")
+	flag.StringVar(&opts.skipListPath, "skip-list", "providers/aws/unsupported_resources.json", "path to the AWS unsupported resource skip-list")
+	flag.Parse()
+
+	inv, err := buildInventory(opts)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+
+	switch opts.format {
+	case "json":
+		err = writeJSON(os.Stdout, inv)
+	case "markdown":
+		err = writeMarkdown(os.Stdout, inv, opts.providerSchema)
+	default:
+		err = fmt.Errorf("unsupported format %q", opts.format)
+	}
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+}

--- a/tools/aws-gap-inventory/main.go
+++ b/tools/aws-gap-inventory/main.go
@@ -17,6 +17,11 @@ func main() {
 	flag.StringVar(&opts.skipListPath, "skip-list", "providers/aws/unsupported_resources.json", "path to the AWS unsupported resource skip-list")
 	flag.Parse()
 
+	if opts.format != "json" && opts.format != "markdown" {
+		fmt.Fprintf(os.Stderr, "unsupported format %q\n", opts.format)
+		os.Exit(1)
+	}
+
 	inv, err := buildInventory(opts)
 	if err != nil {
 		fmt.Fprintln(os.Stderr, err)


### PR DESCRIPTION
Summary:
- add a read-only AWS gap inventory command for Terraformer/docs/provider-schema comparisons
- add unsupported-resource skip-list scaffolding with an initial unsupported EventBridge connection entry
- sync docs/aws.md with current AWS resource registrations and link the inventory docs

References:
- Refs #338


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a guide for running an AWS provider gap inventory and expanded AWS docs with additional supported resource types.
  * Added a registry describing explicitly unsupported AWS resources and rationale.

* **New Features**
  * Introduced an AWS Provider Gap Inventory tool with JSON and Markdown output to compare detected vs. provider-known resources.

* **Tests**
  * Added unit tests covering inventory reports, skip-list validation, duplicate handling, family fallback, and markdown output behavior.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/chenrui333/terraformer/pull/390)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->