### PR TITLE
aws(sesv2): add SESv2 resource imports

### DIFF
--- a/docs/aws.md
+++ b/docs/aws.md
@@ -476,6 +476,10 @@ For AWS provider gap audits and unsupported-resource skip-list maintenance, see 
     * `aws_ses_receipt_rule`
     * `aws_ses_receipt_rule_set`
     * `aws_ses_template`
+*   `sesv2`
+    * `aws_sesv2_configuration_set`
+    * `aws_sesv2_dedicated_ip_pool`
+    * `aws_sesv2_email_identity`
 *   `sfn`
     * `aws_sfn_activity`
     * `aws_sfn_state_machine`

--- a/go.mod
+++ b/go.mod
@@ -407,6 +407,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/directconnect v1.38.17
 	github.com/aws/aws-sdk-go-v2/service/pipes v1.23.22
 	github.com/aws/aws-sdk-go-v2/service/scheduler v1.17.24
+	github.com/aws/aws-sdk-go-v2/service/sesv2 v1.60.4
 	github.com/gofrs/uuid/v3 v3.1.2
 	github.com/golang-jwt/jwt/v4 v4.5.2
 	github.com/hashicorp/go-azure-sdk/sdk v0.20260429.1195329

--- a/go.sum
+++ b/go.sum
@@ -351,6 +351,8 @@ github.com/aws/aws-sdk-go-v2/service/servicecatalog v1.39.15 h1:ZCxvNcAKhyoOtNcB
 github.com/aws/aws-sdk-go-v2/service/servicecatalog v1.39.15/go.mod h1:Ava9lSQtC5dJqB/H+usuyndF17h2o4YWEVF1MYxGss0=
 github.com/aws/aws-sdk-go-v2/service/ses v1.34.24 h1:ZPCoU087iv2IWJKNQyN+MYOqZAM9lEVevS9MHWGG4wI=
 github.com/aws/aws-sdk-go-v2/service/ses v1.34.24/go.mod h1:4T8OWyQ9nkdUrcqHHJkyibP5TfcWDTe4kWL40tiCOcs=
+github.com/aws/aws-sdk-go-v2/service/sesv2 v1.60.4 h1:X/PtmuX/EwPivJ9lHCf3Auo8AktdNc4a9ury4zmGPC4=
+github.com/aws/aws-sdk-go-v2/service/sesv2 v1.60.4/go.mod h1:l5cTwZSX9kzxDHz9IpgZC0XIJ/cc43JL6hZzCd0iTwI=
 github.com/aws/aws-sdk-go-v2/service/sfn v1.40.12 h1:jAnv9iYjIfFchpTYQ77jOix/yd5TkjLqk70g+qQ4js8=
 github.com/aws/aws-sdk-go-v2/service/sfn v1.40.12/go.mod h1:4FYhQ/fQeVDlW53MUOevhxGhJ9RYOYV8HSwyVmFCer0=
 github.com/aws/aws-sdk-go-v2/service/signin v1.0.11 h1:TdJ+HdzOBhU8+iVAOGUTU63VXopcumCOF1paFulHWZc=

--- a/providers/aws/aws_provider.go
+++ b/providers/aws/aws_provider.go
@@ -339,6 +339,7 @@ func (p *AWSProvider) GetSupportedService() map[string]terraformutils.ServiceGen
 		"securityhub":       &AwsFacade{service: &SecurityhubGenerator{}},
 		"servicecatalog":    &AwsFacade{service: &ServiceCatalogGenerator{}},
 		"ses":               &AwsFacade{service: &SesGenerator{}},
+		"sesv2":             &AwsFacade{service: &SesV2Generator{}},
 		"sfn":               &AwsFacade{service: &SfnGenerator{}},
 		"sg":                &AwsFacade{service: &SecurityGenerator{}},
 		"sqs":               &AwsFacade{service: &SqsGenerator{}},

