### PR TITLE
aws(sesv2): add SESv2 child resource imports

### DIFF
--- a/docs/aws.md
+++ b/docs/aws.md
@@ -482,8 +482,12 @@ For AWS provider gap audits and unsupported-resource skip-list maintenance, see 
     * `aws_ses_template`
 *   `sesv2`
     * `aws_sesv2_configuration_set`
+    * `aws_sesv2_configuration_set_event_destination`
     * `aws_sesv2_dedicated_ip_pool`
     * `aws_sesv2_email_identity`
+    * `aws_sesv2_email_identity_feedback_attributes`
+    * `aws_sesv2_email_identity_mail_from_attributes`
+    * `aws_sesv2_email_identity_policy`
 *   `sfn`
     * `aws_sfn_activity`
     * `aws_sfn_state_machine`

--- a/providers/aws/sesv2.go
+++ b/providers/aws/sesv2.go
@@ -5,6 +5,8 @@ package aws
 import (
 	"context"
 	"errors"
+	"fmt"
+	"sort"
 	"strconv"
 	"strings"
 
@@ -14,9 +16,14 @@ import (
 )
 
 const (
-	sesv2ConfigurationSetResourceType = "aws_sesv2_configuration_set"
-	sesv2DedicatedIPPoolResourceType  = "aws_sesv2_dedicated_ip_pool"
-	sesv2EmailIdentityResourceType    = "aws_sesv2_email_identity"
+	sesv2ConfigurationSetResourceType                 = "aws_sesv2_configuration_set"
+	sesv2ConfigurationSetEventDestinationResourceType = "aws_sesv2_configuration_set_event_destination"
+	sesv2DedicatedIPPoolResourceType                  = "aws_sesv2_dedicated_ip_pool"
+	sesv2EmailIdentityResourceType                    = "aws_sesv2_email_identity"
+	sesv2EmailIdentityFeedbackAttributesResourceType  = "aws_sesv2_email_identity_feedback_attributes"
+	sesv2EmailIdentityMailFromAttributesResourceType  = "aws_sesv2_email_identity_mail_from_attributes"
+	sesv2EmailIdentityPolicyResourceType              = "aws_sesv2_email_identity_policy"
+	sesv2ResourceIDSeparator                          = "|"
 )
 
 var sesv2AllowEmptyValues = []string{"tags."}
@@ -45,6 +52,20 @@ func (g *SesV2Generator) InitResources() error {
 	return nil
 }
 
+func (g *SesV2Generator) PostConvertHook() error {
+	for i, resource := range g.Resources {
+		if resource.InstanceInfo.Type != sesv2EmailIdentityPolicyResourceType {
+			continue
+		}
+		policy, ok := resource.Item["policy"].(string)
+		if !ok || policy == "" {
+			continue
+		}
+		g.Resources[i].Item["policy"] = fmt.Sprintf("<<POLICY\n%s\nPOLICY", g.escapeAwsInterpolation(policy))
+	}
+	return nil
+}
+
 func (g *SesV2Generator) loadConfigurationSets(svc *sesv2.Client) error {
 	p := sesv2.NewListConfigurationSetsPaginator(svc, &sesv2.ListConfigurationSetsInput{})
 	for p.HasMorePages() {
@@ -53,9 +74,39 @@ func (g *SesV2Generator) loadConfigurationSets(svc *sesv2.Client) error {
 			return err
 		}
 		for _, configurationSetName := range page.ConfigurationSets {
+			if configurationSetName == "" {
+				continue
+			}
 			if resource, ok := newSESV2ConfigurationSetResource(configurationSetName); ok {
 				g.Resources = append(g.Resources, resource)
 			}
+			if err := g.loadConfigurationSetEventDestinations(svc, configurationSetName); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+func (g *SesV2Generator) loadConfigurationSetEventDestinations(svc *sesv2.Client, configurationSetName string) error {
+	if configurationSetName == "" {
+		return nil
+	}
+	output, err := svc.GetConfigurationSetEventDestinations(context.TODO(), &sesv2.GetConfigurationSetEventDestinationsInput{
+		ConfigurationSetName: &configurationSetName,
+	})
+	if err != nil {
+		if sesv2NotFound(err) {
+			return nil
+		}
+		return err
+	}
+	if output == nil {
+		return nil
+	}
+	for _, destination := range output.EventDestinations {
+		if resource, ok := newSESV2ConfigurationSetEventDestinationResource(configurationSetName, destination); ok {
+			g.Resources = append(g.Resources, resource)
 		}
 	}
 	return nil
@@ -101,6 +152,44 @@ func (g *SesV2Generator) loadEmailIdentities(svc *sesv2.Client) error {
 			if resource, ok := newSESV2EmailIdentityResource(identityName, output); ok {
 				g.Resources = append(g.Resources, resource)
 			}
+			if resource, ok := newSESV2EmailIdentityFeedbackAttributesResource(identityName, output); ok {
+				g.Resources = append(g.Resources, resource)
+			}
+			if resource, ok := newSESV2EmailIdentityMailFromAttributesResource(identityName, output); ok {
+				g.Resources = append(g.Resources, resource)
+			}
+			if err := g.loadEmailIdentityPolicies(svc, identityName); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+func (g *SesV2Generator) loadEmailIdentityPolicies(svc *sesv2.Client, identityName string) error {
+	if identityName == "" {
+		return nil
+	}
+	output, err := svc.GetEmailIdentityPolicies(context.TODO(), &sesv2.GetEmailIdentityPoliciesInput{
+		EmailIdentity: &identityName,
+	})
+	if err != nil {
+		if sesv2NotFound(err) {
+			return nil
+		}
+		return err
+	}
+	if output == nil {
+		return nil
+	}
+	policyNames := make([]string, 0, len(output.Policies))
+	for policyName := range output.Policies {
+		policyNames = append(policyNames, policyName)
+	}
+	sort.Strings(policyNames)
+	for _, policyName := range policyNames {
+		if resource, ok := newSESV2EmailIdentityPolicyResource(identityName, policyName, output.Policies[policyName]); ok {
+			g.Resources = append(g.Resources, resource)
 		}
 	}
 	return nil
@@ -117,6 +206,25 @@ func newSESV2ConfigurationSetResource(configurationSetName string) (terraformuti
 		"aws",
 		map[string]string{
 			"configuration_set_name": configurationSetName,
+		},
+		sesv2AllowEmptyValues,
+		map[string]interface{}{},
+	), true
+}
+
+func newSESV2ConfigurationSetEventDestinationResource(configurationSetName string, destination sesv2types.EventDestination) (terraformutils.Resource, bool) {
+	eventDestinationName := StringValue(destination.Name)
+	if configurationSetName == "" || eventDestinationName == "" {
+		return terraformutils.Resource{}, false
+	}
+	return terraformutils.NewResource(
+		sesv2ConfigurationSetEventDestinationImportID(configurationSetName, eventDestinationName),
+		sesv2ResourceName("configuration_set_event_destination", configurationSetName, eventDestinationName),
+		sesv2ConfigurationSetEventDestinationResourceType,
+		"aws",
+		map[string]string{
+			"configuration_set_name": configurationSetName,
+			"event_destination_name": eventDestinationName,
 		},
 		sesv2AllowEmptyValues,
 		map[string]interface{}{},
@@ -157,6 +265,67 @@ func newSESV2EmailIdentityResource(identityName string, output *sesv2.GetEmailId
 	), true
 }
 
+func newSESV2EmailIdentityFeedbackAttributesResource(identityName string, output *sesv2.GetEmailIdentityOutput) (terraformutils.Resource, bool) {
+	if identityName == "" || output == nil {
+		return terraformutils.Resource{}, false
+	}
+	return terraformutils.NewResource(
+		sesv2EmailIdentityFeedbackAttributesImportID(identityName),
+		sesv2ResourceName("email_identity_feedback_attributes", identityName),
+		sesv2EmailIdentityFeedbackAttributesResourceType,
+		"aws",
+		map[string]string{
+			"email_identity":           identityName,
+			"email_forwarding_enabled": strconv.FormatBool(output.FeedbackForwardingStatus),
+		},
+		sesv2AllowEmptyValues,
+		map[string]interface{}{},
+	), true
+}
+
+func newSESV2EmailIdentityMailFromAttributesResource(identityName string, output *sesv2.GetEmailIdentityOutput) (terraformutils.Resource, bool) {
+	if identityName == "" || output == nil || output.MailFromAttributes == nil {
+		return terraformutils.Resource{}, false
+	}
+	mailFromDomain := StringValue(output.MailFromAttributes.MailFromDomain)
+	behaviorOnMXFailure := string(output.MailFromAttributes.BehaviorOnMxFailure)
+	if mailFromDomain == "" || behaviorOnMXFailure == "" {
+		return terraformutils.Resource{}, false
+	}
+	return terraformutils.NewResource(
+		sesv2EmailIdentityMailFromAttributesImportID(identityName),
+		sesv2ResourceName("email_identity_mail_from_attributes", identityName),
+		sesv2EmailIdentityMailFromAttributesResourceType,
+		"aws",
+		map[string]string{
+			"behavior_on_mx_failure": behaviorOnMXFailure,
+			"email_identity":         identityName,
+			"mail_from_domain":       mailFromDomain,
+		},
+		sesv2AllowEmptyValues,
+		map[string]interface{}{},
+	), true
+}
+
+func newSESV2EmailIdentityPolicyResource(identityName, policyName, policy string) (terraformutils.Resource, bool) {
+	if identityName == "" || policyName == "" || policy == "" {
+		return terraformutils.Resource{}, false
+	}
+	return terraformutils.NewResource(
+		sesv2EmailIdentityPolicyImportID(identityName, policyName),
+		sesv2ResourceName("email_identity_policy", identityName, policyName),
+		sesv2EmailIdentityPolicyResourceType,
+		"aws",
+		map[string]string{
+			"email_identity": identityName,
+			"policy":         policy,
+			"policy_name":    policyName,
+		},
+		sesv2AllowEmptyValues,
+		map[string]interface{}{},
+	), true
+}
+
 func sesv2EmailIdentityImportable(output *sesv2.GetEmailIdentityOutput) bool {
 	if output == nil || output.DkimAttributes == nil {
 		return true
@@ -175,12 +344,28 @@ func sesv2ConfigurationSetImportID(configurationSetName string) string {
 	return configurationSetName
 }
 
+func sesv2ConfigurationSetEventDestinationImportID(configurationSetName, eventDestinationName string) string {
+	return strings.Join([]string{configurationSetName, eventDestinationName}, sesv2ResourceIDSeparator)
+}
+
 func sesv2DedicatedIPPoolImportID(poolName string) string {
 	return poolName
 }
 
 func sesv2EmailIdentityImportID(identityName string) string {
 	return identityName
+}
+
+func sesv2EmailIdentityFeedbackAttributesImportID(identityName string) string {
+	return identityName
+}
+
+func sesv2EmailIdentityMailFromAttributesImportID(identityName string) string {
+	return identityName
+}
+
+func sesv2EmailIdentityPolicyImportID(identityName, policyName string) string {
+	return strings.Join([]string{identityName, policyName}, sesv2ResourceIDSeparator)
 }
 
 func sesv2ResourceName(parts ...string) string {

--- a/providers/aws/sesv2_test.go
+++ b/providers/aws/sesv2_test.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"testing"
 
+	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/sesv2"
 	sesv2types "github.com/aws/aws-sdk-go-v2/service/sesv2/types"
 	"github.com/chenrui333/terraformer/terraformutils"
@@ -18,8 +19,12 @@ func TestSESV2ImportIDs(t *testing.T) {
 		want string
 	}{
 		{name: "configuration set", got: sesv2ConfigurationSetImportID("config-set"), want: "config-set"},
+		{name: "configuration set event destination", got: sesv2ConfigurationSetEventDestinationImportID("config-set", "events"), want: "config-set|events"},
 		{name: "dedicated IP pool", got: sesv2DedicatedIPPoolImportID("pool-a"), want: "pool-a"},
 		{name: "email identity", got: sesv2EmailIdentityImportID("sender@example.com"), want: "sender@example.com"},
+		{name: "email identity feedback attributes", got: sesv2EmailIdentityFeedbackAttributesImportID("sender@example.com"), want: "sender@example.com"},
+		{name: "email identity mail from attributes", got: sesv2EmailIdentityMailFromAttributesImportID("sender@example.com"), want: "sender@example.com"},
+		{name: "email identity policy", got: sesv2EmailIdentityPolicyImportID("sender@example.com", "policy-a"), want: "sender@example.com|policy-a"},
 	}
 
 	for _, tt := range tests {
@@ -40,6 +45,28 @@ func TestNewSESV2ConfigurationSetResource(t *testing.T) {
 
 	if _, ok := newSESV2ConfigurationSetResource(""); ok {
 		t.Fatal("newSESV2ConfigurationSetResource() ok = true for empty configuration set name, want false")
+	}
+}
+
+func TestNewSESV2ConfigurationSetEventDestinationResource(t *testing.T) {
+	resource, ok := newSESV2ConfigurationSetEventDestinationResource("config-set", sesv2types.EventDestination{
+		Name: aws.String("events"),
+	})
+	if !ok {
+		t.Fatal("newSESV2ConfigurationSetEventDestinationResource() ok = false, want true")
+	}
+	assertSESV2ResourceAttributes(t, resource, sesv2ConfigurationSetEventDestinationResourceType, "config-set|events",
+		[]string{"configuration_set_event_destination", "config-set", "events"},
+		map[string]string{
+			"configuration_set_name": "config-set",
+			"event_destination_name": "events",
+		})
+
+	if _, ok := newSESV2ConfigurationSetEventDestinationResource("", sesv2types.EventDestination{Name: aws.String("events")}); ok {
+		t.Fatal("newSESV2ConfigurationSetEventDestinationResource() ok = true for empty configuration set name, want false")
+	}
+	if _, ok := newSESV2ConfigurationSetEventDestinationResource("config-set", sesv2types.EventDestination{}); ok {
+		t.Fatal("newSESV2ConfigurationSetEventDestinationResource() ok = true for empty event destination name, want false")
 	}
 }
 
@@ -72,6 +99,86 @@ func TestNewSESV2EmailIdentityResource(t *testing.T) {
 		},
 	}); ok {
 		t.Fatal("newSESV2EmailIdentityResource() ok = true for BYODKIM identity, want false")
+	}
+}
+
+func TestNewSESV2EmailIdentityFeedbackAttributesResource(t *testing.T) {
+	resource, ok := newSESV2EmailIdentityFeedbackAttributesResource("sender@example.com", &sesv2.GetEmailIdentityOutput{
+		FeedbackForwardingStatus: true,
+	})
+	if !ok {
+		t.Fatal("newSESV2EmailIdentityFeedbackAttributesResource() ok = false, want true")
+	}
+	assertSESV2ResourceAttributes(t, resource, sesv2EmailIdentityFeedbackAttributesResourceType, "sender@example.com",
+		[]string{"email_identity_feedback_attributes", "sender@example.com"},
+		map[string]string{
+			"email_identity":           "sender@example.com",
+			"email_forwarding_enabled": "true",
+		})
+
+	if _, ok := newSESV2EmailIdentityFeedbackAttributesResource("", &sesv2.GetEmailIdentityOutput{}); ok {
+		t.Fatal("newSESV2EmailIdentityFeedbackAttributesResource() ok = true for empty identity name, want false")
+	}
+	if _, ok := newSESV2EmailIdentityFeedbackAttributesResource("sender@example.com", nil); ok {
+		t.Fatal("newSESV2EmailIdentityFeedbackAttributesResource() ok = true for nil identity output, want false")
+	}
+}
+
+func TestNewSESV2EmailIdentityMailFromAttributesResource(t *testing.T) {
+	resource, ok := newSESV2EmailIdentityMailFromAttributesResource("example.com", &sesv2.GetEmailIdentityOutput{
+		MailFromAttributes: &sesv2types.MailFromAttributes{
+			BehaviorOnMxFailure: sesv2types.BehaviorOnMxFailureRejectMessage,
+			MailFromDomain:      aws.String("bounce.example.com"),
+		},
+	})
+	if !ok {
+		t.Fatal("newSESV2EmailIdentityMailFromAttributesResource() ok = false, want true")
+	}
+	assertSESV2ResourceAttributes(t, resource, sesv2EmailIdentityMailFromAttributesResourceType, "example.com",
+		[]string{"email_identity_mail_from_attributes", "example.com"},
+		map[string]string{
+			"behavior_on_mx_failure": "REJECT_MESSAGE",
+			"email_identity":         "example.com",
+			"mail_from_domain":       "bounce.example.com",
+		})
+
+	if _, ok := newSESV2EmailIdentityMailFromAttributesResource("", &sesv2.GetEmailIdentityOutput{}); ok {
+		t.Fatal("newSESV2EmailIdentityMailFromAttributesResource() ok = true for empty identity name, want false")
+	}
+	if _, ok := newSESV2EmailIdentityMailFromAttributesResource("example.com", &sesv2.GetEmailIdentityOutput{}); ok {
+		t.Fatal("newSESV2EmailIdentityMailFromAttributesResource() ok = true without mail-from attributes, want false")
+	}
+	if _, ok := newSESV2EmailIdentityMailFromAttributesResource("example.com", &sesv2.GetEmailIdentityOutput{
+		MailFromAttributes: &sesv2types.MailFromAttributes{
+			BehaviorOnMxFailure: sesv2types.BehaviorOnMxFailureRejectMessage,
+		},
+	}); ok {
+		t.Fatal("newSESV2EmailIdentityMailFromAttributesResource() ok = true without mail-from domain, want false")
+	}
+}
+
+func TestNewSESV2EmailIdentityPolicyResource(t *testing.T) {
+	policy := `{"Version":"2012-10-17"}`
+	resource, ok := newSESV2EmailIdentityPolicyResource("sender@example.com", "policy-a", policy)
+	if !ok {
+		t.Fatal("newSESV2EmailIdentityPolicyResource() ok = false, want true")
+	}
+	assertSESV2ResourceAttributes(t, resource, sesv2EmailIdentityPolicyResourceType, "sender@example.com|policy-a",
+		[]string{"email_identity_policy", "sender@example.com", "policy-a"},
+		map[string]string{
+			"email_identity": "sender@example.com",
+			"policy":         policy,
+			"policy_name":    "policy-a",
+		})
+
+	if _, ok := newSESV2EmailIdentityPolicyResource("", "policy-a", policy); ok {
+		t.Fatal("newSESV2EmailIdentityPolicyResource() ok = true for empty identity name, want false")
+	}
+	if _, ok := newSESV2EmailIdentityPolicyResource("sender@example.com", "", policy); ok {
+		t.Fatal("newSESV2EmailIdentityPolicyResource() ok = true for empty policy name, want false")
+	}
+	if _, ok := newSESV2EmailIdentityPolicyResource("sender@example.com", "policy-a", ""); ok {
+		t.Fatal("newSESV2EmailIdentityPolicyResource() ok = true for empty policy, want false")
 	}
 }
 
@@ -125,6 +232,8 @@ func TestSESV2ResourceNameAvoidsSanitizedCollisions(t *testing.T) {
 		{name: "separator boundary", first: []string{"email_identity", "a_b", "c"}, second: []string{"email_identity", "a", "b_c"}},
 		{name: "at sign encoding", first: []string{"email_identity", "a@example.com"}, second: []string{"email_identity", "a-0040-example.com"}},
 		{name: "slash encoding", first: []string{"configuration_set", "a/b"}, second: []string{"configuration_set", "a-002F-b"}},
+		{name: "event destination composite", first: []string{"configuration_set_event_destination", "a_b", "c"}, second: []string{"configuration_set_event_destination", "a", "b_c"}},
+		{name: "policy composite", first: []string{"email_identity_policy", "a|b", "c"}, second: []string{"email_identity_policy", "a", "b|c"}},
 	}
 
 	for _, tt := range tests {
@@ -138,7 +247,41 @@ func TestSESV2ResourceNameAvoidsSanitizedCollisions(t *testing.T) {
 	}
 }
 
+func TestSESV2PostConvertHookWrapsPolicy(t *testing.T) {
+	resource, ok := newSESV2EmailIdentityPolicyResource("sender@example.com", "policy-a", `{"Resource":"${aws:username}"}`)
+	if !ok {
+		t.Fatal("newSESV2EmailIdentityPolicyResource() ok = false, want true")
+	}
+	resource.Item = map[string]interface{}{
+		"policy": `{"Resource":"${aws:username}"}`,
+	}
+	generator := SesV2Generator{
+		AWSService: AWSService{
+			Service: terraformutils.Service{
+				Resources: []terraformutils.Resource{resource},
+			},
+		},
+	}
+
+	if err := generator.PostConvertHook(); err != nil {
+		t.Fatalf("PostConvertHook() error = %v", err)
+	}
+
+	want := "<<POLICY\n{\"Resource\":\"$${aws:username}\"}\nPOLICY"
+	if got := generator.Resources[0].Item["policy"]; got != want {
+		t.Fatalf("policy = %q, want %q", got, want)
+	}
+}
+
 func assertSESV2Resource(t *testing.T, resource terraformutils.Resource, resourceType, resourceID, attributeName, attributeValue string) {
+	t.Helper()
+
+	assertSESV2ResourceAttributes(t, resource, resourceType, resourceID, stringsForSESV2ResourceName(resourceType, attributeValue), map[string]string{
+		attributeName: attributeValue,
+	})
+}
+
+func assertSESV2ResourceAttributes(t *testing.T, resource terraformutils.Resource, resourceType, resourceID string, nameParts []string, attributes map[string]string) {
 	t.Helper()
 
 	if resource.InstanceInfo.Type != resourceType {
@@ -147,10 +290,12 @@ func assertSESV2Resource(t *testing.T, resource terraformutils.Resource, resourc
 	if resource.InstanceState.ID != resourceID {
 		t.Fatalf("resource ID = %q, want %q", resource.InstanceState.ID, resourceID)
 	}
-	if got := resource.InstanceState.Attributes[attributeName]; got != attributeValue {
-		t.Fatalf("attribute %q = %q, want %q", attributeName, got, attributeValue)
+	for name, want := range attributes {
+		if got := resource.InstanceState.Attributes[name]; got != want {
+			t.Fatalf("attribute %q = %q, want %q", name, got, want)
+		}
 	}
-	wantName := terraformutils.TfSanitize(sesv2ResourceName(stringsForSESV2ResourceName(resourceType, attributeValue)...))
+	wantName := terraformutils.TfSanitize(sesv2ResourceName(nameParts...))
 	if resource.ResourceName != wantName {
 		t.Fatalf("resource name = %q, want %q", resource.ResourceName, wantName)
 	}


### PR DESCRIPTION
## Summary

- add SESv2 child-resource import discovery for configuration set event destinations, identity feedback attributes, identity Mail-From attributes, and identity policies
- seed import IDs as `configuration_set_name|event_destination_name`, `email_identity`, and `email_identity|policy_name`
- update docs/aws.md for supported SESv2 child resources
- add unit tests for SESv2 child-resource helper behavior and policy heredoc handling

## References

- #338

## Validation

```bash
go test ./providers/aws -run 'Test.*SES|Test.*Ses|Test.*ses'
go test ./providers/aws/... ./terraformutils/...
go run ./tools/aws-gap-inventory \
  -docs docs/aws.md \
  -aws-dir providers/aws \
  -skip-list providers/aws/unsupported_resources.json \
  -format markdown
git diff --check
```

## Notes

Skipped/deferred resources:
- `aws_sesv2_email_identity_mail_from_attributes`: identities without custom Mail-From attributes are skipped because there is no child configuration to preserve.
- `aws_sesv2_dedicated_ip_assignment`: deferred to a dedicated IP follow-up.
- `aws_sesv2_contact_list`: deferred to a customer-engagement SESv2 follow-up.
- `aws_sesv2_account_suppression_attributes`, `aws_sesv2_account_vdm_attributes`: deferred to singleton account-settings follow-up.
- `aws_sesv2_tenant`, `aws_sesv2_tenant_resource_association`: deferred to tenant-specific follow-up.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds import discovery for SESv2 child resources to expand coverage and enable importing of configuration set event destinations and email identity attributes/policies. Updates docs and tests to reflect the new resources and stable policy handling.

- **New Features**
  - Import support for `aws_sesv2_configuration_set_event_destination`, `aws_sesv2_email_identity_feedback_attributes`, `aws_sesv2_email_identity_mail_from_attributes`, and `aws_sesv2_email_identity_policy`.
  - Import IDs: `configuration_set_name|event_destination_name`, `email_identity`, `email_identity|policy_name`.
  - Wrap `email_identity_policy` JSON in a heredoc and escape `${}` to prevent interpolation.
  - Deterministic policy import order via sorted policy names.
  - Docs updated (`docs/aws.md`); unit tests added for helpers and heredoc handling.

<sup>Written for commit 3549eb7dff6c0bbcd9d5b2554f268b2b98e0518b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

