### PR TITLE
aws(dms): add core DMS resource imports

### DIFF
--- a/docs/aws.md
+++ b/docs/aws.md
@@ -202,6 +202,11 @@ For AWS provider gap audits and unsupported-resource skip-list maintenance, see 
     * `aws_datapipeline_pipeline`
 *   `devicefarm`
     * `aws_devicefarm_project`
+*   `dms`
+    * `aws_dms_endpoint`
+    * `aws_dms_replication_instance`
+    * `aws_dms_replication_subnet_group`
+    * `aws_dms_replication_task`
 *   `docdb`
     * `aws_docdb_cluster`
     * `aws_docdb_cluster_instance`

--- a/go.mod
+++ b/go.mod
@@ -46,6 +46,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/cognitoidentity v1.33.24
 	github.com/aws/aws-sdk-go-v2/service/cognitoidentityprovider v1.60.2
 	github.com/aws/aws-sdk-go-v2/service/configservice v1.62.3
+	github.com/aws/aws-sdk-go-v2/service/databasemigrationservice v1.62.2
 	github.com/aws/aws-sdk-go-v2/service/datapipeline v1.30.22
 	github.com/aws/aws-sdk-go-v2/service/devicefarm v1.38.10
 	github.com/aws/aws-sdk-go-v2/service/docdb v1.48.15

--- a/go.sum
+++ b/go.sum
@@ -251,6 +251,8 @@ github.com/aws/aws-sdk-go-v2/service/cognitoidentityprovider v1.60.2 h1:pZxE29WA
 github.com/aws/aws-sdk-go-v2/service/cognitoidentityprovider v1.60.2/go.mod h1:nbe4Nf/HOY+e54Dl+yjv04scYTGTC+4ZthbfOuPTXQs=
 github.com/aws/aws-sdk-go-v2/service/configservice v1.62.3 h1:8rcAUMhCUuQe7kVBTBLPqMsJWFSVDPSFdpFexVQEEdU=
 github.com/aws/aws-sdk-go-v2/service/configservice v1.62.3/go.mod h1:PvCpYWzh0/jwa8v3jYJOaDobKiKQzFm1hI7+4Ms3J90=
+github.com/aws/aws-sdk-go-v2/service/databasemigrationservice v1.62.2 h1:+vWChWbLMrEzHuKtm2koCaGoZo6Cnu8OpYH0fsdSLEI=
+github.com/aws/aws-sdk-go-v2/service/databasemigrationservice v1.62.2/go.mod h1:Qa7SOwwtaE9VticcY52FgDIXJZLS1jz+Y6fiCdLUdRU=
 github.com/aws/aws-sdk-go-v2/service/datapipeline v1.30.22 h1:th7UIseI06gZDd/7ntsyUJmVVbbowq4ypEUh8gf5+OU=
 github.com/aws/aws-sdk-go-v2/service/datapipeline v1.30.22/go.mod h1:vNpeL80rYCglcJXUOeCbC8/qQ9vMclvff5kFMNf7iI0=
 github.com/aws/aws-sdk-go-v2/service/devicefarm v1.38.10 h1:57LpTN6FaBV417EbwvNC0/rdFRhZm/nrf01XEXPy+nI=

--- a/providers/aws/aws_provider.go
+++ b/providers/aws/aws_provider.go
@@ -289,6 +289,7 @@ func (p *AWSProvider) GetSupportedService() map[string]terraformutils.ServiceGen
 		"customer_gateway":  &AwsFacade{service: &CustomerGatewayGenerator{}},
 		"datapipeline":      &AwsFacade{service: &DataPipelineGenerator{}},
 		"devicefarm":        &AwsFacade{service: &DeviceFarmGenerator{}},
+		"dms":               &AwsFacade{service: &DmsGenerator{}},
 		"docdb":             &AwsFacade{service: &DocDBGenerator{}},
 		"dx":                &AwsFacade{service: &DirectConnectGenerator{}},
 		"dynamodb":          &AwsFacade{service: &DynamoDbGenerator{}},