--- a/providers/aws/sesv2.go
+++ b/providers/aws/sesv2.go
@@ -1,0 +1,173 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package aws
+
+import (
+	"context"
+	"strconv"
+	"strings"
+
+	"github.com/aws/aws-sdk-go-v2/service/sesv2"
+	sesv2types "github.com/aws/aws-sdk-go-v2/service/sesv2/types"
+	"github.com/chenrui333/terraformer/terraformutils"
+)
+
+const (
+	sesv2ConfigurationSetResourceType = "aws_sesv2_configuration_set"
+	sesv2DedicatedIPPoolResourceType  = "aws_sesv2_dedicated_ip_pool"
+	sesv2EmailIdentityResourceType    = "aws_sesv2_email_identity"
+)
+
+var sesv2AllowEmptyValues = []string{"tags."}
+
+type SesV2Generator struct {
+	AWSService
+}
+
+func (g *SesV2Generator) InitResources() error {
+	config, e := g.generateConfig()
+	if e != nil {
+		return e
+	}
+	svc := sesv2.NewFromConfig(config)
+
+	if err := g.loadConfigurationSets(svc); err != nil {
+		return err
+	}
+	if err := g.loadDedicatedIPPools(svc); err != nil {
+		return err
+	}
+	if err := g.loadEmailIdentities(svc); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (g *SesV2Generator) loadConfigurationSets(svc *sesv2.Client) error {
+	p := sesv2.NewListConfigurationSetsPaginator(svc, &sesv2.ListConfigurationSetsInput{})
+	for p.HasMorePages() {
+		page, err := p.NextPage(context.TODO())
+		if err != nil {
+			return err
+		}
+		for _, configurationSetName := range page.ConfigurationSets {
+			if resource, ok := newSESV2ConfigurationSetResource(configurationSetName); ok {
+				g.Resources = append(g.Resources, resource)
+			}
+		}
+	}
+	return nil
+}
+
+func (g *SesV2Generator) loadDedicatedIPPools(svc *sesv2.Client) error {
+	p := sesv2.NewListDedicatedIpPoolsPaginator(svc, &sesv2.ListDedicatedIpPoolsInput{})
+	for p.HasMorePages() {
+		page, err := p.NextPage(context.TODO())
+		if err != nil {
+			return err
+		}
+		for _, poolName := range page.DedicatedIpPools {
+			if resource, ok := newSESV2DedicatedIPPoolResource(poolName); ok {
+				g.Resources = append(g.Resources, resource)
+			}
+		}
+	}
+	return nil
+}
+
+func (g *SesV2Generator) loadEmailIdentities(svc *sesv2.Client) error {
+	p := sesv2.NewListEmailIdentitiesPaginator(svc, &sesv2.ListEmailIdentitiesInput{})
+	for p.HasMorePages() {
+		page, err := p.NextPage(context.TODO())
+		if err != nil {
+			return err
+		}
+		for _, identity := range page.EmailIdentities {
+			if resource, ok := newSESV2EmailIdentityResource(identity); ok {
+				g.Resources = append(g.Resources, resource)
+			}
+		}
+	}
+	return nil
+}
+
+func newSESV2ConfigurationSetResource(configurationSetName string) (terraformutils.Resource, bool) {
+	if configurationSetName == "" {
+		return terraformutils.Resource{}, false
+	}
+	return terraformutils.NewResource(
+		sesv2ConfigurationSetImportID(configurationSetName),
+		sesv2ResourceName("configuration_set", configurationSetName),
+		sesv2ConfigurationSetResourceType,
+		"aws",
+		map[string]string{
+			"configuration_set_name": configurationSetName,
+		},
+		sesv2AllowEmptyValues,
+		map[string]interface{}{},
+	), true
+}
+
+func newSESV2DedicatedIPPoolResource(poolName string) (terraformutils.Resource, bool) {
+	if poolName == "" {
+		return terraformutils.Resource{}, false
+	}
+	return terraformutils.NewResource(
+		sesv2DedicatedIPPoolImportID(poolName),
+		sesv2ResourceName("dedicated_ip_pool", poolName),
+		sesv2DedicatedIPPoolResourceType,
+		"aws",
+		map[string]string{
+			"pool_name": poolName,
+		},
+		sesv2AllowEmptyValues,
+		map[string]interface{}{},
+	), true
+}
+
+func newSESV2EmailIdentityResource(identity sesv2types.IdentityInfo) (terraformutils.Resource, bool) {
+	identityName := StringValue(identity.IdentityName)
+	if identityName == "" {
+		return terraformutils.Resource{}, false
+	}
+	return terraformutils.NewResource(
+		sesv2EmailIdentityImportID(identityName),
+		sesv2ResourceName("email_identity", identityName),
+		sesv2EmailIdentityResourceType,
+		"aws",
+		map[string]string{
+			"email_identity": identityName,
+		},
+		sesv2AllowEmptyValues,
+		map[string]interface{}{},
+	), true
+}
+
+func sesv2ConfigurationSetImportID(configurationSetName string) string {
+	return configurationSetName
+}
+
+func sesv2DedicatedIPPoolImportID(poolName string) string {
+	return poolName
+}
+
+func sesv2EmailIdentityImportID(identityName string) string {
+	return identityName
+}
+
+func sesv2ResourceName(parts ...string) string {
+	var name strings.Builder
+	for _, part := range parts {
+		if part == "" {
+			continue
+		}
+		if name.Len() > 0 {
+			name.WriteString("_")
+		}
+		name.WriteString(strconv.Itoa(len(part)))
+		name.WriteString("_")
+		name.WriteString(part)
+	}
+	return name.String()
+}

--- a/providers/aws/sesv2.go
+++ b/providers/aws/sesv2.go
@@ -4,6 +4,7 @@ package aws
 
 import (
 	"context"
+	"errors"
 	"strconv"
 	"strings"
 
@@ -84,7 +85,20 @@ func (g *SesV2Generator) loadEmailIdentities(svc *sesv2.Client) error {
 			return err
 		}
 		for _, identity := range page.EmailIdentities {
-			if resource, ok := newSESV2EmailIdentityResource(identity); ok {
+			identityName := StringValue(identity.IdentityName)
+			if identityName == "" {
+				continue
+			}
+			output, err := svc.GetEmailIdentity(context.TODO(), &sesv2.GetEmailIdentityInput{
+				EmailIdentity: &identityName,
+			})
+			if err != nil {
+				if sesv2NotFound(err) {
+					continue
+				}
+				return err
+			}
+			if resource, ok := newSESV2EmailIdentityResource(identityName, output); ok {
 				g.Resources = append(g.Resources, resource)
 			}
 		}
@@ -126,9 +140,8 @@ func newSESV2DedicatedIPPoolResource(poolName string) (terraformutils.Resource, 
 	), true
 }
 
-func newSESV2EmailIdentityResource(identity sesv2types.IdentityInfo) (terraformutils.Resource, bool) {
-	identityName := StringValue(identity.IdentityName)
-	if identityName == "" {
+func newSESV2EmailIdentityResource(identityName string, output *sesv2.GetEmailIdentityOutput) (terraformutils.Resource, bool) {
+	if identityName == "" || !sesv2EmailIdentityImportable(output) {
 		return terraformutils.Resource{}, false
 	}
 	return terraformutils.NewResource(
@@ -142,6 +155,20 @@ func newSESV2EmailIdentityResource(identity sesv2types.IdentityInfo) (terraformu
 		sesv2AllowEmptyValues,
 		map[string]interface{}{},
 	), true
+}
+
+func sesv2EmailIdentityImportable(output *sesv2.GetEmailIdentityOutput) bool {
+	if output == nil || output.DkimAttributes == nil {
+		return true
+	}
+	// BYODKIM private keys are sensitive and are not returned by SESv2, so importing
+	// external-signing identities would generate Terraform that can reset DKIM mode.
+	return output.DkimAttributes.SigningAttributesOrigin != sesv2types.DkimSigningAttributesOriginExternal
+}
+
+func sesv2NotFound(err error) bool {
+	var notFound *sesv2types.NotFoundException
+	return errors.As(err, &notFound)
 }
 
 func sesv2ConfigurationSetImportID(configurationSetName string) string {

--- a/providers/aws/sesv2_test.go
+++ b/providers/aws/sesv2_test.go
@@ -1,0 +1,122 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package aws
+
+import (
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	sesv2types "github.com/aws/aws-sdk-go-v2/service/sesv2/types"
+	"github.com/chenrui333/terraformer/terraformutils"
+)
+
+func TestSESV2ImportIDs(t *testing.T) {
+	tests := []struct {
+		name string
+		got  string
+		want string
+	}{
+		{name: "configuration set", got: sesv2ConfigurationSetImportID("config-set"), want: "config-set"},
+		{name: "dedicated IP pool", got: sesv2DedicatedIPPoolImportID("pool-a"), want: "pool-a"},
+		{name: "email identity", got: sesv2EmailIdentityImportID("sender@example.com"), want: "sender@example.com"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.got != tt.want {
+				t.Fatalf("import ID = %q, want %q", tt.got, tt.want)
+			}
+		})
+	}
+}
+
+func TestNewSESV2ConfigurationSetResource(t *testing.T) {
+	resource, ok := newSESV2ConfigurationSetResource("config-set")
+	if !ok {
+		t.Fatal("newSESV2ConfigurationSetResource() ok = false, want true")
+	}
+	assertSESV2Resource(t, resource, sesv2ConfigurationSetResourceType, "config-set", "configuration_set_name", "config-set")
+
+	if _, ok := newSESV2ConfigurationSetResource(""); ok {
+		t.Fatal("newSESV2ConfigurationSetResource() ok = true for empty configuration set name, want false")
+	}
+}
+
+func TestNewSESV2DedicatedIPPoolResource(t *testing.T) {
+	resource, ok := newSESV2DedicatedIPPoolResource("pool-a")
+	if !ok {
+		t.Fatal("newSESV2DedicatedIPPoolResource() ok = false, want true")
+	}
+	assertSESV2Resource(t, resource, sesv2DedicatedIPPoolResourceType, "pool-a", "pool_name", "pool-a")
+
+	if _, ok := newSESV2DedicatedIPPoolResource(""); ok {
+		t.Fatal("newSESV2DedicatedIPPoolResource() ok = true for empty pool name, want false")
+	}
+}
+
+func TestNewSESV2EmailIdentityResource(t *testing.T) {
+	resource, ok := newSESV2EmailIdentityResource(sesv2types.IdentityInfo{
+		IdentityName: aws.String("sender@example.com"),
+	})
+	if !ok {
+		t.Fatal("newSESV2EmailIdentityResource() ok = false, want true")
+	}
+	assertSESV2Resource(t, resource, sesv2EmailIdentityResourceType, "sender@example.com", "email_identity", "sender@example.com")
+
+	if _, ok := newSESV2EmailIdentityResource(sesv2types.IdentityInfo{}); ok {
+		t.Fatal("newSESV2EmailIdentityResource() ok = true for empty identity name, want false")
+	}
+}
+
+func TestSESV2ResourceNameAvoidsSanitizedCollisions(t *testing.T) {
+	tests := []struct {
+		name   string
+		first  []string
+		second []string
+	}{
+		{name: "separator boundary", first: []string{"email_identity", "a_b", "c"}, second: []string{"email_identity", "a", "b_c"}},
+		{name: "at sign encoding", first: []string{"email_identity", "a@example.com"}, second: []string{"email_identity", "a-0040-example.com"}},
+		{name: "slash encoding", first: []string{"configuration_set", "a/b"}, second: []string{"configuration_set", "a-002F-b"}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			first := terraformutils.TfSanitize(sesv2ResourceName(tt.first...))
+			second := terraformutils.TfSanitize(sesv2ResourceName(tt.second...))
+			if first == second {
+				t.Fatalf("sesv2ResourceName() generated duplicate sanitized names %q", first)
+			}
+		})
+	}
+}
+
+func assertSESV2Resource(t *testing.T, resource terraformutils.Resource, resourceType, resourceID, attributeName, attributeValue string) {
+	t.Helper()
+
+	if resource.InstanceInfo.Type != resourceType {
+		t.Fatalf("resource type = %q, want %q", resource.InstanceInfo.Type, resourceType)
+	}
+	if resource.InstanceState.ID != resourceID {
+		t.Fatalf("resource ID = %q, want %q", resource.InstanceState.ID, resourceID)
+	}
+	if got := resource.InstanceState.Attributes[attributeName]; got != attributeValue {
+		t.Fatalf("attribute %q = %q, want %q", attributeName, got, attributeValue)
+	}
+	wantName := terraformutils.TfSanitize(sesv2ResourceName(stringsForSESV2ResourceName(resourceType, attributeValue)...))
+	if resource.ResourceName != wantName {
+		t.Fatalf("resource name = %q, want %q", resource.ResourceName, wantName)
+	}
+}
+
+func stringsForSESV2ResourceName(resourceType, name string) []string {
+	switch resourceType {
+	case sesv2ConfigurationSetResourceType:
+		return []string{"configuration_set", name}
+	case sesv2DedicatedIPPoolResourceType:
+		return []string{"dedicated_ip_pool", name}
+	case sesv2EmailIdentityResourceType:
+		return []string{"email_identity", name}
+	default:
+		return []string{name}
+	}
+}

--- a/providers/aws/sesv2_test.go
+++ b/providers/aws/sesv2_test.go
@@ -3,9 +3,10 @@
 package aws
 
 import (
+	"errors"
 	"testing"
 
-	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/sesv2"
 	sesv2types "github.com/aws/aws-sdk-go-v2/service/sesv2/types"
 	"github.com/chenrui333/terraformer/terraformutils"
 )
@@ -55,16 +56,63 @@ func TestNewSESV2DedicatedIPPoolResource(t *testing.T) {
 }
 
 func TestNewSESV2EmailIdentityResource(t *testing.T) {
-	resource, ok := newSESV2EmailIdentityResource(sesv2types.IdentityInfo{
-		IdentityName: aws.String("sender@example.com"),
-	})
+	resource, ok := newSESV2EmailIdentityResource("sender@example.com", &sesv2.GetEmailIdentityOutput{})
 	if !ok {
 		t.Fatal("newSESV2EmailIdentityResource() ok = false, want true")
 	}
 	assertSESV2Resource(t, resource, sesv2EmailIdentityResourceType, "sender@example.com", "email_identity", "sender@example.com")
 
-	if _, ok := newSESV2EmailIdentityResource(sesv2types.IdentityInfo{}); ok {
+	if _, ok := newSESV2EmailIdentityResource("", &sesv2.GetEmailIdentityOutput{}); ok {
 		t.Fatal("newSESV2EmailIdentityResource() ok = true for empty identity name, want false")
+	}
+
+	if _, ok := newSESV2EmailIdentityResource("example.com", &sesv2.GetEmailIdentityOutput{
+		DkimAttributes: &sesv2types.DkimAttributes{
+			SigningAttributesOrigin: sesv2types.DkimSigningAttributesOriginExternal,
+		},
+	}); ok {
+		t.Fatal("newSESV2EmailIdentityResource() ok = true for BYODKIM identity, want false")
+	}
+}
+
+func TestSESV2EmailIdentityImportable(t *testing.T) {
+	tests := []struct {
+		name   string
+		output *sesv2.GetEmailIdentityOutput
+		want   bool
+	}{
+		{name: "nil output", output: nil, want: true},
+		{name: "no DKIM attributes", output: &sesv2.GetEmailIdentityOutput{}, want: true},
+		{name: "easy DKIM", output: &sesv2.GetEmailIdentityOutput{
+			DkimAttributes: &sesv2types.DkimAttributes{
+				SigningAttributesOrigin: sesv2types.DkimSigningAttributesOriginAwsSes,
+			},
+		}, want: true},
+		{name: "BYODKIM", output: &sesv2.GetEmailIdentityOutput{
+			DkimAttributes: &sesv2types.DkimAttributes{
+				SigningAttributesOrigin: sesv2types.DkimSigningAttributesOriginExternal,
+			},
+		}, want: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := sesv2EmailIdentityImportable(tt.output); got != tt.want {
+				t.Fatalf("sesv2EmailIdentityImportable() = %t, want %t", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestSESV2NotFound(t *testing.T) {
+	if !sesv2NotFound(&sesv2types.NotFoundException{}) {
+		t.Fatal("sesv2NotFound() = false for NotFoundException, want true")
+	}
+	if sesv2NotFound(errors.New("boom")) {
+		t.Fatal("sesv2NotFound() = true for generic error, want false")
+	}
+	if sesv2NotFound(nil) {
+		t.Fatal("sesv2NotFound() = true for nil error, want false")
 	}
 }
 


### PR DESCRIPTION
## Summary

- add SESv2 import discovery for email identities, configuration sets, and dedicated IP pools
- register the `sesv2` AWS service
- seed import IDs as each resource name/identity
- update docs/aws.md for supported SESv2 resources
- add unit tests for SESv2 resource helper behavior

## References

- #338

## Validation

```bash
go test ./providers/aws -run 'Test.*SES|Test.*Ses|Test.*ses'
go test ./providers/aws/... ./terraformutils/...
go run ./tools/aws-gap-inventory \
  -docs docs/aws.md \
  -aws-dir providers/aws \
  -skip-list providers/aws/unsupported_resources.json \
  -format markdown
git diff --check
```

## Notes

Skipped/deferred resources:
- `aws_sesv2_email_identity` domains using BYODKIM (`SigningAttributesOrigin=EXTERNAL`): skipped because SESv2 does not return the sensitive private key Terraform needs to preserve that mode.
- `aws_sesv2_configuration_set_event_destination`: child resource with composite ID; defer to a separate SESv2 child-resource PR.
- `aws_sesv2_email_identity_feedback_attributes`: identity attribute resource; defer with other identity children.
- `aws_sesv2_email_identity_mail_from_attributes`: identity attribute resource; defer with other identity children.
- `aws_sesv2_dedicated_ip_assignment`: dedicated-IP child assignment; defer to a dedicated IP follow-up.
- `aws_sesv2_email_identity_policy`: identity policy child resource; defer to a policy follow-up.
- `aws_sesv2_contact_list`: contact-list resource; defer to a separate customer-engagement SESv2 PR.
- `aws_sesv2_account_suppression_attributes`, `aws_sesv2_account_vdm_attributes`: account-wide settings; defer to singleton account-settings follow-up.
- `aws_sesv2_tenant`, `aws_sesv2_tenant_resource_association`: newer tenant resources; defer to tenant-specific follow-up.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds SESv2 import support for configuration sets, dedicated IP pools, and email identities, and registers `sesv2` with updated AWS docs. Skips BYODKIM (external DKIM) identities to avoid unsafe imports.

- **New Features**
  - Register `sesv2` and update `docs/aws.md`.
  - Import discovery for `aws_sesv2_configuration_set`, `aws_sesv2_dedicated_ip_pool`, and `aws_sesv2_email_identity`, seeding IDs by name.
  - Add unit tests for SESv2 resource helpers.
  - Add `github.com/aws/aws-sdk-go-v2/service/sesv2 v1.60.4`.

- **Bug Fixes**
  - Skip BYODKIM (external DKIM) email identities to prevent resetting DKIM mode during import.

<sup>Written for commit fc579c4e4f98f952b109ecc2665784ac73013eb9. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for AWS SESv2 (Simple Email Service v2) resources, enabling management of configuration sets, dedicated IP pools, and email identities through Terraform.

* **Documentation**
  * Updated AWS supported services documentation to include SESv2 resource types.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/chenrui333/terraformer/pull/398)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
