### PR TITLE
aws(lambda): add Lambda child resource imports

### DIFF
--- a/docs/aws.md
+++ b/docs/aws.md
@@ -341,10 +341,12 @@ For AWS provider gap audits and unsupported-resource skip-list maintenance, see 
     * `aws_lambda_event_source_mapping`
     * `aws_lambda_function`
     * `aws_lambda_function_event_invoke_config`
+    * `aws_lambda_function_recursion_config`
     * `aws_lambda_function_url`
     * `aws_lambda_layer_version`
     * `aws_lambda_permission`
     * `aws_lambda_provisioned_concurrency_config`
+    * `aws_lambda_runtime_management_config`
 *   `logs`
     * `aws_cloudwatch_log_account_policy`
     * `aws_cloudwatch_log_data_protection_policy`

--- a/providers/aws/lambda.go
+++ b/providers/aws/lambda.go
@@ -19,6 +19,11 @@ import (
 
 var lambdaAllowEmptyValues = []string{"tags."}
 
+const (
+	lambdaFunctionRecursionConfigResourceType = "aws_lambda_function_recursion_config"
+	lambdaRuntimeManagementConfigResourceType = "aws_lambda_runtime_management_config"
+)
+
 type LambdaGenerator struct {
 	AWSService
 }
@@ -57,6 +62,8 @@ func (g *LambdaGenerator) InitResources() error {
 		lambdaOptionalResourceLoader{name: "aliases", load: func() error { return g.addAliases(svc, functions) }},
 		lambdaOptionalResourceLoader{name: "function URLs", load: func() error { return g.addFunctionURLs(svc, functions) }},
 		lambdaOptionalResourceLoader{name: "provisioned concurrency configs", load: func() error { return g.addProvisionedConcurrencyConfigs(svc, functions) }},
+		lambdaOptionalResourceLoader{name: "function recursion configs", load: func() error { return g.addFunctionRecursionConfigs(svc, functions) }},
+		lambdaOptionalResourceLoader{name: "runtime management configs", load: func() error { return g.addRuntimeManagementConfigs(svc, functions) }},
 		lambdaOptionalResourceLoader{name: "code signing configs", load: func() error { return g.addCodeSigningConfigs(svc) }},
 	)
 	err = g.addEventSourceMappings(svc)
@@ -264,6 +271,93 @@ func (g *LambdaGenerator) addFunctionURLs(svc *lambda.Client, functions []lambda
 	return nil
 }
 
+func (g *LambdaGenerator) addFunctionRecursionConfigs(svc *lambda.Client, functions []lambdaFunctionReference) error {
+	for _, function := range functions {
+		config, err := svc.GetFunctionRecursionConfig(context.TODO(), &lambda.GetFunctionRecursionConfigInput{
+			FunctionName: &function.name,
+		})
+		if err != nil {
+			if lambdaResourceNotFound(err) {
+				continue
+			}
+			return err
+		}
+		resource, ok := newLambdaFunctionRecursionConfigResource(function.name, config)
+		if !ok {
+			continue
+		}
+		g.Resources = append(g.Resources, resource)
+	}
+	return nil
+}
+
+func newLambdaFunctionRecursionConfigResource(functionName string, config *lambda.GetFunctionRecursionConfigOutput) (terraformutils.Resource, bool) {
+	if functionName == "" || config == nil {
+		return terraformutils.Resource{}, false
+	}
+	recursiveLoop := string(config.RecursiveLoop)
+	if recursiveLoop == "" {
+		return terraformutils.Resource{}, false
+	}
+	return terraformutils.NewResource(
+		lambdaFunctionRecursionConfigImportID(functionName),
+		lambdaResourceNameWithLengths("function_recursion_config", functionName),
+		lambdaFunctionRecursionConfigResourceType,
+		"aws",
+		map[string]string{
+			"function_name":  functionName,
+			"recursive_loop": recursiveLoop,
+		},
+		lambdaAllowEmptyValues,
+		map[string]interface{}{},
+	), true
+}
+
+func (g *LambdaGenerator) addRuntimeManagementConfigs(svc *lambda.Client, functions []lambdaFunctionReference) error {
+	for _, function := range functions {
+		config, err := svc.GetRuntimeManagementConfig(context.TODO(), &lambda.GetRuntimeManagementConfigInput{
+			FunctionName: &function.name,
+		})
+		if err != nil {
+			if lambdaResourceNotFound(err) {
+				continue
+			}
+			return err
+		}
+		resource, ok := newLambdaRuntimeManagementConfigResource(function.name, "", config)
+		if !ok {
+			continue
+		}
+		g.Resources = append(g.Resources, resource)
+	}
+	return nil
+}
+
+func newLambdaRuntimeManagementConfigResource(functionName, qualifier string, config *lambda.GetRuntimeManagementConfigOutput) (terraformutils.Resource, bool) {
+	if functionName == "" || config == nil {
+		return terraformutils.Resource{}, false
+	}
+	attributes := map[string]string{
+		"function_name": functionName,
+		"qualifier":     qualifier,
+	}
+	if runtimeVersionARN := StringValue(config.RuntimeVersionArn); runtimeVersionARN != "" {
+		attributes["runtime_version_arn"] = runtimeVersionARN
+	}
+	if updateRuntimeOn := string(config.UpdateRuntimeOn); updateRuntimeOn != "" {
+		attributes["update_runtime_on"] = updateRuntimeOn
+	}
+	return terraformutils.NewResource(
+		lambdaRuntimeManagementConfigImportID(functionName, qualifier),
+		lambdaResourceNameWithLengths("runtime_management_config", functionName, qualifier),
+		lambdaRuntimeManagementConfigResourceType,
+		"aws",
+		attributes,
+		lambdaAllowEmptyValues,
+		map[string]interface{}{},
+	), true
+}
+
 func (g *LambdaGenerator) addProvisionedConcurrencyConfigs(svc *lambda.Client, functions []lambdaFunctionReference) error {
 	for _, function := range functions {
 		p := lambda.NewListProvisionedConcurrencyConfigsPaginator(svc, &lambda.ListProvisionedConcurrencyConfigsInput{
@@ -382,6 +476,14 @@ func lambdaProvisionedConcurrencyConfigImportID(functionName, qualifier string) 
 	return functionName + "," + qualifier
 }
 
+func lambdaFunctionRecursionConfigImportID(functionName string) string {
+	return functionName
+}
+
+func lambdaRuntimeManagementConfigImportID(functionName, qualifier string) string {
+	return functionName + "," + qualifier
+}
+
 func lambdaQualifierFromFunctionARN(functionARN, functionName string) string {
 	_, qualifiedName, found := strings.Cut(functionARN, ":function:")
 	if !found || qualifiedName == "" || qualifiedName == functionName {
@@ -412,6 +514,22 @@ func lambdaResourceName(parts ...string) string {
 		name += part
 	}
 	return name
+}
+
+func lambdaResourceNameWithLengths(parts ...string) string {
+	var name strings.Builder
+	for _, part := range parts {
+		if part == "" {
+			continue
+		}
+		if name.Len() > 0 {
+			name.WriteString("_")
+		}
+		name.WriteString(strconv.Itoa(len(part)))
+		name.WriteString("_")
+		name.WriteString(part)
+	}
+	return name.String()
 }
 
 func lambdaResourceNotFound(err error) bool {

--- a/providers/aws/lambda.go
+++ b/providers/aws/lambda.go
@@ -315,22 +315,63 @@ func newLambdaFunctionRecursionConfigResource(functionName string, config *lambd
 
 func (g *LambdaGenerator) addRuntimeManagementConfigs(svc *lambda.Client, functions []lambdaFunctionReference) error {
 	for _, function := range functions {
-		config, err := svc.GetRuntimeManagementConfig(context.TODO(), &lambda.GetRuntimeManagementConfigInput{
-			FunctionName: &function.name,
-		})
-		if err != nil {
-			if lambdaResourceNotFound(err) {
-				continue
-			}
+		if err := g.addRuntimeManagementConfig(svc, function.name, ""); err != nil {
 			return err
 		}
-		resource, ok := newLambdaRuntimeManagementConfigResource(function.name, "", config)
-		if !ok {
-			continue
+
+		p := lambda.NewListVersionsByFunctionPaginator(svc, &lambda.ListVersionsByFunctionInput{
+			FunctionName: &function.name,
+		})
+		for p.HasMorePages() {
+			page, err := p.NextPage(context.TODO())
+			if err != nil {
+				if lambdaResourceNotFound(err) {
+					break
+				}
+				return err
+			}
+			for _, version := range page.Versions {
+				qualifier, ok := lambdaRuntimeManagementConfigQualifier(version)
+				if !ok {
+					continue
+				}
+				if err := g.addRuntimeManagementConfig(svc, function.name, qualifier); err != nil {
+					return err
+				}
+			}
 		}
-		g.Resources = append(g.Resources, resource)
 	}
 	return nil
+}
+
+func (g *LambdaGenerator) addRuntimeManagementConfig(svc *lambda.Client, functionName, qualifier string) error {
+	input := &lambda.GetRuntimeManagementConfigInput{
+		FunctionName: &functionName,
+	}
+	if qualifier != "" {
+		input.Qualifier = &qualifier
+	}
+	config, err := svc.GetRuntimeManagementConfig(context.TODO(), input)
+	if err != nil {
+		if lambdaResourceNotFound(err) {
+			return nil
+		}
+		return err
+	}
+	resource, ok := newLambdaRuntimeManagementConfigResource(functionName, qualifier, config)
+	if !ok {
+		return nil
+	}
+	g.Resources = append(g.Resources, resource)
+	return nil
+}
+
+func lambdaRuntimeManagementConfigQualifier(version lambdatypes.FunctionConfiguration) (string, bool) {
+	qualifier := StringValue(version.Version)
+	if qualifier == "" || qualifier == "$LATEST" {
+		return "", false
+	}
+	return qualifier, true
 }
 
 func newLambdaRuntimeManagementConfigResource(functionName, qualifier string, config *lambda.GetRuntimeManagementConfigOutput) (terraformutils.Resource, bool) {

--- a/providers/aws/lambda_test.go
+++ b/providers/aws/lambda_test.go
@@ -6,7 +6,10 @@ import (
 	"errors"
 	"testing"
 
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/lambda"
 	lambdatypes "github.com/aws/aws-sdk-go-v2/service/lambda/types"
+	"github.com/chenrui333/terraformer/terraformutils"
 )
 
 func TestLambdaAliasImportID(t *testing.T) {
@@ -38,6 +41,32 @@ func TestLambdaFunctionURLImportID(t *testing.T) {
 func TestLambdaProvisionedConcurrencyConfigImportID(t *testing.T) {
 	if got, want := lambdaProvisionedConcurrencyConfigImportID("my-function", "prod"), "my-function,prod"; got != want {
 		t.Fatalf("lambdaProvisionedConcurrencyConfigImportID() = %q, want %q", got, want)
+	}
+}
+
+func TestLambdaFunctionRecursionConfigImportID(t *testing.T) {
+	if got, want := lambdaFunctionRecursionConfigImportID("my-function"), "my-function"; got != want {
+		t.Fatalf("lambdaFunctionRecursionConfigImportID() = %q, want %q", got, want)
+	}
+}
+
+func TestLambdaRuntimeManagementConfigImportID(t *testing.T) {
+	tests := []struct {
+		name         string
+		functionName string
+		qualifier    string
+		want         string
+	}{
+		{name: "unqualified", functionName: "my-function", want: "my-function,"},
+		{name: "qualified", functionName: "my-function", qualifier: "prod", want: "my-function,prod"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := lambdaRuntimeManagementConfigImportID(tt.functionName, tt.qualifier); got != tt.want {
+				t.Fatalf("lambdaRuntimeManagementConfigImportID() = %q, want %q", got, tt.want)
+			}
+		})
 	}
 }
 
@@ -136,6 +165,106 @@ func TestLambdaResourceName(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			if got := lambdaResourceName(tt.parts...); got != tt.want {
 				t.Fatalf("lambdaResourceName() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestNewLambdaFunctionRecursionConfigResource(t *testing.T) {
+	resource, ok := newLambdaFunctionRecursionConfigResource("my-function", &lambda.GetFunctionRecursionConfigOutput{
+		RecursiveLoop: lambdatypes.RecursiveLoopTerminate,
+	})
+	if !ok {
+		t.Fatal("newLambdaFunctionRecursionConfigResource() ok = false, want true")
+	}
+	if resource.InstanceInfo.Type != lambdaFunctionRecursionConfigResourceType {
+		t.Fatalf("resource type = %q, want %q", resource.InstanceInfo.Type, lambdaFunctionRecursionConfigResourceType)
+	}
+	if resource.InstanceState.ID != "my-function" {
+		t.Fatalf("resource ID = %q, want %q", resource.InstanceState.ID, "my-function")
+	}
+	wantName := terraformutils.TfSanitize(lambdaResourceNameWithLengths("function_recursion_config", "my-function"))
+	if resource.ResourceName != wantName {
+		t.Fatalf("resource name = %q, want %q", resource.ResourceName, wantName)
+	}
+	wantAttributes := map[string]string{
+		"function_name":  "my-function",
+		"recursive_loop": "Terminate",
+	}
+	for key, want := range wantAttributes {
+		if got := resource.InstanceState.Attributes[key]; got != want {
+			t.Fatalf("attribute %q = %q, want %q", key, got, want)
+		}
+	}
+	if _, ok := newLambdaFunctionRecursionConfigResource("", &lambda.GetFunctionRecursionConfigOutput{
+		RecursiveLoop: lambdatypes.RecursiveLoopTerminate,
+	}); ok {
+		t.Fatal("newLambdaFunctionRecursionConfigResource() ok = true for empty function name, want false")
+	}
+	if _, ok := newLambdaFunctionRecursionConfigResource("my-function", nil); ok {
+		t.Fatal("newLambdaFunctionRecursionConfigResource() ok = true for nil config, want false")
+	}
+	if _, ok := newLambdaFunctionRecursionConfigResource("my-function", &lambda.GetFunctionRecursionConfigOutput{}); ok {
+		t.Fatal("newLambdaFunctionRecursionConfigResource() ok = true for empty recursive_loop, want false")
+	}
+}
+
+func TestNewLambdaRuntimeManagementConfigResource(t *testing.T) {
+	resource, ok := newLambdaRuntimeManagementConfigResource("my-function", "", &lambda.GetRuntimeManagementConfigOutput{
+		RuntimeVersionArn: aws.String("arn:aws:lambda:us-east-1::runtime:abcd"),
+		UpdateRuntimeOn:   lambdatypes.UpdateRuntimeOnManual,
+	})
+	if !ok {
+		t.Fatal("newLambdaRuntimeManagementConfigResource() ok = false, want true")
+	}
+	if resource.InstanceInfo.Type != lambdaRuntimeManagementConfigResourceType {
+		t.Fatalf("resource type = %q, want %q", resource.InstanceInfo.Type, lambdaRuntimeManagementConfigResourceType)
+	}
+	if resource.InstanceState.ID != "my-function," {
+		t.Fatalf("resource ID = %q, want %q", resource.InstanceState.ID, "my-function,")
+	}
+	wantName := terraformutils.TfSanitize(lambdaResourceNameWithLengths("runtime_management_config", "my-function", ""))
+	if resource.ResourceName != wantName {
+		t.Fatalf("resource name = %q, want %q", resource.ResourceName, wantName)
+	}
+	wantAttributes := map[string]string{
+		"function_name":       "my-function",
+		"qualifier":           "",
+		"runtime_version_arn": "arn:aws:lambda:us-east-1::runtime:abcd",
+		"update_runtime_on":   "Manual",
+	}
+	for key, want := range wantAttributes {
+		if got := resource.InstanceState.Attributes[key]; got != want {
+			t.Fatalf("attribute %q = %q, want %q", key, got, want)
+		}
+	}
+	if _, ok := newLambdaRuntimeManagementConfigResource("", "", &lambda.GetRuntimeManagementConfigOutput{
+		UpdateRuntimeOn: lambdatypes.UpdateRuntimeOnAuto,
+	}); ok {
+		t.Fatal("newLambdaRuntimeManagementConfigResource() ok = true for empty function name, want false")
+	}
+	if _, ok := newLambdaRuntimeManagementConfigResource("my-function", "", nil); ok {
+		t.Fatal("newLambdaRuntimeManagementConfigResource() ok = true for nil config, want false")
+	}
+}
+
+func TestLambdaResourceNameWithLengthsAvoidsSanitizedCollisions(t *testing.T) {
+	tests := []struct {
+		name   string
+		first  []string
+		second []string
+	}{
+		{name: "separator boundary", first: []string{"runtime_management_config", "a_b", "c"}, second: []string{"runtime_management_config", "a", "b_c"}},
+		{name: "slash encoding", first: []string{"runtime_management_config", "a/b", "c"}, second: []string{"runtime_management_config", "a-002F-b", "c"}},
+		{name: "qualifier separator encoding", first: []string{"runtime_management_config", "function:prod"}, second: []string{"runtime_management_config", "function-003A-prod"}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			first := terraformutils.TfSanitize(lambdaResourceNameWithLengths(tt.first...))
+			second := terraformutils.TfSanitize(lambdaResourceNameWithLengths(tt.second...))
+			if first == second {
+				t.Fatalf("lambdaResourceNameWithLengths() generated duplicate sanitized names %q", first)
 			}
 		})
 	}

--- a/providers/aws/lambda_test.go
+++ b/providers/aws/lambda_test.go
@@ -58,13 +58,37 @@ func TestLambdaRuntimeManagementConfigImportID(t *testing.T) {
 		want         string
 	}{
 		{name: "unqualified", functionName: "my-function", want: "my-function,"},
-		{name: "qualified", functionName: "my-function", qualifier: "prod", want: "my-function,prod"},
+		{name: "qualified version", functionName: "my-function", qualifier: "1", want: "my-function,1"},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			if got := lambdaRuntimeManagementConfigImportID(tt.functionName, tt.qualifier); got != tt.want {
 				t.Fatalf("lambdaRuntimeManagementConfigImportID() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestLambdaRuntimeManagementConfigQualifier(t *testing.T) {
+	tests := []struct {
+		name    string
+		version string
+		want    string
+		wantOK  bool
+	}{
+		{name: "published version", version: "1", want: "1", wantOK: true},
+		{name: "latest version", version: "$LATEST"},
+		{name: "empty version"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, ok := lambdaRuntimeManagementConfigQualifier(lambdatypes.FunctionConfiguration{
+				Version: aws.String(tt.version),
+			})
+			if got != tt.want || ok != tt.wantOK {
+				t.Fatalf("lambdaRuntimeManagementConfigQualifier() = %q, %t, want %q, %t", got, ok, tt.want, tt.wantOK)
 			}
 		})
 	}
@@ -237,6 +261,18 @@ func TestNewLambdaRuntimeManagementConfigResource(t *testing.T) {
 		if got := resource.InstanceState.Attributes[key]; got != want {
 			t.Fatalf("attribute %q = %q, want %q", key, got, want)
 		}
+	}
+	qualifiedResource, ok := newLambdaRuntimeManagementConfigResource("my-function", "1", &lambda.GetRuntimeManagementConfigOutput{
+		UpdateRuntimeOn: lambdatypes.UpdateRuntimeOnAuto,
+	})
+	if !ok {
+		t.Fatal("newLambdaRuntimeManagementConfigResource() ok = false for qualified version, want true")
+	}
+	if qualifiedResource.InstanceState.ID != "my-function,1" {
+		t.Fatalf("qualified resource ID = %q, want %q", qualifiedResource.InstanceState.ID, "my-function,1")
+	}
+	if got := qualifiedResource.InstanceState.Attributes["qualifier"]; got != "1" {
+		t.Fatalf("qualified resource qualifier = %q, want %q", got, "1")
 	}
 	if _, ok := newLambdaRuntimeManagementConfigResource("", "", &lambda.GetRuntimeManagementConfigOutput{
 		UpdateRuntimeOn: lambdatypes.UpdateRuntimeOnAuto,


### PR DESCRIPTION
## Summary

- add Lambda import discovery for function recursion configs and runtime management configs
- seed import IDs as `function_name`, `function_name,`, and `function_name,<published-version>`
- document supported Lambda resources in docs/aws.md
- add unit tests for ID/resource helper behavior, version qualifier handling, and collision-resistant names

## References

- #338

## Validation

```bash
go test ./providers/aws -run 'Test.*Lambda|Test.*lambda'
go test ./providers/aws/... ./terraformutils/...
git diff --check
```

## Notes

Skipped/deferred resources:
- `aws_lambda_layer_version_permission`: provider import/read models one layer-version policy and reads the first statement, so per-statement discovery would be unsafe.
- `aws_lambda_invocation`: action-style resource with payload-hash IDs and no meaningful refresh discovery.
- `aws_lambda_capacity_provider`: top-level Lambda capacity-provider resource; defer to a separate narrow PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for AWS Lambda function recursion configuration
  * Added support for AWS Lambda runtime management configuration

* **Documentation**
  * Updated AWS Lambda supported services list to include the new resource types

* **Tests**
  * Added unit tests covering import ID formatting, qualifier handling, resource construction, and name collision avoidance for the new Lambda configs

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/chenrui333/terraformer/pull/393)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->