### PR TITLE
aws(logs): add CloudWatch Logs delivery imports

### DIFF
--- a/docs/aws.md
+++ b/docs/aws.md
@@ -353,6 +353,10 @@ For AWS provider gap audits and unsupported-resource skip-list maintenance, see 
 *   `logs`
     * `aws_cloudwatch_log_account_policy`
     * `aws_cloudwatch_log_data_protection_policy`
+    * `aws_cloudwatch_log_delivery`
+    * `aws_cloudwatch_log_delivery_destination`
+    * `aws_cloudwatch_log_delivery_destination_policy`
+    * `aws_cloudwatch_log_delivery_source`
     * `aws_cloudwatch_log_destination`
     * `aws_cloudwatch_log_destination_policy`
     * `aws_cloudwatch_log_group`

--- a/providers/aws/logs.go
+++ b/providers/aws/logs.go
@@ -17,8 +17,12 @@ import (
 var logsAllowEmptyValues = []string{"tags."}
 
 const (
-	logsDestinationPolicyResourceType = "aws_cloudwatch_log_destination_policy"
-	logsIndexPolicyResourceType       = "aws_cloudwatch_log_index_policy"
+	logsDeliveryResourceType                  = "aws_cloudwatch_log_delivery"
+	logsDeliveryDestinationResourceType       = "aws_cloudwatch_log_delivery_destination"
+	logsDeliveryDestinationPolicyResourceType = "aws_cloudwatch_log_delivery_destination_policy"
+	logsDeliverySourceResourceType            = "aws_cloudwatch_log_delivery_source"
+	logsDestinationPolicyResourceType         = "aws_cloudwatch_log_destination_policy"
+	logsIndexPolicyResourceType               = "aws_cloudwatch_log_index_policy"
 )
 
 var logsAccountPolicyTypes = []types.PolicyType{
@@ -93,6 +97,9 @@ func (g *LogsGenerator) InitResources() error {
 		logsOptionalResourceLoader{name: "data protection policies", load: func() error { return g.addDataProtectionPolicies(svc, logGroupNames) }},
 		logsOptionalResourceLoader{name: "destinations", load: func() error { return g.addDestinations(svc) }},
 		logsOptionalResourceLoader{name: "index policies", load: func() error { return g.addIndexPolicies(svc, logGroupNames) }},
+		logsOptionalResourceLoader{name: "delivery sources", load: func() error { return g.addDeliverySources(svc) }},
+		logsOptionalResourceLoader{name: "delivery destinations", load: func() error { return g.addDeliveryDestinations(svc) }},
+		logsOptionalResourceLoader{name: "deliveries", load: func() error { return g.addDeliveries(svc) }},
 		logsOptionalResourceLoader{name: "resource policies", load: func() error { return g.addResourcePolicies(svc) }},
 		logsOptionalResourceLoader{name: "account policies", load: func() error { return g.addAccountPolicies(svc) }},
 		logsOptionalResourceLoader{name: "query definitions", load: func() error { return g.addQueryDefinitions(svc) }},
@@ -251,6 +258,73 @@ func (g *LogsGenerator) addIndexPolicies(svc *cloudwatchlogs.Client, logGroupNam
 			nextToken = output.NextToken
 			if !awsHasMorePages(nextToken) {
 				break
+			}
+		}
+	}
+	return nil
+}
+
+func (g *LogsGenerator) addDeliverySources(svc *cloudwatchlogs.Client) error {
+	p := cloudwatchlogs.NewDescribeDeliverySourcesPaginator(svc, &cloudwatchlogs.DescribeDeliverySourcesInput{})
+	for p.HasMorePages() {
+		page, err := p.NextPage(context.TODO())
+		if err != nil {
+			return err
+		}
+		for _, source := range page.DeliverySources {
+			if resource, ok := newLogsDeliverySourceResource(source); ok {
+				g.Resources = append(g.Resources, resource)
+			}
+		}
+	}
+	return nil
+}
+
+func (g *LogsGenerator) addDeliveryDestinations(svc *cloudwatchlogs.Client) error {
+	p := cloudwatchlogs.NewDescribeDeliveryDestinationsPaginator(svc, &cloudwatchlogs.DescribeDeliveryDestinationsInput{})
+	for p.HasMorePages() {
+		page, err := p.NextPage(context.TODO())
+		if err != nil {
+			return err
+		}
+		for _, destination := range page.DeliveryDestinations {
+			destinationName := StringValue(destination.Name)
+			if resource, ok := newLogsDeliveryDestinationResource(destination); ok {
+				g.Resources = append(g.Resources, resource)
+			}
+			if destinationName == "" {
+				continue
+			}
+			policy, err := svc.GetDeliveryDestinationPolicy(context.TODO(), &cloudwatchlogs.GetDeliveryDestinationPolicyInput{
+				DeliveryDestinationName: &destinationName,
+			})
+			if err != nil {
+				if logsResourceNotFound(err) {
+					continue
+				}
+				return err
+			}
+			if policy == nil || policy.Policy == nil {
+				continue
+			}
+			if resource, ok := newLogsDeliveryDestinationPolicyResource(destinationName, *policy.Policy); ok {
+				g.Resources = append(g.Resources, resource)
+			}
+		}
+	}
+	return nil
+}
+
+func (g *LogsGenerator) addDeliveries(svc *cloudwatchlogs.Client) error {
+	p := cloudwatchlogs.NewDescribeDeliveriesPaginator(svc, &cloudwatchlogs.DescribeDeliveriesInput{})
+	for p.HasMorePages() {
+		page, err := p.NextPage(context.TODO())
+		if err != nil {
+			return err
+		}
+		for _, delivery := range page.Deliveries {
+			if resource, ok := newLogsDeliveryResource(delivery); ok {
+				g.Resources = append(g.Resources, resource)
 			}
 		}
 	}
@@ -445,4 +519,107 @@ func newLogsIndexPolicyResource(logGroupName string, policy types.IndexPolicy) (
 		},
 		logsAllowEmptyValues,
 		map[string]interface{}{}), true
+}
+
+func newLogsDeliverySourceResource(source types.DeliverySource) (terraformutils.Resource, bool) {
+	if !logsDeliverySourceImportable(source) {
+		return terraformutils.Resource{}, false
+	}
+
+	sourceName := StringValue(source.Name)
+	resourceArn := source.ResourceArns[0]
+	return terraformutils.NewResource(
+		sourceName,
+		logsDeliveryResourceName("delivery_source", sourceName),
+		logsDeliverySourceResourceType,
+		"aws",
+		map[string]string{
+			"log_type":     StringValue(source.LogType),
+			"name":         sourceName,
+			"resource_arn": resourceArn,
+		},
+		logsAllowEmptyValues,
+		map[string]interface{}{}), true
+}
+
+func logsDeliverySourceImportable(source types.DeliverySource) bool {
+	if StringValue(source.Name) == "" || StringValue(source.LogType) == "" || len(source.ResourceArns) == 0 || source.ResourceArns[0] == "" {
+		return false
+	}
+	return source.StatusReason != types.DeliverySourceStatusReasonResourceDeleted
+}
+
+func newLogsDeliveryDestinationResource(destination types.DeliveryDestination) (terraformutils.Resource, bool) {
+	destinationName := StringValue(destination.Name)
+	if destinationName == "" {
+		return terraformutils.Resource{}, false
+	}
+
+	return terraformutils.NewResource(
+		destinationName,
+		logsDeliveryResourceName("delivery_destination", destinationName),
+		logsDeliveryDestinationResourceType,
+		"aws",
+		map[string]string{
+			"name": destinationName,
+		},
+		logsAllowEmptyValues,
+		map[string]interface{}{}), true
+}
+
+func newLogsDeliveryDestinationPolicyResource(destinationName string, policy types.Policy) (terraformutils.Resource, bool) {
+	if destinationName == "" || StringValue(policy.DeliveryDestinationPolicy) == "" {
+		return terraformutils.Resource{}, false
+	}
+
+	return terraformutils.NewResource(
+		destinationName,
+		logsDeliveryResourceName("delivery_destination_policy", destinationName),
+		logsDeliveryDestinationPolicyResourceType,
+		"aws",
+		map[string]string{
+			"delivery_destination_name":   destinationName,
+			"delivery_destination_policy": StringValue(policy.DeliveryDestinationPolicy),
+		},
+		logsAllowEmptyValues,
+		map[string]interface{}{}), true
+}
+
+func newLogsDeliveryResource(delivery types.Delivery) (terraformutils.Resource, bool) {
+	deliveryID := StringValue(delivery.Id)
+	deliverySourceName := StringValue(delivery.DeliverySourceName)
+	deliveryDestinationArn := StringValue(delivery.DeliveryDestinationArn)
+	if deliveryID == "" || deliverySourceName == "" || deliveryDestinationArn == "" {
+		return terraformutils.Resource{}, false
+	}
+
+	return terraformutils.NewResource(
+		deliveryID,
+		logsDeliveryResourceName("delivery", deliveryID),
+		logsDeliveryResourceType,
+		"aws",
+		map[string]string{
+			"delivery_destination_arn": deliveryDestinationArn,
+			"delivery_source_name":     deliverySourceName,
+		},
+		logsAllowEmptyValues,
+		map[string]interface{}{}), true
+}
+
+func logsDeliveryResourceName(parts ...string) string {
+	return logsResourceNameWithLengths(parts...)
+}
+
+func logsResourceNameWithLengths(parts ...string) string {
+	var name string
+	for _, part := range parts {
+		if part == "" {
+			continue
+		}
+		if name != "" {
+			name += "_"
+		}
+		name += fmt.Sprintf("%d_%s", len(part), part)
+	}
+	return name
 }