--- a/providers/aws/dms.go
+++ b/providers/aws/dms.go
@@ -1,0 +1,232 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package aws
+
+import (
+	"context"
+	"strings"
+
+	"github.com/aws/aws-sdk-go-v2/service/databasemigrationservice"
+	dmstypes "github.com/aws/aws-sdk-go-v2/service/databasemigrationservice/types"
+	"github.com/chenrui333/terraformer/terraformutils"
+)
+
+const (
+	dmsReplicationInstanceResourceType    = "aws_dms_replication_instance"
+	dmsReplicationSubnetGroupResourceType = "aws_dms_replication_subnet_group"
+	dmsEndpointResourceType               = "aws_dms_endpoint"
+	dmsReplicationTaskResourceType        = "aws_dms_replication_task"
+
+	dmsReplicationInstanceStatusAvailable = "available"
+	dmsReplicationTaskStatusReady         = "ready"
+	dmsReplicationTaskStatusRunning       = "running"
+	dmsReplicationTaskStatusStopped       = "stopped"
+
+	dmsEndpointEngineS3 = "s3"
+)
+
+var dmsAllowEmptyValues = []string{"tags."}
+
+type DmsGenerator struct {
+	AWSService
+}
+
+func (g *DmsGenerator) InitResources() error {
+	config, e := g.generateConfig()
+	if e != nil {
+		return e
+	}
+	svc := databasemigrationservice.NewFromConfig(config)
+
+	if err := g.loadReplicationInstances(svc); err != nil {
+		return err
+	}
+	if err := g.loadReplicationSubnetGroups(svc); err != nil {
+		return err
+	}
+	if err := g.loadEndpoints(svc); err != nil {
+		return err
+	}
+	if err := g.loadReplicationTasks(svc); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (g *DmsGenerator) loadReplicationInstances(svc *databasemigrationservice.Client) error {
+	p := databasemigrationservice.NewDescribeReplicationInstancesPaginator(svc, &databasemigrationservice.DescribeReplicationInstancesInput{})
+	for p.HasMorePages() {
+		page, err := p.NextPage(context.TODO())
+		if err != nil {
+			return err
+		}
+		for _, instance := range page.ReplicationInstances {
+			if resource, ok := newDMSReplicationInstanceResource(instance); ok {
+				g.Resources = append(g.Resources, resource)
+			}
+		}
+	}
+	return nil
+}
+
+func (g *DmsGenerator) loadReplicationSubnetGroups(svc *databasemigrationservice.Client) error {
+	p := databasemigrationservice.NewDescribeReplicationSubnetGroupsPaginator(svc, &databasemigrationservice.DescribeReplicationSubnetGroupsInput{})
+	for p.HasMorePages() {
+		page, err := p.NextPage(context.TODO())
+		if err != nil {
+			return err
+		}
+		for _, group := range page.ReplicationSubnetGroups {
+			if resource, ok := newDMSReplicationSubnetGroupResource(group); ok {
+				g.Resources = append(g.Resources, resource)
+			}
+		}
+	}
+	return nil
+}
+
+func (g *DmsGenerator) loadEndpoints(svc *databasemigrationservice.Client) error {
+	p := databasemigrationservice.NewDescribeEndpointsPaginator(svc, &databasemigrationservice.DescribeEndpointsInput{})
+	for p.HasMorePages() {
+		page, err := p.NextPage(context.TODO())
+		if err != nil {
+			return err
+		}
+		for _, endpoint := range page.Endpoints {
+			if resource, ok := newDMSEndpointResource(endpoint); ok {
+				g.Resources = append(g.Resources, resource)
+			}
+		}
+	}
+	return nil
+}
+
+func (g *DmsGenerator) loadReplicationTasks(svc *databasemigrationservice.Client) error {
+	p := databasemigrationservice.NewDescribeReplicationTasksPaginator(svc, &databasemigrationservice.DescribeReplicationTasksInput{})
+	for p.HasMorePages() {
+		page, err := p.NextPage(context.TODO())
+		if err != nil {
+			return err
+		}
+		for _, task := range page.ReplicationTasks {
+			if resource, ok := newDMSReplicationTaskResource(task); ok {
+				g.Resources = append(g.Resources, resource)
+			}
+		}
+	}
+	return nil
+}
+
+func newDMSReplicationInstanceResource(instance dmstypes.ReplicationInstance) (terraformutils.Resource, bool) {
+	identifier := StringValue(instance.ReplicationInstanceIdentifier)
+	if identifier == "" || !dmsReplicationInstanceImportable(instance) {
+		return terraformutils.Resource{}, false
+	}
+	return terraformutils.NewSimpleResource(
+		identifier,
+		dmsResourceName("replication-instance", identifier),
+		dmsReplicationInstanceResourceType,
+		"aws",
+		dmsAllowEmptyValues,
+	), true
+}
+
+func newDMSReplicationSubnetGroupResource(group dmstypes.ReplicationSubnetGroup) (terraformutils.Resource, bool) {
+	identifier := StringValue(group.ReplicationSubnetGroupIdentifier)
+	if identifier == "" || !dmsStableStatusImportable(StringValue(group.SubnetGroupStatus)) {
+		return terraformutils.Resource{}, false
+	}
+	return terraformutils.NewSimpleResource(
+		identifier,
+		dmsResourceName("replication-subnet-group", identifier),
+		dmsReplicationSubnetGroupResourceType,
+		"aws",
+		dmsAllowEmptyValues,
+	), true
+}
+
+func newDMSEndpointResource(endpoint dmstypes.Endpoint) (terraformutils.Resource, bool) {
+	identifier := StringValue(endpoint.EndpointIdentifier)
+	if identifier == "" || !dmsEndpointImportable(endpoint) {
+		return terraformutils.Resource{}, false
+	}
+	return terraformutils.NewSimpleResource(
+		identifier,
+		dmsResourceName("endpoint", identifier),
+		dmsEndpointResourceType,
+		"aws",
+		dmsAllowEmptyValues,
+	), true
+}
+
+func newDMSReplicationTaskResource(task dmstypes.ReplicationTask) (terraformutils.Resource, bool) {
+	identifier := StringValue(task.ReplicationTaskIdentifier)
+	if identifier == "" || !dmsReplicationTaskImportable(task) {
+		return terraformutils.Resource{}, false
+	}
+	return terraformutils.NewSimpleResource(
+		identifier,
+		dmsResourceName("replication-task", identifier),
+		dmsReplicationTaskResourceType,
+		"aws",
+		dmsAllowEmptyValues,
+	), true
+}
+
+func dmsResourceName(parts ...string) string {
+	var cleanParts []string
+	for _, part := range parts {
+		if part != "" {
+			cleanParts = append(cleanParts, part)
+		}
+	}
+	if len(cleanParts) == 0 {
+		return "dms-resource"
+	}
+	return strings.Join(cleanParts, "/")
+}
+
+func dmsReplicationInstanceImportable(instance dmstypes.ReplicationInstance) bool {
+	return strings.EqualFold(StringValue(instance.ReplicationInstanceStatus), dmsReplicationInstanceStatusAvailable)
+}
+
+func dmsEndpointImportable(endpoint dmstypes.Endpoint) bool {
+	if strings.EqualFold(StringValue(endpoint.EngineName), dmsEndpointEngineS3) {
+		return false
+	}
+	return dmsStableStatusImportable(StringValue(endpoint.Status))
+}
+
+func dmsReplicationTaskImportable(task dmstypes.ReplicationTask) bool {
+	switch strings.ToLower(StringValue(task.Status)) {
+	case dmsReplicationTaskStatusReady, dmsReplicationTaskStatusRunning, dmsReplicationTaskStatusStopped:
+		return true
+	default:
+		return false
+	}
+}
+
+func dmsStableStatusImportable(status string) bool {
+	status = strings.ToLower(strings.TrimSpace(status))
+	if status == "" {
+		return false
+	}
+	unsafeFragments := []string{
+		"creat",
+		"delet",
+		"fail",
+		"modif",
+		"moving",
+		"starting",
+		"stopping",
+		"testing",
+		"upgrading",
+	}
+	for _, fragment := range unsafeFragments {
+		if strings.Contains(status, fragment) {
+			return false
+		}
+	}
+	return true
+}

--- a/providers/aws/dms_test.go
+++ b/providers/aws/dms_test.go
@@ -1,0 +1,191 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package aws
+
+import (
+	"testing"
+
+	dmstypes "github.com/aws/aws-sdk-go-v2/service/databasemigrationservice/types"
+	"github.com/chenrui333/terraformer/terraformutils"
+)
+
+func TestDMSResourceName(t *testing.T) {
+	tests := []struct {
+		name  string
+		parts []string
+		want  string
+	}{
+		{name: "filters empty parts", parts: []string{"", "endpoint", "", "orders"}, want: "endpoint/orders"},
+		{name: "preserves segment boundaries", parts: []string{"replication-task", "orders"}, want: "replication-task/orders"},
+		{name: "fallback", parts: nil, want: "dms-resource"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := dmsResourceName(tt.parts...)
+			if got != tt.want {
+				t.Fatalf("dmsResourceName() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestDMSResourceNamesAvoidTypeCollisions(t *testing.T) {
+	endpoint := dmsResourceName("endpoint", "shared")
+	task := dmsResourceName("replication-task", "shared")
+	if endpoint == task {
+		t.Fatalf("resource names collide: %q", endpoint)
+	}
+}
+
+func TestNewDMSReplicationInstanceResource(t *testing.T) {
+	resource, ok := newDMSReplicationInstanceResource(dmstypes.ReplicationInstance{
+		ReplicationInstanceIdentifier: dmsString("dms-ri"),
+		ReplicationInstanceStatus:     dmsString("available"),
+	})
+	assertDMSResource(t, resource, ok, "dms-ri", dmsResourceName("replication-instance", "dms-ri"), dmsReplicationInstanceResourceType)
+
+	if _, ok := newDMSReplicationInstanceResource(dmstypes.ReplicationInstance{ReplicationInstanceStatus: dmsString("available")}); ok {
+		t.Fatal("replication instance with empty identifier should be skipped")
+	}
+	if _, ok := newDMSReplicationInstanceResource(dmstypes.ReplicationInstance{
+		ReplicationInstanceIdentifier: dmsString("dms-ri"),
+		ReplicationInstanceStatus:     dmsString("creating"),
+	}); ok {
+		t.Fatal("creating replication instance should be skipped")
+	}
+}
+
+func TestNewDMSReplicationSubnetGroupResource(t *testing.T) {
+	resource, ok := newDMSReplicationSubnetGroupResource(dmstypes.ReplicationSubnetGroup{
+		ReplicationSubnetGroupIdentifier: dmsString("dms-subnets"),
+		SubnetGroupStatus:                dmsString("Complete"),
+	})
+	assertDMSResource(t, resource, ok, "dms-subnets", dmsResourceName("replication-subnet-group", "dms-subnets"), dmsReplicationSubnetGroupResourceType)
+
+	if _, ok := newDMSReplicationSubnetGroupResource(dmstypes.ReplicationSubnetGroup{SubnetGroupStatus: dmsString("Complete")}); ok {
+		t.Fatal("replication subnet group with empty identifier should be skipped")
+	}
+	if _, ok := newDMSReplicationSubnetGroupResource(dmstypes.ReplicationSubnetGroup{
+		ReplicationSubnetGroupIdentifier: dmsString("dms-subnets"),
+		SubnetGroupStatus:                dmsString("deleting"),
+	}); ok {
+		t.Fatal("deleting replication subnet group should be skipped")
+	}
+}
+
+func TestNewDMSEndpointResource(t *testing.T) {
+	resource, ok := newDMSEndpointResource(dmstypes.Endpoint{
+		EndpointIdentifier: dmsString("source-endpoint"),
+		EngineName:         dmsString("postgres"),
+		Status:             dmsString("active"),
+	})
+	assertDMSResource(t, resource, ok, "source-endpoint", dmsResourceName("endpoint", "source-endpoint"), dmsEndpointResourceType)
+
+	if _, ok := newDMSEndpointResource(dmstypes.Endpoint{Status: dmsString("active")}); ok {
+		t.Fatal("endpoint with empty identifier should be skipped")
+	}
+	if _, ok := newDMSEndpointResource(dmstypes.Endpoint{
+		EndpointIdentifier: dmsString("s3-target"),
+		EngineName:         dmsString("s3"),
+		Status:             dmsString("active"),
+	}); ok {
+		t.Fatal("S3 endpoint should be skipped for aws_dms_endpoint")
+	}
+	if _, ok := newDMSEndpointResource(dmstypes.Endpoint{
+		EndpointIdentifier: dmsString("source-endpoint"),
+		EngineName:         dmsString("postgres"),
+		Status:             dmsString("failed"),
+	}); ok {
+		t.Fatal("failed endpoint should be skipped")
+	}
+}
+
+func TestNewDMSReplicationTaskResource(t *testing.T) {
+	resource, ok := newDMSReplicationTaskResource(dmstypes.ReplicationTask{
+		ReplicationTaskIdentifier: dmsString("orders-task"),
+		Status:                    dmsString("ready"),
+	})
+	assertDMSResource(t, resource, ok, "orders-task", dmsResourceName("replication-task", "orders-task"), dmsReplicationTaskResourceType)
+
+	if _, ok := newDMSReplicationTaskResource(dmstypes.ReplicationTask{Status: dmsString("ready")}); ok {
+		t.Fatal("replication task with empty identifier should be skipped")
+	}
+	if _, ok := newDMSReplicationTaskResource(dmstypes.ReplicationTask{
+		ReplicationTaskIdentifier: dmsString("orders-task"),
+		Status:                    dmsString("creating"),
+	}); ok {
+		t.Fatal("creating replication task should be skipped")
+	}
+}
+
+func TestDMSReplicationInstanceImportable(t *testing.T) {
+	if !dmsReplicationInstanceImportable(dmstypes.ReplicationInstance{ReplicationInstanceStatus: dmsString("available")}) {
+		t.Fatal("available replication instance should be importable")
+	}
+	for _, status := range []string{"creating", "deleting", "failed", "modifying", "upgrading", ""} {
+		if dmsReplicationInstanceImportable(dmstypes.ReplicationInstance{ReplicationInstanceStatus: dmsString(status)}) {
+			t.Fatalf("replication instance status %q should not be importable", status)
+		}
+	}
+}
+
+func TestDMSEndpointImportable(t *testing.T) {
+	if !dmsEndpointImportable(dmstypes.Endpoint{EngineName: dmsString("postgres"), Status: dmsString("active")}) {
+		t.Fatal("active non-S3 endpoint should be importable")
+	}
+	if dmsEndpointImportable(dmstypes.Endpoint{EngineName: dmsString("s3"), Status: dmsString("active")}) {
+		t.Fatal("S3 endpoint should not be imported as aws_dms_endpoint")
+	}
+	if dmsEndpointImportable(dmstypes.Endpoint{EngineName: dmsString("postgres"), Status: dmsString("failed")}) {
+		t.Fatal("failed endpoint should not be importable")
+	}
+	if dmsEndpointImportable(dmstypes.Endpoint{EngineName: dmsString("postgres")}) {
+		t.Fatal("endpoint with empty status should not be importable")
+	}
+}
+
+func TestDMSReplicationTaskImportable(t *testing.T) {
+	for _, status := range []string{"ready", "running", "stopped"} {
+		if !dmsReplicationTaskImportable(dmstypes.ReplicationTask{Status: dmsString(status)}) {
+			t.Fatalf("replication task status %q should be importable", status)
+		}
+	}
+	for _, status := range []string{"creating", "deleting", "failed", "failed-move", "modifying", "moving", "starting", "stopping", ""} {
+		if dmsReplicationTaskImportable(dmstypes.ReplicationTask{Status: dmsString(status)}) {
+			t.Fatalf("replication task status %q should not be importable", status)
+		}
+	}
+}
+
+func TestDMSStableStatusImportable(t *testing.T) {
+	for _, status := range []string{"active", "available", "Complete", "ready", "running", "stopped"} {
+		if !dmsStableStatusImportable(status) {
+			t.Fatalf("status %q should be importable", status)
+		}
+	}
+	for _, status := range []string{"", "creating", "deleting", "failed", "failed-move", "modifying", "moving", "starting", "stopping", "testing", "upgrading"} {
+		if dmsStableStatusImportable(status) {
+			t.Fatalf("status %q should not be importable", status)
+		}
+	}
+}
+
+func assertDMSResource(t *testing.T, resource terraformutils.Resource, ok bool, wantID, wantName, wantType string) {
+	t.Helper()
+	if !ok {
+		t.Fatal("resource was skipped")
+	}
+	if got := resource.InstanceState.ID; got != wantID {
+		t.Fatalf("resource ID = %q, want %q", got, wantID)
+	}
+	if got := resource.ResourceName; got != terraformutils.TfSanitize(wantName) {
+		t.Fatalf("resource name = %q, want %q", got, terraformutils.TfSanitize(wantName))
+	}
+	if got := resource.InstanceInfo.Type; got != wantType {
+		t.Fatalf("resource type = %q, want %q", got, wantType)
+	}
+}
+
+func dmsString(value string) *string {
+	return &value
+}


### PR DESCRIPTION
## Summary

- add AWS DMS import discovery for replication instances, replication subnet groups, endpoints, and replication tasks
- register the `dms` AWS service in Terraformer
- seed import IDs from DMS identifiers: `replication_instance_id`, `replication_subnet_group_id`, `endpoint_id`, and `replication_task_id`
- document supported DMS resources in docs/aws.md
- add unit tests for resource helper behavior and status eligibility

## References

- #338

## Validation

```bash
go test ./providers/aws -run 'Test.*DMS|Test.*Dms|Test.*dms'
go test ./providers/aws/... ./terraformutils/...
go run ./tools/aws-gap-inventory -docs docs/aws.md -aws-dir providers/aws -skip-list providers/aws/unsupported_resources.json -format json
git diff --check
```

## Notes

Skipped/deferred resources:
- aws_dms_certificate: deferred to keep this PR to the core DMS data path
- aws_dms_event_subscription: deferred; importable by name but event source coverage should be reviewed separately
- aws_dms_replication_config: deferred; serverless replication config uses ARN import and additional replication-state handling
- aws_dms_s3_endpoint: deferred; discovered through DMS endpoints but represented by a separate Terraform resource


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds core AWS DMS import discovery and registers `dms` in the AWS provider so replication instances, subnet groups, endpoints, and tasks can be imported. Applies simple, safe status checks and uses native identifiers for clean import IDs.

- **New Features**
  - Register `dms` and import `aws_dms_replication_instance`, `aws_dms_replication_subnet_group`, `aws_dms_endpoint`, `aws_dms_replication_task`.
  - Import rules: instances only when `available`; tasks when `ready|running|stopped`; endpoints require stable status and skip `s3`.
  - Document supported resources in `docs/aws.md` and add unit tests for helpers and eligibility.

- **Dependencies**
  - Add `github.com/aws/aws-sdk-go-v2/service/databasemigrationservice v1.62.2`.

<sup>Written for commit b0e4949fe6716cfa8f0f96530a5354ae7cfa82e5. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for AWS Database Migration Service (DMS) resources, including endpoints, replication instances, replication subnet groups, and replication tasks.

* **Documentation**
  * Updated AWS documentation to include DMS supported services.

* **Tests**
  * Added comprehensive unit tests for DMS resource handling and importability validation.

* **Chores**
  * Updated dependencies to support DMS functionality.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/chenrui333/terraformer/pull/395)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->