### PR TITLE
aws(dms): add serverless replication config imports

### DIFF
--- a/docs/aws.md
+++ b/docs/aws.md
@@ -217,6 +217,7 @@ For AWS provider gap audits and unsupported-resource skip-list maintenance, see 
     * `aws_dms_certificate`
     * `aws_dms_endpoint`
     * `aws_dms_event_subscription`
+    * `aws_dms_replication_config`
     * `aws_dms_replication_instance`
     * `aws_dms_replication_subnet_group`
     * `aws_dms_replication_task`

--- a/providers/aws/dms.go
+++ b/providers/aws/dms.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/aws/aws-sdk-go-v2/service/databasemigrationservice"
 	dmstypes "github.com/aws/aws-sdk-go-v2/service/databasemigrationservice/types"
+	"github.com/aws/smithy-go"
 	"github.com/chenrui333/terraformer/terraformutils"
 )
 
@@ -64,7 +65,15 @@ func (g *DmsGenerator) loadOptionalResources(loaders []dmsOptionalResourceLoader
 
 func dmsOptionalResourceErrorSkippable(err error) bool {
 	var notFound *dmstypes.ResourceNotFoundFault
-	return errors.As(err, &notFound)
+	if errors.As(err, &notFound) {
+		return true
+	}
+	var accessDenied *dmstypes.AccessDeniedFault
+	if errors.As(err, &accessDenied) {
+		return true
+	}
+	var apiErr smithy.APIError
+	return errors.As(err, &apiErr) && strings.Contains(strings.ToLower(apiErr.ErrorCode()), "accessdenied")
 }
 
 func (g *DmsGenerator) InitResources() error {

--- a/providers/aws/dms.go
+++ b/providers/aws/dms.go
@@ -18,6 +18,7 @@ import (
 const (
 	dmsCertificateResourceType            = "aws_dms_certificate"
 	dmsEventSubscriptionResourceType      = "aws_dms_event_subscription"
+	dmsReplicationConfigResourceType      = "aws_dms_replication_config"
 	dmsReplicationInstanceResourceType    = "aws_dms_replication_instance"
 	dmsReplicationSubnetGroupResourceType = "aws_dms_replication_subnet_group"
 	dmsEndpointResourceType               = "aws_dms_endpoint"
@@ -88,6 +89,7 @@ func (g *DmsGenerator) InitResources() error {
 	if err := g.loadOptionalResources([]dmsOptionalResourceLoader{
 		{name: "certificates", load: func() error { return g.loadCertificates(svc) }},
 		{name: "event subscriptions", load: func() error { return g.loadEventSubscriptions(svc) }},
+		{name: "replication configs", load: func() error { return g.loadReplicationConfigs(svc) }},
 	}); err != nil {
 		return err
 	}
@@ -191,6 +193,22 @@ func (g *DmsGenerator) loadEventSubscriptions(svc *databasemigrationservice.Clie
 	return nil
 }
 
+func (g *DmsGenerator) loadReplicationConfigs(svc *databasemigrationservice.Client) error {
+	p := databasemigrationservice.NewDescribeReplicationConfigsPaginator(svc, &databasemigrationservice.DescribeReplicationConfigsInput{})
+	for p.HasMorePages() {
+		page, err := p.NextPage(context.TODO())
+		if err != nil {
+			return err
+		}
+		for _, config := range page.ReplicationConfigs {
+			if resource, ok := newDMSReplicationConfigResource(config); ok {
+				g.Resources = append(g.Resources, resource)
+			}
+		}
+	}
+	return nil
+}
+
 func newDMSCertificateResource(certificate dmstypes.Certificate) (terraformutils.Resource, bool) {
 	identifier := StringValue(certificate.CertificateIdentifier)
 	if identifier == "" || !dmsCertificateImportable(certificate) {
@@ -227,6 +245,22 @@ func newDMSEventSubscriptionResource(subscription dmstypes.EventSubscription) (t
 		attributes,
 		dmsAllowEmptyValues,
 		additionalFields,
+	), true
+}
+
+func newDMSReplicationConfigResource(config dmstypes.ReplicationConfig) (terraformutils.Resource, bool) {
+	importID := dmsReplicationConfigImportID(config)
+	if importID == "" || !dmsReplicationConfigImportable(config) {
+		return terraformutils.Resource{}, false
+	}
+	return terraformutils.NewResource(
+		importID,
+		dmsReplicationConfigResourceName(config),
+		dmsReplicationConfigResourceType,
+		"aws",
+		dmsReplicationConfigAttributes(config),
+		dmsAllowEmptyValues,
+		map[string]interface{}{},
 	), true
 }
 
@@ -299,6 +333,15 @@ func dmsResourceName(parts ...string) string {
 	return strings.Join(cleanParts, "/")
 }
 
+func dmsReplicationConfigImportID(config dmstypes.ReplicationConfig) string {
+	return StringValue(config.ReplicationConfigArn)
+}
+
+func dmsReplicationConfigResourceName(config dmstypes.ReplicationConfig) string {
+	arnSuffix := arnLastSegment(dmsReplicationConfigImportID(config), ":")
+	return dmsResourceName("replication-config", StringValue(config.ReplicationConfigIdentifier), arnSuffix)
+}
+
 func dmsCertificateImportable(certificate dmstypes.Certificate) bool {
 	return StringValue(certificate.CertificatePem) != "" || len(certificate.CertificateWallet) > 0
 }
@@ -326,6 +369,72 @@ func dmsEventSubscriptionSourceTypeImportable(sourceType string) bool {
 	default:
 		return false
 	}
+}
+
+func dmsReplicationConfigImportable(config dmstypes.ReplicationConfig) bool {
+	if config.IsReadOnly != nil && *config.IsReadOnly {
+		return false
+	}
+	return StringValue(config.ReplicationConfigArn) != "" &&
+		StringValue(config.ReplicationConfigIdentifier) != "" &&
+		config.ReplicationType != "" &&
+		StringValue(config.SourceEndpointArn) != "" &&
+		StringValue(config.TargetEndpointArn) != "" &&
+		StringValue(config.TableMappings) != "" &&
+		dmsReplicationConfigComputeConfigImportable(config.ComputeConfig)
+}
+
+func dmsReplicationConfigComputeConfigImportable(computeConfig *dmstypes.ComputeConfig) bool {
+	return computeConfig != nil &&
+		StringValue(computeConfig.ReplicationSubnetGroupId) != "" &&
+		computeConfig.MaxCapacityUnits != nil &&
+		*computeConfig.MaxCapacityUnits > 0
+}
+
+func dmsReplicationConfigAttributes(config dmstypes.ReplicationConfig) map[string]string {
+	attributes := map[string]string{
+		"compute_config.#":              "1",
+		"replication_config_identifier": StringValue(config.ReplicationConfigIdentifier),
+		"replication_type":              string(config.ReplicationType),
+		"source_endpoint_arn":           StringValue(config.SourceEndpointArn),
+		"table_mappings":                StringValue(config.TableMappings),
+		"target_endpoint_arn":           StringValue(config.TargetEndpointArn),
+	}
+	if settings := StringValue(config.ReplicationSettings); settings != "" {
+		attributes["replication_settings"] = settings
+	}
+	if settings := StringValue(config.SupplementalSettings); settings != "" {
+		attributes["supplemental_settings"] = settings
+	}
+	if config.ComputeConfig == nil {
+		return attributes
+	}
+
+	computeConfig := config.ComputeConfig
+	attributes["compute_config.0.replication_subnet_group_id"] = StringValue(computeConfig.ReplicationSubnetGroupId)
+	attributes["compute_config.0.max_capacity_units"] = strconv.Itoa(int(*computeConfig.MaxCapacityUnits))
+	if value := StringValue(computeConfig.AvailabilityZone); value != "" {
+		attributes["compute_config.0.availability_zone"] = value
+	}
+	if value := StringValue(computeConfig.DnsNameServers); value != "" {
+		attributes["compute_config.0.dns_name_servers"] = value
+	}
+	if value := StringValue(computeConfig.KmsKeyId); value != "" {
+		attributes["compute_config.0.kms_key_id"] = value
+	}
+	if computeConfig.MinCapacityUnits != nil {
+		attributes["compute_config.0.min_capacity_units"] = strconv.Itoa(int(*computeConfig.MinCapacityUnits))
+	}
+	if computeConfig.MultiAZ != nil {
+		attributes["compute_config.0.multi_az"] = strconv.FormatBool(*computeConfig.MultiAZ)
+	}
+	if value := StringValue(computeConfig.PreferredMaintenanceWindow); value != "" {
+		attributes["compute_config.0.preferred_maintenance_window"] = value
+	}
+	for key, value := range dmsStringSliceAttributes("compute_config.0.vpc_security_group_ids", computeConfig.VpcSecurityGroupIds) {
+		attributes[key] = value
+	}
+	return attributes
 }
 
 func dmsReplicationInstanceImportable(instance dmstypes.ReplicationInstance) bool {

--- a/providers/aws/dms_test.go
+++ b/providers/aws/dms_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	dmstypes "github.com/aws/aws-sdk-go-v2/service/databasemigrationservice/types"
+	"github.com/aws/smithy-go"
 	"github.com/chenrui333/terraformer/terraformutils"
 )
 
@@ -65,6 +66,32 @@ func TestDMSOptionalResourceLoaderErrors(t *testing.T) {
 		}
 	})
 
+	t.Run("skips access denied", func(t *testing.T) {
+		g := DmsGenerator{}
+		calledNext := false
+		err := g.loadOptionalResources([]dmsOptionalResourceLoader{
+			{
+				name: "replication configs",
+				load: func() error {
+					return &dmstypes.AccessDeniedFault{}
+				},
+			},
+			{
+				name: "event subscriptions",
+				load: func() error {
+					calledNext = true
+					return nil
+				},
+			},
+		})
+		if err != nil {
+			t.Fatalf("loadOptionalResources() error = %v, want nil", err)
+		}
+		if !calledNext {
+			t.Fatal("loadOptionalResources() should continue after access denied")
+		}
+	})
+
 	t.Run("returns unexpected error", func(t *testing.T) {
 		g := DmsGenerator{}
 		boom := errors.New("boom")
@@ -91,6 +118,28 @@ func TestDMSOptionalResourceLoaderErrors(t *testing.T) {
 			t.Fatal("loadOptionalResources() should stop after unexpected error")
 		}
 	})
+}
+
+func TestDMSOptionalResourceErrorSkippable(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{name: "resource not found", err: &dmstypes.ResourceNotFoundFault{}, want: true},
+		{name: "typed access denied", err: &dmstypes.AccessDeniedFault{}, want: true},
+		{name: "generic access denied", err: &smithy.GenericAPIError{Code: "AccessDeniedException"}, want: true},
+		{name: "generic access denied fault", err: &smithy.GenericAPIError{Code: "AccessDeniedFault"}, want: true},
+		{name: "unexpected generic error", err: &smithy.GenericAPIError{Code: "ThrottlingException"}, want: false},
+		{name: "plain error", err: errors.New("boom"), want: false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := dmsOptionalResourceErrorSkippable(tt.err); got != tt.want {
+				t.Fatalf("dmsOptionalResourceErrorSkippable() = %v, want %v", got, tt.want)
+			}
+		})
+	}
 }
 
 func TestNewDMSCertificateResource(t *testing.T) {

--- a/providers/aws/dms_test.go
+++ b/providers/aws/dms_test.go
@@ -192,6 +192,122 @@ func TestNewDMSEventSubscriptionResource(t *testing.T) {
 	}
 }
 