--- a/providers/aws/logs.go
+++ b/providers/aws/logs.go
@@ -302,7 +302,8 @@ func (g *LogsGenerator) addDeliveryDestinations(svc *cloudwatchlogs.Client) erro
 				if logsResourceNotFound(err) {
 					continue
 				}
-				return err
+				log.Printf("skipping CloudWatch Logs delivery destination policy discovery for %s: %v", destinationName, err)
+				continue
 			}
 			if policy == nil || policy.Policy == nil {
 				continue

--- a/providers/aws/logs_test.go
+++ b/providers/aws/logs_test.go
@@ -261,3 +261,274 @@ func TestNewLogsIndexPolicyResource(t *testing.T) {
 		})
 	}
 }
+
+func TestNewLogsDeliverySourceResource(t *testing.T) {
+	sourceName := "api-delivery-source"
+	logType := "ACCESS_LOGS"
+	resourceArn := "arn:aws:apigateway:us-east-1::/restapis/api-id"
+
+	tests := []struct {
+		name   string
+		source types.DeliverySource
+		wantOK bool
+	}{
+		{
+			name: "active delivery source",
+			source: types.DeliverySource{
+				LogType:      &logType,
+				Name:         &sourceName,
+				ResourceArns: []string{resourceArn},
+				Status:       types.DeliverySourceStatusActive,
+			},
+			wantOK: true,
+		},
+		{
+			name: "source without name is skipped",
+			source: types.DeliverySource{
+				LogType:      &logType,
+				ResourceArns: []string{resourceArn},
+			},
+		},
+		{
+			name: "source without log type is skipped",
+			source: types.DeliverySource{
+				Name:         &sourceName,
+				ResourceArns: []string{resourceArn},
+			},
+		},
+		{
+			name: "source without resource ARN is skipped",
+			source: types.DeliverySource{
+				LogType: &logType,
+				Name:    &sourceName,
+			},
+		},
+		{
+			name: "source with deleted backing resource is skipped",
+			source: types.DeliverySource{
+				LogType:      &logType,
+				Name:         &sourceName,
+				ResourceArns: []string{resourceArn},
+				StatusReason: types.DeliverySourceStatusReasonResourceDeleted,
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			resource, ok := newLogsDeliverySourceResource(tt.source)
+			if ok != tt.wantOK {
+				t.Fatalf("newLogsDeliverySourceResource() ok = %t, want %t", ok, tt.wantOK)
+			}
+			if !ok {
+				return
+			}
+			if got := resource.InstanceState.ID; got != sourceName {
+				t.Fatalf("resource ID = %q, want %q", got, sourceName)
+			}
+			if got := resource.InstanceInfo.Type; got != logsDeliverySourceResourceType {
+				t.Fatalf("resource type = %q, want %q", got, logsDeliverySourceResourceType)
+			}
+			if got := resource.InstanceState.Attributes["name"]; got != sourceName {
+				t.Fatalf("name = %q, want %q", got, sourceName)
+			}
+			if got := resource.InstanceState.Attributes["log_type"]; got != logType {
+				t.Fatalf("log_type = %q, want %q", got, logType)
+			}
+			if got := resource.InstanceState.Attributes["resource_arn"]; got != resourceArn {
+				t.Fatalf("resource_arn = %q, want %q", got, resourceArn)
+			}
+		})
+	}
+}
+
+func TestLogsDeliveryResourceNamesPreservePartBoundaries(t *testing.T) {
+	logType := "ACCESS_LOGS"
+	resourceArn := "arn:aws:apigateway:us-east-1::/restapis/api-id"
+	leftName := "a/b"
+	rightName := "a-002F-b"
+
+	left, ok := newLogsDeliverySourceResource(types.DeliverySource{
+		LogType:      &logType,
+		Name:         &leftName,
+		ResourceArns: []string{resourceArn},
+	})
+	if !ok {
+		t.Fatal("newLogsDeliverySourceResource() should create left resource")
+	}
+	right, ok := newLogsDeliverySourceResource(types.DeliverySource{
+		LogType:      &logType,
+		Name:         &rightName,
+		ResourceArns: []string{resourceArn},
+	})
+	if !ok {
+		t.Fatal("newLogsDeliverySourceResource() should create right resource")
+	}
+	if left.ResourceName == right.ResourceName {
+		t.Fatalf("delivery source resource names collide: %q", left.ResourceName)
+	}
+}
+
+func TestNewLogsDeliveryDestinationResource(t *testing.T) {
+	destinationName := "central-delivery-destination"
+
+	tests := []struct {
+		name        string
+		destination types.DeliveryDestination
+		wantOK      bool
+	}{
+		{
+			name: "delivery destination",
+			destination: types.DeliveryDestination{
+				Name: &destinationName,
+			},
+			wantOK: true,
+		},
+		{
+			name: "destination without name is skipped",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			resource, ok := newLogsDeliveryDestinationResource(tt.destination)
+			if ok != tt.wantOK {
+				t.Fatalf("newLogsDeliveryDestinationResource() ok = %t, want %t", ok, tt.wantOK)
+			}
+			if !ok {
+				return
+			}
+			if got := resource.InstanceState.ID; got != destinationName {
+				t.Fatalf("resource ID = %q, want %q", got, destinationName)
+			}
+			if got := resource.InstanceInfo.Type; got != logsDeliveryDestinationResourceType {
+				t.Fatalf("resource type = %q, want %q", got, logsDeliveryDestinationResourceType)
+			}
+			if got := resource.InstanceState.Attributes["name"]; got != destinationName {
+				t.Fatalf("name = %q, want %q", got, destinationName)
+			}
+		})
+	}
+}
+
+func TestNewLogsDeliveryDestinationPolicyResource(t *testing.T) {
+	destinationName := "central-delivery-destination"
+	policyDocument := "{}"
+
+	tests := []struct {
+		name            string
+		destinationName string
+		policy          types.Policy
+		wantOK          bool
+	}{
+		{
+			name:            "delivery destination policy",
+			destinationName: destinationName,
+			policy: types.Policy{
+				DeliveryDestinationPolicy: &policyDocument,
+			},
+			wantOK: true,
+		},
+		{
+			name: "policy without destination name is skipped",
+			policy: types.Policy{
+				DeliveryDestinationPolicy: &policyDocument,
+			},
+		},
+		{
+			name:            "policy without document is skipped",
+			destinationName: destinationName,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			resource, ok := newLogsDeliveryDestinationPolicyResource(tt.destinationName, tt.policy)
+			if ok != tt.wantOK {
+				t.Fatalf("newLogsDeliveryDestinationPolicyResource() ok = %t, want %t", ok, tt.wantOK)
+			}
+			if !ok {
+				return
+			}
+			if got := resource.InstanceState.ID; got != destinationName {
+				t.Fatalf("resource ID = %q, want %q", got, destinationName)
+			}
+			if got := resource.InstanceInfo.Type; got != logsDeliveryDestinationPolicyResourceType {
+				t.Fatalf("resource type = %q, want %q", got, logsDeliveryDestinationPolicyResourceType)
+			}
+			if got := resource.InstanceState.Attributes["delivery_destination_name"]; got != destinationName {
+				t.Fatalf("delivery_destination_name = %q, want %q", got, destinationName)
+			}
+			if got := resource.InstanceState.Attributes["delivery_destination_policy"]; got != policyDocument {
+				t.Fatalf("delivery_destination_policy = %q, want %q", got, policyDocument)
+			}
+		})
+	}
+}
+
+func TestNewLogsDeliveryResource(t *testing.T) {
+	deliveryID := "delivery-1234567890"
+	sourceName := "api-delivery-source"
+	destinationArn := "arn:aws:logs:us-east-1:123456789012:delivery-destination:central"
+
+	tests := []struct {
+		name     string
+		delivery types.Delivery
+		wantOK   bool
+	}{
+		{
+			name: "delivery",
+			delivery: types.Delivery{
+				DeliveryDestinationArn: &destinationArn,
+				DeliverySourceName:     &sourceName,
+				Id:                     &deliveryID,
+			},
+			wantOK: true,
+		},
+		{
+			name: "delivery without ID is skipped",
+			delivery: types.Delivery{
+				DeliveryDestinationArn: &destinationArn,
+				DeliverySourceName:     &sourceName,
+			},
+		},
+		{
+			name: "delivery without source is skipped",
+			delivery: types.Delivery{
+				DeliveryDestinationArn: &destinationArn,
+				Id:                     &deliveryID,
+			},
+		},
+		{
+			name: "delivery without destination is skipped",
+			delivery: types.Delivery{
+				DeliverySourceName: &sourceName,
+				Id:                 &deliveryID,
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			resource, ok := newLogsDeliveryResource(tt.delivery)
+			if ok != tt.wantOK {
+				t.Fatalf("newLogsDeliveryResource() ok = %t, want %t", ok, tt.wantOK)
+			}
+			if !ok {
+				return
+			}
+			if got := resource.InstanceState.ID; got != deliveryID {
+				t.Fatalf("resource ID = %q, want %q", got, deliveryID)
+			}
+			if got := resource.InstanceInfo.Type; got != logsDeliveryResourceType {
+				t.Fatalf("resource type = %q, want %q", got, logsDeliveryResourceType)
+			}
+			if got := resource.InstanceState.Attributes["delivery_source_name"]; got != sourceName {
+				t.Fatalf("delivery_source_name = %q, want %q", got, sourceName)
+			}
+			if got := resource.InstanceState.Attributes["delivery_destination_arn"]; got != destinationArn {
+				t.Fatalf("delivery_destination_arn = %q, want %q", got, destinationArn)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

- add CloudWatch Logs delivery import discovery for deliveries, delivery sources, delivery destinations, and delivery destination policies
- seed import IDs as delivery ID, delivery source name, delivery destination name, and delivery destination name
- update docs/aws.md for supported delivery resources
- add unit tests for delivery resource helper behavior

## References

- #338

## Validation

```bash
go run ./tools/aws-gap-inventory \
  -docs docs/aws.md \
  -aws-dir providers/aws \
  -skip-list providers/aws/unsupported_resources.json \
  -format markdown

go test ./providers/aws -run 'Test.*Logs|Test.*CloudWatch|Test.*cloudwatch|Test.*logs'
go test ./providers/aws/... ./terraformutils/... ./tools/aws-gap-inventory/...
```

## Notes

Skipped/deferred resources:
- Delivery sources with missing `name`, `log_type`, `resource_arn`, or `RESOURCE_DELETED` backing resource state are skipped during discovery.
- `aws_cloudwatch_log_anomaly_detector`, `aws_cloudwatch_log_stream`, and `aws_cloudwatch_log_transformer` remain deferred for separate focused PRs.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add discovery and import support for CloudWatch Logs deliveries, sources, destinations, and destination policies with stable IDs. Keeps destination policy lookup resilient so discovery continues even when some destinations fail.

- **New Features**
  - Import `aws_cloudwatch_log_delivery`, `aws_cloudwatch_log_delivery_source`, `aws_cloudwatch_log_delivery_destination`, and `aws_cloudwatch_log_delivery_destination_policy`.
  - Seed IDs from delivery ID and source/destination names; use collision-safe names. Skip sources missing name/log_type/resource_arn or with `RESOURCE_DELETED`. Docs and tests updated.

- **Bug Fixes**
  - Harden destination policy discovery by ignoring not-found and per-destination API errors.

<sup>Written for commit 1187a183776df1651a653d2ca8d2bb8c5da62d6f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Extended CloudWatch Logs discovery to support delivery sources, delivery destinations, and delivery resources for more complete import coverage.

* **Documentation**
  * Added documentation listing supported CloudWatch Logs delivery-related resource types.

* **Tests**
  * Added comprehensive test coverage for new delivery resource construction, validation, and naming behavior.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/chenrui333/terraformer/pull/397)

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/chenrui333/terraformer/pull/397)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->