### PR TITLE
aws(logs): add CloudWatch Logs anomaly detector imports

### DIFF
--- a/docs/aws.md
+++ b/docs/aws.md
@@ -354,6 +354,7 @@ For AWS provider gap audits and unsupported-resource skip-list maintenance, see 
     * `aws_lambda_runtime_management_config`
 *   `logs`
     * `aws_cloudwatch_log_account_policy`
+    * `aws_cloudwatch_log_anomaly_detector`
     * `aws_cloudwatch_log_data_protection_policy`
     * `aws_cloudwatch_log_delivery`
     * `aws_cloudwatch_log_delivery_destination`

--- a/providers/aws/logs.go
+++ b/providers/aws/logs.go
@@ -12,6 +12,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/cloudwatchlogs"
 	"github.com/aws/aws-sdk-go-v2/service/cloudwatchlogs/types"
 	"github.com/chenrui333/terraformer/terraformutils"
+	"github.com/chenrui333/terraformer/terraformutils/tfcompat"
 )
 
 var logsAllowEmptyValues = []string{"tags."}
@@ -658,14 +659,19 @@ func newLogsAnomalyDetectorResource(detector types.AnomalyDetector) (terraformut
 		attributes[key] = value
 	}
 
-	return terraformutils.NewResource(
+	resource := terraformutils.NewResource(
 		detectorARN,
 		logsAnomalyDetectorResourceName(StringValue(detector.DetectorName), detectorARN),
 		logsAnomalyDetectorResourceType,
 		"aws",
 		attributes,
 		logsAllowEmptyValues,
-		map[string]interface{}{}), true
+		map[string]interface{}{})
+	if resource.InstanceState.Meta == nil {
+		resource.InstanceState.Meta = map[string]interface{}{}
+	}
+	resource.InstanceState.Meta[tfcompat.MetaKeyPreserveIDAfterRefresh] = true
+	return resource, true
 }
 
 func logsAnomalyDetectorEnabledValue(status types.AnomalyDetectorStatus) (bool, bool) {

--- a/providers/aws/logs.go
+++ b/providers/aws/logs.go
@@ -17,6 +17,7 @@ import (
 var logsAllowEmptyValues = []string{"tags."}
 
 const (
+	logsAnomalyDetectorResourceType           = "aws_cloudwatch_log_anomaly_detector"
 	logsDeliveryResourceType                  = "aws_cloudwatch_log_delivery"
 	logsDeliveryDestinationResourceType       = "aws_cloudwatch_log_delivery_destination"
 	logsDeliveryDestinationPolicyResourceType = "aws_cloudwatch_log_delivery_destination_policy"
@@ -100,6 +101,7 @@ func (g *LogsGenerator) InitResources() error {
 		logsOptionalResourceLoader{name: "delivery sources", load: func() error { return g.addDeliverySources(svc) }},
 		logsOptionalResourceLoader{name: "delivery destinations", load: func() error { return g.addDeliveryDestinations(svc) }},
 		logsOptionalResourceLoader{name: "deliveries", load: func() error { return g.addDeliveries(svc) }},
+		logsOptionalResourceLoader{name: "anomaly detectors", load: func() error { return g.addAnomalyDetectors(svc) }},
 		logsOptionalResourceLoader{name: "resource policies", load: func() error { return g.addResourcePolicies(svc) }},
 		logsOptionalResourceLoader{name: "account policies", load: func() error { return g.addAccountPolicies(svc) }},
 		logsOptionalResourceLoader{name: "query definitions", load: func() error { return g.addQueryDefinitions(svc) }},
@@ -325,6 +327,22 @@ func (g *LogsGenerator) addDeliveries(svc *cloudwatchlogs.Client) error {
 		}
 		for _, delivery := range page.Deliveries {
 			if resource, ok := newLogsDeliveryResource(delivery); ok {
+				g.Resources = append(g.Resources, resource)
+			}
+		}
+	}
+	return nil
+}
+
+func (g *LogsGenerator) addAnomalyDetectors(svc *cloudwatchlogs.Client) error {
+	p := cloudwatchlogs.NewListLogAnomalyDetectorsPaginator(svc, &cloudwatchlogs.ListLogAnomalyDetectorsInput{})
+	for p.HasMorePages() {
+		page, err := p.NextPage(context.TODO())
+		if err != nil {
+			return err
+		}
+		for _, detector := range page.AnomalyDetectors {
+			if resource, ok := newLogsAnomalyDetectorResource(detector); ok {
 				g.Resources = append(g.Resources, resource)
 			}
 		}
@@ -623,4 +641,68 @@ func logsResourceNameWithLengths(parts ...string) string {
 		name += fmt.Sprintf("%d_%s", len(part), part)
 	}
 	return name
+}
+
+func newLogsAnomalyDetectorResource(detector types.AnomalyDetector) (terraformutils.Resource, bool) {
+	detectorARN := StringValue(detector.AnomalyDetectorArn)
+	enabled, ok := logsAnomalyDetectorEnabledValue(detector.AnomalyDetectorStatus)
+	if !ok || detectorARN == "" || !logsStringListValuesComplete(detector.LogGroupArnList) {
+		return terraformutils.Resource{}, false
+	}
+
+	attributes := map[string]string{
+		"arn":     detectorARN,
+		"enabled": strconv.FormatBool(enabled),
+	}
+	for key, value := range logsStringListAttributes("log_group_arn_list", detector.LogGroupArnList) {
+		attributes[key] = value
+	}
+
+	return terraformutils.NewResource(
+		detectorARN,
+		logsAnomalyDetectorResourceName(StringValue(detector.DetectorName), detectorARN),
+		logsAnomalyDetectorResourceType,
+		"aws",
+		attributes,
+		logsAllowEmptyValues,
+		map[string]interface{}{}), true
+}
+
+func logsAnomalyDetectorEnabledValue(status types.AnomalyDetectorStatus) (bool, bool) {
+	switch status {
+	case "":
+		return false, false
+	case types.AnomalyDetectorStatusDeleted:
+		return false, false
+	case types.AnomalyDetectorStatusPaused:
+		return false, true
+	default:
+		return true, true
+	}
+}
+
+func logsAnomalyDetectorResourceName(detectorName, detectorARN string) string {
+	return logsResourceNameWithLengths("anomaly_detector", detectorName, detectorARN)
+}
+
+func logsStringListAttributes(name string, values []string) map[string]string {
+	attributes := map[string]string{
+		name + ".#": strconv.Itoa(len(values)),
+	}
+	for i, value := range values {
+		attributes[fmt.Sprintf("%s.%d", name, i)] = value
+	}
+	return attributes
+}
+
+func logsStringListValuesComplete(values []string) bool {
+	if len(values) == 0 {
+		return false
+	}
+	for _, value := range values {
+		if value == "" {
+			return false
+		}
+	}
+	return true
 }

--- a/providers/aws/logs_test.go
+++ b/providers/aws/logs_test.go
@@ -532,3 +532,152 @@ func TestNewLogsDeliveryResource(t *testing.T) {
 		})
 	}
 }
