### PR TITLE
aws(logs): add CloudWatch Logs follow-up imports

### DIFF
--- a/docs/aws.md
+++ b/docs/aws.md
@@ -349,7 +349,9 @@ For AWS provider gap audits and unsupported-resource skip-list maintenance, see 
     * `aws_cloudwatch_log_account_policy`
     * `aws_cloudwatch_log_data_protection_policy`
     * `aws_cloudwatch_log_destination`
+    * `aws_cloudwatch_log_destination_policy`
     * `aws_cloudwatch_log_group`
+    * `aws_cloudwatch_log_index_policy`
     * `aws_cloudwatch_log_metric_filter`
     * `aws_cloudwatch_log_resource_policy`
     * `aws_cloudwatch_log_subscription_filter`

--- a/providers/aws/logs.go
+++ b/providers/aws/logs.go
@@ -16,6 +16,11 @@ import (
 
 var logsAllowEmptyValues = []string{"tags."}
 
+const (
+	logsDestinationPolicyResourceType = "aws_cloudwatch_log_destination_policy"
+	logsIndexPolicyResourceType       = "aws_cloudwatch_log_index_policy"
+)
+
 var logsAccountPolicyTypes = []types.PolicyType{
 	types.PolicyTypeDataProtectionPolicy,
 	types.PolicyTypeSubscriptionFilterPolicy,
@@ -87,6 +92,7 @@ func (g *LogsGenerator) InitResources() error {
 		logsOptionalResourceLoader{name: "subscription filters", load: func() error { return g.addSubscriptionFilters(svc, logGroupNames) }},
 		logsOptionalResourceLoader{name: "data protection policies", load: func() error { return g.addDataProtectionPolicies(svc, logGroupNames) }},
 		logsOptionalResourceLoader{name: "destinations", load: func() error { return g.addDestinations(svc) }},
+		logsOptionalResourceLoader{name: "index policies", load: func() error { return g.addIndexPolicies(svc, logGroupNames) }},
 		logsOptionalResourceLoader{name: "resource policies", load: func() error { return g.addResourcePolicies(svc) }},
 		logsOptionalResourceLoader{name: "account policies", load: func() error { return g.addAccountPolicies(svc) }},
 		logsOptionalResourceLoader{name: "query definitions", load: func() error { return g.addQueryDefinitions(svc) }},
@@ -215,6 +221,37 @@ func (g *LogsGenerator) addDestinations(svc *cloudwatchlogs.Client) error {
 				"aws_cloudwatch_log_destination",
 				"aws",
 				logsAllowEmptyValues))
+			if resource, ok := newLogsDestinationPolicyResource(destination); ok {
+				g.Resources = append(g.Resources, resource)
+			}
+		}
+	}
+	return nil
+}
+
+func (g *LogsGenerator) addIndexPolicies(svc *cloudwatchlogs.Client, logGroupNames []string) error {
+	for _, logGroupName := range logGroupNames {
+		var nextToken *string
+		for {
+			output, err := svc.DescribeIndexPolicies(context.TODO(), &cloudwatchlogs.DescribeIndexPoliciesInput{
+				LogGroupIdentifiers: []string{logGroupName},
+				NextToken:           nextToken,
+			})
+			if err != nil {
+				if logsResourceNotFound(err) {
+					break
+				}
+				return err
+			}
+			for _, policy := range output.IndexPolicies {
+				if resource, ok := newLogsIndexPolicyResource(logGroupName, policy); ok {
+					g.Resources = append(g.Resources, resource)
+				}
+			}
+			nextToken = output.NextToken
+			if !awsHasMorePages(nextToken) {
+				break
+			}
 		}
 	}
 	return nil
@@ -370,4 +407,42 @@ func logsResourcePolicyResource(policy types.ResourcePolicy) (string, string, ma
 	return policyName, policyName, map[string]string{
 		"policy_name": policyName,
 	}
+}
+
+func newLogsDestinationPolicyResource(destination types.Destination) (terraformutils.Resource, bool) {
+	destinationName := StringValue(destination.DestinationName)
+	if destinationName == "" || StringValue(destination.AccessPolicy) == "" {
+		return terraformutils.Resource{}, false
+	}
+
+	return terraformutils.NewResource(
+		destinationName,
+		destinationName,
+		logsDestinationPolicyResourceType,
+		"aws",
+		map[string]string{
+			"destination_name": destinationName,
+		},
+		logsAllowEmptyValues,
+		map[string]interface{}{}), true
+}
+
+func newLogsIndexPolicyResource(logGroupName string, policy types.IndexPolicy) (terraformutils.Resource, bool) {
+	if logGroupName == "" || StringValue(policy.PolicyDocument) == "" {
+		return terraformutils.Resource{}, false
+	}
+	if policy.Source != "" && policy.Source != types.IndexSourceLogGroup {
+		return terraformutils.Resource{}, false
+	}
+
+	return terraformutils.NewResource(
+		logGroupName,
+		logGroupName,
+		logsIndexPolicyResourceType,
+		"aws",
+		map[string]string{
+			"log_group_name": logGroupName,
+		},
+		logsAllowEmptyValues,
+		map[string]interface{}{}), true
 }

--- a/providers/aws/logs_test.go
+++ b/providers/aws/logs_test.go
@@ -135,3 +135,129 @@ func TestLogsResourcePolicyResource(t *testing.T) {
 		})
 	}
 }
