### PR TITLE
aws(bedrock): add model invocation logging configuration imports

### DIFF
--- a/docs/aws.md
+++ b/docs/aws.md
@@ -132,6 +132,7 @@ For AWS provider gap audits and unsupported-resource skip-list maintenance, see 
 *   `bedrock`
     * `aws_bedrock_guardrail`
     * `aws_bedrock_inference_profile`
+    * `aws_bedrock_model_invocation_logging_configuration`
     * `aws_bedrock_provisioned_model_throughput`
 *   `budgets`
     * `aws_budgets_budget`

--- a/providers/aws/bedrock.go
+++ b/providers/aws/bedrock.go
@@ -17,6 +17,7 @@ import (
 const (
 	bedrockGuardrailResourceType                  = "aws_bedrock_guardrail"
 	bedrockInferenceProfileResourceType           = "aws_bedrock_inference_profile"
+	bedrockModelInvocationLoggingResourceType     = "aws_bedrock_model_invocation_logging_configuration"
 	bedrockProvisionedModelThroughputResourceType = "aws_bedrock_provisioned_model_throughput"
 	bedrockGuardrailImportIDSeparator             = ","
 	bedrockResourceNameFallback                   = "bedrock-resource"
@@ -27,6 +28,7 @@ var (
 	bedrockResourceTypes    = []string{
 		bedrockServiceName(bedrockGuardrailResourceType),
 		bedrockServiceName(bedrockInferenceProfileResourceType),
+		bedrockServiceName(bedrockModelInvocationLoggingResourceType),
 		bedrockServiceName(bedrockProvisionedModelThroughputResourceType),
 	}
 )
@@ -73,6 +75,11 @@ func (g *BedrockGenerator) InitResources() error {
 	}
 	if g.shouldLoadBedrockResource(bedrockServiceName(bedrockInferenceProfileResourceType)) {
 		if err := g.loadInferenceProfiles(svc); err != nil {
+			return err
+		}
+	}
+	if g.shouldLoadBedrockResource(bedrockServiceName(bedrockModelInvocationLoggingResourceType)) {
+		if err := g.loadModelInvocationLoggingConfiguration(svc, config.Region); err != nil {
 			return err
 		}
 	}
@@ -157,6 +164,20 @@ func (g *BedrockGenerator) loadInferenceProfiles(svc *bedrock.Client) error {
 	return nil
 }
 
+func (g *BedrockGenerator) loadModelInvocationLoggingConfiguration(svc *bedrock.Client, region string) error {
+	output, err := svc.GetModelInvocationLoggingConfiguration(context.TODO(), &bedrock.GetModelInvocationLoggingConfigurationInput{})
+	if err != nil {
+		if bedrockResourceNotFound(err) {
+			return nil
+		}
+		return err
+	}
+	if resource, ok := newBedrockModelInvocationLoggingResource(region, output); ok {
+		g.Resources = append(g.Resources, resource)
+	}
+	return nil
+}
+
 func (g *BedrockGenerator) loadProvisionedModelThroughputs(svc *bedrock.Client) error {
 	p := bedrock.NewListProvisionedModelThroughputsPaginator(svc, &bedrock.ListProvisionedModelThroughputsInput{})
 	for p.HasMorePages() {
@@ -220,6 +241,19 @@ func newBedrockInferenceProfileResource(profile bedrocktypes.InferenceProfileSum
 	), true
 }
 
+func newBedrockModelInvocationLoggingResource(region string, output *bedrock.GetModelInvocationLoggingConfigurationOutput) (terraformutils.Resource, bool) {
+	if region == "" || !bedrockModelInvocationLoggingConfigured(output) {
+		return terraformutils.Resource{}, false
+	}
+	return terraformutils.NewSimpleResource(
+		bedrockModelInvocationLoggingImportID(region),
+		bedrockResourceName("model-invocation-logging-configuration", region),
+		bedrockModelInvocationLoggingResourceType,
+		"aws",
+		bedrockAllowEmptyValues,
+	), true
+}
+
 func newBedrockProvisionedModelThroughputResource(throughput bedrocktypes.ProvisionedModelSummary) (terraformutils.Resource, bool) {
 	provisionedModelARN := StringValue(throughput.ProvisionedModelArn)
 	modelARN := StringValue(throughput.ModelArn)
@@ -248,6 +282,10 @@ func bedrockGuardrailImportID(guardrailID, version string) string {
 	return guardrailID + bedrockGuardrailImportIDSeparator + version
 }
 
+func bedrockModelInvocationLoggingImportID(region string) string {
+	return region
+}
+
 func bedrockResourceName(parts ...string) string {
 	var cleanParts []string
 	for _, part := range parts {
@@ -267,6 +305,10 @@ func bedrockGuardrailImportable(status bedrocktypes.GuardrailStatus) bool {
 
 func bedrockInferenceProfileImportable(profile bedrocktypes.InferenceProfileSummary) bool {
 	return profile.Type == bedrocktypes.InferenceProfileTypeApplication && profile.Status == bedrocktypes.InferenceProfileStatusActive
+}
+
+func bedrockModelInvocationLoggingConfigured(output *bedrock.GetModelInvocationLoggingConfigurationOutput) bool {
+	return output != nil && output.LoggingConfig != nil
 }
 
 func bedrockProvisionedModelThroughputImportable(status bedrocktypes.ProvisionedModelStatus) bool {

--- a/providers/aws/bedrock_test.go
+++ b/providers/aws/bedrock_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/bedrock"
 	bedrocktypes "github.com/aws/aws-sdk-go-v2/service/bedrock/types"
 	"github.com/chenrui333/terraformer/terraformutils"
 )
@@ -16,6 +17,14 @@ func TestBedrockGuardrailImportID(t *testing.T) {
 	want := "gr-1234567890,DRAFT"
 	if got != want {
 		t.Fatalf("bedrockGuardrailImportID() = %q, want %q", got, want)
+	}
+}
+
+func TestBedrockModelInvocationLoggingImportID(t *testing.T) {
+	got := bedrockModelInvocationLoggingImportID("us-east-1")
+	want := "us-east-1"
+	if got != want {
+		t.Fatalf("bedrockModelInvocationLoggingImportID() = %q, want %q", got, want)
 	}
 }
 
@@ -37,6 +46,7 @@ func TestBedrockShouldLoadResourceHonorsTypedFilters(t *testing.T) {
 	g := BedrockGenerator{}
 	if !g.shouldLoadBedrockResource("bedrock_guardrail") ||
 		!g.shouldLoadBedrockResource("bedrock_inference_profile") ||
+		!g.shouldLoadBedrockResource("bedrock_model_invocation_logging_configuration") ||
 		!g.shouldLoadBedrockResource("bedrock_provisioned_model_throughput") {
 		t.Fatal("without typed filters, all Bedrock resource families should be loaded")
 	}
@@ -52,8 +62,23 @@ func TestBedrockShouldLoadResourceHonorsTypedFilters(t *testing.T) {
 	if g.shouldLoadBedrockResource("bedrock_inference_profile") {
 		t.Fatal("typed guardrail filter should not load inference profiles")
 	}
+	if g.shouldLoadBedrockResource("bedrock_model_invocation_logging_configuration") {
+		t.Fatal("typed guardrail filter should not load model invocation logging configuration")
+	}
 	if g.shouldLoadBedrockResource("bedrock_provisioned_model_throughput") {
 		t.Fatal("typed guardrail filter should not load provisioned throughputs")
+	}
+
+	g.Filter = []terraformutils.ResourceFilter{{
+		ServiceName:      "bedrock_model_invocation_logging_configuration",
+		FieldPath:        "id",
+		AcceptableValues: []string{"us-east-1"},
+	}}
+	if !g.shouldLoadBedrockResource("bedrock_model_invocation_logging_configuration") {
+		t.Fatal("typed logging filter should load model invocation logging configuration")
+	}
+	if g.shouldLoadBedrockResource("bedrock_guardrail") {
+		t.Fatal("typed logging filter should not load guardrails")
 	}
 }
 
@@ -94,8 +119,14 @@ func TestBedrockShouldLoadResourceAllowsUntypedFilters(t *testing.T) {
 					},
 				},
 			}
-			if !g.shouldLoadBedrockResource("bedrock_inference_profile") {
-				t.Fatal("untyped filter should keep broad Bedrock discovery available")
+			for _, serviceName := range []string{
+				"bedrock_inference_profile",
+				"bedrock_model_invocation_logging_configuration",
+				"bedrock_provisioned_model_throughput",
+			} {
+				if !g.shouldLoadBedrockResource(serviceName) {
+					t.Fatalf("untyped filter should keep %s discovery available", serviceName)
+				}
 			}
 		})
 	}
@@ -165,6 +196,29 @@ func TestNewBedrockInferenceProfileResource(t *testing.T) {
 		Type:               bedrocktypes.InferenceProfileTypeSystemDefined,
 	}); ok {
 		t.Fatal("system-defined inference profile should be skipped")
+	}
+}
+
+func TestNewBedrockModelInvocationLoggingResource(t *testing.T) {
+	output := &bedrock.GetModelInvocationLoggingConfigurationOutput{
+		LoggingConfig: &bedrocktypes.LoggingConfig{},
+	}
+	resource, ok := newBedrockModelInvocationLoggingResource("us-east-1", output)
+	assertBedrockResource(t, resource, ok, "us-east-1", bedrockModelInvocationLoggingResourceType)
+	otherRegion, ok := newBedrockModelInvocationLoggingResource("us-west-2", output)
+	assertBedrockResource(t, otherRegion, ok, "us-west-2", bedrockModelInvocationLoggingResourceType)
+	if resource.ResourceName == otherRegion.ResourceName {
+		t.Fatal("logging configuration resource names should be region-specific")
+	}
+
+	if _, ok := newBedrockModelInvocationLoggingResource("", output); ok {
+		t.Fatal("logging configuration without region should be skipped")
+	}
+	if _, ok := newBedrockModelInvocationLoggingResource("us-east-1", nil); ok {
+		t.Fatal("nil logging configuration output should be skipped")
+	}
+	if _, ok := newBedrockModelInvocationLoggingResource("us-east-1", &bedrock.GetModelInvocationLoggingConfigurationOutput{}); ok {
+		t.Fatal("unconfigured logging should be skipped")
 	}
 }
 
@@ -276,9 +330,15 @@ func TestBedrockInitialCleanupHonorsTypedFilters(t *testing.T) {
 	if !ok {
 		t.Fatal("newBedrockProvisionedModelThroughputResource() should create throughput")
 	}
+	logging, ok := newBedrockModelInvocationLoggingResource("us-east-1", &bedrock.GetModelInvocationLoggingConfigurationOutput{
+		LoggingConfig: &bedrocktypes.LoggingConfig{},
+	})
+	if !ok {
+		t.Fatal("newBedrockModelInvocationLoggingResource() should create logging configuration")
+	}
 
 	g := BedrockGenerator{}
-	g.Resources = []terraformutils.Resource{guardrail, profile, throughput}
+	g.Resources = []terraformutils.Resource{guardrail, profile, throughput, logging}
 	g.Filter = []terraformutils.ResourceFilter{{
 		ServiceName:      "bedrock_guardrail",
 		FieldPath:        "id",
@@ -296,9 +356,9 @@ func TestBedrockInitialCleanupHonorsTypedFilters(t *testing.T) {
 }
 
 func TestBedrockInitialCleanupPreservesGlobalFilters(t *testing.T) {
-	guardrail, profile, throughput := bedrockTestResources(t)
+	guardrail, profile, logging, throughput := bedrockTestResources(t)
 	g := BedrockGenerator{}
-	g.Resources = []terraformutils.Resource{guardrail, profile, throughput}
+	g.Resources = []terraformutils.Resource{guardrail, profile, logging, throughput}
 	g.Filter = []terraformutils.ResourceFilter{
 		{
 			ServiceName:      "bedrock_guardrail",
@@ -313,8 +373,8 @@ func TestBedrockInitialCleanupPreservesGlobalFilters(t *testing.T) {
 
 	g.InitialCleanup()
 
-	if len(g.Resources) != 3 {
-		t.Fatalf("InitialCleanup() resources len = %d, want 3", len(g.Resources))
+	if len(g.Resources) != 4 {
+		t.Fatalf("InitialCleanup() resources len = %d, want 4", len(g.Resources))
 	}
 }
 
@@ -334,7 +394,7 @@ func assertBedrockResource(t *testing.T, resource terraformutils.Resource, ok bo
 	}
 }
 
-func bedrockTestResources(t *testing.T) (terraformutils.Resource, terraformutils.Resource, terraformutils.Resource) {
+func bedrockTestResources(t *testing.T) (terraformutils.Resource, terraformutils.Resource, terraformutils.Resource, terraformutils.Resource) {
 	t.Helper()
 	guardrail, ok := newBedrockGuardrailResource(bedrocktypes.GuardrailSummary{
 		Id:      aws.String("gr-1234567890"),
@@ -354,6 +414,12 @@ func bedrockTestResources(t *testing.T) (terraformutils.Resource, terraformutils
 	if !ok {
 		t.Fatal("newBedrockInferenceProfileResource() should create profile")
 	}
+	logging, ok := newBedrockModelInvocationLoggingResource("us-east-1", &bedrock.GetModelInvocationLoggingConfigurationOutput{
+		LoggingConfig: &bedrocktypes.LoggingConfig{},
+	})
+	if !ok {
+		t.Fatal("newBedrockModelInvocationLoggingResource() should create logging configuration")
+	}
 	modelUnits := int32(2)
 	throughput, ok := newBedrockProvisionedModelThroughputResource(bedrocktypes.ProvisionedModelSummary{
 		ModelArn:             aws.String("arn:aws:bedrock:us-east-1::foundation-model/amazon.nova-pro-v1:0"),
@@ -365,5 +431,5 @@ func bedrockTestResources(t *testing.T) (terraformutils.Resource, terraformutils
 	if !ok {
 		t.Fatal("newBedrockProvisionedModelThroughputResource() should create throughput")
 	}
-	return guardrail, profile, throughput
+	return guardrail, profile, logging, throughput
 }


### PR DESCRIPTION
## Summary

- add Bedrock model invocation logging configuration import discovery
- seed import IDs as the AWS Region
- skip absent/unconfigured logging configuration responses
- update docs/aws.md for `aws_bedrock_model_invocation_logging_configuration`
- add unit tests for Bedrock logging configuration helper and typed-filter behavior

## References

- #338

## Validation

```bash
go test ./providers/aws -run 'Test.*Bedrock|Test.*bedrock'
go test ./providers/aws/... ./terraformutils/...
go run ./tools/aws-gap-inventory \
  -docs docs/aws.md \
  -aws-dir providers/aws \
  -skip-list providers/aws/unsupported_resources.json \
  -format markdown
git diff --check
```

## Notes

Skipped/deferred resources:
- `aws_bedrock_custom_model`: deferred for customization-job-based discovery
- `aws_bedrock_guardrail_version`: deferred for focused guardrail-version discovery
- `aws_bedrockagent_*`: deferred for a Bedrock Agent service-family PR
- `aws_bedrockagentcore_*`: deferred for a Bedrock Agent Core service-family PR


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds import discovery for Bedrock model invocation logging configuration, using the AWS region as the import ID and skipping unconfigured responses. Updates docs and tests, and wires the resource into typed-filter handling.

- **New Features**
  - Discover and import `aws_bedrock_model_invocation_logging_configuration`.
  - Import ID is the AWS region.
  - Skip when the logging configuration is absent or not found.
  - Support typed filters for this resource family.
  - Update `docs/aws.md`.
  - Add unit tests for the helper and filter behavior.

<sup>Written for commit 19c1d30d3954a4d883760d1751abe1e3a9f1c31b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for AWS Bedrock Model Invocation Logging Configuration resource.

* **Documentation**
  * Updated supported services list to reflect new Bedrock resource type.

* **Tests**
  * Added test coverage for new Bedrock logging configuration support.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/chenrui333/terraformer/pull/407)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->