### PR TITLE
aws(ssoadmin): add SSO Admin and Identity Store follow-up imports

### DIFF
--- a/docs/aws.md
+++ b/docs/aws.md
@@ -483,6 +483,12 @@ For AWS provider gap audits and unsupported-resource skip-list maintenance, see 
 *   `sns`
     * `aws_sns_topic`
     * `aws_sns_topic_subscription`
+*   `ssoadmin`
+    * `aws_ssoadmin_customer_managed_policy_attachment`
+    * `aws_ssoadmin_managed_policy_attachment`
+    * `aws_ssoadmin_permission_set`
+    * `aws_ssoadmin_permission_set_inline_policy`
+    * `aws_ssoadmin_permissions_boundary_attachment`
 *   `sqs`
     * `aws_sqs_queue`
     * `aws_sqs_queue_policy`

--- a/providers/aws/aws_provider.go
+++ b/providers/aws/aws_provider.go
@@ -343,6 +343,7 @@ func (p *AWSProvider) GetSupportedService() map[string]terraformutils.ServiceGen
 		"sg":                &AwsFacade{service: &SecurityGenerator{}},
 		"sqs":               &AwsFacade{service: &SqsGenerator{}},
 		"sns":               &AwsFacade{service: &SnsGenerator{}},
+		"ssoadmin":          &AwsFacade{service: &SSOAdminGenerator{}},
 		"ssm":               &AwsFacade{service: &SsmGenerator{}},
 		"subnet":            &AwsFacade{service: &SubnetGenerator{}},
 		"swf":               &AwsFacade{service: &SWFGenerator{}},