+func TestNewDMSReplicationConfigResource(t *testing.T) {
+	multiAZ := false
+	resource, ok := newDMSReplicationConfigResource(dmstypes.ReplicationConfig{
+		ComputeConfig: &dmstypes.ComputeConfig{
+			AvailabilityZone:           dmsString("us-east-1a"),
+			DnsNameServers:             dmsString("1.1.1.1,2.2.2.2"),
+			KmsKeyId:                   dmsString("arn:aws:kms:us-east-1:123456789012:key/example"),
+			MaxCapacityUnits:           dmsInt32(64),
+			MinCapacityUnits:           dmsInt32(2),
+			MultiAZ:                    &multiAZ,
+			PreferredMaintenanceWindow: dmsString("sun:23:45-mon:00:30"),
+			ReplicationSubnetGroupId:   dmsString("dms-subnets"),
+			VpcSecurityGroupIds:        []string{"sg-1", "sg-2"},
+		},
+		ReplicationConfigArn:        dmsString("arn:aws:dms:us-east-1:123456789012:replication-config:ABC123"),
+		ReplicationConfigIdentifier: dmsString("orders"),
+		ReplicationSettings:         dmsString("{\"Logging\":{\"EnableLogging\":true}}"),
+		ReplicationType:             dmstypes.MigrationTypeValueCdc,
+		SourceEndpointArn:           dmsString("arn:aws:dms:us-east-1:123456789012:endpoint:SOURCE"),
+		SupplementalSettings:        dmsString("{}"),
+		TableMappings:               dmsString("{\"rules\":[]}"),
+		TargetEndpointArn:           dmsString("arn:aws:dms:us-east-1:123456789012:endpoint:TARGET"),
+	})
+	assertDMSResource(
+		t,
+		resource,
+		ok,
+		"arn:aws:dms:us-east-1:123456789012:replication-config:ABC123",
+		dmsResourceName("replication-config", "orders", "ABC123"),
+		dmsReplicationConfigResourceType,
+	)
+
+	attributes := resource.InstanceState.Attributes
+	expected := map[string]string{
+		"compute_config.#":                              "1",
+		"compute_config.0.availability_zone":            "us-east-1a",
+		"compute_config.0.dns_name_servers":             "1.1.1.1,2.2.2.2",
+		"compute_config.0.kms_key_id":                   "arn:aws:kms:us-east-1:123456789012:key/example",
+		"compute_config.0.max_capacity_units":           "64",
+		"compute_config.0.min_capacity_units":           "2",
+		"compute_config.0.multi_az":                     "false",
+		"compute_config.0.preferred_maintenance_window": "sun:23:45-mon:00:30",
+		"compute_config.0.replication_subnet_group_id":  "dms-subnets",
+		"compute_config.0.vpc_security_group_ids.#":     "2",
+		"compute_config.0.vpc_security_group_ids.1":     "sg-2",
+		"replication_config_identifier":                 "orders",
+		"replication_settings":                          "{\"Logging\":{\"EnableLogging\":true}}",
+		"replication_type":                              "cdc",
+		"source_endpoint_arn":                           "arn:aws:dms:us-east-1:123456789012:endpoint:SOURCE",
+		"supplemental_settings":                         "{}",
+		"table_mappings":                                "{\"rules\":[]}",
+		"target_endpoint_arn":                           "arn:aws:dms:us-east-1:123456789012:endpoint:TARGET",
+	}
+	for key, want := range expected {
+		if got := attributes[key]; got != want {
+			t.Fatalf("%s = %q, want %q", key, got, want)
+		}
+	}
+}
+
+func TestNewDMSReplicationConfigResourceSkipsUnsafeConfigs(t *testing.T) {
+	validConfig := func() dmstypes.ReplicationConfig {
+		return dmstypes.ReplicationConfig{
+			ComputeConfig: &dmstypes.ComputeConfig{
+				MaxCapacityUnits:         dmsInt32(64),
+				ReplicationSubnetGroupId: dmsString("dms-subnets"),
+			},
+			ReplicationConfigArn:        dmsString("arn:aws:dms:us-east-1:123456789012:replication-config:ABC123"),
+			ReplicationConfigIdentifier: dmsString("orders"),
+			ReplicationType:             dmstypes.MigrationTypeValueCdc,
+			SourceEndpointArn:           dmsString("arn:aws:dms:us-east-1:123456789012:endpoint:SOURCE"),
+			TableMappings:               dmsString("{\"rules\":[]}"),
+			TargetEndpointArn:           dmsString("arn:aws:dms:us-east-1:123456789012:endpoint:TARGET"),
+		}
+	}
+
+	tests := []struct {
+		name   string
+		mutate func(*dmstypes.ReplicationConfig)
+	}{
+		{name: "empty ARN", mutate: func(config *dmstypes.ReplicationConfig) { config.ReplicationConfigArn = nil }},
+		{name: "empty identifier", mutate: func(config *dmstypes.ReplicationConfig) { config.ReplicationConfigIdentifier = nil }},
+		{name: "empty replication type", mutate: func(config *dmstypes.ReplicationConfig) { config.ReplicationType = "" }},
+		{name: "empty source endpoint ARN", mutate: func(config *dmstypes.ReplicationConfig) { config.SourceEndpointArn = nil }},
+		{name: "empty target endpoint ARN", mutate: func(config *dmstypes.ReplicationConfig) { config.TargetEndpointArn = nil }},
+		{name: "empty table mappings", mutate: func(config *dmstypes.ReplicationConfig) { config.TableMappings = nil }},
+		{name: "missing compute config", mutate: func(config *dmstypes.ReplicationConfig) { config.ComputeConfig = nil }},
+		{name: "missing replication subnet group", mutate: func(config *dmstypes.ReplicationConfig) { config.ComputeConfig.ReplicationSubnetGroupId = nil }},
+		{name: "missing max capacity", mutate: func(config *dmstypes.ReplicationConfig) { config.ComputeConfig.MaxCapacityUnits = nil }},
+		{name: "read-only", mutate: func(config *dmstypes.ReplicationConfig) { config.IsReadOnly = dmsBool(true) }},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			config := validConfig()
+			tt.mutate(&config)
+			if _, ok := newDMSReplicationConfigResource(config); ok {
+				t.Fatal("replication config should be skipped")
+			}
+		})
+	}
+}
+
+func TestDMSReplicationConfigResourceNameAvoidsARNCollisions(t *testing.T) {
+	first := dmsReplicationConfigResourceName(dmstypes.ReplicationConfig{
+		ReplicationConfigArn:        dmsString("arn:aws:dms:us-east-1:123456789012:replication-config:ABC123"),
+		ReplicationConfigIdentifier: dmsString("orders"),
+	})
+	second := dmsReplicationConfigResourceName(dmstypes.ReplicationConfig{
+		ReplicationConfigArn:        dmsString("arn:aws:dms:us-east-1:123456789012:replication-config:XYZ789"),
+		ReplicationConfigIdentifier: dmsString("orders"),
+	})
+	if first == second {
+		t.Fatalf("replication config resource names collide: %q", first)
+	}
+}
+
 func TestNewDMSReplicationInstanceResource(t *testing.T) {
 	resource, ok := newDMSReplicationInstanceResource(dmstypes.ReplicationInstance{
 		ReplicationInstanceIdentifier: dmsString("dms-ri"),
@@ -463,5 +579,13 @@ func assertDMSAllowEmptyValue(t *testing.T, resource terraformutils.Resource, wa
 }
 
 func dmsString(value string) *string {
+	return &value
+}
+
+func dmsBool(value bool) *bool {
+	return &value
+}
+
+func dmsInt32(value int32) *int32 {
 	return &value
 }


### PR DESCRIPTION
## Summary

- add DMS Serverless replication config discovery for `aws_dms_replication_config`
- seed import IDs as DMS replication config ARNs
- seed required replication config and compute config attributes returned by `DescribeReplicationConfigs`
- update `docs/aws.md` for the supported DMS replication config resource
- add unit tests for import IDs, resource attributes, collision-resistant names, and unsafe config skips

## References

- #338

## Validation

```bash
go test ./providers/aws -run 'Test.*DMS|Test.*Dms|Test.*dms'
go test ./providers/aws/... ./terraformutils/...
go run ./tools/aws-gap-inventory \
  -docs docs/aws.md \
  -aws-dir providers/aws \
  -skip-list providers/aws/unsupported_resources.json \
  -format markdown
git diff --check
```

## Notes

Skipped/deferred resources:
- `aws_dms_serverless_replication_config`: no separate resource exists in the current Terraform AWS provider; DMS Serverless replication configs are represented by `aws_dms_replication_config`
- `aws_dms_s3_endpoint`: deferred for endpoint-engine-specific follow-up

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds discovery and import for DMS Serverless replication configs as `aws_dms_replication_config`, with full attribute seeding and collision-safe names. Also treats `AccessDenied` on optional DMS APIs as skippable to avoid failing imports.

- **New Features**
  - Discover and import via `DescribeReplicationConfigs` (use ARN as import ID).
  - Seed required attributes including `compute_config`; handle optional fields; skip read-only/incomplete configs; update docs and tests.

- **Bug Fixes**
  - Skip optional resource loads on `AccessDenied` (typed or generic `smithy` API errors) and continue with others; add tests.

<sup>Written for commit e3eb7e6c6342e312b189e07e775ca116054b2d78. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Terraformer now discovers and generates Terraform resources for AWS DMS replication configurations, including compute configuration settings.

* **Documentation**
  * Updated AWS supported services documentation to include DMS replication configuration resources.

* **Tests**
  * Added test coverage for DMS replication configuration generation, validation, safety checks, and naming collision handling.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/chenrui333/terraformer/pull/408)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->