### PR TITLE
aws(ssoadmin): add account assignment imports

### DIFF
--- a/docs/aws.md
+++ b/docs/aws.md
@@ -503,6 +503,7 @@ For AWS provider gap audits and unsupported-resource skip-list maintenance, see 
     * `aws_sns_topic`
     * `aws_sns_topic_subscription`
 *   `ssoadmin`
+    * `aws_ssoadmin_account_assignment`
     * `aws_ssoadmin_customer_managed_policy_attachment`
     * `aws_ssoadmin_managed_policy_attachment`
     * `aws_ssoadmin_permission_set`

--- a/providers/aws/ssoadmin.go
+++ b/providers/aws/ssoadmin.go
@@ -19,6 +19,7 @@ var ssoAdminAllowEmptyValues = []string{"tags."}
 
 const (
 	ssoAdminPermissionSetResourceType                     = "aws_ssoadmin_permission_set"
+	ssoAdminAccountAssignmentResourceType                 = "aws_ssoadmin_account_assignment"
 	ssoAdminManagedPolicyAttachmentResourceType           = "aws_ssoadmin_managed_policy_attachment"
 	ssoAdminCustomerManagedPolicyAttachmentResourceType   = "aws_ssoadmin_customer_managed_policy_attachment"
 	ssoAdminPermissionSetInlinePolicyResourceType         = "aws_ssoadmin_permission_set_inline_policy"
@@ -133,7 +134,10 @@ func (g *SSOAdminGenerator) loadPermissionSetChildren(svc *ssoadmin.Client, inst
 	if err := g.loadPermissionSetInlinePolicy(svc, instanceARN, permissionSetARN); err != nil {
 		return err
 	}
-	return g.loadPermissionsBoundaryAttachment(svc, instanceARN, permissionSetARN)
+	if err := g.loadPermissionsBoundaryAttachment(svc, instanceARN, permissionSetARN); err != nil {
+		return err
+	}
+	return g.loadAccountAssignments(svc, instanceARN, permissionSetARN)
 }
 
 func describeSSOAdminPermissionSet(svc *ssoadmin.Client, instanceARN, permissionSetARN string) (*ssotypes.PermissionSet, error) {
@@ -230,6 +234,53 @@ func (g *SSOAdminGenerator) loadPermissionsBoundaryAttachment(svc *ssoadmin.Clie
 	return nil
 }
 
+func (g *SSOAdminGenerator) loadAccountAssignments(svc *ssoadmin.Client, instanceARN, permissionSetARN string) error {
+	p := ssoadmin.NewListAccountsForProvisionedPermissionSetPaginator(svc, &ssoadmin.ListAccountsForProvisionedPermissionSetInput{
+		InstanceArn:      aws.String(instanceARN),
+		PermissionSetArn: aws.String(permissionSetARN),
+	})
+	for p.HasMorePages() {
+		page, err := p.NextPage(context.TODO())
+		if err != nil {
+			return err
+		}
+		for _, accountID := range page.AccountIds {
+			if accountID == "" {
+				continue
+			}
+			if err := g.loadAccountAssignmentsForAccount(svc, instanceARN, permissionSetARN, accountID); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+func (g *SSOAdminGenerator) loadAccountAssignmentsForAccount(svc *ssoadmin.Client, instanceARN, permissionSetARN, accountID string) error {
+	p := ssoadmin.NewListAccountAssignmentsPaginator(svc, &ssoadmin.ListAccountAssignmentsInput{
+		AccountId:        aws.String(accountID),
+		InstanceArn:      aws.String(instanceARN),
+		PermissionSetArn: aws.String(permissionSetARN),
+	})
+	for p.HasMorePages() {
+		page, err := p.NextPage(context.TODO())
+		if err != nil {
+			return err
+		}
+		for _, assignment := range page.AccountAssignments {
+			targetID := StringValue(assignment.AccountId)
+			if targetID == "" {
+				targetID = accountID
+			}
+			if !ssoAdminAccountAssignmentConfigured(targetID, assignment) {
+				continue
+			}
+			g.Resources = append(g.Resources, newSSOAdminAccountAssignmentResource(instanceARN, permissionSetARN, targetID, string(ssotypes.TargetTypeAwsAccount), assignment))
+		}
+	}
+	return nil
+}
+
 func newSSOAdminPermissionSetResource(instanceARN string, permissionSet *ssotypes.PermissionSet) terraformutils.Resource {
 	permissionSetARN := StringValue(permissionSet.PermissionSetArn)
 	attributes := map[string]string{
@@ -255,6 +306,28 @@ func newSSOAdminPermissionSetResource(instanceARN string, permissionSet *ssotype
 		ssoAdminPermissionSetResourceID(permissionSetARN, instanceARN),
 		ssoAdminResourceName(StringValue(permissionSet.Name), permissionSetARN, instanceARN),
 		ssoAdminPermissionSetResourceType,
+		"aws",
+		attributes,
+		ssoAdminAllowEmptyValues,
+		map[string]interface{}{},
+	)
+}
+
+func newSSOAdminAccountAssignmentResource(instanceARN, permissionSetARN, targetID, targetType string, assignment ssotypes.AccountAssignment) terraformutils.Resource {
+	principalID := StringValue(assignment.PrincipalId)
+	principalType := string(assignment.PrincipalType)
+	attributes := map[string]string{
+		"instance_arn":       instanceARN,
+		"permission_set_arn": permissionSetARN,
+		"principal_id":       principalID,
+		"principal_type":     principalType,
+		"target_id":          targetID,
+		"target_type":        targetType,
+	}
+	return terraformutils.NewResource(
+		ssoAdminAccountAssignmentResourceID(principalID, principalType, targetID, targetType, permissionSetARN, instanceARN),
+		ssoAdminAccountAssignmentResourceName(instanceARN, permissionSetARN, principalID, principalType, targetID, targetType),
+		ssoAdminAccountAssignmentResourceType,
 		"aws",
 		attributes,
 		ssoAdminAllowEmptyValues,
@@ -348,12 +421,20 @@ func ssoAdminPermissionSetResourceID(permissionSetARN, instanceARN string) strin
 	return strings.Join([]string{permissionSetARN, instanceARN}, ssoAdminResourceIDSeparator)
 }
 
+func ssoAdminAccountAssignmentResourceID(principalID, principalType, targetID, targetType, permissionSetARN, instanceARN string) string {
+	return strings.Join([]string{principalID, principalType, targetID, targetType, permissionSetARN, instanceARN}, ssoAdminResourceIDSeparator)
+}
+
 func ssoAdminManagedPolicyAttachmentResourceID(managedPolicyARN, permissionSetARN, instanceARN string) string {
 	return strings.Join([]string{managedPolicyARN, permissionSetARN, instanceARN}, ssoAdminResourceIDSeparator)
 }
 
 func ssoAdminCustomerManagedPolicyAttachmentResourceID(policyName, policyPath, permissionSetARN, instanceARN string) string {
 	return strings.Join([]string{policyName, policyPath, permissionSetARN, instanceARN}, ssoAdminResourceIDSeparator)
+}
+
+func ssoAdminAccountAssignmentResourceName(instanceARN, permissionSetARN, principalID, principalType, targetID, targetType string) string {
+	return ssoAdminResourceName(permissionSetARN, targetID, targetType, principalType, principalID, instanceARN)
 }
 
 func ssoAdminResourceName(parts ...string) string {
@@ -377,6 +458,10 @@ func ssoAdminPermissionsBoundaryConfigured(boundary *ssotypes.PermissionsBoundar
 		return false
 	}
 	return StringValue(boundary.CustomerManagedPolicyReference.Name) != ""
+}
+
+func ssoAdminAccountAssignmentConfigured(targetID string, assignment ssotypes.AccountAssignment) bool {
+	return targetID != "" && StringValue(assignment.PrincipalId) != "" && string(assignment.PrincipalType) != ""
 }
 
 func ssoAdminCustomerManagedPolicyPath(path *string) string {

--- a/providers/aws/ssoadmin.go
+++ b/providers/aws/ssoadmin.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"sort"
 	"strings"
 	"time"
 
@@ -125,7 +126,11 @@ func (g *SSOAdminGenerator) loadPermissionSets(svc *ssoadmin.Client, instanceARN
 }
 
 func (g *SSOAdminGenerator) loadPermissionSetChildren(svc *ssoadmin.Client, instanceARN, permissionSetARN string) error {
-	if err := g.loadManagedPolicyAttachments(svc, instanceARN, permissionSetARN); err != nil {
+	accountAssignmentRefs, err := g.loadAccountAssignments(svc, instanceARN, permissionSetARN)
+	if err != nil {
+		return err
+	}
+	if err := g.loadManagedPolicyAttachments(svc, instanceARN, permissionSetARN, accountAssignmentRefs); err != nil {
 		return err
 	}
 	if err := g.loadCustomerManagedPolicyAttachments(svc, instanceARN, permissionSetARN); err != nil {
@@ -137,7 +142,7 @@ func (g *SSOAdminGenerator) loadPermissionSetChildren(svc *ssoadmin.Client, inst
 	if err := g.loadPermissionsBoundaryAttachment(svc, instanceARN, permissionSetARN); err != nil {
 		return err
 	}
-	return g.loadAccountAssignments(svc, instanceARN, permissionSetARN)
+	return nil
 }
 
 func describeSSOAdminPermissionSet(svc *ssoadmin.Client, instanceARN, permissionSetARN string) (*ssotypes.PermissionSet, error) {
@@ -154,7 +159,7 @@ func describeSSOAdminPermissionSet(svc *ssoadmin.Client, instanceARN, permission
 	return output.PermissionSet, nil
 }
 
-func (g *SSOAdminGenerator) loadManagedPolicyAttachments(svc *ssoadmin.Client, instanceARN, permissionSetARN string) error {
+func (g *SSOAdminGenerator) loadManagedPolicyAttachments(svc *ssoadmin.Client, instanceARN, permissionSetARN string, accountAssignmentRefs []string) error {
 	p := ssoadmin.NewListManagedPoliciesInPermissionSetPaginator(svc, &ssoadmin.ListManagedPoliciesInPermissionSetInput{
 		InstanceArn:      aws.String(instanceARN),
 		PermissionSetArn: aws.String(permissionSetARN),
@@ -168,7 +173,7 @@ func (g *SSOAdminGenerator) loadManagedPolicyAttachments(svc *ssoadmin.Client, i
 			if StringValue(policy.Arn) == "" {
 				continue
 			}
-			g.Resources = append(g.Resources, newSSOAdminManagedPolicyAttachmentResource(instanceARN, permissionSetARN, policy))
+			g.Resources = append(g.Resources, newSSOAdminManagedPolicyAttachmentResource(instanceARN, permissionSetARN, policy, accountAssignmentRefs))
 		}
 	}
 	return nil
@@ -234,38 +239,43 @@ func (g *SSOAdminGenerator) loadPermissionsBoundaryAttachment(svc *ssoadmin.Clie
 	return nil
 }
 
-func (g *SSOAdminGenerator) loadAccountAssignments(svc *ssoadmin.Client, instanceARN, permissionSetARN string) error {
+func (g *SSOAdminGenerator) loadAccountAssignments(svc *ssoadmin.Client, instanceARN, permissionSetARN string) ([]string, error) {
 	p := ssoadmin.NewListAccountsForProvisionedPermissionSetPaginator(svc, &ssoadmin.ListAccountsForProvisionedPermissionSetInput{
 		InstanceArn:      aws.String(instanceARN),
 		PermissionSetArn: aws.String(permissionSetARN),
 	})
+	var accountAssignmentRefs []string
 	for p.HasMorePages() {
 		page, err := p.NextPage(context.TODO())
 		if err != nil {
-			return err
+			return nil, err
 		}
 		for _, accountID := range page.AccountIds {
 			if accountID == "" {
 				continue
 			}
-			if err := g.loadAccountAssignmentsForAccount(svc, instanceARN, permissionSetARN, accountID); err != nil {
-				return err
+			refs, err := g.loadAccountAssignmentsForAccount(svc, instanceARN, permissionSetARN, accountID)
+			if err != nil {
+				return nil, err
 			}
+			accountAssignmentRefs = append(accountAssignmentRefs, refs...)
 		}
 	}
-	return nil
+	sort.Strings(accountAssignmentRefs)
+	return accountAssignmentRefs, nil
 }
 
-func (g *SSOAdminGenerator) loadAccountAssignmentsForAccount(svc *ssoadmin.Client, instanceARN, permissionSetARN, accountID string) error {
+func (g *SSOAdminGenerator) loadAccountAssignmentsForAccount(svc *ssoadmin.Client, instanceARN, permissionSetARN, accountID string) ([]string, error) {
 	p := ssoadmin.NewListAccountAssignmentsPaginator(svc, &ssoadmin.ListAccountAssignmentsInput{
 		AccountId:        aws.String(accountID),
 		InstanceArn:      aws.String(instanceARN),
 		PermissionSetArn: aws.String(permissionSetARN),
 	})
+	var accountAssignmentRefs []string
 	for p.HasMorePages() {
 		page, err := p.NextPage(context.TODO())
 		if err != nil {
-			return err
+			return nil, err
 		}
 		for _, assignment := range page.AccountAssignments {
 			targetID := StringValue(assignment.AccountId)
@@ -275,10 +285,12 @@ func (g *SSOAdminGenerator) loadAccountAssignmentsForAccount(svc *ssoadmin.Clien
 			if !ssoAdminAccountAssignmentConfigured(targetID, assignment) {
 				continue
 			}
-			g.Resources = append(g.Resources, newSSOAdminAccountAssignmentResource(instanceARN, permissionSetARN, targetID, string(ssotypes.TargetTypeAwsAccount), assignment))
+			resource := newSSOAdminAccountAssignmentResource(instanceARN, permissionSetARN, targetID, string(ssotypes.TargetTypeAwsAccount), assignment)
+			g.Resources = append(g.Resources, resource)
+			accountAssignmentRefs = append(accountAssignmentRefs, resource.InstanceInfo.Id)
 		}
 	}
-	return nil
+	return accountAssignmentRefs, nil
 }
 
 func newSSOAdminPermissionSetResource(instanceARN string, permissionSet *ssotypes.PermissionSet) terraformutils.Resource {
@@ -335,7 +347,7 @@ func newSSOAdminAccountAssignmentResource(instanceARN, permissionSetARN, targetI
 	)
 }
 
-func newSSOAdminManagedPolicyAttachmentResource(instanceARN, permissionSetARN string, policy ssotypes.AttachedManagedPolicy) terraformutils.Resource {
+func newSSOAdminManagedPolicyAttachmentResource(instanceARN, permissionSetARN string, policy ssotypes.AttachedManagedPolicy, accountAssignmentRefs []string) terraformutils.Resource {
 	policyARN := StringValue(policy.Arn)
 	attributes := map[string]string{
 		"instance_arn":       instanceARN,
@@ -345,6 +357,7 @@ func newSSOAdminManagedPolicyAttachmentResource(instanceARN, permissionSetARN st
 	if policyName := StringValue(policy.Name); policyName != "" {
 		attributes["managed_policy_name"] = policyName
 	}
+	additionalFields := ssoAdminAdditionalFieldsWithDependsOn(accountAssignmentRefs)
 	return terraformutils.NewResource(
 		ssoAdminManagedPolicyAttachmentResourceID(policyARN, permissionSetARN, instanceARN),
 		ssoAdminResourceName(permissionSetARN, policyARN, instanceARN),
@@ -352,7 +365,7 @@ func newSSOAdminManagedPolicyAttachmentResource(instanceARN, permissionSetARN st
 		"aws",
 		attributes,
 		ssoAdminAllowEmptyValues,
-		map[string]interface{}{},
+		additionalFields,
 	)
 }
 
@@ -462,6 +475,15 @@ func ssoAdminPermissionsBoundaryConfigured(boundary *ssotypes.PermissionsBoundar
 
 func ssoAdminAccountAssignmentConfigured(targetID string, assignment ssotypes.AccountAssignment) bool {
 	return targetID != "" && StringValue(assignment.PrincipalId) != "" && string(assignment.PrincipalType) != ""
+}
+
+func ssoAdminAdditionalFieldsWithDependsOn(dependsOn []string) map[string]interface{} {
+	if len(dependsOn) == 0 {
+		return map[string]interface{}{}
+	}
+	refs := append([]string(nil), dependsOn...)
+	sort.Strings(refs)
+	return map[string]interface{}{"depends_on": refs}
 }
 
 func ssoAdminCustomerManagedPolicyPath(path *string) string {

--- a/providers/aws/ssoadmin.go
+++ b/providers/aws/ssoadmin.go
@@ -277,7 +277,7 @@ func (g *SSOAdminGenerator) loadAccountAssignmentsForAccount(svc *ssoadmin.Clien
 			if !ssoAdminAccountAssignmentConfigured(targetID, assignment) {
 				continue
 			}
-			g.Resources = append(g.Resources, newSSOAdminAccountAssignmentResource(instanceARN, permissionSetARN, targetID, string(ssotypes.TargetTypeAwsAccount), assignment))
+			g.Resources = append(g.Resources, newSSOAdminAccountAssignmentResource(instanceARN, permissionSetARN, targetID, assignment))
 		}
 	}
 	return nil
@@ -315,9 +315,10 @@ func newSSOAdminPermissionSetResource(instanceARN string, permissionSet *ssotype
 	)
 }
 
-func newSSOAdminAccountAssignmentResource(instanceARN, permissionSetARN, targetID, targetType string, assignment ssotypes.AccountAssignment) terraformutils.Resource {
+func newSSOAdminAccountAssignmentResource(instanceARN, permissionSetARN, targetID string, assignment ssotypes.AccountAssignment) terraformutils.Resource {
 	principalID := StringValue(assignment.PrincipalId)
 	principalType := string(assignment.PrincipalType)
+	targetType := string(ssotypes.TargetTypeAwsAccount)
 	attributes := map[string]string{
 		"instance_arn":       instanceARN,
 		"permission_set_arn": permissionSetARN,

--- a/providers/aws/ssoadmin.go
+++ b/providers/aws/ssoadmin.go
@@ -62,6 +62,7 @@ func (g *SSOAdminGenerator) InitResources() error {
 }
 
 func (g *SSOAdminGenerator) PostConvertHook() error {
+	g.updateManagedPolicyAttachmentDependencies()
 	for i, resource := range g.Resources {
 		if resource.InstanceInfo.Type != ssoAdminPermissionSetInlinePolicyResourceType {
 			continue
@@ -126,11 +127,7 @@ func (g *SSOAdminGenerator) loadPermissionSets(svc *ssoadmin.Client, instanceARN
 }
 
 func (g *SSOAdminGenerator) loadPermissionSetChildren(svc *ssoadmin.Client, instanceARN, permissionSetARN string) error {
-	accountAssignmentRefs, err := g.loadAccountAssignments(svc, instanceARN, permissionSetARN)
-	if err != nil {
-		return err
-	}
-	if err := g.loadManagedPolicyAttachments(svc, instanceARN, permissionSetARN, accountAssignmentRefs); err != nil {
+	if err := g.loadManagedPolicyAttachments(svc, instanceARN, permissionSetARN); err != nil {
 		return err
 	}
 	if err := g.loadCustomerManagedPolicyAttachments(svc, instanceARN, permissionSetARN); err != nil {
@@ -142,7 +139,7 @@ func (g *SSOAdminGenerator) loadPermissionSetChildren(svc *ssoadmin.Client, inst
 	if err := g.loadPermissionsBoundaryAttachment(svc, instanceARN, permissionSetARN); err != nil {
 		return err
 	}
-	return nil
+	return g.loadAccountAssignments(svc, instanceARN, permissionSetARN)
 }
 
 func describeSSOAdminPermissionSet(svc *ssoadmin.Client, instanceARN, permissionSetARN string) (*ssotypes.PermissionSet, error) {
@@ -159,7 +156,7 @@ func describeSSOAdminPermissionSet(svc *ssoadmin.Client, instanceARN, permission
 	return output.PermissionSet, nil
 }
 
-func (g *SSOAdminGenerator) loadManagedPolicyAttachments(svc *ssoadmin.Client, instanceARN, permissionSetARN string, accountAssignmentRefs []string) error {
+func (g *SSOAdminGenerator) loadManagedPolicyAttachments(svc *ssoadmin.Client, instanceARN, permissionSetARN string) error {
 	p := ssoadmin.NewListManagedPoliciesInPermissionSetPaginator(svc, &ssoadmin.ListManagedPoliciesInPermissionSetInput{
 		InstanceArn:      aws.String(instanceARN),
 		PermissionSetArn: aws.String(permissionSetARN),
@@ -173,7 +170,7 @@ func (g *SSOAdminGenerator) loadManagedPolicyAttachments(svc *ssoadmin.Client, i
 			if StringValue(policy.Arn) == "" {
 				continue
 			}
-			g.Resources = append(g.Resources, newSSOAdminManagedPolicyAttachmentResource(instanceARN, permissionSetARN, policy, accountAssignmentRefs))
+			g.Resources = append(g.Resources, newSSOAdminManagedPolicyAttachmentResource(instanceARN, permissionSetARN, policy))
 		}
 	}
 	return nil
@@ -239,43 +236,38 @@ func (g *SSOAdminGenerator) loadPermissionsBoundaryAttachment(svc *ssoadmin.Clie
 	return nil
 }
 
-func (g *SSOAdminGenerator) loadAccountAssignments(svc *ssoadmin.Client, instanceARN, permissionSetARN string) ([]string, error) {
+func (g *SSOAdminGenerator) loadAccountAssignments(svc *ssoadmin.Client, instanceARN, permissionSetARN string) error {
 	p := ssoadmin.NewListAccountsForProvisionedPermissionSetPaginator(svc, &ssoadmin.ListAccountsForProvisionedPermissionSetInput{
 		InstanceArn:      aws.String(instanceARN),
 		PermissionSetArn: aws.String(permissionSetARN),
 	})
-	var accountAssignmentRefs []string
 	for p.HasMorePages() {
 		page, err := p.NextPage(context.TODO())
 		if err != nil {
-			return nil, err
+			return err
 		}
 		for _, accountID := range page.AccountIds {
 			if accountID == "" {
 				continue
 			}
-			refs, err := g.loadAccountAssignmentsForAccount(svc, instanceARN, permissionSetARN, accountID)
-			if err != nil {
-				return nil, err
+			if err := g.loadAccountAssignmentsForAccount(svc, instanceARN, permissionSetARN, accountID); err != nil {
+				return err
 			}
-			accountAssignmentRefs = append(accountAssignmentRefs, refs...)
 		}
 	}
-	sort.Strings(accountAssignmentRefs)
-	return accountAssignmentRefs, nil
+	return nil
 }
 
-func (g *SSOAdminGenerator) loadAccountAssignmentsForAccount(svc *ssoadmin.Client, instanceARN, permissionSetARN, accountID string) ([]string, error) {
+func (g *SSOAdminGenerator) loadAccountAssignmentsForAccount(svc *ssoadmin.Client, instanceARN, permissionSetARN, accountID string) error {
 	p := ssoadmin.NewListAccountAssignmentsPaginator(svc, &ssoadmin.ListAccountAssignmentsInput{
 		AccountId:        aws.String(accountID),
 		InstanceArn:      aws.String(instanceARN),
 		PermissionSetArn: aws.String(permissionSetARN),
 	})
-	var accountAssignmentRefs []string
 	for p.HasMorePages() {
 		page, err := p.NextPage(context.TODO())
 		if err != nil {
-			return nil, err
+			return err
 		}
 		for _, assignment := range page.AccountAssignments {
 			targetID := StringValue(assignment.AccountId)
@@ -285,12 +277,10 @@ func (g *SSOAdminGenerator) loadAccountAssignmentsForAccount(svc *ssoadmin.Clien
 			if !ssoAdminAccountAssignmentConfigured(targetID, assignment) {
 				continue
 			}
-			resource := newSSOAdminAccountAssignmentResource(instanceARN, permissionSetARN, targetID, string(ssotypes.TargetTypeAwsAccount), assignment)
-			g.Resources = append(g.Resources, resource)
-			accountAssignmentRefs = append(accountAssignmentRefs, resource.InstanceInfo.Id)
+			g.Resources = append(g.Resources, newSSOAdminAccountAssignmentResource(instanceARN, permissionSetARN, targetID, string(ssotypes.TargetTypeAwsAccount), assignment))
 		}
 	}
-	return accountAssignmentRefs, nil
+	return nil
 }
 
 func newSSOAdminPermissionSetResource(instanceARN string, permissionSet *ssotypes.PermissionSet) terraformutils.Resource {
@@ -347,7 +337,7 @@ func newSSOAdminAccountAssignmentResource(instanceARN, permissionSetARN, targetI
 	)
 }
 
-func newSSOAdminManagedPolicyAttachmentResource(instanceARN, permissionSetARN string, policy ssotypes.AttachedManagedPolicy, accountAssignmentRefs []string) terraformutils.Resource {
+func newSSOAdminManagedPolicyAttachmentResource(instanceARN, permissionSetARN string, policy ssotypes.AttachedManagedPolicy) terraformutils.Resource {
 	policyARN := StringValue(policy.Arn)
 	attributes := map[string]string{
 		"instance_arn":       instanceARN,
@@ -357,7 +347,6 @@ func newSSOAdminManagedPolicyAttachmentResource(instanceARN, permissionSetARN st
 	if policyName := StringValue(policy.Name); policyName != "" {
 		attributes["managed_policy_name"] = policyName
 	}
-	additionalFields := ssoAdminAdditionalFieldsWithDependsOn(accountAssignmentRefs)
 	return terraformutils.NewResource(
 		ssoAdminManagedPolicyAttachmentResourceID(policyARN, permissionSetARN, instanceARN),
 		ssoAdminResourceName(permissionSetARN, policyARN, instanceARN),
@@ -365,7 +354,7 @@ func newSSOAdminManagedPolicyAttachmentResource(instanceARN, permissionSetARN st
 		"aws",
 		attributes,
 		ssoAdminAllowEmptyValues,
-		additionalFields,
+		map[string]interface{}{},
 	)
 }
 
@@ -460,6 +449,87 @@ func ssoAdminResourceName(parts ...string) string {
 	return strings.Join(nonEmptyParts, ssoAdminResourceNameSeparator)
 }
 
+func (g *SSOAdminGenerator) updateManagedPolicyAttachmentDependencies() {
+	accountAssignmentRefsByPermissionSet := ssoAdminAccountAssignmentRefsByPermissionSet(g.Resources)
+	for i := range g.Resources {
+		if ssoAdminResourceType(g.Resources[i]) != ssoAdminManagedPolicyAttachmentResourceType {
+			continue
+		}
+		permissionSetARN := ssoAdminResourceAttribute(g.Resources[i], "permission_set_arn")
+		ssoAdminSetDependsOn(&g.Resources[i], accountAssignmentRefsByPermissionSet[permissionSetARN])
+	}
+}
+
+func ssoAdminAccountAssignmentRefsByPermissionSet(resources []terraformutils.Resource) map[string][]string {
+	refsByPermissionSet := map[string]map[string]struct{}{}
+	for _, resource := range resources {
+		resourceRef := ssoAdminResourceRef(resource)
+		if ssoAdminResourceType(resource) != ssoAdminAccountAssignmentResourceType || resourceRef == "" {
+			continue
+		}
+		permissionSetARN := ssoAdminResourceAttribute(resource, "permission_set_arn")
+		if permissionSetARN == "" {
+			continue
+		}
+		if refsByPermissionSet[permissionSetARN] == nil {
+			refsByPermissionSet[permissionSetARN] = map[string]struct{}{}
+		}
+		refsByPermissionSet[permissionSetARN][resourceRef] = struct{}{}
+	}
+
+	result := map[string][]string{}
+	for permissionSetARN, refs := range refsByPermissionSet {
+		for ref := range refs {
+			result[permissionSetARN] = append(result[permissionSetARN], ref)
+		}
+		sort.Strings(result[permissionSetARN])
+	}
+	return result
+}
+
+func ssoAdminResourceType(resource terraformutils.Resource) string {
+	if resource.InstanceInfo == nil {
+		return ""
+	}
+	return resource.InstanceInfo.Type
+}
+
+func ssoAdminResourceRef(resource terraformutils.Resource) string {
+	if resource.InstanceInfo == nil {
+		return ""
+	}
+	return resource.InstanceInfo.Id
+}
+
+func ssoAdminResourceAttribute(resource terraformutils.Resource, key string) string {
+	if value, ok := resource.Item[key].(string); ok && value != "" {
+		return value
+	}
+	if resource.InstanceState == nil {
+		return ""
+	}
+	return resource.InstanceState.Attributes[key]
+}
+
+func ssoAdminSetDependsOn(resource *terraformutils.Resource, dependsOn []string) {
+	if len(dependsOn) == 0 {
+		delete(resource.AdditionalFields, "depends_on")
+		if resource.Item != nil {
+			delete(resource.Item, "depends_on")
+		}
+		return
+	}
+	refs := append([]string(nil), dependsOn...)
+	sort.Strings(refs)
+	if resource.AdditionalFields == nil {
+		resource.AdditionalFields = map[string]interface{}{}
+	}
+	resource.AdditionalFields["depends_on"] = refs
+	if resource.Item != nil {
+		resource.Item["depends_on"] = refs
+	}
+}
+
 func ssoAdminPermissionsBoundaryConfigured(boundary *ssotypes.PermissionsBoundary) bool {
 	if boundary == nil {
 		return false
@@ -475,15 +545,6 @@ func ssoAdminPermissionsBoundaryConfigured(boundary *ssotypes.PermissionsBoundar
 
 func ssoAdminAccountAssignmentConfigured(targetID string, assignment ssotypes.AccountAssignment) bool {
 	return targetID != "" && StringValue(assignment.PrincipalId) != "" && string(assignment.PrincipalType) != ""
-}
-
-func ssoAdminAdditionalFieldsWithDependsOn(dependsOn []string) map[string]interface{} {
-	if len(dependsOn) == 0 {
-		return map[string]interface{}{}
-	}
-	refs := append([]string(nil), dependsOn...)
-	sort.Strings(refs)
-	return map[string]interface{}{"depends_on": refs}
 }
 
 func ssoAdminCustomerManagedPolicyPath(path *string) string {

--- a/providers/aws/ssoadmin_test.go
+++ b/providers/aws/ssoadmin_test.go
@@ -14,6 +14,8 @@ const (
 	testSSOAdminInstanceARN      = "arn:aws:sso:::instance/ssoins-1234567890abcdef"
 	testSSOAdminPermissionSetARN = "arn:aws:sso:::permissionSet/ssoins-1234567890abcdef/ps-1234567890abcdef"
 	testSSOAdminPolicyARN        = "arn:aws:iam::aws:policy/ReadOnlyAccess"
+	testSSOAdminAccountID        = "123456789012"
+	testSSOAdminPrincipalID      = "1234567890-11111111-2222-3333-4444-555555555555"
 )
 
 func TestSSOAdminResourceIDs(t *testing.T) {
@@ -37,6 +39,18 @@ func TestSSOAdminResourceIDs(t *testing.T) {
 			got:  ssoAdminCustomerManagedPolicyAttachmentResourceID("Boundary", "/service/", testSSOAdminPermissionSetARN, testSSOAdminInstanceARN),
 			want: "Boundary,/service/," + testSSOAdminPermissionSetARN + "," + testSSOAdminInstanceARN,
 		},
+		{
+			name: "account assignment",
+			got: ssoAdminAccountAssignmentResourceID(
+				testSSOAdminPrincipalID,
+				string(ssotypes.PrincipalTypeUser),
+				testSSOAdminAccountID,
+				string(ssotypes.TargetTypeAwsAccount),
+				testSSOAdminPermissionSetARN,
+				testSSOAdminInstanceARN,
+			),
+			want: testSSOAdminPrincipalID + ",USER," + testSSOAdminAccountID + ",AWS_ACCOUNT," + testSSOAdminPermissionSetARN + "," + testSSOAdminInstanceARN,
+		},
 	}
 
 	for _, tt := range tests {
@@ -45,6 +59,41 @@ func TestSSOAdminResourceIDs(t *testing.T) {
 				t.Fatalf("resource ID = %q, want %q", tt.got, tt.want)
 			}
 		})
+	}
+}
+
+func TestSSOAdminAccountAssignmentResource(t *testing.T) {
+	resource := newSSOAdminAccountAssignmentResource(
+		testSSOAdminInstanceARN,
+		testSSOAdminPermissionSetARN,
+		testSSOAdminAccountID,
+		string(ssotypes.TargetTypeAwsAccount),
+		ssotypes.AccountAssignment{
+			AccountId:        aws.String(testSSOAdminAccountID),
+			PermissionSetArn: aws.String(testSSOAdminPermissionSetARN),
+			PrincipalId:      aws.String(testSSOAdminPrincipalID),
+			PrincipalType:    ssotypes.PrincipalTypeUser,
+		},
+	)
+
+	if got, want := resource.InstanceState.ID, testSSOAdminPrincipalID+",USER,"+testSSOAdminAccountID+",AWS_ACCOUNT,"+testSSOAdminPermissionSetARN+","+testSSOAdminInstanceARN; got != want {
+		t.Fatalf("resource ID = %q, want %q", got, want)
+	}
+	if got, want := resource.InstanceInfo.Type, ssoAdminAccountAssignmentResourceType; got != want {
+		t.Fatalf("resource type = %q, want %q", got, want)
+	}
+	attributes := resource.InstanceState.Attributes
+	for key, want := range map[string]string{
+		"instance_arn":       testSSOAdminInstanceARN,
+		"permission_set_arn": testSSOAdminPermissionSetARN,
+		"principal_id":       testSSOAdminPrincipalID,
+		"principal_type":     "USER",
+		"target_id":          testSSOAdminAccountID,
+		"target_type":        "AWS_ACCOUNT",
+	} {
+		if got := attributes[key]; got != want {
+			t.Fatalf("%s = %q, want %q", key, got, want)
+		}
 	}
 }
 
@@ -288,6 +337,73 @@ func TestSSOAdminResourceNamesDoNotCollapseJoinedParts(t *testing.T) {
 	right := newSSOAdminManagedPolicyAttachmentResource("instance", "a", ssotypes.AttachedManagedPolicy{Arn: aws.String("b_c")})
 	if left.ResourceName == right.ResourceName {
 		t.Fatalf("managed policy attachment resource names collide: %q", left.ResourceName)
+	}
+
+	left = newSSOAdminAccountAssignmentResource(
+		"instance",
+		"permission",
+		"a_b",
+		string(ssotypes.TargetTypeAwsAccount),
+		ssotypes.AccountAssignment{PrincipalId: aws.String("c"), PrincipalType: ssotypes.PrincipalTypeGroup},
+	)
+	right = newSSOAdminAccountAssignmentResource(
+		"instance",
+		"permission",
+		"a",
+		string(ssotypes.TargetTypeAwsAccount),
+		ssotypes.AccountAssignment{PrincipalId: aws.String("b_c"), PrincipalType: ssotypes.PrincipalTypeGroup},
+	)
+	if left.ResourceName == right.ResourceName {
+		t.Fatalf("account assignment resource names collide: %q", left.ResourceName)
+	}
+}
+
+func TestSSOAdminAccountAssignmentConfigured(t *testing.T) {
+	tests := []struct {
+		name       string
+		targetID   string
+		assignment ssotypes.AccountAssignment
+		want       bool
+	}{
+		{
+			name:     "configured",
+			targetID: testSSOAdminAccountID,
+			assignment: ssotypes.AccountAssignment{
+				PrincipalId:   aws.String(testSSOAdminPrincipalID),
+				PrincipalType: ssotypes.PrincipalTypeUser,
+			},
+			want: true,
+		},
+		{
+			name:     "missing target ID",
+			targetID: "",
+			assignment: ssotypes.AccountAssignment{
+				PrincipalId:   aws.String(testSSOAdminPrincipalID),
+				PrincipalType: ssotypes.PrincipalTypeUser,
+			},
+		},
+		{
+			name:     "missing principal ID",
+			targetID: testSSOAdminAccountID,
+			assignment: ssotypes.AccountAssignment{
+				PrincipalType: ssotypes.PrincipalTypeUser,
+			},
+		},
+		{
+			name:     "missing principal type",
+			targetID: testSSOAdminAccountID,
+			assignment: ssotypes.AccountAssignment{
+				PrincipalId: aws.String(testSSOAdminPrincipalID),
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := ssoAdminAccountAssignmentConfigured(tt.targetID, tt.assignment); got != tt.want {
+				t.Fatalf("ssoAdminAccountAssignmentConfigured() = %t, want %t", got, tt.want)
+			}
+		})
 	}
 }
 

--- a/providers/aws/ssoadmin_test.go
+++ b/providers/aws/ssoadmin_test.go
@@ -68,7 +68,6 @@ func TestSSOAdminAccountAssignmentResource(t *testing.T) {
 		testSSOAdminInstanceARN,
 		testSSOAdminPermissionSetARN,
 		testSSOAdminAccountID,
-		string(ssotypes.TargetTypeAwsAccount),
 		ssotypes.AccountAssignment{
 			AccountId:        aws.String(testSSOAdminAccountID),
 			PermissionSetArn: aws.String(testSSOAdminPermissionSetARN),
@@ -170,7 +169,6 @@ func TestSSOAdminPostConvertHookAddsManagedPolicyAttachmentDependsOnFilteredAssi
 		testSSOAdminInstanceARN,
 		testSSOAdminPermissionSetARN,
 		testSSOAdminAccountID,
-		string(ssotypes.TargetTypeAwsAccount),
 		ssotypes.AccountAssignment{
 			AccountId:        aws.String(testSSOAdminAccountID),
 			PermissionSetArn: aws.String(testSSOAdminPermissionSetARN),
@@ -182,7 +180,6 @@ func TestSSOAdminPostConvertHookAddsManagedPolicyAttachmentDependsOnFilteredAssi
 		testSSOAdminInstanceARN,
 		testSSOAdminPermissionSetARN+"-other",
 		testSSOAdminAccountID,
-		string(ssotypes.TargetTypeAwsAccount),
 		ssotypes.AccountAssignment{
 			AccountId:        aws.String(testSSOAdminAccountID),
 			PermissionSetArn: aws.String(testSSOAdminPermissionSetARN + "-other"),
@@ -432,14 +429,12 @@ func TestSSOAdminResourceNamesDoNotCollapseJoinedParts(t *testing.T) {
 		"instance",
 		"permission",
 		"a_b",
-		string(ssotypes.TargetTypeAwsAccount),
 		ssotypes.AccountAssignment{PrincipalId: aws.String("c"), PrincipalType: ssotypes.PrincipalTypeGroup},
 	)
 	right = newSSOAdminAccountAssignmentResource(
 		"instance",
 		"permission",
 		"a",
-		string(ssotypes.TargetTypeAwsAccount),
 		ssotypes.AccountAssignment{PrincipalId: aws.String("b_c"), PrincipalType: ssotypes.PrincipalTypeGroup},
 	)
 	if left.ResourceName == right.ResourceName {

--- a/providers/aws/ssoadmin_test.go
+++ b/providers/aws/ssoadmin_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	ssotypes "github.com/aws/aws-sdk-go-v2/service/ssoadmin/types"
+	"github.com/chenrui333/terraformer/terraformutils"
 )
 
 const (
@@ -134,7 +135,7 @@ func TestSSOAdminManagedPolicyAttachmentResource(t *testing.T) {
 	resource := newSSOAdminManagedPolicyAttachmentResource(testSSOAdminInstanceARN, testSSOAdminPermissionSetARN, ssotypes.AttachedManagedPolicy{
 		Arn:  aws.String(testSSOAdminPolicyARN),
 		Name: aws.String("ReadOnlyAccess"),
-	}, nil)
+	})
 
 	if got, want := resource.InstanceState.ID, testSSOAdminPolicyARN+","+testSSOAdminPermissionSetARN+","+testSSOAdminInstanceARN; got != want {
 		t.Fatalf("resource ID = %q, want %q", got, want)
@@ -158,25 +159,49 @@ func TestSSOAdminManagedPolicyAttachmentResource(t *testing.T) {
 	}
 }
 
-func TestSSOAdminManagedPolicyAttachmentDependsOnAccountAssignments(t *testing.T) {
-	resource := newSSOAdminManagedPolicyAttachmentResource(
+func TestSSOAdminPostConvertHookAddsManagedPolicyAttachmentDependsOnFilteredAssignments(t *testing.T) {
+	managedPolicyAttachment := newSSOAdminManagedPolicyAttachmentResource(
 		testSSOAdminInstanceARN,
 		testSSOAdminPermissionSetARN,
 		ssotypes.AttachedManagedPolicy{Arn: aws.String(testSSOAdminPolicyARN)},
-		[]string{
-			"aws_ssoadmin_account_assignment.tfer--z",
-			"aws_ssoadmin_account_assignment.tfer--a",
+	)
+	managedPolicyAttachment.Item = map[string]interface{}{"permission_set_arn": testSSOAdminPermissionSetARN}
+	matchingAssignment := newSSOAdminAccountAssignmentResource(
+		testSSOAdminInstanceARN,
+		testSSOAdminPermissionSetARN,
+		testSSOAdminAccountID,
+		string(ssotypes.TargetTypeAwsAccount),
+		ssotypes.AccountAssignment{
+			AccountId:        aws.String(testSSOAdminAccountID),
+			PermissionSetArn: aws.String(testSSOAdminPermissionSetARN),
+			PrincipalId:      aws.String(testSSOAdminPrincipalID),
+			PrincipalType:    ssotypes.PrincipalTypeUser,
 		},
 	)
+	otherAssignment := newSSOAdminAccountAssignmentResource(
+		testSSOAdminInstanceARN,
+		testSSOAdminPermissionSetARN+"-other",
+		testSSOAdminAccountID,
+		string(ssotypes.TargetTypeAwsAccount),
+		ssotypes.AccountAssignment{
+			AccountId:        aws.String(testSSOAdminAccountID),
+			PermissionSetArn: aws.String(testSSOAdminPermissionSetARN + "-other"),
+			PrincipalId:      aws.String("1234567890-aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"),
+			PrincipalType:    ssotypes.PrincipalTypeGroup,
+		},
+	)
+	g := &SSOAdminGenerator{}
+	g.Resources = []terraformutils.Resource{managedPolicyAttachment, otherAssignment, matchingAssignment}
 
-	dependsOn, ok := resource.AdditionalFields["depends_on"].([]string)
+	if err := g.PostConvertHook(); err != nil {
+		t.Fatalf("PostConvertHook() error = %v", err)
+	}
+
+	dependsOn, ok := g.Resources[0].Item["depends_on"].([]string)
 	if !ok {
-		t.Fatalf("depends_on type = %T, want []string", resource.AdditionalFields["depends_on"])
+		t.Fatalf("depends_on type = %T, want []string", g.Resources[0].Item["depends_on"])
 	}
-	want := []string{
-		"aws_ssoadmin_account_assignment.tfer--a",
-		"aws_ssoadmin_account_assignment.tfer--z",
-	}
+	want := []string{matchingAssignment.InstanceInfo.Id}
 	if len(dependsOn) != len(want) {
 		t.Fatalf("depends_on = %#v, want %#v", dependsOn, want)
 	}
@@ -184,6 +209,38 @@ func TestSSOAdminManagedPolicyAttachmentDependsOnAccountAssignments(t *testing.T
 		if dependsOn[i] != want[i] {
 			t.Fatalf("depends_on = %#v, want %#v", dependsOn, want)
 		}
+	}
+	additionalDependsOn, ok := g.Resources[0].AdditionalFields["depends_on"].([]string)
+	if !ok || len(additionalDependsOn) != 1 || additionalDependsOn[0] != want[0] {
+		t.Fatalf("additional depends_on = %#v, want %#v", g.Resources[0].AdditionalFields["depends_on"], want)
+	}
+}
+
+func TestSSOAdminPostConvertHookDropsDanglingManagedPolicyAttachmentDependsOn(t *testing.T) {
+	managedPolicyAttachment := newSSOAdminManagedPolicyAttachmentResource(
+		testSSOAdminInstanceARN,
+		testSSOAdminPermissionSetARN,
+		ssotypes.AttachedManagedPolicy{Arn: aws.String(testSSOAdminPolicyARN)},
+	)
+	managedPolicyAttachment.Item = map[string]interface{}{
+		"depends_on":         []string{"aws_ssoadmin_account_assignment.tfer--filtered"},
+		"permission_set_arn": testSSOAdminPermissionSetARN,
+	}
+	managedPolicyAttachment.AdditionalFields = map[string]interface{}{
+		"depends_on": []string{"aws_ssoadmin_account_assignment.tfer--filtered"},
+	}
+	g := &SSOAdminGenerator{}
+	g.Resources = []terraformutils.Resource{managedPolicyAttachment}
+
+	if err := g.PostConvertHook(); err != nil {
+		t.Fatalf("PostConvertHook() error = %v", err)
+	}
+
+	if _, ok := g.Resources[0].Item["depends_on"]; ok {
+		t.Fatalf("unexpected item depends_on = %#v", g.Resources[0].Item["depends_on"])
+	}
+	if _, ok := g.Resources[0].AdditionalFields["depends_on"]; ok {
+		t.Fatalf("unexpected additional depends_on = %#v", g.Resources[0].AdditionalFields["depends_on"])
 	}
 }
 
@@ -365,8 +422,8 @@ func TestSSOAdminPermissionsBoundaryAttachmentResource(t *testing.T) {
 }
 
 func TestSSOAdminResourceNamesDoNotCollapseJoinedParts(t *testing.T) {
-	left := newSSOAdminManagedPolicyAttachmentResource("instance", "a_b", ssotypes.AttachedManagedPolicy{Arn: aws.String("c")}, nil)
-	right := newSSOAdminManagedPolicyAttachmentResource("instance", "a", ssotypes.AttachedManagedPolicy{Arn: aws.String("b_c")}, nil)
+	left := newSSOAdminManagedPolicyAttachmentResource("instance", "a_b", ssotypes.AttachedManagedPolicy{Arn: aws.String("c")})
+	right := newSSOAdminManagedPolicyAttachmentResource("instance", "a", ssotypes.AttachedManagedPolicy{Arn: aws.String("b_c")})
 	if left.ResourceName == right.ResourceName {
 		t.Fatalf("managed policy attachment resource names collide: %q", left.ResourceName)
 	}

--- a/providers/aws/ssoadmin_test.go
+++ b/providers/aws/ssoadmin_test.go
@@ -134,7 +134,7 @@ func TestSSOAdminManagedPolicyAttachmentResource(t *testing.T) {
 	resource := newSSOAdminManagedPolicyAttachmentResource(testSSOAdminInstanceARN, testSSOAdminPermissionSetARN, ssotypes.AttachedManagedPolicy{
 		Arn:  aws.String(testSSOAdminPolicyARN),
 		Name: aws.String("ReadOnlyAccess"),
-	})
+	}, nil)
 
 	if got, want := resource.InstanceState.ID, testSSOAdminPolicyARN+","+testSSOAdminPermissionSetARN+","+testSSOAdminInstanceARN; got != want {
 		t.Fatalf("resource ID = %q, want %q", got, want)
@@ -151,6 +151,38 @@ func TestSSOAdminManagedPolicyAttachmentResource(t *testing.T) {
 	} {
 		if got := attributes[key]; got != want {
 			t.Fatalf("%s = %q, want %q", key, got, want)
+		}
+	}
+	if _, ok := resource.AdditionalFields["depends_on"]; ok {
+		t.Fatalf("unexpected depends_on in %#v", resource.AdditionalFields)
+	}
+}
+
+func TestSSOAdminManagedPolicyAttachmentDependsOnAccountAssignments(t *testing.T) {
+	resource := newSSOAdminManagedPolicyAttachmentResource(
+		testSSOAdminInstanceARN,
+		testSSOAdminPermissionSetARN,
+		ssotypes.AttachedManagedPolicy{Arn: aws.String(testSSOAdminPolicyARN)},
+		[]string{
+			"aws_ssoadmin_account_assignment.tfer--z",
+			"aws_ssoadmin_account_assignment.tfer--a",
+		},
+	)
+
+	dependsOn, ok := resource.AdditionalFields["depends_on"].([]string)
+	if !ok {
+		t.Fatalf("depends_on type = %T, want []string", resource.AdditionalFields["depends_on"])
+	}
+	want := []string{
+		"aws_ssoadmin_account_assignment.tfer--a",
+		"aws_ssoadmin_account_assignment.tfer--z",
+	}
+	if len(dependsOn) != len(want) {
+		t.Fatalf("depends_on = %#v, want %#v", dependsOn, want)
+	}
+	for i := range want {
+		if dependsOn[i] != want[i] {
+			t.Fatalf("depends_on = %#v, want %#v", dependsOn, want)
 		}
 	}
 }
@@ -333,8 +365,8 @@ func TestSSOAdminPermissionsBoundaryAttachmentResource(t *testing.T) {
 }
 
 func TestSSOAdminResourceNamesDoNotCollapseJoinedParts(t *testing.T) {
-	left := newSSOAdminManagedPolicyAttachmentResource("instance", "a_b", ssotypes.AttachedManagedPolicy{Arn: aws.String("c")})
-	right := newSSOAdminManagedPolicyAttachmentResource("instance", "a", ssotypes.AttachedManagedPolicy{Arn: aws.String("b_c")})
+	left := newSSOAdminManagedPolicyAttachmentResource("instance", "a_b", ssotypes.AttachedManagedPolicy{Arn: aws.String("c")}, nil)
+	right := newSSOAdminManagedPolicyAttachmentResource("instance", "a", ssotypes.AttachedManagedPolicy{Arn: aws.String("b_c")}, nil)
 	if left.ResourceName == right.ResourceName {
 		t.Fatalf("managed policy attachment resource names collide: %q", left.ResourceName)
 	}


### PR DESCRIPTION
## Summary

- add SSO Admin account assignment import discovery
- seed import IDs as `principal_id,principal_type,target_id,target_type,permission_set_arn,instance_arn`
- update docs/aws.md for `aws_ssoadmin_account_assignment`
- add unit tests for account assignment ID/resource helper behavior

## References

- #338

## Validation

```bash
go test ./providers/aws -run 'Test.*SSO|Test.*Sso|Test.*sso|Test.*IdentityStore'
go test ./providers/aws/... ./terraformutils/...
go run ./tools/aws-gap-inventory \
  -docs docs/aws.md \
  -aws-dir providers/aws \
  -skip-list providers/aws/unsupported_resources.json \
  -format markdown
git diff --check
```

## Notes

Skipped/deferred resources:
- `aws_ssoadmin_application*`: deferred; outside this account-assignment-only PR.
- `aws_ssoadmin_instance_access_control_attributes`: deferred; outside this account-assignment-only PR.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds import discovery for AWS SSO Admin account assignments and generates `aws_ssoadmin_account_assignment` resources. Updates `docs/aws.md` and adds tests.

- New Features
  - Discover assignments per provisioned permission set and target account in `ssoadmin`.
  - Seed import IDs as `principal_id,principal_type,target_id,target_type,permission_set_arn,instance_arn`.
  - Stable resource names; validate and skip incomplete assignments.

- Bug Fixes
  - Managed policy attachments depend on matching account assignments for the same permission set; dependencies are sorted and dangling `depends_on` entries are removed to preserve destroy ordering.
  - Assignment `target_type` is always `AWS_ACCOUNT`.

<sup>Written for commit 01f2a320668d536f39b103ee8e00388bc11fef91. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for managing AWS SSO account assignments as resources and improved dependency wiring so managed policy attachments depend on relevant account assignments.

* **Documentation**
  * Updated AWS service docs to list the new account assignment resource.

* **Tests**
  * Added tests covering account-assignment resources, configuration validation, and the dependency-wiring behavior.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/chenrui333/terraformer/pull/399)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->