### PR TITLE
aws(bedrock): add Bedrock core resource imports

### DIFF
--- a/docs/aws.md
+++ b/docs/aws.md
@@ -125,6 +125,10 @@ For AWS provider gap audits and unsupported-resource skip-list maintenance, see 
     * `aws_batch_compute_environment`
     * `aws_batch_job_definition`
     * `aws_batch_job_queue`
+*   `bedrock`
+    * `aws_bedrock_guardrail`
+    * `aws_bedrock_inference_profile`
+    * `aws_bedrock_provisioned_model_throughput`
 *   `budgets`
     * `aws_budgets_budget`
 *   `cloud9`

--- a/go.mod
+++ b/go.mod
@@ -404,6 +404,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/appconfig v1.43.15
 	github.com/aws/aws-sdk-go-v2/service/appmesh v1.35.14
 	github.com/aws/aws-sdk-go-v2/service/backup v1.55.2
+	github.com/aws/aws-sdk-go-v2/service/bedrock v1.59.2
 	github.com/aws/aws-sdk-go-v2/service/directconnect v1.38.17
 	github.com/aws/aws-sdk-go-v2/service/pipes v1.23.22
 	github.com/aws/aws-sdk-go-v2/service/scheduler v1.17.24

--- a/go.sum
+++ b/go.sum
@@ -219,6 +219,8 @@ github.com/aws/aws-sdk-go-v2/service/backup v1.55.2 h1:WhdT1PwOjTjKLGuD9lJDyNMgY
 github.com/aws/aws-sdk-go-v2/service/backup v1.55.2/go.mod h1:uMh3ZDoLKhXldYL1qcBYy1HsNQfKgL/w8iF2onOyoKY=
 github.com/aws/aws-sdk-go-v2/service/batch v1.64.1 h1:+Nm5tPlRgOVQB/uMvphSNyJI9WKyIdE2FlTCMXEqqns=
 github.com/aws/aws-sdk-go-v2/service/batch v1.64.1/go.mod h1:EHhfaNTxntvYHmSdHGLLSxuerqkMIlXY9lWjl+CJJxg=
+github.com/aws/aws-sdk-go-v2/service/bedrock v1.59.2 h1:TdYgGWLuNqQGNNVHzMwBEkg1fsyoaOfd+aP3xKfIeDM=
+github.com/aws/aws-sdk-go-v2/service/bedrock v1.59.2/go.mod h1:v/+a2bHvfo04yQC/p2HOK1iJF6V59OwCfCSf4iYgob4=
 github.com/aws/aws-sdk-go-v2/service/budgets v1.43.6 h1:2C1Fx5PAPB+8Se7nwnxAElSMW5KxuDVwzBu6t2qtlfg=
 github.com/aws/aws-sdk-go-v2/service/budgets v1.43.6/go.mod h1:W/ACxHO2V65T11t9KLLG+pQytcYk206Ff5b5lbGeMF8=
 github.com/aws/aws-sdk-go-v2/service/cloud9 v1.33.22 h1:NiWafOOhAC6Wcnj9L/xd371nvXMuoSqblNzRJ2vB2nE=

--- a/providers/aws/aws_provider.go
+++ b/providers/aws/aws_provider.go
@@ -273,6 +273,7 @@ func (p *AWSProvider) GetSupportedService() map[string]terraformutils.ServiceGen
 		"auto_scaling":      &AwsFacade{service: &AutoScalingGenerator{}},
 		"backup":            &AwsFacade{service: &BackupGenerator{}},
 		"batch":             &AwsFacade{service: &BatchGenerator{}},
+		"bedrock":           &AwsFacade{service: &BedrockGenerator{}},
 		"budgets":           &AwsFacade{service: &BudgetsGenerator{}},
 		"cloud9":            &AwsFacade{service: &Cloud9Generator{}},
 		"cloudformation":    &AwsFacade{service: &CloudFormationGenerator{}},

--- a/providers/aws/bedrock.go
+++ b/providers/aws/bedrock.go
@@ -22,10 +22,41 @@ const (
 	bedrockResourceNameFallback                   = "bedrock-resource"
 )
 
