### PR TITLE
aws(sesv2): add SESv2 contact list imports

### DIFF
--- a/docs/aws.md
+++ b/docs/aws.md
@@ -490,6 +490,7 @@ For AWS provider gap audits and unsupported-resource skip-list maintenance, see 
 *   `sesv2`
     * `aws_sesv2_configuration_set`
     * `aws_sesv2_configuration_set_event_destination`
+    * `aws_sesv2_contact_list`
     * `aws_sesv2_dedicated_ip_pool`
     * `aws_sesv2_email_identity`
     * `aws_sesv2_email_identity_feedback_attributes`

--- a/providers/aws/sesv2.go
+++ b/providers/aws/sesv2.go
@@ -278,6 +278,14 @@ func newSESV2ContactListResource(output *sesv2.GetContactListOutput) (terraformu
 	if description := StringValue(output.Description); description != "" {
 		attributes["description"] = description
 	}
+	additionalFields := map[string]interface{}{}
+	topics, ok := sesv2ContactListTopics(output.Topics)
+	if !ok {
+		return terraformutils.Resource{}, false
+	}
+	if len(topics) > 0 {
+		additionalFields["topic"] = topics
+	}
 	return terraformutils.NewResource(
 		sesv2ContactListImportID(contactListName),
 		sesv2ResourceName("contact_list", contactListName),
@@ -285,8 +293,46 @@ func newSESV2ContactListResource(output *sesv2.GetContactListOutput) (terraformu
 		"aws",
 		attributes,
 		sesv2AllowEmptyValues,
-		map[string]interface{}{},
+		additionalFields,
 	), true
+}
+
+func sesv2ContactListTopics(topics []sesv2types.Topic) ([]interface{}, bool) {
+	if len(topics) == 0 {
+		return nil, true
+	}
+	sortedTopics := append([]sesv2types.Topic(nil), topics...)
+	sort.SliceStable(sortedTopics, func(i, j int) bool {
+		return sesv2TopicSortKey(sortedTopics[i]) < sesv2TopicSortKey(sortedTopics[j])
+	})
+	values := make([]interface{}, 0, len(sortedTopics))
+	for _, topic := range sortedTopics {
+		topicName := StringValue(topic.TopicName)
+		displayName := StringValue(topic.DisplayName)
+		defaultSubscriptionStatus := string(topic.DefaultSubscriptionStatus)
+		if topicName == "" || displayName == "" || defaultSubscriptionStatus == "" {
+			return nil, false
+		}
+		value := map[string]interface{}{
+			"default_subscription_status": defaultSubscriptionStatus,
+			"display_name":                displayName,
+			"topic_name":                  topicName,
+		}
+		if topic.Description != nil {
+			value["description"] = StringValue(topic.Description)
+		}
+		values = append(values, value)
+	}
+	return values, true
+}
+
+func sesv2TopicSortKey(topic sesv2types.Topic) string {
+	return strings.Join([]string{
+		StringValue(topic.TopicName),
+		StringValue(topic.DisplayName),
+		string(topic.DefaultSubscriptionStatus),
+		StringValue(topic.Description),
+	}, "\x00")
 }
 
 func newSESV2DedicatedIPPoolResource(poolName string) (terraformutils.Resource, bool) {

--- a/providers/aws/sesv2.go
+++ b/providers/aws/sesv2.go
@@ -18,6 +18,7 @@ import (
 const (
 	sesv2ConfigurationSetResourceType                 = "aws_sesv2_configuration_set"
 	sesv2ConfigurationSetEventDestinationResourceType = "aws_sesv2_configuration_set_event_destination"
+	sesv2ContactListResourceType                      = "aws_sesv2_contact_list"
 	sesv2DedicatedIPPoolResourceType                  = "aws_sesv2_dedicated_ip_pool"
 	sesv2EmailIdentityResourceType                    = "aws_sesv2_email_identity"
 	sesv2EmailIdentityFeedbackAttributesResourceType  = "aws_sesv2_email_identity_feedback_attributes"
@@ -40,6 +41,9 @@ func (g *SesV2Generator) InitResources() error {
 	svc := sesv2.NewFromConfig(config)
 
 	if err := g.loadConfigurationSets(svc); err != nil {
+		return err
+	}
+	if err := g.loadContactLists(svc); err != nil {
 		return err
 	}
 	if err := g.loadDedicatedIPPools(svc); err != nil {
@@ -107,6 +111,35 @@ func (g *SesV2Generator) loadConfigurationSetEventDestinations(svc *sesv2.Client
 	for _, destination := range output.EventDestinations {
 		if resource, ok := newSESV2ConfigurationSetEventDestinationResource(configurationSetName, destination); ok {
 			g.Resources = append(g.Resources, resource)
+		}
+	}
+	return nil
+}
+
+func (g *SesV2Generator) loadContactLists(svc *sesv2.Client) error {
+	p := sesv2.NewListContactListsPaginator(svc, &sesv2.ListContactListsInput{})
+	for p.HasMorePages() {
+		page, err := p.NextPage(context.TODO())
+		if err != nil {
+			return err
+		}
+		for _, contactList := range page.ContactLists {
+			contactListName := StringValue(contactList.ContactListName)
+			if contactListName == "" {
+				continue
+			}
+			output, err := svc.GetContactList(context.TODO(), &sesv2.GetContactListInput{
+				ContactListName: &contactListName,
+			})
+			if err != nil {
+				if sesv2NotFound(err) {
+					continue
+				}
+				return err
+			}
+			if resource, ok := newSESV2ContactListResource(output); ok {
+				g.Resources = append(g.Resources, resource)
+			}
 		}
 	}
 	return nil
@@ -231,6 +264,31 @@ func newSESV2ConfigurationSetEventDestinationResource(configurationSetName strin
 	), true
 }
 
+func newSESV2ContactListResource(output *sesv2.GetContactListOutput) (terraformutils.Resource, bool) {
+	if output == nil {
+		return terraformutils.Resource{}, false
+	}
+	contactListName := StringValue(output.ContactListName)
+	if contactListName == "" {
+		return terraformutils.Resource{}, false
+	}
+	attributes := map[string]string{
+		"contact_list_name": contactListName,
+	}
+	if description := StringValue(output.Description); description != "" {
+		attributes["description"] = description
+	}
+	return terraformutils.NewResource(
+		sesv2ContactListImportID(contactListName),
+		sesv2ResourceName("contact_list", contactListName),
+		sesv2ContactListResourceType,
+		"aws",
+		attributes,
+		sesv2AllowEmptyValues,
+		map[string]interface{}{},
+	), true
+}
+
 func newSESV2DedicatedIPPoolResource(poolName string) (terraformutils.Resource, bool) {
 	if poolName == "" {
 		return terraformutils.Resource{}, false
@@ -346,6 +404,10 @@ func sesv2ConfigurationSetImportID(configurationSetName string) string {
 
 func sesv2ConfigurationSetEventDestinationImportID(configurationSetName, eventDestinationName string) string {
 	return strings.Join([]string{configurationSetName, eventDestinationName}, sesv2ResourceIDSeparator)
+}
+
+func sesv2ContactListImportID(contactListName string) string {
+	return contactListName
 }
 
 func sesv2DedicatedIPPoolImportID(poolName string) string {

--- a/providers/aws/sesv2_test.go
+++ b/providers/aws/sesv2_test.go
@@ -20,6 +20,7 @@ func TestSESV2ImportIDs(t *testing.T) {
 	}{
 		{name: "configuration set", got: sesv2ConfigurationSetImportID("config-set"), want: "config-set"},
 		{name: "configuration set event destination", got: sesv2ConfigurationSetEventDestinationImportID("config-set", "events"), want: "config-set|events"},
+		{name: "contact list", got: sesv2ContactListImportID("contacts"), want: "contacts"},
 		{name: "dedicated IP pool", got: sesv2DedicatedIPPoolImportID("pool-a"), want: "pool-a"},
 		{name: "email identity", got: sesv2EmailIdentityImportID("sender@example.com"), want: "sender@example.com"},
 		{name: "email identity feedback attributes", got: sesv2EmailIdentityFeedbackAttributesImportID("sender@example.com"), want: "sender@example.com"},
@@ -67,6 +68,39 @@ func TestNewSESV2ConfigurationSetEventDestinationResource(t *testing.T) {
 	}
 	if _, ok := newSESV2ConfigurationSetEventDestinationResource("config-set", sesv2types.EventDestination{}); ok {
 		t.Fatal("newSESV2ConfigurationSetEventDestinationResource() ok = true for empty event destination name, want false")
+	}
+}
+
+func TestNewSESV2ContactListResource(t *testing.T) {
+	resource, ok := newSESV2ContactListResource(&sesv2.GetContactListOutput{
+		ContactListName: aws.String("contacts"),
+		Description:     aws.String("primary contact list"),
+	})
+	if !ok {
+		t.Fatal("newSESV2ContactListResource() ok = false, want true")
+	}
+	assertSESV2ResourceAttributes(t, resource, sesv2ContactListResourceType, "contacts",
+		[]string{"contact_list", "contacts"},
+		map[string]string{
+			"contact_list_name": "contacts",
+			"description":       "primary contact list",
+		})
+
+	resource, ok = newSESV2ContactListResource(&sesv2.GetContactListOutput{
+		ContactListName: aws.String("contacts"),
+	})
+	if !ok {
+		t.Fatal("newSESV2ContactListResource() ok = false without description, want true")
+	}
+	if _, ok := resource.InstanceState.Attributes["description"]; ok {
+		t.Fatal("newSESV2ContactListResource() seeded empty description, want omitted")
+	}
+
+	if _, ok := newSESV2ContactListResource(&sesv2.GetContactListOutput{}); ok {
+		t.Fatal("newSESV2ContactListResource() ok = true for empty contact list name, want false")
+	}
+	if _, ok := newSESV2ContactListResource(nil); ok {
+		t.Fatal("newSESV2ContactListResource() ok = true for nil contact list output, want false")
 	}
 }
 
@@ -232,6 +266,7 @@ func TestSESV2ResourceNameAvoidsSanitizedCollisions(t *testing.T) {
 		{name: "separator boundary", first: []string{"email_identity", "a_b", "c"}, second: []string{"email_identity", "a", "b_c"}},
 		{name: "at sign encoding", first: []string{"email_identity", "a@example.com"}, second: []string{"email_identity", "a-0040-example.com"}},
 		{name: "slash encoding", first: []string{"configuration_set", "a/b"}, second: []string{"configuration_set", "a-002F-b"}},
+		{name: "contact list separator", first: []string{"contact_list", "a_b", "c"}, second: []string{"contact_list", "a", "b_c"}},
 		{name: "event destination composite", first: []string{"configuration_set_event_destination", "a_b", "c"}, second: []string{"configuration_set_event_destination", "a", "b_c"}},
 		{name: "policy composite", first: []string{"email_identity_policy", "a|b", "c"}, second: []string{"email_identity_policy", "a", "b|c"}},
 	}
@@ -305,6 +340,8 @@ func stringsForSESV2ResourceName(resourceType, name string) []string {
 	switch resourceType {
 	case sesv2ConfigurationSetResourceType:
 		return []string{"configuration_set", name}
+	case sesv2ContactListResourceType:
+		return []string{"contact_list", name}
 	case sesv2DedicatedIPPoolResourceType:
 		return []string{"dedicated_ip_pool", name}
 	case sesv2EmailIdentityResourceType:

--- a/providers/aws/sesv2_test.go
+++ b/providers/aws/sesv2_test.go
@@ -4,6 +4,7 @@ package aws
 
 import (
 	"errors"
+	"strings"
 	"testing"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
@@ -94,6 +95,54 @@ func TestNewSESV2ContactListResource(t *testing.T) {
 	}
 	if _, ok := resource.InstanceState.Attributes["description"]; ok {
 		t.Fatal("newSESV2ContactListResource() seeded empty description, want omitted")
+	}
+	if _, ok := resource.AdditionalFields["topic"]; ok {
+		t.Fatal("newSESV2ContactListResource() seeded empty topics, want omitted")
+	}
+
+	resource, ok = newSESV2ContactListResource(&sesv2.GetContactListOutput{
+		ContactListName: aws.String("contacts"),
+		Topics: []sesv2types.Topic{
+			{
+				DefaultSubscriptionStatus: sesv2types.SubscriptionStatusOptOut,
+				Description:               aws.String("announcements"),
+				DisplayName:               aws.String("Announcements"),
+				TopicName:                 aws.String("announcements"),
+			},
+			{
+				DefaultSubscriptionStatus: sesv2types.SubscriptionStatusOptIn,
+				DisplayName:               aws.String("News"),
+				TopicName:                 aws.String("news"),
+			},
+		},
+	})
+	if !ok {
+		t.Fatal("newSESV2ContactListResource() ok = false with topics, want true")
+	}
+	assertSESV2ContactListTopics(t, resource, []map[string]interface{}{
+		{
+			"default_subscription_status": "OPT_OUT",
+			"description":                 "announcements",
+			"display_name":                "Announcements",
+			"topic_name":                  "announcements",
+		},
+		{
+			"default_subscription_status": "OPT_IN",
+			"display_name":                "News",
+			"topic_name":                  "news",
+		},
+	})
+
+	if _, ok := newSESV2ContactListResource(&sesv2.GetContactListOutput{
+		ContactListName: aws.String("contacts"),
+		Topics: []sesv2types.Topic{
+			{
+				DefaultSubscriptionStatus: sesv2types.SubscriptionStatusOptIn,
+				DisplayName:               aws.String("News"),
+			},
+		},
+	}); ok {
+		t.Fatal("newSESV2ContactListResource() ok = true for topic without topic name, want false")
 	}
 
 	if _, ok := newSESV2ContactListResource(&sesv2.GetContactListOutput{}); ok {
@@ -282,6 +331,47 @@ func TestSESV2ResourceNameAvoidsSanitizedCollisions(t *testing.T) {
 	}
 }
 
+func TestSESV2ContactListResourceHCLIncludesTopics(t *testing.T) {
+	resource, ok := newSESV2ContactListResource(&sesv2.GetContactListOutput{
+		ContactListName: aws.String("contacts"),
+		Topics: []sesv2types.Topic{
+			{
+				DefaultSubscriptionStatus: sesv2types.SubscriptionStatusOptIn,
+				DisplayName:               aws.String("News"),
+				TopicName:                 aws.String("news"),
+			},
+		},
+	})
+	if !ok {
+		t.Fatal("newSESV2ContactListResource() ok = false, want true")
+	}
+	resource.Item = map[string]interface{}{
+		"contact_list_name": resource.InstanceState.Attributes["contact_list_name"],
+		"topic":             resource.AdditionalFields["topic"],
+	}
+
+	data, err := terraformutils.HclPrintResource([]terraformutils.Resource{resource}, map[string]interface{}{}, "hcl", true)
+	if err != nil {
+		t.Fatalf("HclPrintResource() error = %v", err)
+	}
+	output := string(data)
+	normalizedOutput := strings.Join(strings.Fields(output), " ")
+	for _, want := range []string{
+		"topic {",
+		"default_subscription_status = \"OPT_IN\"",
+		"display_name = \"News\"",
+		"topic_name = \"news\"",
+	} {
+		outputToSearch := output
+		if strings.Contains(want, " = ") {
+			outputToSearch = normalizedOutput
+		}
+		if !strings.Contains(outputToSearch, want) {
+			t.Fatalf("output does not contain %q:\n%s", want, output)
+		}
+	}
+}
+
 func TestSESV2PostConvertHookWrapsPolicy(t *testing.T) {
 	resource, ok := newSESV2EmailIdentityPolicyResource("sender@example.com", "policy-a", `{"Resource":"${aws:username}"}`)
 	if !ok {
@@ -333,6 +423,32 @@ func assertSESV2ResourceAttributes(t *testing.T, resource terraformutils.Resourc
 	wantName := terraformutils.TfSanitize(sesv2ResourceName(nameParts...))
 	if resource.ResourceName != wantName {
 		t.Fatalf("resource name = %q, want %q", resource.ResourceName, wantName)
+	}
+}
+
+func assertSESV2ContactListTopics(t *testing.T, resource terraformutils.Resource, wants []map[string]interface{}) {
+	t.Helper()
+
+	topics, ok := resource.AdditionalFields["topic"].([]interface{})
+	if !ok {
+		t.Fatalf("topic additional field type = %T, want []interface{}", resource.AdditionalFields["topic"])
+	}
+	if len(topics) != len(wants) {
+		t.Fatalf("topic additional field length = %d, want %d", len(topics), len(wants))
+	}
+	for i, want := range wants {
+		got, ok := topics[i].(map[string]interface{})
+		if !ok {
+			t.Fatalf("topic[%d] type = %T, want map[string]interface{}", i, topics[i])
+		}
+		if len(got) != len(want) {
+			t.Fatalf("topic[%d] = %#v, want %#v", i, got, want)
+		}
+		for key, wantValue := range want {
+			if got[key] != wantValue {
+				t.Fatalf("topic[%d][%q] = %q, want %q", i, key, got[key], wantValue)
+			}
+		}
 	}
 }
 


### PR DESCRIPTION
## Summary

- add SESv2 contact list import discovery
- seed import IDs as `contact_list_name`
- update docs/aws.md for `aws_sesv2_contact_list`
- add unit tests for SESv2 contact-list helper behavior

## References

- #338

## Validation

```bash
go test ./providers/aws -run 'Test.*SES|Test.*Ses|Test.*ses'
go test ./providers/aws/... ./terraformutils/...
go run ./tools/aws-gap-inventory \
  -docs docs/aws.md \
  -aws-dir providers/aws \
  -skip-list providers/aws/unsupported_resources.json \
  -format markdown
git diff --check
```

## Notes

Skipped/deferred resources:
- `aws_sesv2_dedicated_ip_assignment`: dedicated IP child assignment; handle separately.
- `aws_sesv2_account_suppression_attributes`, `aws_sesv2_account_vdm_attributes`: account-wide singleton settings; handle separately.
- `aws_sesv2_tenant`, `aws_sesv2_tenant_resource_association`: tenant-specific resources; handle separately.
- Contact/subscriber entries: not in this PR scope.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds SESv2 contact list imports for `aws_sesv2_contact_list`, using the list name as the import ID. Also captures contact list topics and outputs them as `topic` blocks.

- **New Features**
  - Discover contact lists via SESv2 paginator and fetch details; skip not found.
  - Generate `aws_sesv2_contact_list` with `contact_list_name`, optional `description`, and `topic` blocks (sorted and validated); import ID is the list name.
  - Updated `docs/aws.md`; added tests for import IDs, resource naming, topic HCL output, and contact-list helper behavior.

<sup>Written for commit a02558936879b5b970c7d129df093cf0cbcda40a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for importing and managing AWS SESv2 contact lists.

* **Documentation**
  * Updated supported resources list to include SESv2 contact list support.

* **Tests**
  * Added and extended tests to cover contact list import IDs, resource creation, topic validation, name collision handling, and HCL rendering.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/chenrui333/terraformer/pull/406)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->