### PR TITLE
aws(logs): add CloudWatch Logs transformer imports

### DIFF
--- a/docs/aws.md
+++ b/docs/aws.md
@@ -371,6 +371,7 @@ For AWS provider gap audits and unsupported-resource skip-list maintenance, see 
     * `aws_cloudwatch_log_metric_filter`
     * `aws_cloudwatch_log_resource_policy`
     * `aws_cloudwatch_log_subscription_filter`
+    * `aws_cloudwatch_log_transformer`
     * `aws_cloudwatch_query_definition`
 *   `media_package`
     * `aws_media_package_channel`

--- a/providers/aws/logs.go
+++ b/providers/aws/logs.go
@@ -7,12 +7,15 @@ import (
 	"errors"
 	"fmt"
 	"log"
+	"reflect"
 	"strconv"
+	"strings"
 
 	"github.com/aws/aws-sdk-go-v2/service/cloudwatchlogs"
 	"github.com/aws/aws-sdk-go-v2/service/cloudwatchlogs/types"
 	"github.com/chenrui333/terraformer/terraformutils"
 	"github.com/chenrui333/terraformer/terraformutils/tfcompat"
+	"github.com/iancoleman/strcase"
 )
 
 var logsAllowEmptyValues = []string{"tags."}
@@ -25,6 +28,7 @@ const (
 	logsDeliverySourceResourceType            = "aws_cloudwatch_log_delivery_source"
 	logsDestinationPolicyResourceType         = "aws_cloudwatch_log_destination_policy"
 	logsIndexPolicyResourceType               = "aws_cloudwatch_log_index_policy"
+	logsTransformerResourceType               = "aws_cloudwatch_log_transformer"
 )
 
 var logsAccountPolicyTypes = []types.PolicyType{
@@ -79,6 +83,7 @@ func (g *LogsGenerator) InitResources() error {
 	svc := cloudwatchlogs.NewFromConfig(config)
 
 	var logGroupNames []string
+	var logGroups []types.LogGroup
 	p := cloudwatchlogs.NewDescribeLogGroupsPaginator(svc, &cloudwatchlogs.DescribeLogGroupsInput{})
 	for p.HasMorePages() {
 		page, err := p.NextPage(context.TODO())
@@ -86,6 +91,7 @@ func (g *LogsGenerator) InitResources() error {
 			return err
 		}
 		g.Resources = append(g.Resources, g.createResources(page)...)
+		logGroups = append(logGroups, page.LogGroups...)
 		for _, logGroup := range page.LogGroups {
 			logGroupName := StringValue(logGroup.LogGroupName)
 			if logGroupName != "" {
@@ -103,6 +109,7 @@ func (g *LogsGenerator) InitResources() error {
 		logsOptionalResourceLoader{name: "delivery destinations", load: func() error { return g.addDeliveryDestinations(svc) }},
 		logsOptionalResourceLoader{name: "deliveries", load: func() error { return g.addDeliveries(svc) }},
 		logsOptionalResourceLoader{name: "anomaly detectors", load: func() error { return g.addAnomalyDetectors(svc) }},
+		logsOptionalResourceLoader{name: "transformers", load: func() error { return g.addTransformers(svc, logGroups) }},
 		logsOptionalResourceLoader{name: "resource policies", load: func() error { return g.addResourcePolicies(svc) }},
 		logsOptionalResourceLoader{name: "account policies", load: func() error { return g.addAccountPolicies(svc) }},
 		logsOptionalResourceLoader{name: "query definitions", load: func() error { return g.addQueryDefinitions(svc) }},
@@ -346,6 +353,28 @@ func (g *LogsGenerator) addAnomalyDetectors(svc *cloudwatchlogs.Client) error {
 			if resource, ok := newLogsAnomalyDetectorResource(detector); ok {
 				g.Resources = append(g.Resources, resource)
 			}
+		}
+	}
+	return nil
+}
+
+func (g *LogsGenerator) addTransformers(svc *cloudwatchlogs.Client, logGroups []types.LogGroup) error {
+	for _, logGroup := range logGroups {
+		logGroupARN := logsTransformerLogGroupARN(logGroup)
+		if logGroupARN == "" {
+			continue
+		}
+		transformer, err := svc.GetTransformer(context.TODO(), &cloudwatchlogs.GetTransformerInput{
+			LogGroupIdentifier: &logGroupARN,
+		})
+		if err != nil {
+			if logsResourceNotFound(err) {
+				continue
+			}
+			return err
+		}
+		if resource, ok := newLogsTransformerResource(StringValue(logGroup.LogGroupName), logGroupARN, transformer); ok {
+			g.Resources = append(g.Resources, resource)
 		}
 	}
 	return nil
@@ -689,6 +718,152 @@ func logsAnomalyDetectorEnabledValue(status types.AnomalyDetectorStatus) (bool, 
 
 func logsAnomalyDetectorResourceName(detectorName, detectorARN string) string {
 	return logsResourceNameWithLengths("anomaly_detector", detectorName, detectorARN)
+}
+
+func newLogsTransformerResource(logGroupName, logGroupARN string, transformer *cloudwatchlogs.GetTransformerOutput) (terraformutils.Resource, bool) {
+	if logGroupARN == "" || transformer == nil || len(transformer.TransformerConfig) == 0 {
+		return terraformutils.Resource{}, false
+	}
+
+	attributes := map[string]string{
+		"log_group_arn": logGroupARN,
+	}
+	for key, value := range logsTransformerConfigAttributes(transformer.TransformerConfig) {
+		attributes[key] = value
+	}
+
+	resource := terraformutils.NewResource(
+		logGroupARN,
+		logsTransformerResourceName(logGroupName, logGroupARN),
+		logsTransformerResourceType,
+		"aws",
+		attributes,
+		logsAllowEmptyValues,
+		map[string]interface{}{})
+	if resource.InstanceState.Meta == nil {
+		resource.InstanceState.Meta = map[string]interface{}{}
+	}
+	resource.InstanceState.Meta[tfcompat.MetaKeyPreserveIDAfterRefresh] = true
+	return resource, true
+}
+
+func logsTransformerLogGroupARN(logGroup types.LogGroup) string {
+	if logGroupARN := StringValue(logGroup.LogGroupArn); logGroupARN != "" {
+		return logGroupARN
+	}
+	return strings.TrimSuffix(StringValue(logGroup.Arn), ":*")
+}
+
+func logsTransformerResourceName(logGroupName, logGroupARN string) string {
+	return logsResourceNameWithLengths("transformer", logGroupName, logGroupARN)
+}
+
+func logsTransformerConfigAttributes(processors []types.Processor) map[string]string {
+	attributes := map[string]string{
+		"transformer_config.#": strconv.Itoa(len(processors)),
+	}
+	for i, processor := range processors {
+		logsFlattenTransformerValue(reflect.ValueOf(processor), fmt.Sprintf("transformer_config.%d", i), attributes)
+	}
+	return attributes
+}
+
+func logsFlattenTransformerValue(value reflect.Value, path string, attributes map[string]string) {
+	value = logsIndirectTransformerValue(value)
+	if !value.IsValid() {
+		return
+	}
+	switch value.Kind() {
+	case reflect.Struct:
+		valueType := value.Type()
+		for i := 0; i < value.NumField(); i++ {
+			field := valueType.Field(i)
+			if field.PkgPath != "" {
+				continue
+			}
+			fieldValue := value.Field(i)
+			if logsTransformerValueEmpty(fieldValue) {
+				continue
+			}
+			logsFlattenTransformerField(fieldValue, path+"."+logsTransformerFieldName(field.Name), attributes)
+		}
+	case reflect.String:
+		if value.String() != "" {
+			attributes[path] = value.String()
+		}
+	case reflect.Bool:
+		attributes[path] = strconv.FormatBool(value.Bool())
+	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
+		if value.Int() != 0 {
+			attributes[path] = strconv.FormatInt(value.Int(), 10)
+		}
+	case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64:
+		if value.Uint() != 0 {
+			attributes[path] = strconv.FormatUint(value.Uint(), 10)
+		}
+	case reflect.Float32, reflect.Float64:
+		if value.Float() != 0 {
+			attributes[path] = strconv.FormatFloat(value.Float(), 'f', -1, value.Type().Bits())
+		}
+	}
+}
+
+func logsFlattenTransformerField(value reflect.Value, path string, attributes map[string]string) {
+	value = logsIndirectTransformerValue(value)
+	if !value.IsValid() {
+		return
+	}
+	switch value.Kind() {
+	case reflect.Struct:
+		attributes[path+".#"] = "1"
+		logsFlattenTransformerValue(value, path+".0", attributes)
+	case reflect.Slice:
+		attributes[path+".#"] = strconv.Itoa(value.Len())
+		for i := 0; i < value.Len(); i++ {
+			logsFlattenTransformerValue(value.Index(i), fmt.Sprintf("%s.%d", path, i), attributes)
+		}
+	default:
+		logsFlattenTransformerValue(value, path, attributes)
+	}
+}
+
+func logsIndirectTransformerValue(value reflect.Value) reflect.Value {
+	for value.IsValid() && value.Kind() == reflect.Pointer {
+		if value.IsNil() {
+			return reflect.Value{}
+		}
+		value = value.Elem()
+	}
+	return value
+}
+
+func logsTransformerValueEmpty(value reflect.Value) bool {
+	if !value.IsValid() {
+		return true
+	}
+	switch value.Kind() {
+	case reflect.Pointer, reflect.Interface:
+		return value.IsNil()
+	case reflect.Slice, reflect.Map:
+		return value.Len() == 0
+	case reflect.String:
+		return value.String() == ""
+	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
+		return value.Int() == 0
+	case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64:
+		return value.Uint() == 0
+	case reflect.Float32, reflect.Float64:
+		return value.Float() == 0
+	default:
+		return false
+	}
+}
+
+func logsTransformerFieldName(name string) string {
+	if name == "Entries" {
+		return "entry"
+	}
+	return strcase.ToSnake(name)
 }
 
 func logsStringListAttributes(name string, values []string) map[string]string {

--- a/providers/aws/logs_test.go
+++ b/providers/aws/logs_test.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"testing"
 
+	"github.com/aws/aws-sdk-go-v2/service/cloudwatchlogs"
 	"github.com/aws/aws-sdk-go-v2/service/cloudwatchlogs/types"
 	"github.com/chenrui333/terraformer/terraformutils/tfcompat"
 )
@@ -683,5 +684,113 @@ func TestLogsAnomalyDetectorEnabledValue(t *testing.T) {
 				t.Fatalf("logsAnomalyDetectorEnabledValue() enabled = %t, want %t", gotEnabled, tt.wantEnabled)
 			}
 		})
+	}
+}
+
+func TestNewLogsTransformerResource(t *testing.T) {
+	logGroupARN := "arn:aws:logs:us-east-1:123456789012:log-group:/aws/lambda/example"
+	logGroupName := "/aws/lambda/example"
+	source := "@message"
+	destination := "parsed"
+
+	resource, ok := newLogsTransformerResource(logGroupName, logGroupARN, &cloudwatchlogs.GetTransformerOutput{
+		TransformerConfig: []types.Processor{
+			{
+				ParseJSON: &types.ParseJSON{
+					Source:      &source,
+					Destination: &destination,
+				},
+			},
+		},
+	})
+	if !ok {
+		t.Fatal("newLogsTransformerResource() ok = false, want true")
+	}
+	if got := resource.InstanceState.ID; got != logGroupARN {
+		t.Fatalf("resource ID = %q, want %q", got, logGroupARN)
+	}
+	if got := resource.InstanceInfo.Type; got != logsTransformerResourceType {
+		t.Fatalf("resource type = %q, want %q", got, logsTransformerResourceType)
+	}
+	if preserveID, ok := resource.InstanceState.Meta[tfcompat.MetaKeyPreserveIDAfterRefresh].(bool); !ok || !preserveID {
+		t.Fatalf("preserve ID metadata = %v, %t; want true, true", preserveID, ok)
+	}
+	for key, want := range map[string]string{
+		"log_group_arn":                                 logGroupARN,
+		"transformer_config.#":                          "1",
+		"transformer_config.0.parse_json.#":             "1",
+		"transformer_config.0.parse_json.0.source":      source,
+		"transformer_config.0.parse_json.0.destination": destination,
+	} {
+		if got := resource.InstanceState.Attributes[key]; got != want {
+			t.Fatalf("%s = %q, want %q", key, got, want)
+		}
+	}
+	if _, ok := newLogsTransformerResource(logGroupName, "", &cloudwatchlogs.GetTransformerOutput{
+		TransformerConfig: []types.Processor{{ParseJSON: &types.ParseJSON{}}},
+	}); ok {
+		t.Fatal("newLogsTransformerResource() ok = true for empty log group ARN, want false")
+	}
+	if _, ok := newLogsTransformerResource(logGroupName, logGroupARN, &cloudwatchlogs.GetTransformerOutput{}); ok {
+		t.Fatal("newLogsTransformerResource() ok = true for empty transformer config, want false")
+	}
+	if _, ok := newLogsTransformerResource(logGroupName, logGroupARN, nil); ok {
+		t.Fatal("newLogsTransformerResource() ok = true for nil transformer, want false")
+	}
+}
+
+func TestLogsTransformerConfigAttributes(t *testing.T) {
+	key := "env"
+	value := "prod"
+	attributes := logsTransformerConfigAttributes([]types.Processor{
+		{
+			ParseJSON: &types.ParseJSON{},
+		},
+		{
+			AddKeys: &types.AddKeys{
+				Entries: []types.AddKeyEntry{
+					{Key: &key, Value: &value},
+				},
+			},
+		},
+	})
+
+	for key, want := range map[string]string{
+		"transformer_config.#":                                        "2",
+		"transformer_config.0.parse_json.#":                           "1",
+		"transformer_config.1.add_keys.#":                             "1",
+		"transformer_config.1.add_keys.0.entry.#":                     "1",
+		"transformer_config.1.add_keys.0.entry.0.key":                 "env",
+		"transformer_config.1.add_keys.0.entry.0.value":               "prod",
+		"transformer_config.1.add_keys.0.entry.0.overwrite_if_exists": "false",
+	} {
+		if got := attributes[key]; got != want {
+			t.Fatalf("%s = %q, want %q", key, got, want)
+		}
+	}
+	if _, ok := attributes["transformer_config.0.parse_json.0.source"]; ok {
+		t.Fatal("parse_json source was set for an empty processor config, want omitted")
+	}
+}
+
+func TestLogsTransformerLogGroupARN(t *testing.T) {
+	logGroupARN := "arn:aws:logs:us-east-1:123456789012:log-group:/aws/lambda/example"
+	if got := logsTransformerLogGroupARN(types.LogGroup{LogGroupArn: &logGroupARN}); got != logGroupARN {
+		t.Fatalf("logsTransformerLogGroupARN() = %q, want %q", got, logGroupARN)
+	}
+	arnWithWildcard := logGroupARN + ":*"
+	if got := logsTransformerLogGroupARN(types.LogGroup{Arn: &arnWithWildcard}); got != logGroupARN {
+		t.Fatalf("logsTransformerLogGroupARN() = %q, want %q", got, logGroupARN)
+	}
+	if got := logsTransformerLogGroupARN(types.LogGroup{}); got != "" {
+		t.Fatalf("logsTransformerLogGroupARN() = %q, want empty", got)
+	}
+}
+
+func TestLogsTransformerResourceNamesPreservePartBoundaries(t *testing.T) {
+	left := logsTransformerResourceName("a/b", "arn:aws:logs:us-east-1:123456789012:log-group:left")
+	right := logsTransformerResourceName("a-002F-b", "arn:aws:logs:us-east-1:123456789012:log-group:left")
+	if left == right {
+		t.Fatalf("transformer resource names collide: %q", left)
 	}
 }


### PR DESCRIPTION
## Summary

- add CloudWatch Logs transformer import discovery
- seed import IDs as log group ARNs
- update docs/aws.md for aws_cloudwatch_log_transformer
- add unit tests for transformer helper behavior

## References

- #338

## Validation

```bash
go run ./tools/aws-gap-inventory \
  -docs docs/aws.md \
  -aws-dir providers/aws \
  -skip-list providers/aws/unsupported_resources.json \
  -format markdown

go test ./providers/aws -run 'Test.*Logs|Test.*CloudWatch|Test.*cloudwatch|Test.*logs'
go test ./providers/aws/... ./terraformutils/... ./tools/aws-gap-inventory/...
git diff --check
```

## Notes

Skipped/deferred resources:
- `aws_cloudwatch_log_stream`: high-cardinality and ephemeral; needs explicit scale/filter handling.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add CloudWatch Logs transformer import support. Discovers transformers per log group and uses the log group ARN as the import ID to enable `aws_cloudwatch_log_transformer` imports.

- **New Features**
  - Discover and import `aws_cloudwatch_log_transformer` via `GetTransformer` per log group.
  - Use the log group ARN as the import ID (prefers `LogGroupArn`, trims `Arn:*` fallback).
  - Flatten `TransformerConfig` into Terraform-style attributes and preserve ID after refresh.
  - Update docs; add unit tests for ARN handling, config flattening, and resource name collision safety.

<sup>Written for commit fb6ce18b628930287b37b0da1ed78eeb97aaaadd. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added AWS CloudWatch Log Transformers resource support, enabling discovery and management of log transformer resources
* **Documentation**
  * Updated AWS documentation to reflect CloudWatch Log Transformers in supported services

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/chenrui333/terraformer/pull/405)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->