-var bedrockAllowEmptyValues = []string{"tags."}
+var (
+	bedrockAllowEmptyValues = []string{"tags."}
+	bedrockResourceTypes    = []string{
+		bedrockServiceName(bedrockGuardrailResourceType),
+		bedrockServiceName(bedrockInferenceProfileResourceType),
+		bedrockServiceName(bedrockProvisionedModelThroughputResourceType),
+	}
+)
 
 type BedrockGenerator struct {
 	AWSService
+}
+
+func (g *BedrockGenerator) InitialCleanup() {
+	if len(g.Filter) == 0 {
+		return
+	}
+	filteredResources := []terraformutils.Resource{}
+	for _, resource := range g.Resources {
+		serviceName := bedrockServiceName(resource.InstanceInfo.Type)
+		if g.hasTypedBedrockFilter() && !g.hasTypedFilterFor(serviceName) && !g.hasUntypedIDFilter() {
+			continue
+		}
+		allPredicatesTrue := true
+		for _, filter := range g.Filter {
+			if filter.FieldPath != "id" {
+				continue
+			}
+			allPredicatesTrue = allPredicatesTrue && filter.Filter(resource)
+		}
+		if allPredicatesTrue && !terraformutils.ContainsResource(filteredResources, resource) {
+			filteredResources = append(filteredResources, resource)
+		}
+	}
+	g.Resources = filteredResources
 }
 
 func (g *BedrockGenerator) InitResources() error {
@@ -35,17 +66,61 @@ func (g *BedrockGenerator) InitResources() error {
 	}
 	svc := bedrock.NewFromConfig(config)
 
-	if err := g.loadGuardrails(svc); err != nil {
-		return err
+	if g.shouldLoadBedrockResource(bedrockServiceName(bedrockGuardrailResourceType)) {
+		if err := g.loadGuardrails(svc); err != nil {
+			return err
+		}
 	}
-	if err := g.loadInferenceProfiles(svc); err != nil {
-		return err
+	if g.shouldLoadBedrockResource(bedrockServiceName(bedrockInferenceProfileResourceType)) {
+		if err := g.loadInferenceProfiles(svc); err != nil {
+			return err
+		}
 	}
-	if err := g.loadProvisionedModelThroughputs(svc); err != nil {
-		return err
+	if g.shouldLoadBedrockResource(bedrockServiceName(bedrockProvisionedModelThroughputResourceType)) {
+		if err := g.loadProvisionedModelThroughputs(svc); err != nil {
+			return err
+		}
 	}
 
 	return nil
+}
+
+func (g *BedrockGenerator) shouldLoadBedrockResource(serviceName string) bool {
+	if !g.hasTypedBedrockFilter() {
+		return true
+	}
+	return g.hasTypedFilterFor(serviceName) || g.hasUntypedIDFilter()
+}
+
+func (g *BedrockGenerator) hasTypedBedrockFilter() bool {
+	for _, serviceName := range bedrockResourceTypes {
+		if g.hasTypedFilterFor(serviceName) {
+			return true
+		}
+	}
+	return false
+}
+
+func (g *BedrockGenerator) hasTypedFilterFor(serviceName string) bool {
+	for _, filter := range g.Filter {
+		if filter.ServiceName == serviceName {
+			return true
+		}
+	}
+	return false
+}
+
+func (g *BedrockGenerator) hasUntypedIDFilter() bool {
+	for _, filter := range g.Filter {
+		if filter.ServiceName == "" && filter.FieldPath == "id" {
+			return true
+		}
+	}
+	return false
+}
+
+func bedrockServiceName(resourceType string) string {
+	return strings.TrimPrefix(resourceType, "aws_")
 }
 
 func (g *BedrockGenerator) loadGuardrails(svc *bedrock.Client) error {

--- a/providers/aws/bedrock.go
+++ b/providers/aws/bedrock.go
@@ -1,0 +1,204 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package aws
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strconv"
+	"strings"
+
+	"github.com/aws/aws-sdk-go-v2/service/bedrock"
+	bedrocktypes "github.com/aws/aws-sdk-go-v2/service/bedrock/types"
+	"github.com/chenrui333/terraformer/terraformutils"
+)
+
+const (
+	bedrockGuardrailResourceType                  = "aws_bedrock_guardrail"
+	bedrockInferenceProfileResourceType           = "aws_bedrock_inference_profile"
+	bedrockProvisionedModelThroughputResourceType = "aws_bedrock_provisioned_model_throughput"
+	bedrockGuardrailImportIDSeparator             = ","
+	bedrockResourceNameFallback                   = "bedrock-resource"
+)
+
+var bedrockAllowEmptyValues = []string{"tags."}
+
+type BedrockGenerator struct {
+	AWSService
+}
+
+func (g *BedrockGenerator) InitResources() error {
+	config, e := g.generateConfig()
+	if e != nil {
+		return e
+	}
+	svc := bedrock.NewFromConfig(config)
+
+	if err := g.loadGuardrails(svc); err != nil {
+		return err
+	}
+	if err := g.loadInferenceProfiles(svc); err != nil {
+		return err
+	}
+	if err := g.loadProvisionedModelThroughputs(svc); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (g *BedrockGenerator) loadGuardrails(svc *bedrock.Client) error {
+	p := bedrock.NewListGuardrailsPaginator(svc, &bedrock.ListGuardrailsInput{})
+	for p.HasMorePages() {
+		page, err := p.NextPage(context.TODO())
+		if err != nil {
+			return err
+		}
+		for _, guardrail := range page.Guardrails {
+			if resource, ok := newBedrockGuardrailResource(guardrail); ok {
+				g.Resources = append(g.Resources, resource)
+			}
+		}
+	}
+	return nil
+}
+
+func (g *BedrockGenerator) loadInferenceProfiles(svc *bedrock.Client) error {
+	p := bedrock.NewListInferenceProfilesPaginator(svc, &bedrock.ListInferenceProfilesInput{
+		TypeEquals: bedrocktypes.InferenceProfileTypeApplication,
+	})
+	for p.HasMorePages() {
+		page, err := p.NextPage(context.TODO())
+		if err != nil {
+			return err
+		}
+		for _, profile := range page.InferenceProfileSummaries {
+			if resource, ok := newBedrockInferenceProfileResource(profile); ok {
+				g.Resources = append(g.Resources, resource)
+			}
+		}
+	}
+	return nil
+}
+
+func (g *BedrockGenerator) loadProvisionedModelThroughputs(svc *bedrock.Client) error {
+	p := bedrock.NewListProvisionedModelThroughputsPaginator(svc, &bedrock.ListProvisionedModelThroughputsInput{})
+	for p.HasMorePages() {
+		page, err := p.NextPage(context.TODO())
+		if err != nil {
+			return err
+		}
+		for _, throughput := range page.ProvisionedModelSummaries {
+			if resource, ok := newBedrockProvisionedModelThroughputResource(throughput); ok {
+				g.Resources = append(g.Resources, resource)
+			}
+		}
+	}
+	return nil
+}
+
+func newBedrockGuardrailResource(guardrail bedrocktypes.GuardrailSummary) (terraformutils.Resource, bool) {
+	guardrailID := StringValue(guardrail.Id)
+	version := StringValue(guardrail.Version)
+	if guardrailID == "" || version == "" || !bedrockGuardrailImportable(guardrail.Status) {
+		return terraformutils.Resource{}, false
+	}
+	name := StringValue(guardrail.Name)
+	if name == "" {
+		name = guardrailID
+	}
+	return terraformutils.NewResource(
+		bedrockGuardrailImportID(guardrailID, version),
+		bedrockResourceName("guardrail", name, guardrailID, version),
+		bedrockGuardrailResourceType,
+		"aws",
+		map[string]string{
+			"guardrail_id": guardrailID,
+			"version":      version,
+		},
+		bedrockAllowEmptyValues,
+		map[string]interface{}{},
+	), true
+}
+
+func newBedrockInferenceProfileResource(profile bedrocktypes.InferenceProfileSummary) (terraformutils.Resource, bool) {
+	profileID := StringValue(profile.InferenceProfileId)
+	if profileID == "" || !bedrockInferenceProfileImportable(profile) {
+		return terraformutils.Resource{}, false
+	}
+	name := StringValue(profile.InferenceProfileName)
+	if name == "" {
+		name = profileID
+	}
+	return terraformutils.NewResource(
+		profileID,
+		bedrockResourceName("inference-profile", name, profileID),
+		bedrockInferenceProfileResourceType,
+		"aws",
+		map[string]string{
+			"id":   profileID,
+			"name": name,
+		},
+		bedrockAllowEmptyValues,
+		map[string]interface{}{},
+	), true
+}
+
+func newBedrockProvisionedModelThroughputResource(throughput bedrocktypes.ProvisionedModelSummary) (terraformutils.Resource, bool) {
+	provisionedModelARN := StringValue(throughput.ProvisionedModelArn)
+	modelARN := StringValue(throughput.ModelArn)
+	name := StringValue(throughput.ProvisionedModelName)
+	if provisionedModelARN == "" || modelARN == "" || name == "" || throughput.ModelUnits == nil || !bedrockProvisionedModelThroughputImportable(throughput.Status) {
+		return terraformutils.Resource{}, false
+	}
+	return terraformutils.NewResource(
+		provisionedModelARN,
+		bedrockResourceName("provisioned-model-throughput", name, provisionedModelARN),
+		bedrockProvisionedModelThroughputResourceType,
+		"aws",
+		map[string]string{
+			"id":                     provisionedModelARN,
+			"model_arn":              modelARN,
+			"model_units":            strconv.Itoa(int(*throughput.ModelUnits)),
+			"provisioned_model_arn":  provisionedModelARN,
+			"provisioned_model_name": name,
+		},
+		bedrockAllowEmptyValues,
+		map[string]interface{}{},
+	), true
+}
+
+func bedrockGuardrailImportID(guardrailID, version string) string {
+	return guardrailID + bedrockGuardrailImportIDSeparator + version
+}
+
+func bedrockResourceName(parts ...string) string {
+	var cleanParts []string
+	for _, part := range parts {
+		if part != "" {
+			cleanParts = append(cleanParts, fmt.Sprintf("%d-%s", len(part), part))
+		}
+	}
+	if len(cleanParts) == 0 {
+		return bedrockResourceNameFallback
+	}
+	return strings.Join(cleanParts, "/")
+}
+
+func bedrockGuardrailImportable(status bedrocktypes.GuardrailStatus) bool {
+	return status == bedrocktypes.GuardrailStatusReady
+}
+
+func bedrockInferenceProfileImportable(profile bedrocktypes.InferenceProfileSummary) bool {
+	return profile.Type == bedrocktypes.InferenceProfileTypeApplication && profile.Status == bedrocktypes.InferenceProfileStatusActive
+}
+
+func bedrockProvisionedModelThroughputImportable(status bedrocktypes.ProvisionedModelStatus) bool {
+	return status == bedrocktypes.ProvisionedModelStatusInService
+}
+
+func bedrockResourceNotFound(err error) bool {
+	var notFound *bedrocktypes.ResourceNotFoundException
+	return errors.As(err, &notFound)
+}

--- a/providers/aws/bedrock.go
+++ b/providers/aws/bedrock.go
@@ -42,7 +42,7 @@ func (g *BedrockGenerator) InitialCleanup() {
 	filteredResources := []terraformutils.Resource{}
 	for _, resource := range g.Resources {
 		serviceName := bedrockServiceName(resource.InstanceInfo.Type)
-		if g.hasTypedBedrockFilter() && !g.hasTypedFilterFor(serviceName) && !g.hasUntypedIDFilter() {
+		if g.hasTypedBedrockFilter() && !g.hasTypedFilterFor(serviceName) && !g.hasUntypedFilter() {
 			continue
 		}
 		allPredicatesTrue := true
@@ -89,7 +89,7 @@ func (g *BedrockGenerator) shouldLoadBedrockResource(serviceName string) bool {
 	if !g.hasTypedBedrockFilter() {
 		return true
 	}
-	return g.hasTypedFilterFor(serviceName) || g.hasUntypedIDFilter()
+	return g.hasTypedFilterFor(serviceName) || g.hasUntypedFilter()
 }
 
 func (g *BedrockGenerator) hasTypedBedrockFilter() bool {
@@ -110,9 +110,9 @@ func (g *BedrockGenerator) hasTypedFilterFor(serviceName string) bool {
 	return false
 }
 
-func (g *BedrockGenerator) hasUntypedIDFilter() bool {
+func (g *BedrockGenerator) hasUntypedFilter() bool {
 	for _, filter := range g.Filter {
-		if filter.ServiceName == "" && filter.FieldPath == "id" {
+		if filter.ServiceName == "" {
 			return true
 		}
 	}

--- a/providers/aws/bedrock_test.go
+++ b/providers/aws/bedrock_test.go
@@ -57,26 +57,47 @@ func TestBedrockShouldLoadResourceHonorsTypedFilters(t *testing.T) {
 	}
 }
 
-func TestBedrockShouldLoadResourceAllowsUntypedIDFilter(t *testing.T) {
-	g := BedrockGenerator{
-		AWSService: AWSService{
-			Service: terraformutils.Service{
-				Filter: []terraformutils.ResourceFilter{
-					{
-						ServiceName:      "bedrock_guardrail",
-						FieldPath:        "id",
-						AcceptableValues: []string{"gr-1234567890,DRAFT"},
-					},
-					{
-						FieldPath:        "id",
-						AcceptableValues: []string{"arn:aws:bedrock:us-east-1:123456789012:provisioned-model/abc123"},
-					},
-				},
+func TestBedrockShouldLoadResourceAllowsUntypedFilters(t *testing.T) {
+	tests := []struct {
+		name   string
+		filter terraformutils.ResourceFilter
+	}{
+		{
+			name: "id",
+			filter: terraformutils.ResourceFilter{
+				FieldPath:        "id",
+				AcceptableValues: []string{"arn:aws:bedrock:us-east-1:123456789012:provisioned-model/abc123"},
+			},
+		},
+		{
+			name: "post-refresh attribute",
+			filter: terraformutils.ResourceFilter{
+				FieldPath:        "tags.env",
+				AcceptableValues: []string{"prod"},
 			},
 		},
 	}
-	if !g.shouldLoadBedrockResource("bedrock_inference_profile") {
-		t.Fatal("untyped ID filter should keep broad Bedrock discovery available")
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := BedrockGenerator{
+				AWSService: AWSService{
+					Service: terraformutils.Service{
+						Filter: []terraformutils.ResourceFilter{
+							{
+								ServiceName:      "bedrock_guardrail",
+								FieldPath:        "id",
+								AcceptableValues: []string{"gr-1234567890,DRAFT"},
+							},
+							tt.filter,
+						},
+					},
+				},
+			}
+			if !g.shouldLoadBedrockResource("bedrock_inference_profile") {
+				t.Fatal("untyped filter should keep broad Bedrock discovery available")
+			}
+		})
 	}
 }
 
@@ -274,6 +295,29 @@ func TestBedrockInitialCleanupHonorsTypedFilters(t *testing.T) {
 	}
 }
 
+func TestBedrockInitialCleanupPreservesGlobalFilters(t *testing.T) {
+	guardrail, profile, throughput := bedrockTestResources(t)
+	g := BedrockGenerator{}
+	g.Resources = []terraformutils.Resource{guardrail, profile, throughput}
+	g.Filter = []terraformutils.ResourceFilter{
+		{
+			ServiceName:      "bedrock_guardrail",
+			FieldPath:        "id",
+			AcceptableValues: []string{"gr-1234567890,DRAFT"},
+		},
+		{
+			FieldPath:        "tags.env",
+			AcceptableValues: []string{"prod"},
+		},
+	}
+
+	g.InitialCleanup()
+
+	if len(g.Resources) != 3 {
+		t.Fatalf("InitialCleanup() resources len = %d, want 3", len(g.Resources))
+	}
+}
+
 func assertBedrockResource(t *testing.T, resource terraformutils.Resource, ok bool, wantID, wantType string) {
 	t.Helper()
 	if !ok {
@@ -288,4 +332,38 @@ func assertBedrockResource(t *testing.T, resource terraformutils.Resource, ok bo
 	if resource.ResourceName == "" {
 		t.Fatal("resource name should not be empty")
 	}
+}
+
+func bedrockTestResources(t *testing.T) (terraformutils.Resource, terraformutils.Resource, terraformutils.Resource) {
+	t.Helper()
+	guardrail, ok := newBedrockGuardrailResource(bedrocktypes.GuardrailSummary{
+		Id:      aws.String("gr-1234567890"),
+		Name:    aws.String("billing-policy"),
+		Status:  bedrocktypes.GuardrailStatusReady,
+		Version: aws.String("DRAFT"),
+	})
+	if !ok {
+		t.Fatal("newBedrockGuardrailResource() should create guardrail")
+	}
+	profile, ok := newBedrockInferenceProfileResource(bedrocktypes.InferenceProfileSummary{
+		InferenceProfileId:   aws.String("ip-1234567890"),
+		InferenceProfileName: aws.String("application-profile"),
+		Status:               bedrocktypes.InferenceProfileStatusActive,
+		Type:                 bedrocktypes.InferenceProfileTypeApplication,
+	})
+	if !ok {
+		t.Fatal("newBedrockInferenceProfileResource() should create profile")
+	}
+	modelUnits := int32(2)
+	throughput, ok := newBedrockProvisionedModelThroughputResource(bedrocktypes.ProvisionedModelSummary{
+		ModelArn:             aws.String("arn:aws:bedrock:us-east-1::foundation-model/amazon.nova-pro-v1:0"),
+		ModelUnits:           &modelUnits,
+		ProvisionedModelArn:  aws.String("arn:aws:bedrock:us-east-1:123456789012:provisioned-model/abc123"),
+		ProvisionedModelName: aws.String("prod-throughput"),
+		Status:               bedrocktypes.ProvisionedModelStatusInService,
+	})
+	if !ok {
+		t.Fatal("newBedrockProvisionedModelThroughputResource() should create throughput")
+	}
+	return guardrail, profile, throughput
 }

--- a/providers/aws/bedrock_test.go
+++ b/providers/aws/bedrock_test.go
@@ -33,6 +33,53 @@ func TestBedrockResourceNameUniqueness(t *testing.T) {
 	}
 }
 
+func TestBedrockShouldLoadResourceHonorsTypedFilters(t *testing.T) {
+	g := BedrockGenerator{}
+	if !g.shouldLoadBedrockResource("bedrock_guardrail") ||
+		!g.shouldLoadBedrockResource("bedrock_inference_profile") ||
+		!g.shouldLoadBedrockResource("bedrock_provisioned_model_throughput") {
+		t.Fatal("without typed filters, all Bedrock resource families should be loaded")
+	}
+
+	g.Filter = []terraformutils.ResourceFilter{{
+		ServiceName:      "bedrock_guardrail",
+		FieldPath:        "id",
+		AcceptableValues: []string{"gr-1234567890,DRAFT"},
+	}}
+	if !g.shouldLoadBedrockResource("bedrock_guardrail") {
+		t.Fatal("typed guardrail filter should load guardrails")
+	}
+	if g.shouldLoadBedrockResource("bedrock_inference_profile") {
+		t.Fatal("typed guardrail filter should not load inference profiles")
+	}
+	if g.shouldLoadBedrockResource("bedrock_provisioned_model_throughput") {
+		t.Fatal("typed guardrail filter should not load provisioned throughputs")
+	}
+}
+
+func TestBedrockShouldLoadResourceAllowsUntypedIDFilter(t *testing.T) {
+	g := BedrockGenerator{
+		AWSService: AWSService{
+			Service: terraformutils.Service{
+				Filter: []terraformutils.ResourceFilter{
+					{
+						ServiceName:      "bedrock_guardrail",
+						FieldPath:        "id",
+						AcceptableValues: []string{"gr-1234567890,DRAFT"},
+					},
+					{
+						FieldPath:        "id",
+						AcceptableValues: []string{"arn:aws:bedrock:us-east-1:123456789012:provisioned-model/abc123"},
+					},
+				},
+			},
+		},
+	}
+	if !g.shouldLoadBedrockResource("bedrock_inference_profile") {
+		t.Fatal("untyped ID filter should keep broad Bedrock discovery available")
+	}
+}
+
 func TestNewBedrockGuardrailResource(t *testing.T) {
 	resource, ok := newBedrockGuardrailResource(bedrocktypes.GuardrailSummary{
 		Id:      aws.String("gr-1234567890"),
@@ -175,6 +222,55 @@ func TestBedrockResourceNotFound(t *testing.T) {
 	}
 	if bedrockResourceNotFound(errors.New("other error")) {
 		t.Fatal("non-not-found error should not be detected")
+	}
+}
+
+func TestBedrockInitialCleanupHonorsTypedFilters(t *testing.T) {
+	guardrail, ok := newBedrockGuardrailResource(bedrocktypes.GuardrailSummary{
+		Id:      aws.String("gr-1234567890"),
+		Name:    aws.String("billing-policy"),
+		Status:  bedrocktypes.GuardrailStatusReady,
+		Version: aws.String("DRAFT"),
+	})
+	if !ok {
+		t.Fatal("newBedrockGuardrailResource() should create guardrail")
+	}
+	profile, ok := newBedrockInferenceProfileResource(bedrocktypes.InferenceProfileSummary{
+		InferenceProfileId:   aws.String("ip-1234567890"),
+		InferenceProfileName: aws.String("application-profile"),
+		Status:               bedrocktypes.InferenceProfileStatusActive,
+		Type:                 bedrocktypes.InferenceProfileTypeApplication,
+	})
+	if !ok {
+		t.Fatal("newBedrockInferenceProfileResource() should create profile")
+	}
+	modelUnits := int32(2)
+	throughput, ok := newBedrockProvisionedModelThroughputResource(bedrocktypes.ProvisionedModelSummary{
+		ModelArn:             aws.String("arn:aws:bedrock:us-east-1::foundation-model/amazon.nova-pro-v1:0"),
+		ModelUnits:           &modelUnits,
+		ProvisionedModelArn:  aws.String("arn:aws:bedrock:us-east-1:123456789012:provisioned-model/abc123"),
+		ProvisionedModelName: aws.String("prod-throughput"),
+		Status:               bedrocktypes.ProvisionedModelStatusInService,
+	})
+	if !ok {
+		t.Fatal("newBedrockProvisionedModelThroughputResource() should create throughput")
+	}
+
+	g := BedrockGenerator{}
+	g.Resources = []terraformutils.Resource{guardrail, profile, throughput}
+	g.Filter = []terraformutils.ResourceFilter{{
+		ServiceName:      "bedrock_guardrail",
+		FieldPath:        "id",
+		AcceptableValues: []string{"gr-1234567890,DRAFT"},
+	}}
+
+	g.InitialCleanup()
+
+	if len(g.Resources) != 1 {
+		t.Fatalf("InitialCleanup() resources len = %d, want 1", len(g.Resources))
+	}
+	if got := g.Resources[0].InstanceInfo.Type; got != bedrockGuardrailResourceType {
+		t.Fatalf("InitialCleanup() kept resource type = %q, want %s", got, bedrockGuardrailResourceType)
 	}
 }
 

--- a/providers/aws/bedrock_test.go
+++ b/providers/aws/bedrock_test.go
@@ -1,0 +1,195 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package aws
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	bedrocktypes "github.com/aws/aws-sdk-go-v2/service/bedrock/types"
+	"github.com/chenrui333/terraformer/terraformutils"
+)
+
+func TestBedrockGuardrailImportID(t *testing.T) {
+	got := bedrockGuardrailImportID("gr-1234567890", "DRAFT")
+	want := "gr-1234567890,DRAFT"
+	if got != want {
+		t.Fatalf("bedrockGuardrailImportID() = %q, want %q", got, want)
+	}
+}
+
+func TestBedrockResourceNameFallback(t *testing.T) {
+	if got := bedrockResourceName("", ""); got != bedrockResourceNameFallback {
+		t.Fatalf("bedrockResourceName() = %q, want %q", got, bedrockResourceNameFallback)
+	}
+}
+
+func TestBedrockResourceNameUniqueness(t *testing.T) {
+	first := terraformutils.TfSanitize(bedrockResourceName("ab", "c"))
+	second := terraformutils.TfSanitize(bedrockResourceName("a", "bc"))
+	if first == second {
+		t.Fatalf("bedrockResourceName() collision after sanitize: %q", first)
+	}
+}
+
+func TestNewBedrockGuardrailResource(t *testing.T) {
+	resource, ok := newBedrockGuardrailResource(bedrocktypes.GuardrailSummary{
+		Id:      aws.String("gr-1234567890"),
+		Name:    aws.String("billing-policy"),
+		Status:  bedrocktypes.GuardrailStatusReady,
+		Version: aws.String("DRAFT"),
+	})
+	assertBedrockResource(t, resource, ok, "gr-1234567890,DRAFT", bedrockGuardrailResourceType)
+	if got := resource.InstanceState.Attributes["guardrail_id"]; got != "gr-1234567890" {
+		t.Fatalf("guardrail_id attribute = %q, want gr-1234567890", got)
+	}
+	if got := resource.InstanceState.Attributes["version"]; got != "DRAFT" {
+		t.Fatalf("version attribute = %q, want DRAFT", got)
+	}
+
+	if _, ok := newBedrockGuardrailResource(bedrocktypes.GuardrailSummary{
+		Status:  bedrocktypes.GuardrailStatusReady,
+		Version: aws.String("DRAFT"),
+	}); ok {
+		t.Fatal("guardrail without ID should be skipped")
+	}
+	if _, ok := newBedrockGuardrailResource(bedrocktypes.GuardrailSummary{
+		Id:      aws.String("gr-1234567890"),
+		Status:  bedrocktypes.GuardrailStatusReady,
+		Version: aws.String(""),
+	}); ok {
+		t.Fatal("guardrail without version should be skipped")
+	}
+	if _, ok := newBedrockGuardrailResource(bedrocktypes.GuardrailSummary{
+		Id:      aws.String("gr-1234567890"),
+		Status:  bedrocktypes.GuardrailStatusDeleting,
+		Version: aws.String("DRAFT"),
+	}); ok {
+		t.Fatal("deleting guardrail should be skipped")
+	}
+}
+
+func TestNewBedrockInferenceProfileResource(t *testing.T) {
+	resource, ok := newBedrockInferenceProfileResource(bedrocktypes.InferenceProfileSummary{
+		InferenceProfileId:   aws.String("ip-1234567890"),
+		InferenceProfileName: aws.String("application-profile"),
+		Status:               bedrocktypes.InferenceProfileStatusActive,
+		Type:                 bedrocktypes.InferenceProfileTypeApplication,
+	})
+	assertBedrockResource(t, resource, ok, "ip-1234567890", bedrockInferenceProfileResourceType)
+	if got := resource.InstanceState.Attributes["id"]; got != "ip-1234567890" {
+		t.Fatalf("id attribute = %q, want ip-1234567890", got)
+	}
+	if got := resource.InstanceState.Attributes["name"]; got != "application-profile" {
+		t.Fatalf("name attribute = %q, want application-profile", got)
+	}
+
+	if _, ok := newBedrockInferenceProfileResource(bedrocktypes.InferenceProfileSummary{
+		Status: bedrocktypes.InferenceProfileStatusActive,
+		Type:   bedrocktypes.InferenceProfileTypeApplication,
+	}); ok {
+		t.Fatal("inference profile without ID should be skipped")
+	}
+	if _, ok := newBedrockInferenceProfileResource(bedrocktypes.InferenceProfileSummary{
+		InferenceProfileId: aws.String("us.amazon.nova-pro-v1:0"),
+		Status:             bedrocktypes.InferenceProfileStatusActive,
+		Type:               bedrocktypes.InferenceProfileTypeSystemDefined,
+	}); ok {
+		t.Fatal("system-defined inference profile should be skipped")
+	}
+}
+
+func TestNewBedrockProvisionedModelThroughputResource(t *testing.T) {
+	modelUnits := int32(2)
+	resource, ok := newBedrockProvisionedModelThroughputResource(bedrocktypes.ProvisionedModelSummary{
+		ModelArn:             aws.String("arn:aws:bedrock:us-east-1::foundation-model/amazon.nova-pro-v1:0"),
+		ModelUnits:           &modelUnits,
+		ProvisionedModelArn:  aws.String("arn:aws:bedrock:us-east-1:123456789012:provisioned-model/abc123"),
+		ProvisionedModelName: aws.String("prod-throughput"),
+		Status:               bedrocktypes.ProvisionedModelStatusInService,
+	})
+	assertBedrockResource(t, resource, ok, "arn:aws:bedrock:us-east-1:123456789012:provisioned-model/abc123", bedrockProvisionedModelThroughputResourceType)
+	if got := resource.InstanceState.Attributes["model_units"]; got != "2" {
+		t.Fatalf("model_units attribute = %q, want 2", got)
+	}
+	if got := resource.InstanceState.Attributes["model_arn"]; got == "" {
+		t.Fatal("model_arn attribute should be seeded")
+	}
+
+	if _, ok := newBedrockProvisionedModelThroughputResource(bedrocktypes.ProvisionedModelSummary{
+		ModelArn:             aws.String("arn:aws:bedrock:us-east-1::foundation-model/amazon.nova-pro-v1:0"),
+		ProvisionedModelArn:  aws.String("arn:aws:bedrock:us-east-1:123456789012:provisioned-model/abc123"),
+		ProvisionedModelName: aws.String("prod-throughput"),
+		Status:               bedrocktypes.ProvisionedModelStatusInService,
+	}); ok {
+		t.Fatal("throughput without model units should be skipped")
+	}
+	if _, ok := newBedrockProvisionedModelThroughputResource(bedrocktypes.ProvisionedModelSummary{
+		ModelArn:             aws.String("arn:aws:bedrock:us-east-1::foundation-model/amazon.nova-pro-v1:0"),
+		ModelUnits:           &modelUnits,
+		ProvisionedModelArn:  aws.String("arn:aws:bedrock:us-east-1:123456789012:provisioned-model/abc123"),
+		ProvisionedModelName: aws.String("prod-throughput"),
+		Status:               bedrocktypes.ProvisionedModelStatusFailed,
+	}); ok {
+		t.Fatal("failed throughput should be skipped")
+	}
+}
+
+func TestBedrockImportableStatuses(t *testing.T) {
+	if !bedrockGuardrailImportable(bedrocktypes.GuardrailStatusReady) {
+		t.Fatal("READY guardrail should be importable")
+	}
+	for _, status := range []bedrocktypes.GuardrailStatus{
+		bedrocktypes.GuardrailStatusCreating,
+		bedrocktypes.GuardrailStatusUpdating,
+		bedrocktypes.GuardrailStatusVersioning,
+		bedrocktypes.GuardrailStatusFailed,
+		bedrocktypes.GuardrailStatusDeleting,
+	} {
+		if bedrockGuardrailImportable(status) {
+			t.Fatalf("%s guardrail should not be importable", status)
+		}
+	}
+
+	if !bedrockProvisionedModelThroughputImportable(bedrocktypes.ProvisionedModelStatusInService) {
+		t.Fatal("InService throughput should be importable")
+	}
+	for _, status := range []bedrocktypes.ProvisionedModelStatus{
+		bedrocktypes.ProvisionedModelStatusCreating,
+		bedrocktypes.ProvisionedModelStatusUpdating,
+		bedrocktypes.ProvisionedModelStatusFailed,
+	} {
+		if bedrockProvisionedModelThroughputImportable(status) {
+			t.Fatalf("%s throughput should not be importable", status)
+		}
+	}
+}
+
+func TestBedrockResourceNotFound(t *testing.T) {
+	if !bedrockResourceNotFound(&bedrocktypes.ResourceNotFoundException{}) {
+		t.Fatal("ResourceNotFoundException should be detected")
+	}
+	if !bedrockResourceNotFound(errors.Join(errors.New("lookup failed"), &bedrocktypes.ResourceNotFoundException{})) {
+		t.Fatal("wrapped ResourceNotFoundException should be detected")
+	}
+	if bedrockResourceNotFound(errors.New("other error")) {
+		t.Fatal("non-not-found error should not be detected")
+	}
+}
+
+func assertBedrockResource(t *testing.T, resource terraformutils.Resource, ok bool, wantID, wantType string) {
+	t.Helper()
+	if !ok {
+		t.Fatal("resource should be created")
+	}
+	if got := resource.InstanceState.ID; got != wantID {
+		t.Fatalf("resource ID = %q, want %q", got, wantID)
+	}
+	if got := resource.InstanceInfo.Type; got != wantType {
+		t.Fatalf("resource type = %q, want %q", got, wantType)
+	}
+	if resource.ResourceName == "" {
+		t.Fatal("resource name should not be empty")
+	}
+}


### PR DESCRIPTION
## Summary

- add Bedrock import discovery for guardrails, application inference profiles, and provisioned model throughputs
- register the `bedrock` AWS service and add the Bedrock SDK module
- seed import IDs as `guardrail_id,version`, `inference_profile_id`, and `provisioned_model_arn`
- update docs/aws.md for supported Bedrock resources
- add unit tests for Bedrock resource helper behavior

## References

- #338

## Validation

```bash
go test ./providers/aws -run 'Test.*Bedrock|Test.*bedrock'
go test ./providers/aws/... ./terraformutils/...
go run ./tools/aws-gap-inventory \
  -docs docs/aws.md \
  -aws-dir providers/aws \
  -skip-list providers/aws/unsupported_resources.json \
  -format markdown
git diff --check
```

## Notes

Skipped/deferred resources:
- `aws_bedrock_custom_model`: deferred because Terraform import uses the customization job ARN, so discovery should be based on model customization jobs rather than custom model summaries alone.
- `aws_bedrock_guardrail_version`: deferred to keep this PR limited to DRAFT guardrail resources; version discovery needs a second `ListGuardrails` pass per guardrail.
- `aws_bedrock_model_invocation_logging_configuration`: region-scoped singleton resource deferred to a follow-up PR.
- `aws_bedrockagent_*` and `aws_bedrockagentcore_*`: out of scope for this Bedrock core PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for AWS Bedrock service, including guardrails, inference profiles, and provisioned model throughput resources.

* **Documentation**
  * Updated AWS supported services documentation to include Bedrock.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/chenrui333/terraformer/pull/401)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->