### PR TITLE
aws(appstream): add AppStream resource imports

### DIFF
--- a/docs/aws.md
+++ b/docs/aws.md
@@ -92,6 +92,10 @@ For AWS provider gap audits and unsupported-resource skip-list maintenance, see 
     * `aws_appmesh_virtual_node`
     * `aws_appmesh_virtual_router`
     * `aws_appmesh_virtual_service`
+*   `appstream`
+    * `aws_appstream_fleet`
+    * `aws_appstream_fleet_stack_association`
+    * `aws_appstream_stack`
 *   `appsync`
     * `aws_appsync_api_cache`
     * `aws_appsync_api_key`

--- a/go.mod
+++ b/go.mod
@@ -403,6 +403,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/apigatewayv2 v1.34.3
 	github.com/aws/aws-sdk-go-v2/service/appconfig v1.43.15
 	github.com/aws/aws-sdk-go-v2/service/appmesh v1.35.14
+	github.com/aws/aws-sdk-go-v2/service/appstream v1.58.0
 	github.com/aws/aws-sdk-go-v2/service/backup v1.55.2
 	github.com/aws/aws-sdk-go-v2/service/directconnect v1.38.17
 	github.com/aws/aws-sdk-go-v2/service/pipes v1.23.22

--- a/go.sum
+++ b/go.sum
@@ -211,6 +211,8 @@ github.com/aws/aws-sdk-go-v2/service/appconfig v1.43.15 h1:PwZaY+AGC6L7bGde+ESiR
 github.com/aws/aws-sdk-go-v2/service/appconfig v1.43.15/go.mod h1:rvo3cSBQ0Qgt6mF6ITZTZ0ssHQJ0kBcaUpIWCaldJVQ=
 github.com/aws/aws-sdk-go-v2/service/appmesh v1.35.14 h1:31mnzduRd3FyuGCwgdMfPAu6MG1XnQf4zJrPjpZvnbM=
 github.com/aws/aws-sdk-go-v2/service/appmesh v1.35.14/go.mod h1:u/RTn1872BcpTxDnsQXi0AO8nxMch/46nlr3/loCpu8=
+github.com/aws/aws-sdk-go-v2/service/appstream v1.58.0 h1:Z/lDyp10L7bUSQMFq3TS8wvZovf+Kb0zK7//Kp0MYMA=
+github.com/aws/aws-sdk-go-v2/service/appstream v1.58.0/go.mod h1:E5vrX7/8w/HM5rhk2LQyuzF+PKECUmE44tp6xvuNYTc=
 github.com/aws/aws-sdk-go-v2/service/appsync v1.53.7 h1:SjkXYNc15FoovS9k6ML7dO7pkXE3ns66RXwL+rfQVl8=
 github.com/aws/aws-sdk-go-v2/service/appsync v1.53.7/go.mod h1:RcoBov7Pw38ViMxlthKRr1GLgHPPseA+kY2bupWVm10=
 github.com/aws/aws-sdk-go-v2/service/autoscaling v1.66.2 h1:pPd+/Ujqf2+DmPOdB47EN7ox1iC21lu2zlOccUlfHeo=