+
+func TestNewLogsAnomalyDetectorResource(t *testing.T) {
+	detectorARN := "arn:aws:logs:us-east-1:123456789012:anomaly-detector:detector-1"
+	logGroupARN := "arn:aws:logs:us-east-1:123456789012:log-group:/aws/lambda/example"
+	detectorName := "lambda-errors"
+
+	tests := []struct {
+		name        string
+		detector    types.AnomalyDetector
+		wantOK      bool
+		wantEnabled string
+	}{
+		{
+			name: "analyzing detector",
+			detector: types.AnomalyDetector{
+				AnomalyDetectorArn:    &detectorARN,
+				AnomalyDetectorStatus: types.AnomalyDetectorStatusAnalyzing,
+				DetectorName:          &detectorName,
+				LogGroupArnList:       []string{logGroupARN},
+			},
+			wantOK:      true,
+			wantEnabled: "true",
+		},
+		{
+			name: "paused detector",
+			detector: types.AnomalyDetector{
+				AnomalyDetectorArn:    &detectorARN,
+				AnomalyDetectorStatus: types.AnomalyDetectorStatusPaused,
+				DetectorName:          &detectorName,
+				LogGroupArnList:       []string{logGroupARN},
+			},
+			wantOK:      true,
+			wantEnabled: "false",
+		},
+		{
+			name: "failed detector remains importable",
+			detector: types.AnomalyDetector{
+				AnomalyDetectorArn:    &detectorARN,
+				AnomalyDetectorStatus: types.AnomalyDetectorStatusFailed,
+				DetectorName:          &detectorName,
+				LogGroupArnList:       []string{logGroupARN},
+			},
+			wantOK:      true,
+			wantEnabled: "true",
+		},
+		{
+			name: "detector without ARN is skipped",
+			detector: types.AnomalyDetector{
+				AnomalyDetectorStatus: types.AnomalyDetectorStatusAnalyzing,
+				LogGroupArnList:       []string{logGroupARN},
+			},
+		},
+		{
+			name: "detector without log group ARN is skipped",
+			detector: types.AnomalyDetector{
+				AnomalyDetectorArn:    &detectorARN,
+				AnomalyDetectorStatus: types.AnomalyDetectorStatusAnalyzing,
+			},
+		},
+		{
+			name: "detector with empty log group ARN is skipped",
+			detector: types.AnomalyDetector{
+				AnomalyDetectorArn:    &detectorARN,
+				AnomalyDetectorStatus: types.AnomalyDetectorStatusAnalyzing,
+				LogGroupArnList:       []string{""},
+			},
+		},
+		{
+			name: "detector without status is skipped",
+			detector: types.AnomalyDetector{
+				AnomalyDetectorArn: &detectorARN,
+				LogGroupArnList:    []string{logGroupARN},
+			},
+		},
+		{
+			name: "deleted detector is skipped",
+			detector: types.AnomalyDetector{
+				AnomalyDetectorArn:    &detectorARN,
+				AnomalyDetectorStatus: types.AnomalyDetectorStatusDeleted,
+				LogGroupArnList:       []string{logGroupARN},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			resource, ok := newLogsAnomalyDetectorResource(tt.detector)
+			if ok != tt.wantOK {
+				t.Fatalf("newLogsAnomalyDetectorResource() ok = %t, want %t", ok, tt.wantOK)
+			}
+			if !ok {
+				return
+			}
+			if got := resource.InstanceState.ID; got != detectorARN {
+				t.Fatalf("resource ID = %q, want %q", got, detectorARN)
+			}
+			if got := resource.InstanceInfo.Type; got != logsAnomalyDetectorResourceType {
+				t.Fatalf("resource type = %q, want %q", got, logsAnomalyDetectorResourceType)
+			}
+			for key, want := range map[string]string{
+				"arn":                  detectorARN,
+				"enabled":              tt.wantEnabled,
+				"log_group_arn_list.#": "1",
+				"log_group_arn_list.0": logGroupARN,
+			} {
+				if got := resource.InstanceState.Attributes[key]; got != want {
+					t.Fatalf("%s = %q, want %q", key, got, want)
+				}
+			}
+		})
+	}
+}
+
+func TestLogsAnomalyDetectorResourceNamesPreservePartBoundaries(t *testing.T) {
+	left := logsAnomalyDetectorResourceName("a/b", "arn:aws:logs:us-east-1:123456789012:anomaly-detector:left")
+	right := logsAnomalyDetectorResourceName("a-002F-b", "arn:aws:logs:us-east-1:123456789012:anomaly-detector:left")
+	if left == right {
+		t.Fatalf("anomaly detector resource names collide: %q", left)
+	}
+}
+
+func TestLogsAnomalyDetectorEnabledValue(t *testing.T) {
+	tests := []struct {
+		name        string
+		status      types.AnomalyDetectorStatus
+		wantEnabled bool
+		wantOK      bool
+	}{
+		{name: "analyzing", status: types.AnomalyDetectorStatusAnalyzing, wantEnabled: true, wantOK: true},
+		{name: "initializing", status: types.AnomalyDetectorStatusInitializing, wantEnabled: true, wantOK: true},
+		{name: "training", status: types.AnomalyDetectorStatusTraining, wantEnabled: true, wantOK: true},
+		{name: "failed", status: types.AnomalyDetectorStatusFailed, wantEnabled: true, wantOK: true},
+		{name: "paused", status: types.AnomalyDetectorStatusPaused, wantEnabled: false, wantOK: true},
+		{name: "deleted", status: types.AnomalyDetectorStatusDeleted, wantOK: false},
+		{name: "empty", wantOK: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotEnabled, gotOK := logsAnomalyDetectorEnabledValue(tt.status)
+			if gotOK != tt.wantOK {
+				t.Fatalf("logsAnomalyDetectorEnabledValue() ok = %t, want %t", gotOK, tt.wantOK)
+			}
+			if gotEnabled != tt.wantEnabled {
+				t.Fatalf("logsAnomalyDetectorEnabledValue() enabled = %t, want %t", gotEnabled, tt.wantEnabled)
+			}
+		})
+	}
+}