--- a/providers/aws/identitystore.go
+++ b/providers/aws/identitystore.go
@@ -152,9 +152,12 @@ func (g *IdentityStoreGenerator) InitResources() error {
 	}
 
 	for _, identityStoreId := range identityStoreIds {
+		resourceStart := len(g.Resources)
+
 		e = g.InitUserResources(identityStoreId)
 		if e != nil {
 			if identityStoreResourceNotFound(e) {
+				g.Resources = g.Resources[:resourceStart]
 				continue
 			}
 			return e
@@ -163,6 +166,7 @@ func (g *IdentityStoreGenerator) InitResources() error {
 		e = g.InitGroupResources(identityStoreId)
 		if e != nil {
 			if identityStoreResourceNotFound(e) {
+				g.Resources = g.Resources[:resourceStart]
 				continue
 			}
 			return e

--- a/providers/aws/identitystore.go
+++ b/providers/aws/identitystore.go
@@ -5,36 +5,49 @@ package aws
 
 import (
 	"context"
+	"errors"
+	"strings"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/chenrui333/terraformer/terraformutils"
 
 	"github.com/aws/aws-sdk-go-v2/service/identitystore"
-	"github.com/aws/aws-sdk-go-v2/service/identitystore/types"
+	identitystoretypes "github.com/aws/aws-sdk-go-v2/service/identitystore/types"
 	"github.com/aws/aws-sdk-go-v2/service/ssoadmin"
 )
 
 var identityStoreAllowEmptyValues = []string{"tags."}
 
+const (
+	identityStoreGroupResourceType           = "aws_identitystore_group"
+	identityStoreGroupMembershipResourceType = "aws_identitystore_group_membership"
+	identityStoreUserResourceType            = "aws_identitystore_user"
+	identityStoreResourceIDSeparator         = "/"
+	identityStoreResourceNameSeparator       = ":"
+)
+
 type IdentityStoreGenerator struct {
 	AWSService
 }
 
-func (g *IdentityStoreGenerator) GetIdentityStoreId() (*string, error) {
+func (g *IdentityStoreGenerator) GetIdentityStoreIds() ([]string, error) {
 	config, e := g.generateConfig()
 	if e != nil {
 		return nil, e
 	}
 	svc := ssoadmin.NewFromConfig(config)
-	instances, err := svc.ListInstances(context.TODO(), &ssoadmin.ListInstancesInput{})
+	instances, err := listSSOAdminInstances(svc)
 	if err != nil {
 		return nil, err
 	}
-	if len(instances.Instances) == 0 {
-		return nil, nil
+	var identityStoreIds []string
+	for _, instance := range instances {
+		identityStoreId := StringValue(instance.IdentityStoreId)
+		if identityStoreId != "" {
+			identityStoreIds = append(identityStoreIds, identityStoreId)
+		}
 	}
-	identityStoreId := StringValue(instances.Instances[0].IdentityStoreId)
-	return &identityStoreId, nil
+	return identityStoreIds, nil
 }
 
 func (g *IdentityStoreGenerator) InitGroupResources(identityStoreId string) error {
@@ -53,21 +66,17 @@ func (g *IdentityStoreGenerator) InitGroupResources(identityStoreId string) erro
 		}
 		for _, group := range page.Groups {
 			groupId := StringValue(group.GroupId)
-			displayName := StringValue(group.DisplayName)
-			g.Resources = append(g.Resources, terraformutils.NewResource(
-				identityStoreId+"/"+groupId,
-				displayName,
-				"aws_identitystore_group",
-				"aws",
-				map[string]string{
-					"identity_store_id": identityStoreId,
-					"description":       StringValue(group.Description),
-				},
-				identityStoreAllowEmptyValues,
-				map[string]interface{}{},
-			))
+			if groupId == "" {
+				continue
+			}
+			resourceStart := len(g.Resources)
+			g.Resources = append(g.Resources, newIdentityStoreGroupResource(identityStoreId, group))
 			err = g.InitGroupMembershipResources(identityStoreId, groupId)
 			if err != nil {
+				if identityStoreResourceNotFound(err) {
+					g.Resources = g.Resources[:resourceStart]
+					continue
+				}
 				return err
 			}
 		}
@@ -93,27 +102,16 @@ func (g *IdentityStoreGenerator) InitGroupMembershipResources(identityStoreId st
 		for _, user := range page.GroupMemberships {
 			var memberId string
 			switch v := user.MemberId.(type) {
-			case *types.MemberIdMemberUserId:
+			case *identitystoretypes.MemberIdMemberUserId:
 				memberId = v.Value // Value is string
-			case *types.UnknownUnionMember:
-				memberId = v.Tag
 			default:
-				memberId = ""
+				continue
 			}
 			membershipId := StringValue(user.MembershipId)
-			g.Resources = append(g.Resources, terraformutils.NewResource(
-				identityStoreId+"/"+membershipId,
-				"m-"+groupId+"-"+memberId,
-				"aws_identitystore_group_membership",
-				"aws",
-				map[string]string{
-					"identity_store_id": identityStoreId,
-					"group_id":          groupId,
-					"member_id":         memberId,
-				},
-				identityStoreAllowEmptyValues,
-				map[string]interface{}{},
-			))
+			if membershipId == "" || memberId == "" {
+				continue
+			}
+			g.Resources = append(g.Resources, newIdentityStoreGroupMembershipResource(identityStoreId, groupId, memberId, membershipId))
 		}
 	}
 	return nil
@@ -135,45 +133,123 @@ func (g *IdentityStoreGenerator) InitUserResources(identityStoreId string) error
 		}
 		for _, user := range page.Users {
 			userId := StringValue(user.UserId)
-			displayName := StringValue(user.DisplayName)
-			//			name := StringValue(user.Name)
-			userName := StringValue(user.UserName)
-			g.Resources = append(g.Resources, terraformutils.NewResource(
-				identityStoreId+"/"+userId,
-				userName,
-				"aws_identitystore_user",
-				"aws",
-				map[string]string{
-					"identity_store_id": identityStoreId,
-					"display_name":      displayName,
-					"use_name":          userName,
-				},
-				identityStoreAllowEmptyValues,
-				map[string]interface{}{},
-			))
+			if userId == "" {
+				continue
+			}
+			g.Resources = append(g.Resources, newIdentityStoreUserResource(identityStoreId, user))
 		}
 	}
 	return nil
 }
 
 func (g *IdentityStoreGenerator) InitResources() error {
-	identityStoreId, e := g.GetIdentityStoreId()
+	identityStoreIds, e := g.GetIdentityStoreIds()
 	if e != nil {
 		return e
 	}
-	if identityStoreId == nil {
+	if len(identityStoreIds) == 0 {
 		return nil
 	}
 
-	e = g.InitUserResources(*identityStoreId)
-	if e != nil {
-		return e
-	}
+	for _, identityStoreId := range identityStoreIds {
+		e = g.InitUserResources(identityStoreId)
+		if e != nil {
+			if identityStoreResourceNotFound(e) {
+				continue
+			}
+			return e
+		}
 
-	e = g.InitGroupResources(*identityStoreId)
-	if e != nil {
-		return e
+		e = g.InitGroupResources(identityStoreId)
+		if e != nil {
+			if identityStoreResourceNotFound(e) {
+				continue
+			}
+			return e
+		}
 	}
 
 	return nil
+}
+
+func newIdentityStoreGroupResource(identityStoreId string, group identitystoretypes.Group) terraformutils.Resource {
+	groupId := StringValue(group.GroupId)
+	attributes := map[string]string{
+		"group_id":          groupId,
+		"identity_store_id": identityStoreId,
+	}
+	if description := StringValue(group.Description); description != "" {
+		attributes["description"] = description
+	}
+	if displayName := StringValue(group.DisplayName); displayName != "" {
+		attributes["display_name"] = displayName
+	}
+	return terraformutils.NewResource(
+		identityStoreResourceID(identityStoreId, groupId),
+		identityStoreResourceName(StringValue(group.DisplayName), groupId, identityStoreId),
+		identityStoreGroupResourceType,
+		"aws",
+		attributes,
+		identityStoreAllowEmptyValues,
+		map[string]interface{}{},
+	)
+}
+
+func newIdentityStoreGroupMembershipResource(identityStoreId, groupId, memberId, membershipId string) terraformutils.Resource {
+	return terraformutils.NewResource(
+		identityStoreResourceID(identityStoreId, membershipId),
+		identityStoreResourceName(groupId, memberId, membershipId, identityStoreId),
+		identityStoreGroupMembershipResourceType,
+		"aws",
+		map[string]string{
+			"group_id":          groupId,
+			"identity_store_id": identityStoreId,
+			"member_id":         memberId,
+			"membership_id":     membershipId,
+		},
+		identityStoreAllowEmptyValues,
+		map[string]interface{}{},
+	)
+}
+
+func newIdentityStoreUserResource(identityStoreId string, user identitystoretypes.User) terraformutils.Resource {
+	userId := StringValue(user.UserId)
+	attributes := map[string]string{
+		"identity_store_id": identityStoreId,
+		"user_id":           userId,
+	}
+	if displayName := StringValue(user.DisplayName); displayName != "" {
+		attributes["display_name"] = displayName
+	}
+	if userName := StringValue(user.UserName); userName != "" {
+		attributes["user_name"] = userName
+	}
+	return terraformutils.NewResource(
+		identityStoreResourceID(identityStoreId, userId),
+		identityStoreResourceName(StringValue(user.UserName), userId, identityStoreId),
+		identityStoreUserResourceType,
+		"aws",
+		attributes,
+		identityStoreAllowEmptyValues,
+		map[string]interface{}{},
+	)
+}
+
+func identityStoreResourceID(identityStoreId, resourceId string) string {
+	return strings.Join([]string{identityStoreId, resourceId}, identityStoreResourceIDSeparator)
+}
+
+func identityStoreResourceName(parts ...string) string {
+	var nonEmptyParts []string
+	for _, part := range parts {
+		if part != "" {
+			nonEmptyParts = append(nonEmptyParts, part)
+		}
+	}
+	return strings.Join(nonEmptyParts, identityStoreResourceNameSeparator)
+}
+
+func identityStoreResourceNotFound(err error) bool {
+	var notFound *identitystoretypes.ResourceNotFoundException
+	return errors.As(err, &notFound)
 }

--- a/providers/aws/identitystore_test.go
+++ b/providers/aws/identitystore_test.go
@@ -93,8 +93,8 @@ func TestIdentityStoreUserResource(t *testing.T) {
 }
 
 func TestIdentityStoreResourceNamesDoNotCollapseJoinedParts(t *testing.T) {
-	left := newIdentityStoreGroupMembershipResource("store", "a_b", "c", "membership-left")
-	right := newIdentityStoreGroupMembershipResource("store", "a", "b_c", "membership-right")
+	left := newIdentityStoreGroupMembershipResource("store", "a_b", "c", "membership")
+	right := newIdentityStoreGroupMembershipResource("store", "a", "b_c", "membership")
 	if left.ResourceName == right.ResourceName {
 		t.Fatalf("group membership resource names collide: %q", left.ResourceName)
 	}

--- a/providers/aws/identitystore_test.go
+++ b/providers/aws/identitystore_test.go
@@ -1,0 +1,122 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package aws
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	identitystoretypes "github.com/aws/aws-sdk-go-v2/service/identitystore/types"
+)
+
+func TestIdentityStoreResourceID(t *testing.T) {
+	got := identityStoreResourceID("d-1234567890", "g-123")
+	want := "d-1234567890/g-123"
+	if got != want {
+		t.Fatalf("identityStoreResourceID() = %q, want %q", got, want)
+	}
+}
+
+func TestIdentityStoreGroupResource(t *testing.T) {
+	resource := newIdentityStoreGroupResource("d-1234567890", identitystoretypes.Group{
+		Description: aws.String("Engineering team"),
+		DisplayName: aws.String("Engineering"),
+		GroupId:     aws.String("g-123"),
+	})
+
+	if got, want := resource.InstanceState.ID, "d-1234567890/g-123"; got != want {
+		t.Fatalf("resource ID = %q, want %q", got, want)
+	}
+	if got, want := resource.InstanceInfo.Type, identityStoreGroupResourceType; got != want {
+		t.Fatalf("resource type = %q, want %q", got, want)
+	}
+	if got, want := resource.InstanceState.Attributes["identity_store_id"], "d-1234567890"; got != want {
+		t.Fatalf("identity_store_id = %q, want %q", got, want)
+	}
+	if got, want := resource.InstanceState.Attributes["group_id"], "g-123"; got != want {
+		t.Fatalf("group_id = %q, want %q", got, want)
+	}
+	if got, want := resource.InstanceState.Attributes["display_name"], "Engineering"; got != want {
+		t.Fatalf("display_name = %q, want %q", got, want)
+	}
+}
+
+func TestIdentityStoreGroupMembershipResource(t *testing.T) {
+	resource := newIdentityStoreGroupMembershipResource("d-1234567890", "g-123", "u-456", "m-789")
+
+	if got, want := resource.InstanceState.ID, "d-1234567890/m-789"; got != want {
+		t.Fatalf("resource ID = %q, want %q", got, want)
+	}
+	if got, want := resource.InstanceInfo.Type, identityStoreGroupMembershipResourceType; got != want {
+		t.Fatalf("resource type = %q, want %q", got, want)
+	}
+	attributes := resource.InstanceState.Attributes
+	for key, want := range map[string]string{
+		"group_id":          "g-123",
+		"identity_store_id": "d-1234567890",
+		"member_id":         "u-456",
+		"membership_id":     "m-789",
+	} {
+		if got := attributes[key]; got != want {
+			t.Fatalf("%s = %q, want %q", key, got, want)
+		}
+	}
+}
+
+func TestIdentityStoreUserResource(t *testing.T) {
+	resource := newIdentityStoreUserResource("d-1234567890", identitystoretypes.User{
+		DisplayName: aws.String("Jane Doe"),
+		UserId:      aws.String("u-456"),
+		UserName:    aws.String("jane@example.com"),
+	})
+
+	if got, want := resource.InstanceState.ID, "d-1234567890/u-456"; got != want {
+		t.Fatalf("resource ID = %q, want %q", got, want)
+	}
+	if got, want := resource.InstanceInfo.Type, identityStoreUserResourceType; got != want {
+		t.Fatalf("resource type = %q, want %q", got, want)
+	}
+	attributes := resource.InstanceState.Attributes
+	if got, want := attributes["identity_store_id"], "d-1234567890"; got != want {
+		t.Fatalf("identity_store_id = %q, want %q", got, want)
+	}
+	if got, want := attributes["user_id"], "u-456"; got != want {
+		t.Fatalf("user_id = %q, want %q", got, want)
+	}
+	if got, want := attributes["user_name"], "jane@example.com"; got != want {
+		t.Fatalf("user_name = %q, want %q", got, want)
+	}
+	if _, ok := attributes["use_name"]; ok {
+		t.Fatalf("unexpected legacy use_name attribute in %#v", attributes)
+	}
+}
+
+func TestIdentityStoreResourceNamesDoNotCollapseJoinedParts(t *testing.T) {
+	left := newIdentityStoreGroupMembershipResource("store", "a_b", "c", "membership-left")
+	right := newIdentityStoreGroupMembershipResource("store", "a", "b_c", "membership-right")
+	if left.ResourceName == right.ResourceName {
+		t.Fatalf("group membership resource names collide: %q", left.ResourceName)
+	}
+}
+
+func TestIdentityStoreResourceNotFound(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{name: "nil", want: false},
+		{name: "resource not found", err: &identitystoretypes.ResourceNotFoundException{}, want: true},
+		{name: "wrapped resource not found", err: errors.Join(errors.New("lookup failed"), &identitystoretypes.ResourceNotFoundException{}), want: true},
+		{name: "generic", err: errors.New("boom"), want: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := identityStoreResourceNotFound(tt.err); got != tt.want {
+				t.Fatalf("identityStoreResourceNotFound(%v) = %t, want %t", tt.err, got, tt.want)
+			}
+		})
+	}
+}

--- a/providers/aws/ssoadmin.go
+++ b/providers/aws/ssoadmin.go
@@ -5,6 +5,7 @@ package aws
 import (
 	"context"
 	"errors"
+	"fmt"
 	"strings"
 	"time"
 
@@ -54,6 +55,20 @@ func (g *SSOAdminGenerator) InitResources() error {
 			}
 			return err
 		}
+	}
+	return nil
+}
+
+func (g *SSOAdminGenerator) PostConvertHook() error {
+	for i, resource := range g.Resources {
+		if resource.InstanceInfo.Type != ssoAdminPermissionSetInlinePolicyResourceType {
+			continue
+		}
+		inlinePolicy, ok := resource.Item["inline_policy"].(string)
+		if !ok || inlinePolicy == "" {
+			continue
+		}
+		g.Resources[i].Item["inline_policy"] = fmt.Sprintf("<<POLICY\n%s\nPOLICY", g.escapeAwsInterpolation(inlinePolicy))
 	}
 	return nil
 }

--- a/providers/aws/ssoadmin.go
+++ b/providers/aws/ssoadmin.go
@@ -1,0 +1,370 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package aws
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"time"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/ssoadmin"
+	ssotypes "github.com/aws/aws-sdk-go-v2/service/ssoadmin/types"
+	"github.com/chenrui333/terraformer/terraformutils"
+)
+
+var ssoAdminAllowEmptyValues = []string{"tags."}
+
+const (
+	ssoAdminPermissionSetResourceType                     = "aws_ssoadmin_permission_set"
+	ssoAdminManagedPolicyAttachmentResourceType           = "aws_ssoadmin_managed_policy_attachment"
+	ssoAdminCustomerManagedPolicyAttachmentResourceType   = "aws_ssoadmin_customer_managed_policy_attachment"
+	ssoAdminPermissionSetInlinePolicyResourceType         = "aws_ssoadmin_permission_set_inline_policy"
+	ssoAdminPermissionsBoundaryAttachmentResourceType     = "aws_ssoadmin_permissions_boundary_attachment"
+	ssoAdminResourceIDSeparator                           = ","
+	ssoAdminResourceNameSeparator                         = ":"
+	ssoAdminNestedPermissionsBoundaryAttributePrefix      = "permissions_boundary.0"
+	ssoAdminNestedCustomerManagedPolicyReferenceAttribute = "permissions_boundary.0.customer_managed_policy_reference.0"
+)
+
+type SSOAdminGenerator struct {
+	AWSService
+}
+
+func (g *SSOAdminGenerator) InitResources() error {
+	config, err := g.generateConfig()
+	if err != nil {
+		return err
+	}
+	svc := ssoadmin.NewFromConfig(config)
+	instances, err := listSSOAdminInstances(svc)
+	if err != nil {
+		return err
+	}
+	for _, instance := range instances {
+		instanceARN := StringValue(instance.InstanceArn)
+		if instanceARN == "" {
+			continue
+		}
+		if err := g.loadPermissionSets(svc, instanceARN); err != nil {
+			if ssoAdminResourceNotFound(err) {
+				continue
+			}
+			return err
+		}
+	}
+	return nil
+}
+
+func listSSOAdminInstances(svc *ssoadmin.Client) ([]ssotypes.InstanceMetadata, error) {
+	p := ssoadmin.NewListInstancesPaginator(svc, &ssoadmin.ListInstancesInput{})
+	var instances []ssotypes.InstanceMetadata
+	for p.HasMorePages() {
+		page, err := p.NextPage(context.TODO())
+		if err != nil {
+			return nil, err
+		}
+		instances = append(instances, page.Instances...)
+	}
+	return instances, nil
+}
+
+func (g *SSOAdminGenerator) loadPermissionSets(svc *ssoadmin.Client, instanceARN string) error {
+	p := ssoadmin.NewListPermissionSetsPaginator(svc, &ssoadmin.ListPermissionSetsInput{
+		InstanceArn: aws.String(instanceARN),
+	})
+	for p.HasMorePages() {
+		page, err := p.NextPage(context.TODO())
+		if err != nil {
+			return err
+		}
+		for _, permissionSetARN := range page.PermissionSets {
+			if permissionSetARN == "" {
+				continue
+			}
+			permissionSet, err := describeSSOAdminPermissionSet(svc, instanceARN, permissionSetARN)
+			if err != nil {
+				if ssoAdminResourceNotFound(err) {
+					continue
+				}
+				return err
+			}
+			if permissionSet == nil {
+				continue
+			}
+			resourceStart := len(g.Resources)
+			g.Resources = append(g.Resources, newSSOAdminPermissionSetResource(instanceARN, permissionSet))
+			if err := g.loadPermissionSetChildren(svc, instanceARN, permissionSetARN); err != nil {
+				if ssoAdminResourceNotFound(err) {
+					g.Resources = g.Resources[:resourceStart]
+					continue
+				}
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+func (g *SSOAdminGenerator) loadPermissionSetChildren(svc *ssoadmin.Client, instanceARN, permissionSetARN string) error {
+	if err := g.loadManagedPolicyAttachments(svc, instanceARN, permissionSetARN); err != nil {
+		return err
+	}
+	if err := g.loadCustomerManagedPolicyAttachments(svc, instanceARN, permissionSetARN); err != nil {
+		return err
+	}
+	if err := g.loadPermissionSetInlinePolicy(svc, instanceARN, permissionSetARN); err != nil {
+		return err
+	}
+	return g.loadPermissionsBoundaryAttachment(svc, instanceARN, permissionSetARN)
+}
+
+func describeSSOAdminPermissionSet(svc *ssoadmin.Client, instanceARN, permissionSetARN string) (*ssotypes.PermissionSet, error) {
+	output, err := svc.DescribePermissionSet(context.TODO(), &ssoadmin.DescribePermissionSetInput{
+		InstanceArn:      aws.String(instanceARN),
+		PermissionSetArn: aws.String(permissionSetARN),
+	})
+	if err != nil {
+		return nil, err
+	}
+	if output == nil || output.PermissionSet == nil {
+		return nil, nil
+	}
+	return output.PermissionSet, nil
+}
+
+func (g *SSOAdminGenerator) loadManagedPolicyAttachments(svc *ssoadmin.Client, instanceARN, permissionSetARN string) error {
+	p := ssoadmin.NewListManagedPoliciesInPermissionSetPaginator(svc, &ssoadmin.ListManagedPoliciesInPermissionSetInput{
+		InstanceArn:      aws.String(instanceARN),
+		PermissionSetArn: aws.String(permissionSetARN),
+	})
+	for p.HasMorePages() {
+		page, err := p.NextPage(context.TODO())
+		if err != nil {
+			return err
+		}
+		for _, policy := range page.AttachedManagedPolicies {
+			if StringValue(policy.Arn) == "" {
+				continue
+			}
+			g.Resources = append(g.Resources, newSSOAdminManagedPolicyAttachmentResource(instanceARN, permissionSetARN, policy))
+		}
+	}
+	return nil
+}
+
+func (g *SSOAdminGenerator) loadCustomerManagedPolicyAttachments(svc *ssoadmin.Client, instanceARN, permissionSetARN string) error {
+	p := ssoadmin.NewListCustomerManagedPolicyReferencesInPermissionSetPaginator(svc, &ssoadmin.ListCustomerManagedPolicyReferencesInPermissionSetInput{
+		InstanceArn:      aws.String(instanceARN),
+		PermissionSetArn: aws.String(permissionSetARN),
+	})
+	for p.HasMorePages() {
+		page, err := p.NextPage(context.TODO())
+		if err != nil {
+			return err
+		}
+		for _, policy := range page.CustomerManagedPolicyReferences {
+			if StringValue(policy.Name) == "" || StringValue(policy.Path) == "" {
+				continue
+			}
+			g.Resources = append(g.Resources, newSSOAdminCustomerManagedPolicyAttachmentResource(instanceARN, permissionSetARN, policy))
+		}
+	}
+	return nil
+}
+
+func (g *SSOAdminGenerator) loadPermissionSetInlinePolicy(svc *ssoadmin.Client, instanceARN, permissionSetARN string) error {
+	output, err := svc.GetInlinePolicyForPermissionSet(context.TODO(), &ssoadmin.GetInlinePolicyForPermissionSetInput{
+		InstanceArn:      aws.String(instanceARN),
+		PermissionSetArn: aws.String(permissionSetARN),
+	})
+	if err != nil {
+		if ssoAdminResourceNotFound(err) {
+			return nil
+		}
+		return err
+	}
+	inlinePolicy := ""
+	if output != nil {
+		inlinePolicy = StringValue(output.InlinePolicy)
+	}
+	if inlinePolicy == "" {
+		return nil
+	}
+	g.Resources = append(g.Resources, newSSOAdminPermissionSetInlinePolicyResource(instanceARN, permissionSetARN, inlinePolicy))
+	return nil
+}
+
+func (g *SSOAdminGenerator) loadPermissionsBoundaryAttachment(svc *ssoadmin.Client, instanceARN, permissionSetARN string) error {
+	output, err := svc.GetPermissionsBoundaryForPermissionSet(context.TODO(), &ssoadmin.GetPermissionsBoundaryForPermissionSetInput{
+		InstanceArn:      aws.String(instanceARN),
+		PermissionSetArn: aws.String(permissionSetARN),
+	})
+	if err != nil {
+		if ssoAdminResourceNotFound(err) {
+			return nil
+		}
+		return err
+	}
+	if output == nil || output.PermissionsBoundary == nil || !ssoAdminPermissionsBoundaryConfigured(output.PermissionsBoundary) {
+		return nil
+	}
+	g.Resources = append(g.Resources, newSSOAdminPermissionsBoundaryAttachmentResource(instanceARN, permissionSetARN, output.PermissionsBoundary))
+	return nil
+}
+
+func newSSOAdminPermissionSetResource(instanceARN string, permissionSet *ssotypes.PermissionSet) terraformutils.Resource {
+	permissionSetARN := StringValue(permissionSet.PermissionSetArn)
+	attributes := map[string]string{
+		"arn":          permissionSetARN,
+		"instance_arn": instanceARN,
+	}
+	if createdDate := permissionSet.CreatedDate; createdDate != nil {
+		attributes["created_date"] = createdDate.Format(time.RFC3339)
+	}
+	if description := StringValue(permissionSet.Description); description != "" {
+		attributes["description"] = description
+	}
+	if name := StringValue(permissionSet.Name); name != "" {
+		attributes["name"] = name
+	}
+	if relayState := StringValue(permissionSet.RelayState); relayState != "" {
+		attributes["relay_state"] = relayState
+	}
+	if sessionDuration := StringValue(permissionSet.SessionDuration); sessionDuration != "" {
+		attributes["session_duration"] = sessionDuration
+	}
+	return terraformutils.NewResource(
+		ssoAdminPermissionSetResourceID(permissionSetARN, instanceARN),
+		ssoAdminResourceName(StringValue(permissionSet.Name), permissionSetARN, instanceARN),
+		ssoAdminPermissionSetResourceType,
+		"aws",
+		attributes,
+		ssoAdminAllowEmptyValues,
+		map[string]interface{}{},
+	)
+}
+
+func newSSOAdminManagedPolicyAttachmentResource(instanceARN, permissionSetARN string, policy ssotypes.AttachedManagedPolicy) terraformutils.Resource {
+	policyARN := StringValue(policy.Arn)
+	attributes := map[string]string{
+		"instance_arn":       instanceARN,
+		"managed_policy_arn": policyARN,
+		"permission_set_arn": permissionSetARN,
+	}
+	if policyName := StringValue(policy.Name); policyName != "" {
+		attributes["managed_policy_name"] = policyName
+	}
+	return terraformutils.NewResource(
+		ssoAdminManagedPolicyAttachmentResourceID(policyARN, permissionSetARN, instanceARN),
+		ssoAdminResourceName(permissionSetARN, policyARN, instanceARN),
+		ssoAdminManagedPolicyAttachmentResourceType,
+		"aws",
+		attributes,
+		ssoAdminAllowEmptyValues,
+		map[string]interface{}{},
+	)
+}
+
+func newSSOAdminCustomerManagedPolicyAttachmentResource(instanceARN, permissionSetARN string, policy ssotypes.CustomerManagedPolicyReference) terraformutils.Resource {
+	policyName := StringValue(policy.Name)
+	policyPath := StringValue(policy.Path)
+	attributes := map[string]string{
+		"customer_managed_policy_reference.#":      "1",
+		"customer_managed_policy_reference.0.name": policyName,
+		"customer_managed_policy_reference.0.path": policyPath,
+		"instance_arn":       instanceARN,
+		"permission_set_arn": permissionSetARN,
+	}
+	return terraformutils.NewResource(
+		ssoAdminCustomerManagedPolicyAttachmentResourceID(policyName, policyPath, permissionSetARN, instanceARN),
+		ssoAdminResourceName(permissionSetARN, policyPath, policyName, instanceARN),
+		ssoAdminCustomerManagedPolicyAttachmentResourceType,
+		"aws",
+		attributes,
+		ssoAdminAllowEmptyValues,
+		map[string]interface{}{},
+	)
+}
+
+func newSSOAdminPermissionSetInlinePolicyResource(instanceARN, permissionSetARN, inlinePolicy string) terraformutils.Resource {
+	return terraformutils.NewResource(
+		ssoAdminPermissionSetResourceID(permissionSetARN, instanceARN),
+		ssoAdminResourceName(permissionSetARN, "inline-policy", instanceARN),
+		ssoAdminPermissionSetInlinePolicyResourceType,
+		"aws",
+		map[string]string{
+			"inline_policy":      inlinePolicy,
+			"instance_arn":       instanceARN,
+			"permission_set_arn": permissionSetARN,
+		},
+		ssoAdminAllowEmptyValues,
+		map[string]interface{}{},
+	)
+}
+
+func newSSOAdminPermissionsBoundaryAttachmentResource(instanceARN, permissionSetARN string, boundary *ssotypes.PermissionsBoundary) terraformutils.Resource {
+	attributes := map[string]string{
+		"instance_arn":           instanceARN,
+		"permission_set_arn":     permissionSetARN,
+		"permissions_boundary.#": "1",
+	}
+	if managedPolicyARN := StringValue(boundary.ManagedPolicyArn); managedPolicyARN != "" {
+		attributes[ssoAdminNestedPermissionsBoundaryAttributePrefix+".managed_policy_arn"] = managedPolicyARN
+	} else if policy := boundary.CustomerManagedPolicyReference; policy != nil {
+		attributes[ssoAdminNestedPermissionsBoundaryAttributePrefix+".customer_managed_policy_reference.#"] = "1"
+		attributes[ssoAdminNestedCustomerManagedPolicyReferenceAttribute+".name"] = StringValue(policy.Name)
+		attributes[ssoAdminNestedCustomerManagedPolicyReferenceAttribute+".path"] = StringValue(policy.Path)
+	}
+	return terraformutils.NewResource(
+		ssoAdminPermissionSetResourceID(permissionSetARN, instanceARN),
+		ssoAdminResourceName(permissionSetARN, "permissions-boundary", instanceARN),
+		ssoAdminPermissionsBoundaryAttachmentResourceType,
+		"aws",
+		attributes,
+		ssoAdminAllowEmptyValues,
+		map[string]interface{}{},
+	)
+}
+
+func ssoAdminPermissionSetResourceID(permissionSetARN, instanceARN string) string {
+	return strings.Join([]string{permissionSetARN, instanceARN}, ssoAdminResourceIDSeparator)
+}
+
+func ssoAdminManagedPolicyAttachmentResourceID(managedPolicyARN, permissionSetARN, instanceARN string) string {
+	return strings.Join([]string{managedPolicyARN, permissionSetARN, instanceARN}, ssoAdminResourceIDSeparator)
+}
+
+func ssoAdminCustomerManagedPolicyAttachmentResourceID(policyName, policyPath, permissionSetARN, instanceARN string) string {
+	return strings.Join([]string{policyName, policyPath, permissionSetARN, instanceARN}, ssoAdminResourceIDSeparator)
+}
+
+func ssoAdminResourceName(parts ...string) string {
+	var nonEmptyParts []string
+	for _, part := range parts {
+		if part != "" {
+			nonEmptyParts = append(nonEmptyParts, part)
+		}
+	}
+	return strings.Join(nonEmptyParts, ssoAdminResourceNameSeparator)
+}
+
+func ssoAdminPermissionsBoundaryConfigured(boundary *ssotypes.PermissionsBoundary) bool {
+	if boundary == nil {
+		return false
+	}
+	if StringValue(boundary.ManagedPolicyArn) != "" {
+		return true
+	}
+	if boundary.CustomerManagedPolicyReference == nil {
+		return false
+	}
+	return StringValue(boundary.CustomerManagedPolicyReference.Name) != "" &&
+		StringValue(boundary.CustomerManagedPolicyReference.Path) != ""
+}
+
+func ssoAdminResourceNotFound(err error) bool {
+	var notFound *ssotypes.ResourceNotFoundException
+	return errors.As(err, &notFound)
+}

--- a/providers/aws/ssoadmin.go
+++ b/providers/aws/ssoadmin.go
@@ -22,6 +22,7 @@ const (
 	ssoAdminCustomerManagedPolicyAttachmentResourceType   = "aws_ssoadmin_customer_managed_policy_attachment"
 	ssoAdminPermissionSetInlinePolicyResourceType         = "aws_ssoadmin_permission_set_inline_policy"
 	ssoAdminPermissionsBoundaryAttachmentResourceType     = "aws_ssoadmin_permissions_boundary_attachment"
+	ssoAdminDefaultCustomerManagedPolicyPath              = "/"
 	ssoAdminResourceIDSeparator                           = ","
 	ssoAdminResourceNameSeparator                         = ":"
 	ssoAdminNestedPermissionsBoundaryAttributePrefix      = "permissions_boundary.0"
@@ -165,7 +166,7 @@ func (g *SSOAdminGenerator) loadCustomerManagedPolicyAttachments(svc *ssoadmin.C
 			return err
 		}
 		for _, policy := range page.CustomerManagedPolicyReferences {
-			if StringValue(policy.Name) == "" || StringValue(policy.Path) == "" {
+			if StringValue(policy.Name) == "" {
 				continue
 			}
 			g.Resources = append(g.Resources, newSSOAdminCustomerManagedPolicyAttachmentResource(instanceARN, permissionSetARN, policy))
@@ -269,7 +270,7 @@ func newSSOAdminManagedPolicyAttachmentResource(instanceARN, permissionSetARN st
 
 func newSSOAdminCustomerManagedPolicyAttachmentResource(instanceARN, permissionSetARN string, policy ssotypes.CustomerManagedPolicyReference) terraformutils.Resource {
 	policyName := StringValue(policy.Name)
-	policyPath := StringValue(policy.Path)
+	policyPath := ssoAdminCustomerManagedPolicyPath(policy.Path)
 	attributes := map[string]string{
 		"customer_managed_policy_reference.#":      "1",
 		"customer_managed_policy_reference.0.name": policyName,
@@ -315,7 +316,7 @@ func newSSOAdminPermissionsBoundaryAttachmentResource(instanceARN, permissionSet
 	} else if policy := boundary.CustomerManagedPolicyReference; policy != nil {
 		attributes[ssoAdminNestedPermissionsBoundaryAttributePrefix+".customer_managed_policy_reference.#"] = "1"
 		attributes[ssoAdminNestedCustomerManagedPolicyReferenceAttribute+".name"] = StringValue(policy.Name)
-		attributes[ssoAdminNestedCustomerManagedPolicyReferenceAttribute+".path"] = StringValue(policy.Path)
+		attributes[ssoAdminNestedCustomerManagedPolicyReferenceAttribute+".path"] = ssoAdminCustomerManagedPolicyPath(policy.Path)
 	}
 	return terraformutils.NewResource(
 		ssoAdminPermissionSetResourceID(permissionSetARN, instanceARN),
@@ -360,8 +361,14 @@ func ssoAdminPermissionsBoundaryConfigured(boundary *ssotypes.PermissionsBoundar
 	if boundary.CustomerManagedPolicyReference == nil {
 		return false
 	}
-	return StringValue(boundary.CustomerManagedPolicyReference.Name) != "" &&
-		StringValue(boundary.CustomerManagedPolicyReference.Path) != ""
+	return StringValue(boundary.CustomerManagedPolicyReference.Name) != ""
+}
+
+func ssoAdminCustomerManagedPolicyPath(path *string) string {
+	if p := StringValue(path); p != "" {
+		return p
+	}
+	return ssoAdminDefaultCustomerManagedPolicyPath
 }
 
 func ssoAdminResourceNotFound(err error) bool {

--- a/providers/aws/ssoadmin_test.go
+++ b/providers/aws/ssoadmin_test.go
@@ -192,6 +192,24 @@ func TestSSOAdminPermissionSetInlinePolicyResource(t *testing.T) {
 	}
 }
 
+func TestSSOAdminPostConvertHookWrapsInlinePolicy(t *testing.T) {
+	inlinePolicy := "{\"Resource\":\"$" + "{aws:username}\"}"
+	resource := newSSOAdminPermissionSetInlinePolicyResource(testSSOAdminInstanceARN, testSSOAdminPermissionSetARN, inlinePolicy)
+	resource.Item = map[string]interface{}{"inline_policy": inlinePolicy}
+
+	g := &SSOAdminGenerator{}
+	g.Resources = append(g.Resources, resource)
+
+	if err := g.PostConvertHook(); err != nil {
+		t.Fatalf("PostConvertHook() error = %v", err)
+	}
+
+	want := "<<POLICY\n{\"Resource\":\"$" + "$" + "{aws:username}\"}\nPOLICY"
+	if got := g.Resources[0].Item["inline_policy"]; got != want {
+		t.Fatalf("inline_policy = %q, want %q", got, want)
+	}
+}
+
 func TestSSOAdminPermissionsBoundaryAttachmentResource(t *testing.T) {
 	tests := []struct {
 		name       string

--- a/providers/aws/ssoadmin_test.go
+++ b/providers/aws/ssoadmin_test.go
@@ -107,28 +107,66 @@ func TestSSOAdminManagedPolicyAttachmentResource(t *testing.T) {
 }
 
 func TestSSOAdminCustomerManagedPolicyAttachmentResource(t *testing.T) {
-	resource := newSSOAdminCustomerManagedPolicyAttachmentResource(testSSOAdminInstanceARN, testSSOAdminPermissionSetARN, ssotypes.CustomerManagedPolicyReference{
-		Name: aws.String("Boundary"),
-		Path: aws.String("/service/"),
-	})
+	tests := []struct {
+		name       string
+		policy     ssotypes.CustomerManagedPolicyReference
+		policyPath string
+	}{
+		{
+			name:       "explicit path",
+			policy:     ssotypes.CustomerManagedPolicyReference{Name: aws.String("Boundary"), Path: aws.String("/service/")},
+			policyPath: "/service/",
+		},
+		{
+			name:       "default path",
+			policy:     ssotypes.CustomerManagedPolicyReference{Name: aws.String("Boundary")},
+			policyPath: "/",
+		},
+	}
 
-	if got, want := resource.InstanceState.ID, "Boundary,/service/,"+testSSOAdminPermissionSetARN+","+testSSOAdminInstanceARN; got != want {
-		t.Fatalf("resource ID = %q, want %q", got, want)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			resource := newSSOAdminCustomerManagedPolicyAttachmentResource(testSSOAdminInstanceARN, testSSOAdminPermissionSetARN, tt.policy)
+
+			if got, want := resource.InstanceState.ID, "Boundary,"+tt.policyPath+","+testSSOAdminPermissionSetARN+","+testSSOAdminInstanceARN; got != want {
+				t.Fatalf("resource ID = %q, want %q", got, want)
+			}
+			if got, want := resource.InstanceInfo.Type, ssoAdminCustomerManagedPolicyAttachmentResourceType; got != want {
+				t.Fatalf("resource type = %q, want %q", got, want)
+			}
+			attributes := resource.InstanceState.Attributes
+			for key, want := range map[string]string{
+				"customer_managed_policy_reference.#":      "1",
+				"customer_managed_policy_reference.0.name": "Boundary",
+				"customer_managed_policy_reference.0.path": tt.policyPath,
+				"instance_arn":       testSSOAdminInstanceARN,
+				"permission_set_arn": testSSOAdminPermissionSetARN,
+			} {
+				if got := attributes[key]; got != want {
+					t.Fatalf("%s = %q, want %q", key, got, want)
+				}
+			}
+		})
 	}
-	if got, want := resource.InstanceInfo.Type, ssoAdminCustomerManagedPolicyAttachmentResourceType; got != want {
-		t.Fatalf("resource type = %q, want %q", got, want)
+}
+
+func TestSSOAdminCustomerManagedPolicyPath(t *testing.T) {
+	tests := []struct {
+		name string
+		path *string
+		want string
+	}{
+		{name: "nil", want: "/"},
+		{name: "empty", path: aws.String(""), want: "/"},
+		{name: "explicit", path: aws.String("/service/"), want: "/service/"},
 	}
-	attributes := resource.InstanceState.Attributes
-	for key, want := range map[string]string{
-		"customer_managed_policy_reference.#":      "1",
-		"customer_managed_policy_reference.0.name": "Boundary",
-		"customer_managed_policy_reference.0.path": "/service/",
-		"instance_arn":       testSSOAdminInstanceARN,
-		"permission_set_arn": testSSOAdminPermissionSetARN,
-	} {
-		if got := attributes[key]; got != want {
-			t.Fatalf("%s = %q, want %q", key, got, want)
-		}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := ssoAdminCustomerManagedPolicyPath(tt.path); got != tt.want {
+				t.Fatalf("ssoAdminCustomerManagedPolicyPath() = %q, want %q", got, tt.want)
+			}
+		})
 	}
 }
 
@@ -181,6 +219,19 @@ func TestSSOAdminPermissionsBoundaryAttachmentResource(t *testing.T) {
 				"permissions_boundary.0.customer_managed_policy_reference.#":      "1",
 				"permissions_boundary.0.customer_managed_policy_reference.0.name": "Boundary",
 				"permissions_boundary.0.customer_managed_policy_reference.0.path": "/service/",
+			},
+		},
+		{
+			name: "customer managed policy default path",
+			boundary: &ssotypes.PermissionsBoundary{
+				CustomerManagedPolicyReference: &ssotypes.CustomerManagedPolicyReference{
+					Name: aws.String("Boundary"),
+				},
+			},
+			attributes: map[string]string{
+				"permissions_boundary.0.customer_managed_policy_reference.#":      "1",
+				"permissions_boundary.0.customer_managed_policy_reference.0.name": "Boundary",
+				"permissions_boundary.0.customer_managed_policy_reference.0.path": "/",
 			},
 		},
 	}
@@ -243,7 +294,7 @@ func TestSSOAdminPermissionsBoundaryConfigured(t *testing.T) {
 			boundary: &ssotypes.PermissionsBoundary{
 				CustomerManagedPolicyReference: &ssotypes.CustomerManagedPolicyReference{Name: aws.String("Boundary")},
 			},
-			want: false,
+			want: true,
 		},
 	}
 

--- a/providers/aws/ssoadmin_test.go
+++ b/providers/aws/ssoadmin_test.go
@@ -1,0 +1,278 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package aws
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	ssotypes "github.com/aws/aws-sdk-go-v2/service/ssoadmin/types"
+)
+
+const (
+	testSSOAdminInstanceARN      = "arn:aws:sso:::instance/ssoins-1234567890abcdef"
+	testSSOAdminPermissionSetARN = "arn:aws:sso:::permissionSet/ssoins-1234567890abcdef/ps-1234567890abcdef"
+	testSSOAdminPolicyARN        = "arn:aws:iam::aws:policy/ReadOnlyAccess"
+)
+
+func TestSSOAdminResourceIDs(t *testing.T) {
+	tests := []struct {
+		name string
+		got  string
+		want string
+	}{
+		{
+			name: "permission set",
+			got:  ssoAdminPermissionSetResourceID(testSSOAdminPermissionSetARN, testSSOAdminInstanceARN),
+			want: testSSOAdminPermissionSetARN + "," + testSSOAdminInstanceARN,
+		},
+		{
+			name: "managed policy attachment",
+			got:  ssoAdminManagedPolicyAttachmentResourceID(testSSOAdminPolicyARN, testSSOAdminPermissionSetARN, testSSOAdminInstanceARN),
+			want: testSSOAdminPolicyARN + "," + testSSOAdminPermissionSetARN + "," + testSSOAdminInstanceARN,
+		},
+		{
+			name: "customer managed policy attachment",
+			got:  ssoAdminCustomerManagedPolicyAttachmentResourceID("Boundary", "/service/", testSSOAdminPermissionSetARN, testSSOAdminInstanceARN),
+			want: "Boundary,/service/," + testSSOAdminPermissionSetARN + "," + testSSOAdminInstanceARN,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.got != tt.want {
+				t.Fatalf("resource ID = %q, want %q", tt.got, tt.want)
+			}
+		})
+	}
+}
+
+func TestSSOAdminPermissionSetResource(t *testing.T) {
+	resource := newSSOAdminPermissionSetResource(testSSOAdminInstanceARN, &ssotypes.PermissionSet{
+		Description:      aws.String("Read-only access"),
+		Name:             aws.String("ReadOnly"),
+		PermissionSetArn: aws.String(testSSOAdminPermissionSetARN),
+		RelayState:       aws.String("https://example.com/start"),
+		SessionDuration:  aws.String("PT4H"),
+	})
+
+	if got, want := resource.InstanceState.ID, testSSOAdminPermissionSetARN+","+testSSOAdminInstanceARN; got != want {
+		t.Fatalf("resource ID = %q, want %q", got, want)
+	}
+	if got, want := resource.InstanceInfo.Type, ssoAdminPermissionSetResourceType; got != want {
+		t.Fatalf("resource type = %q, want %q", got, want)
+	}
+	attributes := resource.InstanceState.Attributes
+	for key, want := range map[string]string{
+		"arn":              testSSOAdminPermissionSetARN,
+		"description":      "Read-only access",
+		"instance_arn":     testSSOAdminInstanceARN,
+		"name":             "ReadOnly",
+		"relay_state":      "https://example.com/start",
+		"session_duration": "PT4H",
+	} {
+		if got := attributes[key]; got != want {
+			t.Fatalf("%s = %q, want %q", key, got, want)
+		}
+	}
+	if _, ok := attributes["permission_set_arn"]; ok {
+		t.Fatalf("unexpected permission_set_arn attribute in %#v", attributes)
+	}
+}
+
+func TestSSOAdminManagedPolicyAttachmentResource(t *testing.T) {
+	resource := newSSOAdminManagedPolicyAttachmentResource(testSSOAdminInstanceARN, testSSOAdminPermissionSetARN, ssotypes.AttachedManagedPolicy{
+		Arn:  aws.String(testSSOAdminPolicyARN),
+		Name: aws.String("ReadOnlyAccess"),
+	})
+
+	if got, want := resource.InstanceState.ID, testSSOAdminPolicyARN+","+testSSOAdminPermissionSetARN+","+testSSOAdminInstanceARN; got != want {
+		t.Fatalf("resource ID = %q, want %q", got, want)
+	}
+	if got, want := resource.InstanceInfo.Type, ssoAdminManagedPolicyAttachmentResourceType; got != want {
+		t.Fatalf("resource type = %q, want %q", got, want)
+	}
+	attributes := resource.InstanceState.Attributes
+	for key, want := range map[string]string{
+		"instance_arn":        testSSOAdminInstanceARN,
+		"managed_policy_arn":  testSSOAdminPolicyARN,
+		"managed_policy_name": "ReadOnlyAccess",
+		"permission_set_arn":  testSSOAdminPermissionSetARN,
+	} {
+		if got := attributes[key]; got != want {
+			t.Fatalf("%s = %q, want %q", key, got, want)
+		}
+	}
+}
+
+func TestSSOAdminCustomerManagedPolicyAttachmentResource(t *testing.T) {
+	resource := newSSOAdminCustomerManagedPolicyAttachmentResource(testSSOAdminInstanceARN, testSSOAdminPermissionSetARN, ssotypes.CustomerManagedPolicyReference{
+		Name: aws.String("Boundary"),
+		Path: aws.String("/service/"),
+	})
+
+	if got, want := resource.InstanceState.ID, "Boundary,/service/,"+testSSOAdminPermissionSetARN+","+testSSOAdminInstanceARN; got != want {
+		t.Fatalf("resource ID = %q, want %q", got, want)
+	}
+	if got, want := resource.InstanceInfo.Type, ssoAdminCustomerManagedPolicyAttachmentResourceType; got != want {
+		t.Fatalf("resource type = %q, want %q", got, want)
+	}
+	attributes := resource.InstanceState.Attributes
+	for key, want := range map[string]string{
+		"customer_managed_policy_reference.#":      "1",
+		"customer_managed_policy_reference.0.name": "Boundary",
+		"customer_managed_policy_reference.0.path": "/service/",
+		"instance_arn":       testSSOAdminInstanceARN,
+		"permission_set_arn": testSSOAdminPermissionSetARN,
+	} {
+		if got := attributes[key]; got != want {
+			t.Fatalf("%s = %q, want %q", key, got, want)
+		}
+	}
+}
+
+func TestSSOAdminPermissionSetInlinePolicyResource(t *testing.T) {
+	inlinePolicy := "{\"Version\":\"2012-10-17\",\"Statement\":[]}"
+	resource := newSSOAdminPermissionSetInlinePolicyResource(testSSOAdminInstanceARN, testSSOAdminPermissionSetARN, inlinePolicy)
+
+	if got, want := resource.InstanceState.ID, testSSOAdminPermissionSetARN+","+testSSOAdminInstanceARN; got != want {
+		t.Fatalf("resource ID = %q, want %q", got, want)
+	}
+	if got, want := resource.InstanceInfo.Type, ssoAdminPermissionSetInlinePolicyResourceType; got != want {
+		t.Fatalf("resource type = %q, want %q", got, want)
+	}
+	attributes := resource.InstanceState.Attributes
+	for key, want := range map[string]string{
+		"inline_policy":      inlinePolicy,
+		"instance_arn":       testSSOAdminInstanceARN,
+		"permission_set_arn": testSSOAdminPermissionSetARN,
+	} {
+		if got := attributes[key]; got != want {
+			t.Fatalf("%s = %q, want %q", key, got, want)
+		}
+	}
+}
+
+func TestSSOAdminPermissionsBoundaryAttachmentResource(t *testing.T) {
+	tests := []struct {
+		name       string
+		boundary   *ssotypes.PermissionsBoundary
+		attributes map[string]string
+	}{
+		{
+			name: "managed policy",
+			boundary: &ssotypes.PermissionsBoundary{
+				ManagedPolicyArn: aws.String(testSSOAdminPolicyARN),
+			},
+			attributes: map[string]string{
+				"permissions_boundary.0.managed_policy_arn": testSSOAdminPolicyARN,
+			},
+		},
+		{
+			name: "customer managed policy",
+			boundary: &ssotypes.PermissionsBoundary{
+				CustomerManagedPolicyReference: &ssotypes.CustomerManagedPolicyReference{
+					Name: aws.String("Boundary"),
+					Path: aws.String("/service/"),
+				},
+			},
+			attributes: map[string]string{
+				"permissions_boundary.0.customer_managed_policy_reference.#":      "1",
+				"permissions_boundary.0.customer_managed_policy_reference.0.name": "Boundary",
+				"permissions_boundary.0.customer_managed_policy_reference.0.path": "/service/",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			resource := newSSOAdminPermissionsBoundaryAttachmentResource(testSSOAdminInstanceARN, testSSOAdminPermissionSetARN, tt.boundary)
+
+			if got, want := resource.InstanceState.ID, testSSOAdminPermissionSetARN+","+testSSOAdminInstanceARN; got != want {
+				t.Fatalf("resource ID = %q, want %q", got, want)
+			}
+			if got, want := resource.InstanceInfo.Type, ssoAdminPermissionsBoundaryAttachmentResourceType; got != want {
+				t.Fatalf("resource type = %q, want %q", got, want)
+			}
+			attributes := resource.InstanceState.Attributes
+			for key, want := range map[string]string{
+				"instance_arn":           testSSOAdminInstanceARN,
+				"permission_set_arn":     testSSOAdminPermissionSetARN,
+				"permissions_boundary.#": "1",
+			} {
+				if got := attributes[key]; got != want {
+					t.Fatalf("%s = %q, want %q", key, got, want)
+				}
+			}
+			for key, want := range tt.attributes {
+				if got := attributes[key]; got != want {
+					t.Fatalf("%s = %q, want %q", key, got, want)
+				}
+			}
+		})
+	}
+}
+
+func TestSSOAdminResourceNamesDoNotCollapseJoinedParts(t *testing.T) {
+	left := newSSOAdminManagedPolicyAttachmentResource("instance", "a_b", ssotypes.AttachedManagedPolicy{Arn: aws.String("c")})
+	right := newSSOAdminManagedPolicyAttachmentResource("instance", "a", ssotypes.AttachedManagedPolicy{Arn: aws.String("b_c")})
+	if left.ResourceName == right.ResourceName {
+		t.Fatalf("managed policy attachment resource names collide: %q", left.ResourceName)
+	}
+}
+
+func TestSSOAdminPermissionsBoundaryConfigured(t *testing.T) {
+	tests := []struct {
+		name     string
+		boundary *ssotypes.PermissionsBoundary
+		want     bool
+	}{
+		{name: "nil", want: false},
+		{name: "empty", boundary: &ssotypes.PermissionsBoundary{}, want: false},
+		{name: "managed policy", boundary: &ssotypes.PermissionsBoundary{ManagedPolicyArn: aws.String(testSSOAdminPolicyARN)}, want: true},
+		{
+			name: "customer managed policy",
+			boundary: &ssotypes.PermissionsBoundary{
+				CustomerManagedPolicyReference: &ssotypes.CustomerManagedPolicyReference{Name: aws.String("Boundary"), Path: aws.String("/")},
+			},
+			want: true,
+		},
+		{
+			name: "customer managed policy missing path",
+			boundary: &ssotypes.PermissionsBoundary{
+				CustomerManagedPolicyReference: &ssotypes.CustomerManagedPolicyReference{Name: aws.String("Boundary")},
+			},
+			want: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := ssoAdminPermissionsBoundaryConfigured(tt.boundary); got != tt.want {
+				t.Fatalf("ssoAdminPermissionsBoundaryConfigured() = %t, want %t", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestSSOAdminResourceNotFound(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{name: "nil", want: false},
+		{name: "resource not found", err: &ssotypes.ResourceNotFoundException{}, want: true},
+		{name: "wrapped resource not found", err: errors.Join(errors.New("lookup failed"), &ssotypes.ResourceNotFoundException{}), want: true},
+		{name: "generic", err: errors.New("boom"), want: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := ssoAdminResourceNotFound(tt.err); got != tt.want {
+				t.Fatalf("ssoAdminResourceNotFound(%v) = %t, want %t", tt.err, got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Summary:
- add SSO Admin permission-set scoped imports
- harden Identity Store import IDs, seeded attributes, pagination, and deleted-resource handling
- document supported SSO Admin and Identity Store resources

Notes:
- Skips SSO Admin account assignments, application resources, and instance access-control attributes for follow-up PRs.
- References #338.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a new `ssoadmin` importer for permission-set resources and hardens `identitystore` imports with multi-instance support, pagination, stable IDs/names, and resilient not-found handling. Also escapes inline policies to prevent Terraform interpolation issues.

- **New Features**
  - Add `ssoadmin` generator to import:
    - `aws_ssoadmin_permission_set`
    - `aws_ssoadmin_managed_policy_attachment`
    - `aws_ssoadmin_customer_managed_policy_attachment`
    - `aws_ssoadmin_permission_set_inline_policy`
    - `aws_ssoadmin_permissions_boundary_attachment`
  - Register `ssoadmin` in the AWS provider and document supported `ssoadmin` and `identitystore` resources. Scope excludes account assignments, application resources, and instance access-control attributes.

- **Refactors**
  - `identitystore`: enumerate all instances, paginate results, skip empty IDs; fix `user_name` attribute; improve stable IDs/names.
  - Treat “resource not found” as deleted for both `ssoadmin` and `identitystore`, and roll back parent resources when child lookups fail to preserve imports.
  - Escape and HEREDOC-wrap SSO Admin inline policies to avoid Terraform interpolation.
  - Add unit tests for IDs, names, default paths, and error handling.

<sup>Written for commit 7223b82420c2e595b17a02c8c65c33b560de167b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for AWS SSO Admin (IAM Identity Center): enumerates permission sets, managed/customer-managed attachments, inline policies, and permissions boundaries; post-processing wraps inline policy content.
  * Enhanced Identity Store discovery to enumerate resources across all instances.

* **Documentation**
  * Updated supported services list to include ssoadmin.

* **Tests**
  * Added unit tests covering SSO Admin and Identity Store resource generation and error handling.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/chenrui333/terraformer/pull/392)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->