### PR TITLE
aws(dms): add certificate and event subscription imports

### DIFF
--- a/docs/aws.md
+++ b/docs/aws.md
@@ -203,7 +203,9 @@ For AWS provider gap audits and unsupported-resource skip-list maintenance, see 
 *   `devicefarm`
     * `aws_devicefarm_project`
 *   `dms`
+    * `aws_dms_certificate`
     * `aws_dms_endpoint`
+    * `aws_dms_event_subscription`
     * `aws_dms_replication_instance`
     * `aws_dms_replication_subnet_group`
     * `aws_dms_replication_task`

--- a/providers/aws/dms.go
+++ b/providers/aws/dms.go
@@ -4,6 +4,8 @@ package aws
 
 import (
 	"context"
+	"errors"
+	"fmt"
 	"log"
 	"strings"
 
@@ -44,12 +46,23 @@ type dmsOptionalResourceLoader struct {
 	load func() error
 }
 
-func (g *DmsGenerator) loadOptionalResources(loaders []dmsOptionalResourceLoader) {
+func (g *DmsGenerator) loadOptionalResources(loaders []dmsOptionalResourceLoader) error {
 	for _, loader := range loaders {
 		if err := loader.load(); err != nil {
-			log.Printf("Skipping DMS %s: %v", loader.name, err)
+			if dmsOptionalResourceErrorSkippable(err) {
+				log.Printf("Skipping DMS %s: %v", loader.name, err)
+				continue
+			}
+			log.Printf("Failed DMS %s discovery: %v", loader.name, err)
+			return fmt.Errorf("loading DMS %s: %w", loader.name, err)
 		}
 	}
+	return nil
+}
+
+func dmsOptionalResourceErrorSkippable(err error) bool {
+	var notFound *dmstypes.ResourceNotFoundFault
+	return errors.As(err, &notFound)
 }
 
 func (g *DmsGenerator) InitResources() error {
@@ -71,10 +84,12 @@ func (g *DmsGenerator) InitResources() error {
 	if err := g.loadReplicationTasks(svc); err != nil {
 		return err
 	}
-	g.loadOptionalResources([]dmsOptionalResourceLoader{
+	if err := g.loadOptionalResources([]dmsOptionalResourceLoader{
 		{name: "certificates", load: func() error { return g.loadCertificates(svc) }},
 		{name: "event subscriptions", load: func() error { return g.loadEventSubscriptions(svc) }},
-	})
+	}); err != nil {
+		return err
+	}
 
 	return nil
 }
@@ -279,8 +294,7 @@ func dmsCertificateImportable(certificate dmstypes.Certificate) bool {
 func dmsEventSubscriptionImportable(subscription dmstypes.EventSubscription) bool {
 	return strings.EqualFold(StringValue(subscription.Status), dmsEventSubscriptionStatusActive) &&
 		dmsEventSubscriptionSourceTypeImportable(StringValue(subscription.SourceType)) &&
-		StringValue(subscription.SnsTopicArn) != "" &&
-		len(subscription.EventCategoriesList) > 0
+		StringValue(subscription.SnsTopicArn) != ""
 }
 
 func dmsEventSubscriptionSourceTypeImportable(sourceType string) bool {

--- a/providers/aws/dms.go
+++ b/providers/aws/dms.go
@@ -4,6 +4,7 @@ package aws
 
 import (
 	"context"
+	"log"
 	"strings"
 
 	"github.com/aws/aws-sdk-go-v2/service/databasemigrationservice"
@@ -12,10 +13,17 @@ import (
 )
 
 const (
+	dmsCertificateResourceType            = "aws_dms_certificate"
+	dmsEventSubscriptionResourceType      = "aws_dms_event_subscription"
 	dmsReplicationInstanceResourceType    = "aws_dms_replication_instance"
 	dmsReplicationSubnetGroupResourceType = "aws_dms_replication_subnet_group"
 	dmsEndpointResourceType               = "aws_dms_endpoint"
 	dmsReplicationTaskResourceType        = "aws_dms_replication_task"
+
+	dmsEventSubscriptionStatusActive = "active"
+
+	dmsEventSubscriptionSourceTypeReplicationInstance = "replication-instance"
+	dmsEventSubscriptionSourceTypeReplicationTask     = "replication-task"
 
 	dmsReplicationInstanceStatusAvailable = "available"
 	dmsReplicationTaskStatusReady         = "ready"
@@ -29,6 +37,19 @@ var dmsAllowEmptyValues = []string{"tags."}
 
 type DmsGenerator struct {
 	AWSService
+}
+
+type dmsOptionalResourceLoader struct {
+	name string
+	load func() error
+}
+
+func (g *DmsGenerator) loadOptionalResources(loaders []dmsOptionalResourceLoader) {
+	for _, loader := range loaders {
+		if err := loader.load(); err != nil {
+			log.Printf("Skipping DMS %s: %v", loader.name, err)
+		}
+	}
 }
 
 func (g *DmsGenerator) InitResources() error {
@@ -50,6 +71,10 @@ func (g *DmsGenerator) InitResources() error {
 	if err := g.loadReplicationTasks(svc); err != nil {
 		return err
 	}
+	g.loadOptionalResources([]dmsOptionalResourceLoader{
+		{name: "certificates", load: func() error { return g.loadCertificates(svc) }},
+		{name: "event subscriptions", load: func() error { return g.loadEventSubscriptions(svc) }},
+	})
 
 	return nil
 }
@@ -116,6 +141,66 @@ func (g *DmsGenerator) loadReplicationTasks(svc *databasemigrationservice.Client
 		}
 	}
 	return nil
+}
+
+func (g *DmsGenerator) loadCertificates(svc *databasemigrationservice.Client) error {
+	p := databasemigrationservice.NewDescribeCertificatesPaginator(svc, &databasemigrationservice.DescribeCertificatesInput{})
+	for p.HasMorePages() {
+		page, err := p.NextPage(context.TODO())
+		if err != nil {
+			return err
+		}
+		for _, certificate := range page.Certificates {
+			if resource, ok := newDMSCertificateResource(certificate); ok {
+				g.Resources = append(g.Resources, resource)
+			}
+		}
+	}
+	return nil
+}
+
+func (g *DmsGenerator) loadEventSubscriptions(svc *databasemigrationservice.Client) error {
+	p := databasemigrationservice.NewDescribeEventSubscriptionsPaginator(svc, &databasemigrationservice.DescribeEventSubscriptionsInput{})
+	for p.HasMorePages() {
+		page, err := p.NextPage(context.TODO())
+		if err != nil {
+			return err
+		}
+		for _, subscription := range page.EventSubscriptionsList {
+			if resource, ok := newDMSEventSubscriptionResource(subscription); ok {
+				g.Resources = append(g.Resources, resource)
+			}
+		}
+	}
+	return nil
+}
+
+func newDMSCertificateResource(certificate dmstypes.Certificate) (terraformutils.Resource, bool) {
+	identifier := StringValue(certificate.CertificateIdentifier)
+	if identifier == "" || !dmsCertificateImportable(certificate) {
+		return terraformutils.Resource{}, false
+	}
+	return terraformutils.NewSimpleResource(
+		identifier,
+		dmsResourceName("certificate", identifier),
+		dmsCertificateResourceType,
+		"aws",
+		dmsAllowEmptyValues,
+	), true
+}
+
+func newDMSEventSubscriptionResource(subscription dmstypes.EventSubscription) (terraformutils.Resource, bool) {
+	name := StringValue(subscription.CustSubscriptionId)
+	if name == "" || !dmsEventSubscriptionImportable(subscription) {
+		return terraformutils.Resource{}, false
+	}
+	return terraformutils.NewSimpleResource(
+		name,
+		dmsResourceName("event-subscription", name),
+		dmsEventSubscriptionResourceType,
+		"aws",
+		dmsAllowEmptyValues,
+	), true
 }
 
 func newDMSReplicationInstanceResource(instance dmstypes.ReplicationInstance) (terraformutils.Resource, bool) {
@@ -185,6 +270,26 @@ func dmsResourceName(parts ...string) string {
 		return "dms-resource"
 	}
 	return strings.Join(cleanParts, "/")
+}
+
+func dmsCertificateImportable(certificate dmstypes.Certificate) bool {
+	return StringValue(certificate.CertificatePem) != "" || len(certificate.CertificateWallet) > 0
+}
+
+func dmsEventSubscriptionImportable(subscription dmstypes.EventSubscription) bool {
+	return strings.EqualFold(StringValue(subscription.Status), dmsEventSubscriptionStatusActive) &&
+		dmsEventSubscriptionSourceTypeImportable(StringValue(subscription.SourceType)) &&
+		StringValue(subscription.SnsTopicArn) != "" &&
+		len(subscription.EventCategoriesList) > 0
+}
+
+func dmsEventSubscriptionSourceTypeImportable(sourceType string) bool {
+	switch strings.ToLower(sourceType) {
+	case dmsEventSubscriptionSourceTypeReplicationInstance, dmsEventSubscriptionSourceTypeReplicationTask:
+		return true
+	default:
+		return false
+	}
 }
 
 func dmsReplicationInstanceImportable(instance dmstypes.ReplicationInstance) bool {

--- a/providers/aws/dms.go
+++ b/providers/aws/dms.go
@@ -36,7 +36,7 @@ const (
 	dmsEndpointEngineS3 = "s3"
 )
 
-var dmsAllowEmptyValues = []string{"tags."}
+var dmsAllowEmptyValues = []string{"tags.", "^enabled$"}
 
 type DmsGenerator struct {
 	AWSService
@@ -211,6 +211,9 @@ func newDMSEventSubscriptionResource(subscription dmstypes.EventSubscription) (t
 		return terraformutils.Resource{}, false
 	}
 	attributes := dmsStringSliceAttributes("event_categories", subscription.EventCategoriesList)
+	if !subscription.Enabled {
+		attributes["enabled"] = strconv.FormatBool(subscription.Enabled)
+	}
 	additionalFields := map[string]interface{}{}
 	if len(subscription.EventCategoriesList) == 0 {
 		// DMS omits categories for all-category subscriptions, but Terraform still requires an explicit empty set.

--- a/providers/aws/dms.go
+++ b/providers/aws/dms.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"fmt"
 	"log"
+	"strconv"
 	"strings"
 
 	"github.com/aws/aws-sdk-go-v2/service/databasemigrationservice"
@@ -209,12 +210,20 @@ func newDMSEventSubscriptionResource(subscription dmstypes.EventSubscription) (t
 	if name == "" || !dmsEventSubscriptionImportable(subscription) {
 		return terraformutils.Resource{}, false
 	}
-	return terraformutils.NewSimpleResource(
+	attributes := dmsStringSliceAttributes("event_categories", subscription.EventCategoriesList)
+	additionalFields := map[string]interface{}{}
+	if len(subscription.EventCategoriesList) == 0 {
+		// DMS omits categories for all-category subscriptions, but Terraform still requires an explicit empty set.
+		additionalFields["event_categories"] = []interface{}{}
+	}
+	return terraformutils.NewResource(
 		name,
 		dmsResourceName("event-subscription", name),
 		dmsEventSubscriptionResourceType,
 		"aws",
+		attributes,
 		dmsAllowEmptyValues,
+		additionalFields,
 	), true
 }
 
@@ -289,6 +298,16 @@ func dmsResourceName(parts ...string) string {
 
 func dmsCertificateImportable(certificate dmstypes.Certificate) bool {
 	return StringValue(certificate.CertificatePem) != "" || len(certificate.CertificateWallet) > 0
+}
+
+func dmsStringSliceAttributes(prefix string, values []string) map[string]string {
+	attributes := map[string]string{
+		prefix + ".#": strconv.Itoa(len(values)),
+	}
+	for i, value := range values {
+		attributes[prefix+"."+strconv.Itoa(i)] = value
+	}
+	return attributes
 }
 
 func dmsEventSubscriptionImportable(subscription dmstypes.EventSubscription) bool {

--- a/providers/aws/dms_test.go
+++ b/providers/aws/dms_test.go
@@ -117,6 +117,15 @@ func TestNewDMSEventSubscriptionResource(t *testing.T) {
 		Status:              dmsString("active"),
 	})
 	assertDMSResource(t, resource, ok, "dms-events", dmsResourceName("event-subscription", "dms-events"), dmsEventSubscriptionResourceType)
+	if got := resource.InstanceState.Attributes["event_categories.#"]; got != "2" {
+		t.Fatalf("event_categories.# = %q, want 2", got)
+	}
+	if got := resource.InstanceState.Attributes["event_categories.1"]; got != "failure" {
+		t.Fatalf("event_categories.1 = %q, want failure", got)
+	}
+	if _, ok := resource.AdditionalFields["event_categories"]; ok {
+		t.Fatal("non-empty event categories should be read from refreshed state")
+	}
 
 	resource, ok = newDMSEventSubscriptionResource(dmstypes.EventSubscription{
 		CustSubscriptionId: dmsString("dms-all-events"),
@@ -125,6 +134,16 @@ func TestNewDMSEventSubscriptionResource(t *testing.T) {
 		Status:             dmsString("active"),
 	})
 	assertDMSResource(t, resource, ok, "dms-all-events", dmsResourceName("event-subscription", "dms-all-events"), dmsEventSubscriptionResourceType)
+	if got := resource.InstanceState.Attributes["event_categories.#"]; got != "0" {
+		t.Fatalf("all-category event_categories.# = %q, want 0", got)
+	}
+	emptyCategories, ok := resource.AdditionalFields["event_categories"].([]interface{})
+	if !ok {
+		t.Fatalf("all-category event_categories additional field type = %T, want []interface{}", resource.AdditionalFields["event_categories"])
+	}
+	if len(emptyCategories) != 0 {
+		t.Fatalf("all-category event_categories length = %d, want 0", len(emptyCategories))
+	}
 
 	if _, ok := newDMSEventSubscriptionResource(dmstypes.EventSubscription{
 		EventCategoriesList: []string{"creation"},
@@ -244,6 +263,27 @@ func TestDMSCertificateImportable(t *testing.T) {
 	}
 	if dmsCertificateImportable(dmstypes.Certificate{}) {
 		t.Fatal("certificate without PEM or wallet material should not be importable")
+	}
+}
+
+func TestDMSStringSliceAttributes(t *testing.T) {
+	attributes := dmsStringSliceAttributes("event_categories", []string{"creation", "failure"})
+	if got := attributes["event_categories.#"]; got != "2" {
+		t.Fatalf("event_categories.# = %q, want 2", got)
+	}
+	if got := attributes["event_categories.0"]; got != "creation" {
+		t.Fatalf("event_categories.0 = %q, want creation", got)
+	}
+	if got := attributes["event_categories.1"]; got != "failure" {
+		t.Fatalf("event_categories.1 = %q, want failure", got)
+	}
+
+	emptyAttributes := dmsStringSliceAttributes("event_categories", nil)
+	if got := emptyAttributes["event_categories.#"]; got != "0" {
+		t.Fatalf("empty event_categories.# = %q, want 0", got)
+	}
+	if len(emptyAttributes) != 1 {
+		t.Fatalf("empty attributes length = %d, want 1", len(emptyAttributes))
 	}
 }
 

--- a/providers/aws/dms_test.go
+++ b/providers/aws/dms_test.go
@@ -263,8 +263,9 @@ func TestDMSEventSubscriptionImportable(t *testing.T) {
 		t.Fatal("active event subscription without event categories should import all categories")
 	}
 	caseVariant := base
-	caseVariant.SourceType = dmsString("REPLICATION-TASK")
-	caseVariant.Status = dmsString("ACTIVE")
+	caseVariant.SnsTopicArn = dmsString("arn:aws:sns:us-east-1:123456789012:DmS-EvEnTs")
+	caseVariant.SourceType = dmsString("RePlIcAtIoN-InStAnCe")
+	caseVariant.Status = dmsString("AcTiVe")
 	if !dmsEventSubscriptionImportable(caseVariant) {
 		t.Fatal("event subscription importability should be case-insensitive for status and source type")
 	}
@@ -317,7 +318,7 @@ func TestDMSEventSubscriptionSourceTypeImportable(t *testing.T) {
 			t.Fatalf("source type %q should be importable", sourceType)
 		}
 	}
-	for _, sourceType := range []string{"", "replication-server", "security-group"} {
+	for _, sourceType := range []string{"", "replication-server", "security-group", "SeCuRiTy-GrOuP"} {
 		if dmsEventSubscriptionSourceTypeImportable(sourceType) {
 			t.Fatalf("source type %q should not be importable", sourceType)
 		}

--- a/providers/aws/dms_test.go
+++ b/providers/aws/dms_test.go
@@ -3,6 +3,7 @@
 package aws
 
 import (
+	"errors"
 	"testing"
 
 	dmstypes "github.com/aws/aws-sdk-go-v2/service/databasemigrationservice/types"
@@ -37,6 +38,61 @@ func TestDMSResourceNamesAvoidTypeCollisions(t *testing.T) {
 	}
 }
 
+func TestDMSOptionalResourceLoaderErrors(t *testing.T) {
+	t.Run("skips resource not found", func(t *testing.T) {
+		g := DmsGenerator{}
+		calledNext := false
+		err := g.loadOptionalResources([]dmsOptionalResourceLoader{
+			{
+				name: "certificates",
+				load: func() error {
+					return &dmstypes.ResourceNotFoundFault{}
+				},
+			},
+			{
+				name: "event subscriptions",
+				load: func() error {
+					calledNext = true
+					return nil
+				},
+			},
+		})
+		if err != nil {
+			t.Fatalf("loadOptionalResources() error = %v, want nil", err)
+		}
+		if !calledNext {
+			t.Fatal("loadOptionalResources() should continue after skippable error")
+		}
+	})
+
+	t.Run("returns unexpected error", func(t *testing.T) {
+		g := DmsGenerator{}
+		boom := errors.New("boom")
+		calledNext := false
+		err := g.loadOptionalResources([]dmsOptionalResourceLoader{
+			{
+				name: "certificates",
+				load: func() error {
+					return boom
+				},
+			},
+			{
+				name: "event subscriptions",
+				load: func() error {
+					calledNext = true
+					return nil
+				},
+			},
+		})
+		if !errors.Is(err, boom) {
+			t.Fatalf("loadOptionalResources() error = %v, want %v", err, boom)
+		}
+		if calledNext {
+			t.Fatal("loadOptionalResources() should stop after unexpected error")
+		}
+	})
+}
+
 func TestNewDMSCertificateResource(t *testing.T) {
 	resource, ok := newDMSCertificateResource(dmstypes.Certificate{
 		CertificateIdentifier: dmsString("dms-cert"),
@@ -61,6 +117,14 @@ func TestNewDMSEventSubscriptionResource(t *testing.T) {
 		Status:              dmsString("active"),
 	})
 	assertDMSResource(t, resource, ok, "dms-events", dmsResourceName("event-subscription", "dms-events"), dmsEventSubscriptionResourceType)
+
+	resource, ok = newDMSEventSubscriptionResource(dmstypes.EventSubscription{
+		CustSubscriptionId: dmsString("dms-all-events"),
+		SnsTopicArn:        dmsString("arn:aws:sns:us-east-1:123456789012:dms-events"),
+		SourceType:         dmsString("replication-instance"),
+		Status:             dmsString("active"),
+	})
+	assertDMSResource(t, resource, ok, "dms-all-events", dmsResourceName("event-subscription", "dms-all-events"), dmsEventSubscriptionResourceType)
 
 	if _, ok := newDMSEventSubscriptionResource(dmstypes.EventSubscription{
 		EventCategoriesList: []string{"creation"},
@@ -193,6 +257,17 @@ func TestDMSEventSubscriptionImportable(t *testing.T) {
 	if !dmsEventSubscriptionImportable(base) {
 		t.Fatal("active event subscription with supported source type and required fields should be importable")
 	}
+	allCategories := base
+	allCategories.EventCategoriesList = nil
+	if !dmsEventSubscriptionImportable(allCategories) {
+		t.Fatal("active event subscription without event categories should import all categories")
+	}
+	caseVariant := base
+	caseVariant.SourceType = dmsString("REPLICATION-TASK")
+	caseVariant.Status = dmsString("ACTIVE")
+	if !dmsEventSubscriptionImportable(caseVariant) {
+		t.Fatal("event subscription importability should be case-insensitive for status and source type")
+	}
 
 	tests := []struct {
 		name         string
@@ -226,11 +301,6 @@ func TestDMSEventSubscriptionImportable(t *testing.T) {
 			SourceType:          dmsString("replication-instance"),
 			Status:              dmsString("active"),
 		}},
-		{name: "empty event categories", subscription: dmstypes.EventSubscription{
-			SnsTopicArn: dmsString("arn:aws:sns:us-east-1:123456789012:dms-events"),
-			SourceType:  dmsString("replication-instance"),
-			Status:      dmsString("active"),
-		}},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -242,7 +312,7 @@ func TestDMSEventSubscriptionImportable(t *testing.T) {
 }
 
 func TestDMSEventSubscriptionSourceTypeImportable(t *testing.T) {
-	for _, sourceType := range []string{"replication-instance", "replication-task"} {
+	for _, sourceType := range []string{"replication-instance", "replication-task", "REPLICATION-INSTANCE", "RePlIcAtIoN-TaSk"} {
 		if !dmsEventSubscriptionSourceTypeImportable(sourceType) {
 			t.Fatalf("source type %q should be importable", sourceType)
 		}

--- a/providers/aws/dms_test.go
+++ b/providers/aws/dms_test.go
@@ -111,6 +111,7 @@ func TestNewDMSCertificateResource(t *testing.T) {
 func TestNewDMSEventSubscriptionResource(t *testing.T) {
 	resource, ok := newDMSEventSubscriptionResource(dmstypes.EventSubscription{
 		CustSubscriptionId:  dmsString("dms-events"),
+		Enabled:             true,
 		EventCategoriesList: []string{"creation", "failure"},
 		SnsTopicArn:         dmsString("arn:aws:sns:us-east-1:123456789012:dms-events"),
 		SourceType:          dmsString("replication-task"),
@@ -126,9 +127,13 @@ func TestNewDMSEventSubscriptionResource(t *testing.T) {
 	if _, ok := resource.AdditionalFields["event_categories"]; ok {
 		t.Fatal("non-empty event categories should be read from refreshed state")
 	}
+	if _, ok := resource.InstanceState.Attributes["enabled"]; ok {
+		t.Fatal("enabled=true event subscription should use the provider default")
+	}
 
 	resource, ok = newDMSEventSubscriptionResource(dmstypes.EventSubscription{
 		CustSubscriptionId: dmsString("dms-all-events"),
+		Enabled:            true,
 		SnsTopicArn:        dmsString("arn:aws:sns:us-east-1:123456789012:dms-events"),
 		SourceType:         dmsString("replication-instance"),
 		Status:             dmsString("active"),
@@ -144,6 +149,20 @@ func TestNewDMSEventSubscriptionResource(t *testing.T) {
 	if len(emptyCategories) != 0 {
 		t.Fatalf("all-category event_categories length = %d, want 0", len(emptyCategories))
 	}
+
+	resource, ok = newDMSEventSubscriptionResource(dmstypes.EventSubscription{
+		CustSubscriptionId:  dmsString("dms-disabled-events"),
+		Enabled:             false,
+		EventCategoriesList: []string{"creation"},
+		SnsTopicArn:         dmsString("arn:aws:sns:us-east-1:123456789012:dms-events"),
+		SourceType:          dmsString("replication-task"),
+		Status:              dmsString("active"),
+	})
+	assertDMSResource(t, resource, ok, "dms-disabled-events", dmsResourceName("event-subscription", "dms-disabled-events"), dmsEventSubscriptionResourceType)
+	if got := resource.InstanceState.Attributes["enabled"]; got != "false" {
+		t.Fatalf("disabled event subscription enabled = %q, want false", got)
+	}
+	assertDMSAllowEmptyValue(t, resource, "enabled")
 
 	if _, ok := newDMSEventSubscriptionResource(dmstypes.EventSubscription{
 		EventCategoriesList: []string{"creation"},
@@ -431,6 +450,16 @@ func assertDMSResource(t *testing.T, resource terraformutils.Resource, ok bool, 
 	if got := resource.InstanceInfo.Type; got != wantType {
 		t.Fatalf("resource type = %q, want %q", got, wantType)
 	}
+}
+
+func assertDMSAllowEmptyValue(t *testing.T, resource terraformutils.Resource, want string) {
+	t.Helper()
+	for _, value := range resource.AllowEmptyValues {
+		if value == "^"+want+"$" {
+			return
+		}
+	}
+	t.Fatalf("AllowEmptyValues = %v, want anchored %q", resource.AllowEmptyValues, want)
 }
 
 func dmsString(value string) *string {

--- a/providers/aws/dms_test.go
+++ b/providers/aws/dms_test.go
@@ -37,6 +37,59 @@ func TestDMSResourceNamesAvoidTypeCollisions(t *testing.T) {
 	}
 }
 
+func TestNewDMSCertificateResource(t *testing.T) {
+	resource, ok := newDMSCertificateResource(dmstypes.Certificate{
+		CertificateIdentifier: dmsString("dms-cert"),
+		CertificatePem:        dmsString("-----BEGIN CERTIFICATE-----"),
+	})
+	assertDMSResource(t, resource, ok, "dms-cert", dmsResourceName("certificate", "dms-cert"), dmsCertificateResourceType)
+
+	if _, ok := newDMSCertificateResource(dmstypes.Certificate{CertificatePem: dmsString("-----BEGIN CERTIFICATE-----")}); ok {
+		t.Fatal("certificate with empty identifier should be skipped")
+	}
+	if _, ok := newDMSCertificateResource(dmstypes.Certificate{CertificateIdentifier: dmsString("dms-cert")}); ok {
+		t.Fatal("certificate without PEM or wallet material should be skipped")
+	}
+}
+
+func TestNewDMSEventSubscriptionResource(t *testing.T) {
+	resource, ok := newDMSEventSubscriptionResource(dmstypes.EventSubscription{
+		CustSubscriptionId:  dmsString("dms-events"),
+		EventCategoriesList: []string{"creation", "failure"},
+		SnsTopicArn:         dmsString("arn:aws:sns:us-east-1:123456789012:dms-events"),
+		SourceType:          dmsString("replication-task"),
+		Status:              dmsString("active"),
+	})
+	assertDMSResource(t, resource, ok, "dms-events", dmsResourceName("event-subscription", "dms-events"), dmsEventSubscriptionResourceType)
+
+	if _, ok := newDMSEventSubscriptionResource(dmstypes.EventSubscription{
+		EventCategoriesList: []string{"creation"},
+		SnsTopicArn:         dmsString("arn:aws:sns:us-east-1:123456789012:dms-events"),
+		SourceType:          dmsString("replication-task"),
+		Status:              dmsString("active"),
+	}); ok {
+		t.Fatal("event subscription with empty name should be skipped")
+	}
+	if _, ok := newDMSEventSubscriptionResource(dmstypes.EventSubscription{
+		CustSubscriptionId:  dmsString("dms-events"),
+		EventCategoriesList: []string{"creation"},
+		SnsTopicArn:         dmsString("arn:aws:sns:us-east-1:123456789012:dms-events"),
+		SourceType:          dmsString("replication-task"),
+		Status:              dmsString("creating"),
+	}); ok {
+		t.Fatal("creating event subscription should be skipped")
+	}
+	if _, ok := newDMSEventSubscriptionResource(dmstypes.EventSubscription{
+		CustSubscriptionId:  dmsString("dms-events"),
+		EventCategoriesList: []string{"creation"},
+		SnsTopicArn:         dmsString("arn:aws:sns:us-east-1:123456789012:dms-events"),
+		SourceType:          dmsString("security-group"),
+		Status:              dmsString("active"),
+	}); ok {
+		t.Fatal("event subscription with unsupported source type should be skipped")
+	}
+}
+
 func TestNewDMSReplicationInstanceResource(t *testing.T) {
 	resource, ok := newDMSReplicationInstanceResource(dmstypes.ReplicationInstance{
 		ReplicationInstanceIdentifier: dmsString("dms-ri"),
@@ -115,6 +168,89 @@ func TestNewDMSReplicationTaskResource(t *testing.T) {
 		Status:                    dmsString("creating"),
 	}); ok {
 		t.Fatal("creating replication task should be skipped")
+	}
+}
+
+func TestDMSCertificateImportable(t *testing.T) {
+	if !dmsCertificateImportable(dmstypes.Certificate{CertificatePem: dmsString("pem")}) {
+		t.Fatal("certificate with PEM material should be importable")
+	}
+	if !dmsCertificateImportable(dmstypes.Certificate{CertificateWallet: []byte("wallet")}) {
+		t.Fatal("certificate with wallet material should be importable")
+	}
+	if dmsCertificateImportable(dmstypes.Certificate{}) {
+		t.Fatal("certificate without PEM or wallet material should not be importable")
+	}
+}
+
+func TestDMSEventSubscriptionImportable(t *testing.T) {
+	base := dmstypes.EventSubscription{
+		EventCategoriesList: []string{"creation"},
+		SnsTopicArn:         dmsString("arn:aws:sns:us-east-1:123456789012:dms-events"),
+		SourceType:          dmsString("replication-instance"),
+		Status:              dmsString("active"),
+	}
+	if !dmsEventSubscriptionImportable(base) {
+		t.Fatal("active event subscription with supported source type and required fields should be importable")
+	}
+
+	tests := []struct {
+		name         string
+		subscription dmstypes.EventSubscription
+	}{
+		{name: "empty status", subscription: dmstypes.EventSubscription{
+			EventCategoriesList: []string{"creation"},
+			SnsTopicArn:         dmsString("arn:aws:sns:us-east-1:123456789012:dms-events"),
+			SourceType:          dmsString("replication-instance"),
+		}},
+		{name: "creating status", subscription: dmstypes.EventSubscription{
+			EventCategoriesList: []string{"creation"},
+			SnsTopicArn:         dmsString("arn:aws:sns:us-east-1:123456789012:dms-events"),
+			SourceType:          dmsString("replication-instance"),
+			Status:              dmsString("creating"),
+		}},
+		{name: "no permission status", subscription: dmstypes.EventSubscription{
+			EventCategoriesList: []string{"creation"},
+			SnsTopicArn:         dmsString("arn:aws:sns:us-east-1:123456789012:dms-events"),
+			SourceType:          dmsString("replication-instance"),
+			Status:              dmsString("no-permission"),
+		}},
+		{name: "unsupported source type", subscription: dmstypes.EventSubscription{
+			EventCategoriesList: []string{"creation"},
+			SnsTopicArn:         dmsString("arn:aws:sns:us-east-1:123456789012:dms-events"),
+			SourceType:          dmsString("security-group"),
+			Status:              dmsString("active"),
+		}},
+		{name: "empty sns topic arn", subscription: dmstypes.EventSubscription{
+			EventCategoriesList: []string{"creation"},
+			SourceType:          dmsString("replication-instance"),
+			Status:              dmsString("active"),
+		}},
+		{name: "empty event categories", subscription: dmstypes.EventSubscription{
+			SnsTopicArn: dmsString("arn:aws:sns:us-east-1:123456789012:dms-events"),
+			SourceType:  dmsString("replication-instance"),
+			Status:      dmsString("active"),
+		}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if dmsEventSubscriptionImportable(tt.subscription) {
+				t.Fatal("event subscription should not be importable")
+			}
+		})
+	}
+}
+
+func TestDMSEventSubscriptionSourceTypeImportable(t *testing.T) {
+	for _, sourceType := range []string{"replication-instance", "replication-task"} {
+		if !dmsEventSubscriptionSourceTypeImportable(sourceType) {
+			t.Fatalf("source type %q should be importable", sourceType)
+		}
+	}
+	for _, sourceType := range []string{"", "replication-server", "security-group"} {
+		if dmsEventSubscriptionSourceTypeImportable(sourceType) {
+			t.Fatalf("source type %q should not be importable", sourceType)
+		}
 	}
 }
 


### PR DESCRIPTION
## Summary

- add DMS import discovery for `aws_dms_certificate` and `aws_dms_event_subscription`
- seed import IDs from DMS certificate identifiers and event subscription names
- update docs/aws.md for the newly supported DMS resources
- add unit tests for DMS certificate and event subscription helper behavior

## References

- #338

## Validation

```bash
go test ./providers/aws -run 'Test.*DMS|Test.*Dms|Test.*dms'
go test ./providers/aws/... ./terraformutils/...
go run ./tools/aws-gap-inventory \
  -docs docs/aws.md \
  -aws-dir providers/aws \
  -skip-list providers/aws/unsupported_resources.json \
  -format markdown
git diff --check
```

## Notes

Skipped/deferred resources:
- `aws_dms_certificate`: individual certificates are skipped when DMS does not return PEM or wallet material required by Terraform.
- `aws_dms_event_subscription`: individual subscriptions are skipped unless active, backed by a supported source type, and returned with SNS topic ARN plus event categories.
- `aws_dms_replication_config`, `aws_dms_serverless_replication_config`, and `aws_dms_s3_endpoint`: still deferred for separate review.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add import discovery for `aws_dms_certificate` and `aws_dms_event_subscription` with stable IDs. Make optional DMS discovery resilient to NotFound errors.

- **New Features**
  - Discover and import `aws_dms_certificate` (by identifier) and `aws_dms_event_subscription` (by name).
  - Skip certificates without PEM or wallet; skip subscriptions unless active, supported source type, and with an SNS topic ARN.

- **Bug Fixes**
  - Preserve all-category subscriptions by emitting an explicit empty `event_categories`.
  - Preserve disabled subscriptions by explicitly setting `enabled=false`.
  - Treat status and source type case-insensitively during import.
  - Continue discovery on `ResourceNotFoundFault` for optional DMS resources.

<sup>Written for commit 8dc466423ec1b0eae1b31bba88d18d66fdaef743. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for AWS DMS certificate resources and AWS DMS event subscription resources, including optional discovery and generation.

* **Documentation**
  * Updated AWS DMS "Supported services" list to include the new resource types.

* **Tests**
  * Added unit tests covering certificate and event subscription creation, importability rules, and optional-resource loading/error handling.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/chenrui333/terraformer/pull/396)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->