--- a/providers/aws/logs_test.go
+++ b/providers/aws/logs_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/aws/aws-sdk-go-v2/service/cloudwatchlogs/types"
+	"github.com/chenrui333/terraformer/terraformutils/tfcompat"
 )
 
 func TestLogsAccountPolicyTypes(t *testing.T) {
@@ -630,6 +631,9 @@ func TestNewLogsAnomalyDetectorResource(t *testing.T) {
 			}
 			if got := resource.InstanceInfo.Type; got != logsAnomalyDetectorResourceType {
 				t.Fatalf("resource type = %q, want %q", got, logsAnomalyDetectorResourceType)
+			}
+			if preserveID, ok := resource.InstanceState.Meta[tfcompat.MetaKeyPreserveIDAfterRefresh].(bool); !ok || !preserveID {
+				t.Fatalf("preserve ID metadata = %v, %t; want true, true", preserveID, ok)
 			}
 			for key, want := range map[string]string{
 				"arn":                  detectorARN,

--- a/terraformutils/providerwrapper/provider.go
+++ b/terraformutils/providerwrapper/provider.go
@@ -179,6 +179,7 @@ func (p *ProviderWrapper) Refresh(info *tfcompat.InstanceInfo, state *tfcompat.I
 
 	refreshedState := tfcompat.NewInstanceStateShimmedFromValue(resp.NewState, int(schema.ResourceTypes[info.Type].Version))
 	preserveKubernetesManifestID(info.Type, refreshedState, state)
+	preservePriorStateID(refreshedState, state)
 	return refreshedState, nil
 }
 
@@ -204,12 +205,24 @@ func (p *ProviderWrapper) importResourceState(info *tfcompat.InstanceInfo, state
 	}
 	importedState := tfcompat.NewInstanceStateShimmedFromValue(importResponse.ImportedResources[0].State, int(schema.ResourceTypes[info.Type].Version))
 	preserveKubernetesManifestID(info.Type, importedState, state)
+	preservePriorStateID(importedState, state)
 	populateKubernetesManifestFromObject(info.Type, importedState)
 	return importedState, nil
 }
 
 func preserveKubernetesManifestID(resourceType string, next *tfcompat.InstanceState, previous *tfcompat.InstanceState) {
 	if resourceType != kubernetesManifestResourceType || next == nil || next.ID != "" || previous == nil {
+		return
+	}
+	next.ID = previous.ID
+}
+
+func preservePriorStateID(next *tfcompat.InstanceState, previous *tfcompat.InstanceState) {
+	if next == nil || next.ID != "" || previous == nil || previous.ID == "" || previous.Meta == nil {
+		return
+	}
+	preserveID, _ := previous.Meta[tfcompat.MetaKeyPreserveIDAfterRefresh].(bool)
+	if !preserveID {
 		return
 	}
 	next.ID = previous.ID

--- a/terraformutils/providerwrapper/provider_test.go
+++ b/terraformutils/providerwrapper/provider_test.go
@@ -242,6 +242,34 @@ func TestPreserveKubernetesManifestID(t *testing.T) {
 	}
 }
 
+func TestPreservePriorStateID(t *testing.T) {
+	previous := &tfcompat.InstanceState{
+		ID: "arn:aws:logs:us-east-1:123456789012:anomaly-detector:detector-1",
+		Meta: map[string]interface{}{
+			tfcompat.MetaKeyPreserveIDAfterRefresh: true,
+		},
+	}
+	next := &tfcompat.InstanceState{}
+
+	preservePriorStateID(next, previous)
+	if next.ID != previous.ID {
+		t.Fatalf("preserved ID = %q, want %q", next.ID, previous.ID)
+	}
+
+	next.ID = "provider-id"
+	preservePriorStateID(next, previous)
+	if next.ID != "provider-id" {
+		t.Fatalf("existing ID = %q, want provider-id", next.ID)
+	}
+
+	withoutOptIn := &tfcompat.InstanceState{ID: "import-id"}
+	next = &tfcompat.InstanceState{}
+	preservePriorStateID(next, withoutOptIn)
+	if next.ID != "" {
+		t.Fatalf("unmarked ID = %q, want empty", next.ID)
+	}
+}
+
 func assertJSONNumber(t *testing.T, value interface{}, want string) {
 	t.Helper()
 	number, ok := value.(json.Number)

--- a/terraformutils/tfcompat/state.go
+++ b/terraformutils/tfcompat/state.go
@@ -13,6 +13,9 @@ import (
 const (
 	TerraformVersion     = "1.9.0"
 	UnknownVariableValue = "74D93920-ED26-11E3-AC10-0800200C9A66"
+
+	// MetaKeyPreserveIDAfterRefresh marks state whose import ID is not represented by provider attributes.
+	MetaKeyPreserveIDAfterRefresh = "preserve_id_after_refresh"
 )
 
 type InstanceInfo struct {


### PR DESCRIPTION
## Summary

- add CloudWatch Logs anomaly detector import discovery
- seed import IDs as anomaly detector ARNs
- update docs/aws.md for aws_cloudwatch_log_anomaly_detector
- add unit tests for anomaly detector helper behavior

## References

- #338

## Validation

```bash
go run ./tools/aws-gap-inventory \
  -docs docs/aws.md \
  -aws-dir providers/aws \
  -skip-list providers/aws/unsupported_resources.json \
  -format markdown

go test ./providers/aws -run 'Test.*Logs|Test.*CloudWatch|Test.*cloudwatch|Test.*logs'
go test ./providers/aws/... ./terraformutils/... ./tools/aws-gap-inventory/...
git diff --check
```

## Notes

Skipped/deferred resources:
- `aws_cloudwatch_log_stream`: high-cardinality and ephemeral; needs explicit scale/filter handling.
- `aws_cloudwatch_log_transformer`: deferred for a focused transformer PR.
- Deleted or incomplete anomaly detector list entries are skipped because Terraform cannot refresh them safely.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add CloudWatch Logs anomaly detector import discovery, generate `aws_cloudwatch_log_anomaly_detector` resources from ARNs, and preserve import IDs on refresh. Progress on #338.

- **New Features**
  - Import detectors via `ListLogAnomalyDetectors`; set `arn`, `enabled`, and `log_group_arn_list`; use the detector ARN as the import ID.
  - Map status to `enabled` (Paused=false; others=true), skip deleted/incomplete entries, and preserve IDs after refresh using `preserve_id_after_refresh` in state with a provider wrapper helper; updated docs and tests.

<sup>Written for commit 5aeaa54e4a56989c4ba565d8e015d2ae26959771. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for AWS CloudWatch Logs anomaly detector resource discovery and import.

* **Documentation**
  * Updated supported services list to include AWS CloudWatch Logs anomaly detectors.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/chenrui333/terraformer/pull/402)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->