### PR TITLE
feat(aws): add DynamoDB global table imports

### DIFF
--- a/docs/aws.md
+++ b/docs/aws.md
@@ -206,6 +206,7 @@ terraformer import aws --resources=sg --regions=us-east-1
     * `aws_docdb_subnet_group`
 *   `dynamodb`
     * `aws_dynamodb_contributor_insights`
+    * `aws_dynamodb_global_table`
     * `aws_dynamodb_kinesis_streaming_destination`
     * `aws_dynamodb_resource_policy`
     * `aws_dynamodb_table`

--- a/providers/aws/dynamodb.go
+++ b/providers/aws/dynamodb.go
@@ -52,6 +52,7 @@ func (g *DynamoDbGenerator) InitResources() error {
 	}
 
 	loaders := []dynamodbOptionalResourceLoader{
+		{name: "global tables", load: func() error { return g.loadGlobalTables(svc) }},
 		{name: "Kinesis streaming destinations", load: func() error { return g.loadKinesisStreamingDestinations(svc, tables) }},
 		{name: "resource policies", load: func() error { return g.loadResourcePolicies(svc, tables) }},
 		{name: "table exports", load: func() error { return g.loadTableExports(svc) }},
@@ -92,6 +93,46 @@ func (g *DynamoDbGenerator) loadTables(svc *dynamodb.Client) ([]dynamodbTableRef
 		}
 	}
 	return tables, nil
+}
+
+func (g *DynamoDbGenerator) loadGlobalTables(svc *dynamodb.Client) error {
+	input := &dynamodb.ListGlobalTablesInput{}
+	for {
+		output, err := svc.ListGlobalTables(context.TODO(), input)
+		if err != nil {
+			return err
+		}
+		for _, table := range output.GlobalTables {
+			tableName := StringValue(table.GlobalTableName)
+			if tableName == "" || !g.dynamodbGlobalTableImportable(svc, tableName) {
+				continue
+			}
+			g.Resources = append(g.Resources, terraformutils.NewSimpleResource(
+				tableName,
+				tableName,
+				"aws_dynamodb_global_table",
+				"aws",
+				dynamodbAllowEmptyValues,
+			))
+		}
+		input.ExclusiveStartGlobalTableName = output.LastEvaluatedGlobalTableName
+		if !awsHasMorePages(input.ExclusiveStartGlobalTableName) {
+			break
+		}
+	}
+	return nil
+}
+
+func (g *DynamoDbGenerator) dynamodbGlobalTableImportable(svc *dynamodb.Client, tableName string) bool {
+	output, err := svc.DescribeGlobalTable(context.TODO(), &dynamodb.DescribeGlobalTableInput{GlobalTableName: &tableName})
+	if err != nil {
+		log.Printf("Skipping DynamoDB global table %s: %v", tableName, err)
+		return false
+	}
+	if output == nil || output.GlobalTableDescription == nil {
+		return false
+	}
+	return dynamodbGlobalTableStatusImportable(output.GlobalTableDescription.GlobalTableStatus)
 }
 
 func (g *DynamoDbGenerator) tableReference(svc *dynamodb.Client, tableName string) dynamodbTableReference {
@@ -303,6 +344,10 @@ func dynamodbKinesisStreamingDestinationImportable(destination dynamodbtypes.Kin
 
 func dynamodbTableExportImportable(export dynamodbtypes.ExportSummary) bool {
 	return export.ExportStatus != ""
+}
+
+func dynamodbGlobalTableStatusImportable(status dynamodbtypes.GlobalTableStatus) bool {
+	return status == dynamodbtypes.GlobalTableStatusActive
 }
 
 func dynamodbResourcePolicyMissing(err error) bool {

--- a/providers/aws/dynamodb_test.go
+++ b/providers/aws/dynamodb_test.go
@@ -123,6 +123,22 @@ func TestDynamoDBTableExportImportable(t *testing.T) {
 	}
 }
 
+func TestDynamoDBGlobalTableStatusImportable(t *testing.T) {
+	if !dynamodbGlobalTableStatusImportable(dynamodbtypes.GlobalTableStatusActive) {
+		t.Fatal("active global table should be importable")
+	}
+	for _, status := range []dynamodbtypes.GlobalTableStatus{
+		dynamodbtypes.GlobalTableStatusCreating,
+		dynamodbtypes.GlobalTableStatusDeleting,
+		dynamodbtypes.GlobalTableStatusUpdating,
+		"",
+	} {
+		if dynamodbGlobalTableStatusImportable(status) {
+			t.Fatalf("global table status %q should not be importable", status)
+		}
+	}
+}
+
 func TestDynamoDBResourcePolicyTargets(t *testing.T) {
 	table := dynamodbTableReference{
 		name:      "events",


### PR DESCRIPTION
Summary:
- add DynamoDB legacy global table discovery via ListGlobalTables and DescribeGlobalTable
- import only ACTIVE global tables by table name
- document aws_dynamodb_global_table support

References:
- Refs #338

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds import support for DynamoDB legacy global tables and documents `aws_dynamodb_global_table` as supported. This enables importing only healthy global tables and avoids noisy failures.

- **New Features**
  - Discover global tables via ListGlobalTables + DescribeGlobalTable; import only ACTIVE tables by name and skip others with safe logging.
  - Add docs entry for `aws_dynamodb_global_table` and a unit test for global table status eligibility.

<sup>Written for commit 1493a25aa57ca4b6498e2a05746fd352c445e1bf. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Support for importing DynamoDB global tables during AWS imports; only active global tables are eligible.

* **Documentation**
  * AWS docs updated to list the DynamoDB global table resource as a supported service.

* **Tests**
  * Added unit tests to validate global table import eligibility logic.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/chenrui333/terraformer/pull/391)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->