+
+func TestNewLogsDestinationPolicyResource(t *testing.T) {
+	destinationName := "central-logs"
+	accessPolicy := "{}"
+
+	tests := []struct {
+		name        string
+		destination types.Destination
+		wantOK      bool
+	}{
+		{
+			name: "destination with access policy",
+			destination: types.Destination{
+				AccessPolicy:    &accessPolicy,
+				DestinationName: &destinationName,
+			},
+			wantOK: true,
+		},
+		{
+			name: "destination without access policy is skipped",
+			destination: types.Destination{
+				DestinationName: &destinationName,
+			},
+		},
+		{
+			name: "destination without name is skipped",
+			destination: types.Destination{
+				AccessPolicy: &accessPolicy,
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			resource, ok := newLogsDestinationPolicyResource(tt.destination)
+			if ok != tt.wantOK {
+				t.Fatalf("newLogsDestinationPolicyResource() ok = %t, want %t", ok, tt.wantOK)
+			}
+			if !ok {
+				return
+			}
+			if got := resource.InstanceState.ID; got != destinationName {
+				t.Fatalf("resource ID = %q, want %q", got, destinationName)
+			}
+			if got := resource.InstanceInfo.Type; got != logsDestinationPolicyResourceType {
+				t.Fatalf("resource type = %q, want %q", got, logsDestinationPolicyResourceType)
+			}
+			if got := resource.InstanceState.Attributes["destination_name"]; got != destinationName {
+				t.Fatalf("destination_name = %q, want %q", got, destinationName)
+			}
+		})
+	}
+}
+
+func TestNewLogsIndexPolicyResource(t *testing.T) {
+	logGroupName := "/aws/lambda/example"
+	policyDocument := "{}"
+
+	tests := []struct {
+		name         string
+		logGroupName string
+		policy       types.IndexPolicy
+		wantOK       bool
+	}{
+		{
+			name:         "log group policy",
+			logGroupName: logGroupName,
+			policy: types.IndexPolicy{
+				PolicyDocument: &policyDocument,
+				Source:         types.IndexSourceLogGroup,
+			},
+			wantOK: true,
+		},
+		{
+			name:         "policy without source is accepted",
+			logGroupName: logGroupName,
+			policy: types.IndexPolicy{
+				PolicyDocument: &policyDocument,
+			},
+			wantOK: true,
+		},
+		{
+			name:         "account policy is skipped",
+			logGroupName: logGroupName,
+			policy: types.IndexPolicy{
+				PolicyDocument: &policyDocument,
+				Source:         types.IndexSourceAccount,
+			},
+		},
+		{
+			name: "empty log group is skipped",
+			policy: types.IndexPolicy{
+				PolicyDocument: &policyDocument,
+				Source:         types.IndexSourceLogGroup,
+			},
+		},
+		{
+			name:         "policy without document is skipped",
+			logGroupName: logGroupName,
+			policy: types.IndexPolicy{
+				Source: types.IndexSourceLogGroup,
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			resource, ok := newLogsIndexPolicyResource(tt.logGroupName, tt.policy)
+			if ok != tt.wantOK {
+				t.Fatalf("newLogsIndexPolicyResource() ok = %t, want %t", ok, tt.wantOK)
+			}
+			if !ok {
+				return
+			}
+			if got := resource.InstanceState.ID; got != tt.logGroupName {
+				t.Fatalf("resource ID = %q, want %q", got, tt.logGroupName)
+			}
+			if got := resource.InstanceInfo.Type; got != logsIndexPolicyResourceType {
+				t.Fatalf("resource type = %q, want %q", got, logsIndexPolicyResourceType)
+			}
+			if got := resource.InstanceState.Attributes["log_group_name"]; got != tt.logGroupName {
+				t.Fatalf("log_group_name = %q, want %q", got, tt.logGroupName)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

- add CloudWatch Logs import discovery for destination policies and log-group index policies
- seed import IDs as `destination_name` and `log_group_name`
- update docs/aws.md for the supported Logs resources
- add unit tests for resource helper behavior

## References

- #338

## Validation

```bash
go run ./tools/aws-gap-inventory \
  -docs docs/aws.md \
  -aws-dir providers/aws \
  -skip-list providers/aws/unsupported_resources.json \
  -format markdown

go test ./providers/aws -run 'Test.*Logs|Test.*CloudWatch|Test.*cloudwatch|Test.*logs'
go test ./providers/aws/... ./terraformutils/... ./tools/aws-gap-inventory/...
```

## Notes

Skipped/deferred resources:
- `aws_cloudwatch_log_delivery`, `aws_cloudwatch_log_delivery_source`, `aws_cloudwatch_log_delivery_destination`, `aws_cloudwatch_log_delivery_destination_policy`: deferred for a focused delivery API PR.
- `aws_cloudwatch_log_anomaly_detector`: deferred for a focused anomaly detector PR.
- `aws_cloudwatch_log_stream`: deferred because log streams are high-cardinality and ephemeral, so discovery needs explicit scale/filter handling.
- `aws_cloudwatch_log_transformer`: deferred for a focused transformer PR.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds import discovery for CloudWatch Logs destination policies and log‑group index policies to close coverage gaps.

- New Features
  - Import `aws_cloudwatch_log_destination_policy` when a destination has an access policy.
  - Import `aws_cloudwatch_log_index_policy` for log groups via `DescribeIndexPolicies`.
  - Seed import IDs as `destination_name` and `log_group_name`.
  - Update `docs/aws.md` and add unit tests for resource helpers.

<sup>Written for commit f8af91cc0966737df58953ce313bf5099b77fd63. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for CloudWatch Logs index policies and destination policies in Terraform discovery.

* **Documentation**
  * Updated AWS supported services documentation with additional CloudWatch Logs resource types.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/chenrui333/terraformer/pull/394)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->