--- a/providers/aws/appstream.go
+++ b/providers/aws/appstream.go
@@ -129,7 +129,7 @@ func (g *AppStreamGenerator) loadFleetStackAssociationsForFleet(svc *appstream.C
 
 func newAppStreamFleetResource(fleet appstreamtypes.Fleet) (terraformutils.Resource, bool) {
 	name := StringValue(fleet.Name)
-	if name == "" || !appStreamFleetImportable(fleet) {
+	if name == "" {
 		return terraformutils.Resource{}, false
 	}
 	return terraformutils.NewSimpleResource(
@@ -183,15 +183,6 @@ func appStreamResourceName(parts ...string) string {
 		return "appstream-resource"
 	}
 	return strings.Join(cleanParts, "/")
-}
-
-func appStreamFleetImportable(fleet appstreamtypes.Fleet) bool {
-	switch fleet.State {
-	case appstreamtypes.FleetStateRunning, appstreamtypes.FleetStateStopped:
-		return true
-	default:
-		return false
-	}
 }
 
 func appStreamNextToken(token *string) *string {

--- a/providers/aws/appstream.go
+++ b/providers/aws/appstream.go
@@ -1,0 +1,207 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package aws
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/appstream"
+	appstreamtypes "github.com/aws/aws-sdk-go-v2/service/appstream/types"
+	"github.com/chenrui333/terraformer/terraformutils"
+)
+
+const (
+	appStreamFleetResourceType                 = "aws_appstream_fleet"
+	appStreamStackResourceType                 = "aws_appstream_stack"
+	appStreamFleetStackAssociationResourceType = "aws_appstream_fleet_stack_association"
+
+	appStreamFleetStackAssociationIDSeparator = "/"
+)
+
+var appStreamAllowEmptyValues = []string{"tags."}
+
+type AppStreamGenerator struct {
+	AWSService
+}
+
+func (g *AppStreamGenerator) InitResources() error {
+	config, e := g.generateConfig()
+	if e != nil {
+		return e
+	}
+	svc := appstream.NewFromConfig(config)
+
+	fleetNames, err := g.loadFleets(svc)
+	if err != nil {
+		return err
+	}
+	if err := g.loadStacks(svc); err != nil {
+		return err
+	}
+	return g.loadFleetStackAssociations(svc, fleetNames)
+}
+
+func (g *AppStreamGenerator) loadFleets(svc *appstream.Client) ([]string, error) {
+	var fleetNames []string
+	input := &appstream.DescribeFleetsInput{}
+	for {
+		page, err := svc.DescribeFleets(context.TODO(), input)
+		if err != nil {
+			return nil, err
+		}
+		for _, fleet := range page.Fleets {
+			resource, ok := newAppStreamFleetResource(fleet)
+			if !ok {
+				continue
+			}
+			g.Resources = append(g.Resources, resource)
+			fleetNames = append(fleetNames, StringValue(fleet.Name))
+		}
+		nextToken := appStreamNextToken(page.NextToken)
+		if nextToken == nil {
+			break
+		}
+		input.NextToken = nextToken
+	}
+	return fleetNames, nil
+}
+
+func (g *AppStreamGenerator) loadStacks(svc *appstream.Client) error {
+	input := &appstream.DescribeStacksInput{}
+	for {
+		page, err := svc.DescribeStacks(context.TODO(), input)
+		if err != nil {
+			return err
+		}
+		for _, stack := range page.Stacks {
+			if resource, ok := newAppStreamStackResource(stack); ok {
+				g.Resources = append(g.Resources, resource)
+			}
+		}
+		nextToken := appStreamNextToken(page.NextToken)
+		if nextToken == nil {
+			break
+		}
+		input.NextToken = nextToken
+	}
+	return nil
+}
+
+func (g *AppStreamGenerator) loadFleetStackAssociations(svc *appstream.Client, fleetNames []string) error {
+	for _, fleetName := range fleetNames {
+		if err := g.loadFleetStackAssociationsForFleet(svc, fleetName); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (g *AppStreamGenerator) loadFleetStackAssociationsForFleet(svc *appstream.Client, fleetName string) error {
+	if fleetName == "" {
+		return nil
+	}
+	input := &appstream.ListAssociatedStacksInput{FleetName: aws.String(fleetName)}
+	for {
+		page, err := svc.ListAssociatedStacks(context.TODO(), input)
+		if appStreamResourceNotFound(err) {
+			return nil
+		}
+		if err != nil {
+			return err
+		}
+		for _, stackName := range page.Names {
+			if resource, ok := newAppStreamFleetStackAssociationResource(fleetName, stackName); ok {
+				g.Resources = append(g.Resources, resource)
+			}
+		}
+		nextToken := appStreamNextToken(page.NextToken)
+		if nextToken == nil {
+			break
+		}
+		input.NextToken = nextToken
+	}
+	return nil
+}
+
+func newAppStreamFleetResource(fleet appstreamtypes.Fleet) (terraformutils.Resource, bool) {
+	name := StringValue(fleet.Name)
+	if name == "" || !appStreamFleetImportable(fleet) {
+		return terraformutils.Resource{}, false
+	}
+	return terraformutils.NewSimpleResource(
+		name,
+		appStreamResourceName("fleet", name),
+		appStreamFleetResourceType,
+		"aws",
+		appStreamAllowEmptyValues,
+	), true
+}
+
+func newAppStreamStackResource(stack appstreamtypes.Stack) (terraformutils.Resource, bool) {
+	name := StringValue(stack.Name)
+	if name == "" {
+		return terraformutils.Resource{}, false
+	}
+	return terraformutils.NewSimpleResource(
+		name,
+		appStreamResourceName("stack", name),
+		appStreamStackResourceType,
+		"aws",
+		appStreamAllowEmptyValues,
+	), true
+}
+
+func newAppStreamFleetStackAssociationResource(fleetName, stackName string) (terraformutils.Resource, bool) {
+	if fleetName == "" || stackName == "" {
+		return terraformutils.Resource{}, false
+	}
+	return terraformutils.NewSimpleResource(
+		appStreamFleetStackAssociationImportID(fleetName, stackName),
+		appStreamResourceName("fleet-stack-association", fleetName, stackName),
+		appStreamFleetStackAssociationResourceType,
+		"aws",
+		appStreamAllowEmptyValues,
+	), true
+}
+
+func appStreamFleetStackAssociationImportID(fleetName, stackName string) string {
+	return strings.Join([]string{fleetName, stackName}, appStreamFleetStackAssociationIDSeparator)
+}
+
+func appStreamResourceName(parts ...string) string {
+	cleanParts := []string{}
+	for _, part := range parts {
+		if part != "" {
+			cleanParts = append(cleanParts, fmt.Sprintf("%d/%s", len(part), part))
+		}
+	}
+	if len(cleanParts) == 0 {
+		return "appstream-resource"
+	}
+	return strings.Join(cleanParts, "/")
+}
+
+func appStreamFleetImportable(fleet appstreamtypes.Fleet) bool {
+	switch fleet.State {
+	case appstreamtypes.FleetStateRunning, appstreamtypes.FleetStateStopped:
+		return true
+	default:
+		return false
+	}
+}
+
+func appStreamNextToken(token *string) *string {
+	if StringValue(token) == "" {
+		return nil
+	}
+	return token
+}
+
+func appStreamResourceNotFound(err error) bool {
+	var notFound *appstreamtypes.ResourceNotFoundException
+	return errors.As(err, &notFound)
+}

--- a/providers/aws/appstream_test.go
+++ b/providers/aws/appstream_test.go
@@ -1,0 +1,144 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package aws
+
+import (
+	"errors"
+	"testing"
+
+	appstreamtypes "github.com/aws/aws-sdk-go-v2/service/appstream/types"
+	"github.com/chenrui333/terraformer/terraformutils"
+)
+
+func TestNewAppStreamFleetResource(t *testing.T) {
+	for _, state := range []appstreamtypes.FleetState{appstreamtypes.FleetStateRunning, appstreamtypes.FleetStateStopped} {
+		resource, ok := newAppStreamFleetResource(appstreamtypes.Fleet{
+			Name:  appStreamString("core-fleet"),
+			State: state,
+		})
+		assertAppStreamResource(t, resource, ok, "core-fleet", appStreamResourceName("fleet", "core-fleet"), appStreamFleetResourceType)
+	}
+
+	if _, ok := newAppStreamFleetResource(appstreamtypes.Fleet{State: appstreamtypes.FleetStateRunning}); ok {
+		t.Fatal("fleet with empty name should be skipped")
+	}
+	if _, ok := newAppStreamFleetResource(appstreamtypes.Fleet{
+		Name:  appStreamString("starting-fleet"),
+		State: appstreamtypes.FleetStateStarting,
+	}); ok {
+		t.Fatal("starting fleet should be skipped")
+	}
+}
+
+func TestNewAppStreamStackResource(t *testing.T) {
+	resource, ok := newAppStreamStackResource(appstreamtypes.Stack{Name: appStreamString("core-stack")})
+	assertAppStreamResource(t, resource, ok, "core-stack", appStreamResourceName("stack", "core-stack"), appStreamStackResourceType)
+
+	if _, ok := newAppStreamStackResource(appstreamtypes.Stack{}); ok {
+		t.Fatal("stack with empty name should be skipped")
+	}
+}
+
+func TestNewAppStreamFleetStackAssociationResource(t *testing.T) {
+	resource, ok := newAppStreamFleetStackAssociationResource("core-fleet", "core-stack")
+	assertAppStreamResource(t, resource, ok, "core-fleet/core-stack", appStreamResourceName("fleet-stack-association", "core-fleet", "core-stack"), appStreamFleetStackAssociationResourceType)
+
+	if got := resource.InstanceInfo.Type; got != appStreamFleetStackAssociationResourceType {
+		t.Fatalf("resource type = %q, want %q", got, appStreamFleetStackAssociationResourceType)
+	}
+	if _, ok := newAppStreamFleetStackAssociationResource("", "core-stack"); ok {
+		t.Fatal("association with empty fleet name should be skipped")
+	}
+	if _, ok := newAppStreamFleetStackAssociationResource("core-fleet", ""); ok {
+		t.Fatal("association with empty stack name should be skipped")
+	}
+}
+
+func TestAppStreamFleetStackAssociationImportID(t *testing.T) {
+	got := appStreamFleetStackAssociationImportID("fleetName", "stackName")
+	want := "fleetName/stackName"
+	if got != want {
+		t.Fatalf("association import ID = %q, want %q", got, want)
+	}
+}
+
+func TestAppStreamResourceNamesPreserveSegmentBoundaries(t *testing.T) {
+	left, ok := newAppStreamFleetStackAssociationResource("a/b_c", "d")
+	if !ok {
+		t.Fatal("left association should be importable")
+	}
+	right, ok := newAppStreamFleetStackAssociationResource("a", "b_c/d")
+	if !ok {
+		t.Fatal("right association should be importable")
+	}
+	if left.ResourceName == right.ResourceName {
+		t.Fatalf("association resource names collide: %q", left.ResourceName)
+	}
+}
+
+func TestAppStreamFleetImportable(t *testing.T) {
+	for _, state := range []appstreamtypes.FleetState{appstreamtypes.FleetStateRunning, appstreamtypes.FleetStateStopped} {
+		if !appStreamFleetImportable(appstreamtypes.Fleet{State: state}) {
+			t.Fatalf("fleet state %q should be importable", state)
+		}
+	}
+	for _, state := range []appstreamtypes.FleetState{"", appstreamtypes.FleetStateStarting, appstreamtypes.FleetStateStopping} {
+		if appStreamFleetImportable(appstreamtypes.Fleet{State: state}) {
+			t.Fatalf("fleet state %q should not be importable", state)
+		}
+	}
+}
+
+func TestAppStreamNextToken(t *testing.T) {
+	if got := appStreamNextToken(nil); got != nil {
+		t.Fatalf("nil token = %v, want nil", got)
+	}
+	if got := appStreamNextToken(appStreamString("")); got != nil {
+		t.Fatalf("empty token = %v, want nil", got)
+	}
+	token := appStreamString("next")
+	if got := appStreamNextToken(token); got != token {
+		t.Fatalf("next token pointer = %p, want %p", got, token)
+	}
+}
+
+func TestAppStreamResourceNotFound(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{name: "nil", want: false},
+		{name: "resource not found", err: &appstreamtypes.ResourceNotFoundException{}, want: true},
+		{name: "wrapped resource not found", err: errors.Join(errors.New("lookup failed"), &appstreamtypes.ResourceNotFoundException{}), want: true},
+		{name: "generic", err: errors.New("boom"), want: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := appStreamResourceNotFound(tt.err); got != tt.want {
+				t.Fatalf("appStreamResourceNotFound(%v) = %t, want %t", tt.err, got, tt.want)
+			}
+		})
+	}
+}
+
+func assertAppStreamResource(t *testing.T, resource terraformutils.Resource, ok bool, wantID, wantName, wantType string) {
+	t.Helper()
+	if !ok {
+		t.Fatal("resource was skipped")
+	}
+	if got := resource.InstanceState.ID; got != wantID {
+		t.Fatalf("resource ID = %q, want %q", got, wantID)
+	}
+	if got := resource.ResourceName; got != terraformutils.TfSanitize(wantName) {
+		t.Fatalf("resource name = %q, want %q", got, terraformutils.TfSanitize(wantName))
+	}
+	if got := resource.InstanceInfo.Type; got != wantType {
+		t.Fatalf("resource type = %q, want %q", got, wantType)
+	}
+}
+
+func appStreamString(value string) *string {
+	return &value
+}

--- a/providers/aws/appstream_test.go
+++ b/providers/aws/appstream_test.go
@@ -11,7 +11,13 @@ import (
 )
 
 func TestNewAppStreamFleetResource(t *testing.T) {
-	for _, state := range []appstreamtypes.FleetState{appstreamtypes.FleetStateRunning, appstreamtypes.FleetStateStopped} {
+	for _, state := range []appstreamtypes.FleetState{
+		"",
+		appstreamtypes.FleetStateRunning,
+		appstreamtypes.FleetStateStopped,
+		appstreamtypes.FleetStateStarting,
+		appstreamtypes.FleetStateStopping,
+	} {
 		resource, ok := newAppStreamFleetResource(appstreamtypes.Fleet{
 			Name:  appStreamString("core-fleet"),
 			State: state,
@@ -21,12 +27,6 @@ func TestNewAppStreamFleetResource(t *testing.T) {
 
 	if _, ok := newAppStreamFleetResource(appstreamtypes.Fleet{State: appstreamtypes.FleetStateRunning}); ok {
 		t.Fatal("fleet with empty name should be skipped")
-	}
-	if _, ok := newAppStreamFleetResource(appstreamtypes.Fleet{
-		Name:  appStreamString("starting-fleet"),
-		State: appstreamtypes.FleetStateStarting,
-	}); ok {
-		t.Fatal("starting fleet should be skipped")
 	}
 }
 
@@ -73,19 +73,6 @@ func TestAppStreamResourceNamesPreserveSegmentBoundaries(t *testing.T) {
 	}
 	if left.ResourceName == right.ResourceName {
 		t.Fatalf("association resource names collide: %q", left.ResourceName)
-	}
-}
-
-func TestAppStreamFleetImportable(t *testing.T) {
-	for _, state := range []appstreamtypes.FleetState{appstreamtypes.FleetStateRunning, appstreamtypes.FleetStateStopped} {
-		if !appStreamFleetImportable(appstreamtypes.Fleet{State: state}) {
-			t.Fatalf("fleet state %q should be importable", state)
-		}
-	}
-	for _, state := range []appstreamtypes.FleetState{"", appstreamtypes.FleetStateStarting, appstreamtypes.FleetStateStopping} {
-		if appStreamFleetImportable(appstreamtypes.Fleet{State: state}) {
-			t.Fatalf("fleet state %q should not be importable", state)
-		}
 	}
 }
 

--- a/providers/aws/aws_provider.go
+++ b/providers/aws/aws_provider.go
@@ -269,6 +269,7 @@ func (p *AWSProvider) GetSupportedService() map[string]terraformutils.ServiceGen
 		"api_gatewayv2":     &AwsFacade{service: &APIGatewayV2Generator{}},
 		"appconfig":         &AwsFacade{service: &AppConfigGenerator{}},
 		"appmesh":           &AwsFacade{service: &AppMeshGenerator{}},
+		"appstream":         &AwsFacade{service: &AppStreamGenerator{}},
 		"appsync":           &AwsFacade{service: &AppSyncGenerator{}},
 		"auto_scaling":      &AwsFacade{service: &AutoScalingGenerator{}},
 		"backup":            &AwsFacade{service: &BackupGenerator{}},

--- a/providers/aws/unsupported_resources.json
+++ b/providers/aws/unsupported_resources.json
@@ -2,6 +2,18 @@
   "version": 1,
   "resources": [
     {
+      "resource": "aws_appstream_directory_config",
+      "service_family": "appstream",
+      "reason": "AppStream directory configs require service_account_credentials.account_password, which is a sensitive required field that AppStream DescribeDirectoryConfigs does not return.",
+      "evidence": "Terraform AWS provider marks service_account_credentials.account_password as required and reuses prior state during Read; the AppStream DescribeDirectoryConfigs API documentation states the account password is not returned in the actual response.",
+      "status": "unsupported",
+      "references": [
+        "https://github.com/chenrui333/terraformer/issues/338",
+        "https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/appstream_directory_config",
+        "https://docs.aws.amazon.com/appstream2/latest/APIReference/API_DescribeDirectoryConfigs.html"
+      ]
+    },
+    {
       "resource": "aws_cloudwatch_event_connection",
       "service_family": "cloudwatch",
       "reason": "EventBridge connection credentials are write-only secrets; Terraformer cannot discover the required auth_parameters values from EventBridge APIs.",


### PR DESCRIPTION
## Summary

- add AppStream import discovery for `aws_appstream_fleet`, `aws_appstream_stack`, and `aws_appstream_fleet_stack_association`
- register the `appstream` AWS service
- seed import IDs as fleet name, stack name, and `fleet_name/stack_name`
- update docs/aws.md for supported AppStream resources
- add an unsupported-resource entry for `aws_appstream_directory_config`
- add unit tests for AppStream resource helper behavior

## References

- #338

## Validation

```bash
go test ./providers/aws -run 'Test.*AppStream|Test.*Appstream|Test.*appstream'
go test ./providers/aws/... ./terraformutils/...
go run ./tools/aws-gap-inventory \
  -docs docs/aws.md \
  -aws-dir providers/aws \
  -skip-list providers/aws/unsupported_resources.json \
  -format markdown
git diff --check
```

## Notes

Skipped/deferred resources:
- `aws_appstream_directory_config`: unsupported because the required sensitive `service_account_credentials.account_password` is not returned by `DescribeDirectoryConfigs`.
- `aws_appstream_image_builder`: deferred to keep the first Lane 6 PR to the core fleet/stack path and leave image-builder state handling for a follow-up.
- `aws_appstream_user`: deferred to a follow-up focused on USERPOOL user import coverage.
- `aws_appstream_user_stack_association`: deferred with user imports so the USERPOOL association path can be reviewed together.
- `aws_appstream_application`, `aws_appstream_application_fleet_association`, and `aws_appstream_entitlement`: not exposed by the Terraform AWS provider schema used for this inventory pass.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds AppStream import discovery for `aws_appstream_fleet`, `aws_appstream_stack`, and `aws_appstream_fleet_stack_association`, and registers the `appstream` service. Fleets now import regardless of state.

- **New Features**
  - Import `aws_appstream_fleet`, `aws_appstream_stack`, and `aws_appstream_fleet_stack_association`; IDs use fleet name, stack name, and "fleet_name/stack_name". Fleets import in any state (Running, Stopped, Starting, Stopping).
  - Register `appstream` in the AWS provider and update docs.
  - Add unit tests for naming, pagination, not-found handling, and association IDs.
  - Mark `aws_appstream_directory_config` unsupported (password not returned by DescribeDirectoryConfigs).

- **Dependencies**
  - Add `github.com/aws/aws-sdk-go-v2/service/appstream` v1.58.0.

<sup>Written for commit 8d4cc7890c6e88fc2345de3b06da7d4bf9d1680c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for importing AWS AppStream resources: Fleets, Stacks, and Fleet–Stack Associations. Fleets are importable when in Running or Stopped states.

* **Documentation**
  * Updated supported services to include AppStream.
  * Marked aws_appstream_directory_config as unsupported due to API limitations with sensitive credential fields.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/chenrui333/terraformer/pull/400)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->