### PR TITLE
aws(appstream): add AppStream user imports

### DIFF
--- a/docs/aws.md
+++ b/docs/aws.md
@@ -96,6 +96,8 @@ For AWS provider gap audits and unsupported-resource skip-list maintenance, see 
     * `aws_appstream_fleet`
     * `aws_appstream_fleet_stack_association`
     * `aws_appstream_stack`
+    * `aws_appstream_user`
+    * `aws_appstream_user_stack_association`
 *   `appsync`
     * `aws_appsync_api_cache`
     * `aws_appsync_api_key`

--- a/providers/aws/appstream.go
+++ b/providers/aws/appstream.go
@@ -43,7 +43,8 @@ func (g *AppStreamGenerator) InitResources() error {
 	if err != nil {
 		return err
 	}
-	if err := g.loadStacks(svc); err != nil {
+	stackNames, err := g.loadStacks(svc)
+	if err != nil {
 		return err
 	}
 	if err := g.loadFleetStackAssociations(svc, fleetNames); err != nil {
@@ -52,7 +53,7 @@ func (g *AppStreamGenerator) InitResources() error {
 	if err := g.loadUsers(svc); err != nil {
 		return err
 	}
-	return g.loadUserStackAssociations(svc)
+	return g.loadUserStackAssociations(svc, stackNames)
 }
 
 func (g *AppStreamGenerator) loadFleets(svc *appstream.Client) ([]string, error) {
@@ -80,16 +81,18 @@ func (g *AppStreamGenerator) loadFleets(svc *appstream.Client) ([]string, error)
 	return fleetNames, nil
 }
 
-func (g *AppStreamGenerator) loadStacks(svc *appstream.Client) error {
+func (g *AppStreamGenerator) loadStacks(svc *appstream.Client) ([]string, error) {
+	var stackNames []string
 	input := &appstream.DescribeStacksInput{}
 	for {
 		page, err := svc.DescribeStacks(context.TODO(), input)
 		if err != nil {
-			return err
+			return nil, err
 		}
 		for _, stack := range page.Stacks {
 			if resource, ok := newAppStreamStackResource(stack); ok {
 				g.Resources = append(g.Resources, resource)
+				stackNames = append(stackNames, StringValue(stack.Name))
 			}
 		}
 		nextToken := appStreamNextToken(page.NextToken)
@@ -98,7 +101,7 @@ func (g *AppStreamGenerator) loadStacks(svc *appstream.Client) error {
 		}
 		input.NextToken = nextToken
 	}
-	return nil
+	return stackNames, nil
 }
 
 func (g *AppStreamGenerator) loadFleetStackAssociations(svc *appstream.Client, fleetNames []string) error {
@@ -163,9 +166,19 @@ func (g *AppStreamGenerator) loadUsers(svc *appstream.Client) error {
 	return nil
 }
 
-func (g *AppStreamGenerator) loadUserStackAssociations(svc *appstream.Client) error {
-	input := &appstream.DescribeUserStackAssociationsInput{
-		AuthenticationType: appstreamtypes.AuthenticationTypeUserpool,
+func (g *AppStreamGenerator) loadUserStackAssociations(svc *appstream.Client, stackNames []string) error {
+	for _, stackName := range stackNames {
+		if err := g.loadUserStackAssociationsForStack(svc, stackName); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (g *AppStreamGenerator) loadUserStackAssociationsForStack(svc *appstream.Client, stackName string) error {
+	input, ok := appStreamUserStackAssociationsInput(stackName)
+	if !ok {
+		return nil
 	}
 	for {
 		page, err := svc.DescribeUserStackAssociations(context.TODO(), input)
@@ -282,6 +295,16 @@ func appStreamUserImportID(userName string, authType appstreamtypes.Authenticati
 
 func appStreamUserStackAssociationImportID(userName string, authType appstreamtypes.AuthenticationType, stackName string) string {
 	return strings.Join([]string{userName, string(authType), stackName}, appStreamUserStackAssociationIDSeparator)
+}
+
+func appStreamUserStackAssociationsInput(stackName string) (*appstream.DescribeUserStackAssociationsInput, bool) {
+	if stackName == "" {
+		return nil, false
+	}
+	return &appstream.DescribeUserStackAssociationsInput{
+		AuthenticationType: appstreamtypes.AuthenticationTypeUserpool,
+		StackName:          aws.String(stackName),
+	}, true
 }
 
 func appStreamResourceName(parts ...string) string {

--- a/providers/aws/appstream.go
+++ b/providers/aws/appstream.go
@@ -18,8 +18,12 @@ const (
 	appStreamFleetResourceType                 = "aws_appstream_fleet"
 	appStreamStackResourceType                 = "aws_appstream_stack"
 	appStreamFleetStackAssociationResourceType = "aws_appstream_fleet_stack_association"
+	appStreamUserResourceType                  = "aws_appstream_user"
+	appStreamUserStackAssociationResourceType  = "aws_appstream_user_stack_association"
 
 	appStreamFleetStackAssociationIDSeparator = "/"
+	appStreamUserIDSeparator                  = "/"
+	appStreamUserStackAssociationIDSeparator  = "/"
 )
 
 var appStreamAllowEmptyValues = []string{"tags."}
@@ -42,7 +46,13 @@ func (g *AppStreamGenerator) InitResources() error {
 	if err := g.loadStacks(svc); err != nil {
 		return err
 	}
-	return g.loadFleetStackAssociations(svc, fleetNames)
+	if err := g.loadFleetStackAssociations(svc, fleetNames); err != nil {
+		return err
+	}
+	if err := g.loadUsers(svc); err != nil {
+		return err
+	}
+	return g.loadUserStackAssociations(svc)
 }
 
 func (g *AppStreamGenerator) loadFleets(svc *appstream.Client) ([]string, error) {
@@ -127,6 +137,58 @@ func (g *AppStreamGenerator) loadFleetStackAssociationsForFleet(svc *appstream.C
 	return nil
 }
 
+func (g *AppStreamGenerator) loadUsers(svc *appstream.Client) error {
+	input := &appstream.DescribeUsersInput{
+		AuthenticationType: appstreamtypes.AuthenticationTypeUserpool,
+	}
+	for {
+		page, err := svc.DescribeUsers(context.TODO(), input)
+		if appStreamResourceNotFound(err) {
+			return nil
+		}
+		if err != nil {
+			return err
+		}
+		for _, user := range page.Users {
+			if resource, ok := newAppStreamUserResource(user); ok {
+				g.Resources = append(g.Resources, resource)
+			}
+		}
+		nextToken := appStreamNextToken(page.NextToken)
+		if nextToken == nil {
+			break
+		}
+		input.NextToken = nextToken
+	}
+	return nil
+}
+
+func (g *AppStreamGenerator) loadUserStackAssociations(svc *appstream.Client) error {
+	input := &appstream.DescribeUserStackAssociationsInput{
+		AuthenticationType: appstreamtypes.AuthenticationTypeUserpool,
+	}
+	for {
+		page, err := svc.DescribeUserStackAssociations(context.TODO(), input)
+		if appStreamResourceNotFound(err) {
+			return nil
+		}
+		if err != nil {
+			return err
+		}
+		for _, association := range page.UserStackAssociations {
+			if resource, ok := newAppStreamUserStackAssociationResource(association); ok {
+				g.Resources = append(g.Resources, resource)
+			}
+		}
+		nextToken := appStreamNextToken(page.NextToken)
+		if nextToken == nil {
+			break
+		}
+		input.NextToken = nextToken
+	}
+	return nil
+}
+
 func newAppStreamFleetResource(fleet appstreamtypes.Fleet) (terraformutils.Resource, bool) {
 	name := StringValue(fleet.Name)
 	if name == "" {
@@ -168,8 +230,58 @@ func newAppStreamFleetStackAssociationResource(fleetName, stackName string) (ter
 	), true
 }
 
+func newAppStreamUserResource(user appstreamtypes.User) (terraformutils.Resource, bool) {
+	userName := StringValue(user.UserName)
+	authType := user.AuthenticationType
+	if userName == "" || authType == "" {
+		return terraformutils.Resource{}, false
+	}
+	return terraformutils.NewResource(
+		appStreamUserImportID(userName, authType),
+		appStreamResourceName("user", string(authType), userName),
+		appStreamUserResourceType,
+		"aws",
+		map[string]string{
+			"authentication_type": string(authType),
+			"user_name":           userName,
+		},
+		appStreamAllowEmptyValues,
+		map[string]interface{}{},
+	), true
+}
+
+func newAppStreamUserStackAssociationResource(association appstreamtypes.UserStackAssociation) (terraformutils.Resource, bool) {
+	userName := StringValue(association.UserName)
+	stackName := StringValue(association.StackName)
+	authType := association.AuthenticationType
+	if userName == "" || stackName == "" || authType == "" {
+		return terraformutils.Resource{}, false
+	}
+	return terraformutils.NewResource(
+		appStreamUserStackAssociationImportID(userName, authType, stackName),
+		appStreamResourceName("user-stack-association", string(authType), userName, stackName),
+		appStreamUserStackAssociationResourceType,
+		"aws",
+		map[string]string{
+			"authentication_type": string(authType),
+			"stack_name":          stackName,
+			"user_name":           userName,
+		},
+		appStreamAllowEmptyValues,
+		map[string]interface{}{},
+	), true
+}
+
 func appStreamFleetStackAssociationImportID(fleetName, stackName string) string {
 	return strings.Join([]string{fleetName, stackName}, appStreamFleetStackAssociationIDSeparator)
+}
+
+func appStreamUserImportID(userName string, authType appstreamtypes.AuthenticationType) string {
+	return strings.Join([]string{userName, string(authType)}, appStreamUserIDSeparator)
+}
+
+func appStreamUserStackAssociationImportID(userName string, authType appstreamtypes.AuthenticationType, stackName string) string {
+	return strings.Join([]string{userName, string(authType), stackName}, appStreamUserStackAssociationIDSeparator)
 }
 
 func appStreamResourceName(parts ...string) string {

--- a/providers/aws/appstream_test.go
+++ b/providers/aws/appstream_test.go
@@ -126,6 +126,26 @@ func TestAppStreamUserStackAssociationImportID(t *testing.T) {
 	}
 }
 
+func TestAppStreamUserStackAssociationsInput(t *testing.T) {
+	input, ok := appStreamUserStackAssociationsInput("core-stack")
+	if !ok {
+		t.Fatal("stack-filtered association input should be built")
+	}
+	if got := input.AuthenticationType; got != appstreamtypes.AuthenticationTypeUserpool {
+		t.Fatalf("authentication type = %q, want %q", got, appstreamtypes.AuthenticationTypeUserpool)
+	}
+	if got := StringValue(input.StackName); got != "core-stack" {
+		t.Fatalf("stack name = %q, want %q", got, "core-stack")
+	}
+	if input.UserName != nil {
+		t.Fatalf("user name = %v, want nil", input.UserName)
+	}
+
+	if _, ok := appStreamUserStackAssociationsInput(""); ok {
+		t.Fatal("association input with empty stack name should be skipped")
+	}
+}
+
 func TestAppStreamResourceNamesPreserveSegmentBoundaries(t *testing.T) {
 	left, ok := newAppStreamFleetStackAssociationResource("a/b_c", "d")
 	if !ok {

--- a/providers/aws/appstream_test.go
+++ b/providers/aws/appstream_test.go
@@ -54,11 +54,75 @@ func TestNewAppStreamFleetStackAssociationResource(t *testing.T) {
 	}
 }
 
+func TestNewAppStreamUserResource(t *testing.T) {
+	resource, ok := newAppStreamUserResource(appstreamtypes.User{
+		AuthenticationType: appstreamtypes.AuthenticationTypeUserpool,
+		UserName:           appStreamString("user@example.com"),
+	})
+	assertAppStreamResource(t, resource, ok, "user@example.com/USERPOOL", appStreamResourceName("user", "USERPOOL", "user@example.com"), appStreamUserResourceType)
+	assertAppStreamAttribute(t, resource, "authentication_type", "USERPOOL")
+	assertAppStreamAttribute(t, resource, "user_name", "user@example.com")
+
+	if _, ok := newAppStreamUserResource(appstreamtypes.User{AuthenticationType: appstreamtypes.AuthenticationTypeUserpool}); ok {
+		t.Fatal("user with empty user name should be skipped")
+	}
+	if _, ok := newAppStreamUserResource(appstreamtypes.User{UserName: appStreamString("user@example.com")}); ok {
+		t.Fatal("user with empty authentication type should be skipped")
+	}
+}
+
+func TestNewAppStreamUserStackAssociationResource(t *testing.T) {
+	resource, ok := newAppStreamUserStackAssociationResource(appstreamtypes.UserStackAssociation{
+		AuthenticationType: appstreamtypes.AuthenticationTypeUserpool,
+		StackName:          appStreamString("core-stack"),
+		UserName:           appStreamString("user@example.com"),
+	})
+	assertAppStreamResource(t, resource, ok, "user@example.com/USERPOOL/core-stack", appStreamResourceName("user-stack-association", "USERPOOL", "user@example.com", "core-stack"), appStreamUserStackAssociationResourceType)
+	assertAppStreamAttribute(t, resource, "authentication_type", "USERPOOL")
+	assertAppStreamAttribute(t, resource, "stack_name", "core-stack")
+	assertAppStreamAttribute(t, resource, "user_name", "user@example.com")
+
+	if _, ok := newAppStreamUserStackAssociationResource(appstreamtypes.UserStackAssociation{
+		AuthenticationType: appstreamtypes.AuthenticationTypeUserpool,
+		StackName:          appStreamString("core-stack"),
+	}); ok {
+		t.Fatal("user-stack association with empty user name should be skipped")
+	}
+	if _, ok := newAppStreamUserStackAssociationResource(appstreamtypes.UserStackAssociation{
+		AuthenticationType: appstreamtypes.AuthenticationTypeUserpool,
+		UserName:           appStreamString("user@example.com"),
+	}); ok {
+		t.Fatal("user-stack association with empty stack name should be skipped")
+	}
+	if _, ok := newAppStreamUserStackAssociationResource(appstreamtypes.UserStackAssociation{
+		StackName: appStreamString("core-stack"),
+		UserName:  appStreamString("user@example.com"),
+	}); ok {
+		t.Fatal("user-stack association with empty authentication type should be skipped")
+	}
+}
+
 func TestAppStreamFleetStackAssociationImportID(t *testing.T) {
 	got := appStreamFleetStackAssociationImportID("fleetName", "stackName")
 	want := "fleetName/stackName"
 	if got != want {
 		t.Fatalf("association import ID = %q, want %q", got, want)
+	}
+}
+
+func TestAppStreamUserImportID(t *testing.T) {
+	got := appStreamUserImportID("user@example.com", appstreamtypes.AuthenticationTypeUserpool)
+	want := "user@example.com/USERPOOL"
+	if got != want {
+		t.Fatalf("user import ID = %q, want %q", got, want)
+	}
+}
+
+func TestAppStreamUserStackAssociationImportID(t *testing.T) {
+	got := appStreamUserStackAssociationImportID("user@example.com", appstreamtypes.AuthenticationTypeUserpool, "stackName")
+	want := "user@example.com/USERPOOL/stackName"
+	if got != want {
+		t.Fatalf("user-stack association import ID = %q, want %q", got, want)
 	}
 }
 
@@ -73,6 +137,26 @@ func TestAppStreamResourceNamesPreserveSegmentBoundaries(t *testing.T) {
 	}
 	if left.ResourceName == right.ResourceName {
 		t.Fatalf("association resource names collide: %q", left.ResourceName)
+	}
+
+	left, ok = newAppStreamUserStackAssociationResource(appstreamtypes.UserStackAssociation{
+		AuthenticationType: appstreamtypes.AuthenticationTypeUserpool,
+		StackName:          appStreamString("d"),
+		UserName:           appStreamString("a/b_c"),
+	})
+	if !ok {
+		t.Fatal("left user-stack association should be importable")
+	}
+	right, ok = newAppStreamUserStackAssociationResource(appstreamtypes.UserStackAssociation{
+		AuthenticationType: appstreamtypes.AuthenticationTypeUserpool,
+		StackName:          appStreamString("b_c/d"),
+		UserName:           appStreamString("a"),
+	})
+	if !ok {
+		t.Fatal("right user-stack association should be importable")
+	}
+	if left.ResourceName == right.ResourceName {
+		t.Fatalf("user-stack association resource names collide: %q", left.ResourceName)
 	}
 }
 
@@ -123,6 +207,13 @@ func assertAppStreamResource(t *testing.T, resource terraformutils.Resource, ok 
 	}
 	if got := resource.InstanceInfo.Type; got != wantType {
 		t.Fatalf("resource type = %q, want %q", got, wantType)
+	}
+}
+
+func assertAppStreamAttribute(t *testing.T, resource terraformutils.Resource, key, want string) {
+	t.Helper()
+	if got := resource.InstanceState.Attributes[key]; got != want {
+		t.Fatalf("resource attribute %q = %q, want %q", key, got, want)
 	}
 }
 


### PR DESCRIPTION
## Summary

- add AppStream import discovery for `aws_appstream_user` and `aws_appstream_user_stack_association`
- seed import IDs as `user_name/authentication_type` and `user_name/authentication_type/stack_name`
- update docs/aws.md for supported AppStream user resources
- add unit tests for AppStream user helper behavior

## References

- #338

## Validation

```bash
go test ./providers/aws -run 'Test.*AppStream|Test.*Appstream|Test.*appstream'
go test ./providers/aws/... ./terraformutils/...
go run ./tools/aws-gap-inventory \
  -docs docs/aws.md \
  -aws-dir providers/aws \
  -skip-list providers/aws/unsupported_resources.json \
  -format markdown
git diff --check
```

## Notes

Skipped/deferred resources:
- `aws_appstream_directory_config`: already marked unsupported because required service account password is sensitive and not returned by AppStream
- `aws_appstream_image_builder`: still deferred from the AppStream core PR and outside this user-only PR
- `aws_appstream_application`, `aws_appstream_application_fleet_association`, `aws_appstream_entitlement`: not in Terraform AWS provider v6.44.0 schema

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add import discovery for AppStream users and stack-scoped user–stack associations. Enables importing `aws_appstream_user` and `aws_appstream_user_stack_association` with stable IDs and updates docs.

- **New Features**
  - Discover and import `aws_appstream_user` and `aws_appstream_user_stack_association` (USERPOOL auth only).
  - Use deterministic import IDs: `user_name/authentication_type` and `user_name/authentication_type/stack_name`.
  - Updated `docs/aws.md`; added unit tests for user and user–stack helpers.

- **Bug Fixes**
  - Scope user–stack association discovery by stack to avoid unfiltered queries; handle not-found responses.

<sup>Written for commit e977fe25f11257096a0a137e95561892100b4643. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

