### PR TITLE
aws(appstream): add AppStream image builder imports

### DIFF
--- a/docs/aws.md
+++ b/docs/aws.md
@@ -95,6 +95,7 @@ For AWS provider gap audits and unsupported-resource skip-list maintenance, see 
 *   `appstream`
     * `aws_appstream_fleet`
     * `aws_appstream_fleet_stack_association`
+    * `aws_appstream_image_builder`
     * `aws_appstream_stack`
     * `aws_appstream_user`
     * `aws_appstream_user_stack_association`

--- a/providers/aws/appstream.go
+++ b/providers/aws/appstream.go
@@ -16,6 +16,7 @@ import (
 
 const (
 	appStreamFleetResourceType                 = "aws_appstream_fleet"
+	appStreamImageBuilderResourceType          = "aws_appstream_image_builder"
 	appStreamStackResourceType                 = "aws_appstream_stack"
 	appStreamFleetStackAssociationResourceType = "aws_appstream_fleet_stack_association"
 	appStreamUserResourceType                  = "aws_appstream_user"
@@ -45,6 +46,9 @@ func (g *AppStreamGenerator) InitResources() error {
 	}
 	stackNames, err := g.loadStacks(svc)
 	if err != nil {
+		return err
+	}
+	if err := g.loadImageBuilders(svc); err != nil {
 		return err
 	}
 	if err := g.loadFleetStackAssociations(svc, fleetNames); err != nil {
@@ -102,6 +106,30 @@ func (g *AppStreamGenerator) loadStacks(svc *appstream.Client) ([]string, error)
 		input.NextToken = nextToken
 	}
 	return stackNames, nil
+}
+
+func (g *AppStreamGenerator) loadImageBuilders(svc *appstream.Client) error {
+	input := &appstream.DescribeImageBuildersInput{}
+	for {
+		page, err := svc.DescribeImageBuilders(context.TODO(), input)
+		if appStreamResourceNotFound(err) {
+			return nil
+		}
+		if err != nil {
+			return err
+		}
+		for _, imageBuilder := range page.ImageBuilders {
+			if resource, ok := newAppStreamImageBuilderResource(imageBuilder); ok {
+				g.Resources = append(g.Resources, resource)
+			}
+		}
+		nextToken := appStreamNextToken(page.NextToken)
+		if nextToken == nil {
+			break
+		}
+		input.NextToken = nextToken
+	}
+	return nil
 }
 
 func (g *AppStreamGenerator) loadFleetStackAssociations(svc *appstream.Client, fleetNames []string) error {
@@ -230,6 +258,26 @@ func newAppStreamStackResource(stack appstreamtypes.Stack) (terraformutils.Resou
 	), true
 }
 
+func newAppStreamImageBuilderResource(imageBuilder appstreamtypes.ImageBuilder) (terraformutils.Resource, bool) {
+	name := StringValue(imageBuilder.Name)
+	instanceType := StringValue(imageBuilder.InstanceType)
+	if name == "" || instanceType == "" || !appStreamImageBuilderStateImportable(imageBuilder.State) {
+		return terraformutils.Resource{}, false
+	}
+	return terraformutils.NewResource(
+		appStreamImageBuilderImportID(name),
+		appStreamResourceName("image-builder", name),
+		appStreamImageBuilderResourceType,
+		"aws",
+		map[string]string{
+			"instance_type": instanceType,
+			"name":          name,
+		},
+		appStreamAllowEmptyValues,
+		map[string]interface{}{},
+	), true
+}
+
 func newAppStreamFleetStackAssociationResource(fleetName, stackName string) (terraformutils.Resource, bool) {
 	if fleetName == "" || stackName == "" {
 		return terraformutils.Resource{}, false
@@ -289,6 +337,10 @@ func appStreamFleetStackAssociationImportID(fleetName, stackName string) string 
 	return strings.Join([]string{fleetName, stackName}, appStreamFleetStackAssociationIDSeparator)
 }
 
+func appStreamImageBuilderImportID(name string) string {
+	return name
+}
+
 func appStreamUserImportID(userName string, authType appstreamtypes.AuthenticationType) string {
 	return strings.Join([]string{userName, string(authType)}, appStreamUserIDSeparator)
 }
@@ -305,6 +357,15 @@ func appStreamUserStackAssociationsInput(stackName string) (*appstream.DescribeU
 		AuthenticationType: appstreamtypes.AuthenticationTypeUserpool,
 		StackName:          aws.String(stackName),
 	}, true
+}
+
+func appStreamImageBuilderStateImportable(state appstreamtypes.ImageBuilderState) bool {
+	switch state {
+	case "", appstreamtypes.ImageBuilderStateDeleting, appstreamtypes.ImageBuilderStateFailed:
+		return false
+	default:
+		return true
+	}
 }
 
 func appStreamResourceName(parts ...string) string {

--- a/providers/aws/appstream.go
+++ b/providers/aws/appstream.go
@@ -361,7 +361,7 @@ func appStreamUserStackAssociationsInput(stackName string) (*appstream.DescribeU
 
 func appStreamImageBuilderStateImportable(state appstreamtypes.ImageBuilderState) bool {
 	switch state {
-	case "", appstreamtypes.ImageBuilderStateDeleting, appstreamtypes.ImageBuilderStateFailed:
+	case "", appstreamtypes.ImageBuilderStateDeleting:
 		return false
 	default:
 		return true

--- a/providers/aws/appstream_test.go
+++ b/providers/aws/appstream_test.go
@@ -64,6 +64,13 @@ func TestNewAppStreamImageBuilderResource(t *testing.T) {
 	if _, ok := newAppStreamImageBuilderResource(appstreamtypes.ImageBuilder{
 		InstanceType: appStreamString("stream.standard.medium"),
 		Name:         appStreamString("core-image-builder"),
+		State:        appstreamtypes.ImageBuilderStateFailed,
+	}); !ok {
+		t.Fatal("failed image builder with identifiers should be importable")
+	}
+	if _, ok := newAppStreamImageBuilderResource(appstreamtypes.ImageBuilder{
+		InstanceType: appStreamString("stream.standard.medium"),
+		Name:         appStreamString("core-image-builder"),
 		State:        appstreamtypes.ImageBuilderStateDeleting,
 	}); ok {
 		t.Fatal("deleting image builder should be skipped")
@@ -203,9 +210,9 @@ func TestAppStreamImageBuilderStateImportable(t *testing.T) {
 		{name: "pending syncing apps", state: appstreamtypes.ImageBuilderStatePendingSyncingApps, want: true},
 		{name: "syncing apps", state: appstreamtypes.ImageBuilderStateSyncingApps, want: true},
 		{name: "pending image import", state: appstreamtypes.ImageBuilderStatePendingImageImport, want: true},
+		{name: "failed", state: appstreamtypes.ImageBuilderStateFailed, want: true},
 		{name: "empty", want: false},
 		{name: "deleting", state: appstreamtypes.ImageBuilderStateDeleting, want: false},
-		{name: "failed", state: appstreamtypes.ImageBuilderStateFailed, want: false},
 	}
 
 	for _, tt := range tests {

--- a/providers/aws/appstream_test.go
+++ b/providers/aws/appstream_test.go
@@ -39,6 +39,37 @@ func TestNewAppStreamStackResource(t *testing.T) {
 	}
 }
 
+func TestNewAppStreamImageBuilderResource(t *testing.T) {
+	resource, ok := newAppStreamImageBuilderResource(appstreamtypes.ImageBuilder{
+		InstanceType: appStreamString("stream.standard.medium"),
+		Name:         appStreamString("core-image-builder"),
+		State:        appstreamtypes.ImageBuilderStateRunning,
+	})
+	assertAppStreamResource(t, resource, ok, "core-image-builder", appStreamResourceName("image-builder", "core-image-builder"), appStreamImageBuilderResourceType)
+	assertAppStreamAttribute(t, resource, "instance_type", "stream.standard.medium")
+	assertAppStreamAttribute(t, resource, "name", "core-image-builder")
+
+	if _, ok := newAppStreamImageBuilderResource(appstreamtypes.ImageBuilder{
+		InstanceType: appStreamString("stream.standard.medium"),
+		State:        appstreamtypes.ImageBuilderStateRunning,
+	}); ok {
+		t.Fatal("image builder with empty name should be skipped")
+	}
+	if _, ok := newAppStreamImageBuilderResource(appstreamtypes.ImageBuilder{
+		Name:  appStreamString("core-image-builder"),
+		State: appstreamtypes.ImageBuilderStateRunning,
+	}); ok {
+		t.Fatal("image builder with empty instance type should be skipped")
+	}
+	if _, ok := newAppStreamImageBuilderResource(appstreamtypes.ImageBuilder{
+		InstanceType: appStreamString("stream.standard.medium"),
+		Name:         appStreamString("core-image-builder"),
+		State:        appstreamtypes.ImageBuilderStateDeleting,
+	}); ok {
+		t.Fatal("deleting image builder should be skipped")
+	}
+}
+
 func TestNewAppStreamFleetStackAssociationResource(t *testing.T) {
 	resource, ok := newAppStreamFleetStackAssociationResource("core-fleet", "core-stack")
 	assertAppStreamResource(t, resource, ok, "core-fleet/core-stack", appStreamResourceName("fleet-stack-association", "core-fleet", "core-stack"), appStreamFleetStackAssociationResourceType)
@@ -110,6 +141,14 @@ func TestAppStreamFleetStackAssociationImportID(t *testing.T) {
 	}
 }
 
+func TestAppStreamImageBuilderImportID(t *testing.T) {
+	got := appStreamImageBuilderImportID("imageBuilderName")
+	want := "imageBuilderName"
+	if got != want {
+		t.Fatalf("image builder import ID = %q, want %q", got, want)
+	}
+}
+
 func TestAppStreamUserImportID(t *testing.T) {
 	got := appStreamUserImportID("user@example.com", appstreamtypes.AuthenticationTypeUserpool)
 	want := "user@example.com/USERPOOL"
@@ -146,6 +185,38 @@ func TestAppStreamUserStackAssociationsInput(t *testing.T) {
 	}
 }
 
+func TestAppStreamImageBuilderStateImportable(t *testing.T) {
+	tests := []struct {
+		name  string
+		state appstreamtypes.ImageBuilderState
+		want  bool
+	}{
+		{name: "running", state: appstreamtypes.ImageBuilderStateRunning, want: true},
+		{name: "stopped", state: appstreamtypes.ImageBuilderStateStopped, want: true},
+		{name: "pending", state: appstreamtypes.ImageBuilderStatePending, want: true},
+		{name: "updating agent", state: appstreamtypes.ImageBuilderStateUpdatingAgent, want: true},
+		{name: "stopping", state: appstreamtypes.ImageBuilderStateStopping, want: true},
+		{name: "rebooting", state: appstreamtypes.ImageBuilderStateRebooting, want: true},
+		{name: "snapshotting", state: appstreamtypes.ImageBuilderStateSnapshotting, want: true},
+		{name: "updating", state: appstreamtypes.ImageBuilderStateUpdating, want: true},
+		{name: "pending qualification", state: appstreamtypes.ImageBuilderStatePendingQualification, want: true},
+		{name: "pending syncing apps", state: appstreamtypes.ImageBuilderStatePendingSyncingApps, want: true},
+		{name: "syncing apps", state: appstreamtypes.ImageBuilderStateSyncingApps, want: true},
+		{name: "pending image import", state: appstreamtypes.ImageBuilderStatePendingImageImport, want: true},
+		{name: "empty", want: false},
+		{name: "deleting", state: appstreamtypes.ImageBuilderStateDeleting, want: false},
+		{name: "failed", state: appstreamtypes.ImageBuilderStateFailed, want: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := appStreamImageBuilderStateImportable(tt.state); got != tt.want {
+				t.Fatalf("appStreamImageBuilderStateImportable(%q) = %t, want %t", tt.state, got, tt.want)
+			}
+		})
+	}
+}
+
 func TestAppStreamResourceNamesPreserveSegmentBoundaries(t *testing.T) {
 	left, ok := newAppStreamFleetStackAssociationResource("a/b_c", "d")
 	if !ok {
@@ -177,6 +248,26 @@ func TestAppStreamResourceNamesPreserveSegmentBoundaries(t *testing.T) {
 	}
 	if left.ResourceName == right.ResourceName {
 		t.Fatalf("user-stack association resource names collide: %q", left.ResourceName)
+	}
+
+	imageBuilderLeft, ok := newAppStreamImageBuilderResource(appstreamtypes.ImageBuilder{
+		InstanceType: appStreamString("stream.standard.medium"),
+		Name:         appStreamString("a/b_c"),
+		State:        appstreamtypes.ImageBuilderStateRunning,
+	})
+	if !ok {
+		t.Fatal("left image builder should be importable")
+	}
+	imageBuilderRight, ok := newAppStreamImageBuilderResource(appstreamtypes.ImageBuilder{
+		InstanceType: appStreamString("stream.standard.medium"),
+		Name:         appStreamString("a-002F-b_c"),
+		State:        appstreamtypes.ImageBuilderStateRunning,
+	})
+	if !ok {
+		t.Fatal("right image builder should be importable")
+	}
+	if imageBuilderLeft.ResourceName == imageBuilderRight.ResourceName {
+		t.Fatalf("image builder resource names collide: %q", imageBuilderLeft.ResourceName)
 	}
 }
 


### PR DESCRIPTION
## Summary

- add AppStream image builder import discovery
- seed import IDs as image-builder names
- update docs/aws.md for `aws_appstream_image_builder`
- add unit tests for AppStream image-builder helper behavior

## References

- #338

## Validation

```bash
go test ./providers/aws -run 'Test.*AppStream|Test.*Appstream|Test.*appstream'
go test ./providers/aws/... ./terraformutils/...
go run ./tools/aws-gap-inventory \
  -docs docs/aws.md \
  -aws-dir providers/aws \
  -skip-list providers/aws/unsupported_resources.json \
  -format markdown
git diff --check
```

## Notes

Skipped/deferred resources:
- `aws_appstream_directory_config`: already unsupported because required service account password is sensitive and not returned by AppStream
- `aws_appstream_application` / `aws_appstream_application_fleet_association` / `aws_appstream_entitlement`: not in Terraform AWS provider v6.44.0 schema during this inventory pass

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds import discovery for AWS AppStream image builders to expand coverage of `aws_appstream_image_builder`. Updates docs and adds tests.

- **New Features**
  - Discover image builders via `DescribeImageBuilders` with pagination.
  - Import when name and instance type exist and state is not deleting; failed builders are included. Import ID is the builder name.
  - Documented in `docs/aws.md`; added unit tests for import logic, state handling, and naming.

<sup>Written for commit c491230a0e016acbd1d4141fca2d155b2ee5b9e2. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * AWS AppStream Image Builders are now available for import, enabling management of image builder resources alongside other AppStream services

* **Documentation**
  * Updated the supported services list to document AWS AppStream Image Builders as an importable resource

* **Tests**
  * Expanded test coverage to validate AppStream Image Builder import functionality and state handling

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/chenrui333/terraformer/pull/409)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->