### PR TITLE
aws(ssoadmin): add instance access control attributes imports

### DIFF
--- a/docs/aws.md
+++ b/docs/aws.md
@@ -511,6 +511,7 @@ For AWS provider gap audits and unsupported-resource skip-list maintenance, see 
 *   `ssoadmin`
     * `aws_ssoadmin_account_assignment`
     * `aws_ssoadmin_customer_managed_policy_attachment`
+    * `aws_ssoadmin_instance_access_control_attributes`
     * `aws_ssoadmin_managed_policy_attachment`
     * `aws_ssoadmin_permission_set`
     * `aws_ssoadmin_permission_set_inline_policy`

--- a/providers/aws/ssoadmin.go
+++ b/providers/aws/ssoadmin.go
@@ -71,14 +71,19 @@ func (g *SSOAdminGenerator) InitResources() error {
 func (g *SSOAdminGenerator) PostConvertHook() error {
 	g.updateManagedPolicyAttachmentDependencies()
 	for i, resource := range g.Resources {
-		if resource.InstanceInfo.Type != ssoAdminPermissionSetInlinePolicyResourceType {
+		if resource.InstanceInfo == nil {
 			continue
 		}
-		inlinePolicy, ok := resource.Item["inline_policy"].(string)
-		if !ok || inlinePolicy == "" {
-			continue
+		switch resource.InstanceInfo.Type {
+		case ssoAdminPermissionSetInlinePolicyResourceType:
+			inlinePolicy, ok := resource.Item["inline_policy"].(string)
+			if !ok || inlinePolicy == "" {
+				continue
+			}
+			g.Resources[i].Item["inline_policy"] = fmt.Sprintf("<<POLICY\n%s\nPOLICY", g.escapeAwsInterpolation(inlinePolicy))
+		case ssoAdminInstanceAccessControlAttributesResourceType:
+			ssoAdminEscapeInstanceAccessControlAttributeSources(g.Resources[i].Item)
 		}
-		g.Resources[i].Item["inline_policy"] = fmt.Sprintf("<<POLICY\n%s\nPOLICY", g.escapeAwsInterpolation(inlinePolicy))
 	}
 	return nil
 }
@@ -650,6 +655,66 @@ func ssoAdminAccessControlAttributes(config *ssotypes.InstanceAccessControlAttri
 
 func ssoAdminInstanceAccessControlAttributesNotConfigured(err error) bool {
 	return ssoAdminResourceNotFound(err)
+}
+
+func ssoAdminEscapeInstanceAccessControlAttributeSources(item map[string]interface{}) {
+	attributes, ok := item["attribute"].([]interface{})
+	if !ok {
+		return
+	}
+	for _, attribute := range attributes {
+		attributeMap, ok := attribute.(map[string]interface{})
+		if !ok {
+			continue
+		}
+		values, ok := attributeMap["value"].([]interface{})
+		if !ok {
+			continue
+		}
+		for _, value := range values {
+			valueMap, ok := value.(map[string]interface{})
+			if !ok {
+				continue
+			}
+			ssoAdminEscapeAccessControlAttributeSourceValues(valueMap)
+		}
+	}
+}
+
+func ssoAdminEscapeAccessControlAttributeSourceValues(valueMap map[string]interface{}) {
+	switch sources := valueMap["source"].(type) {
+	case []interface{}:
+		for i, source := range sources {
+			sourceString, ok := source.(string)
+			if !ok || sourceString == "" {
+				continue
+			}
+			sources[i] = ssoAdminEscapeTerraformTemplateMarkers(sourceString)
+		}
+	case []string:
+		for i, source := range sources {
+			if source == "" {
+				continue
+			}
+			sources[i] = ssoAdminEscapeTerraformTemplateMarkers(source)
+		}
+	}
+}
+
+func ssoAdminEscapeTerraformTemplateMarkers(value string) string {
+	value = ssoAdminEscapeTerraformTemplateMarker(value, "${", '$')
+	return ssoAdminEscapeTerraformTemplateMarker(value, "%{", '%')
+}
+
+func ssoAdminEscapeTerraformTemplateMarker(value, marker string, escape byte) string {
+	var escaped strings.Builder
+	for i := 0; i < len(value); i++ {
+		if strings.HasPrefix(value[i:], marker) && (i == 0 || value[i-1] != escape) {
+			escaped.WriteByte(escape)
+		}
+		escaped.WriteByte(value[i])
+	}
+	return escaped.String()
 }
 
 func ssoAdminCustomerManagedPolicyPath(path *string) string {

--- a/providers/aws/ssoadmin.go
+++ b/providers/aws/ssoadmin.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"fmt"
 	"sort"
+	"strconv"
 	"strings"
 	"time"
 
@@ -21,6 +22,7 @@ var ssoAdminAllowEmptyValues = []string{"tags."}
 const (
 	ssoAdminPermissionSetResourceType                     = "aws_ssoadmin_permission_set"
 	ssoAdminAccountAssignmentResourceType                 = "aws_ssoadmin_account_assignment"
+	ssoAdminInstanceAccessControlAttributesResourceType   = "aws_ssoadmin_instance_access_control_attributes"
 	ssoAdminManagedPolicyAttachmentResourceType           = "aws_ssoadmin_managed_policy_attachment"
 	ssoAdminCustomerManagedPolicyAttachmentResourceType   = "aws_ssoadmin_customer_managed_policy_attachment"
 	ssoAdminPermissionSetInlinePolicyResourceType         = "aws_ssoadmin_permission_set_inline_policy"
@@ -51,8 +53,13 @@ func (g *SSOAdminGenerator) InitResources() error {
 		if instanceARN == "" {
 			continue
 		}
+		resourceStart := len(g.Resources)
+		if err := g.loadInstanceAccessControlAttributes(svc, instanceARN); err != nil {
+			return err
+		}
 		if err := g.loadPermissionSets(svc, instanceARN); err != nil {
 			if ssoAdminResourceNotFound(err) {
+				g.Resources = g.Resources[:resourceStart]
 				continue
 			}
 			return err
@@ -154,6 +161,23 @@ func describeSSOAdminPermissionSet(svc *ssoadmin.Client, instanceARN, permission
 		return nil, nil
 	}
 	return output.PermissionSet, nil
+}
+
+func (g *SSOAdminGenerator) loadInstanceAccessControlAttributes(svc *ssoadmin.Client, instanceARN string) error {
+	output, err := svc.DescribeInstanceAccessControlAttributeConfiguration(context.TODO(), &ssoadmin.DescribeInstanceAccessControlAttributeConfigurationInput{
+		InstanceArn: aws.String(instanceARN),
+	})
+	if err != nil {
+		if ssoAdminInstanceAccessControlAttributesNotConfigured(err) {
+			return nil
+		}
+		return err
+	}
+	if output == nil || !ssoAdminInstanceAccessControlAttributesConfigured(output.InstanceAccessControlAttributeConfiguration) {
+		return nil
+	}
+	g.Resources = append(g.Resources, newSSOAdminInstanceAccessControlAttributesResource(instanceARN, output.InstanceAccessControlAttributeConfiguration))
+	return nil
 }
 
 func (g *SSOAdminGenerator) loadManagedPolicyAttachments(svc *ssoadmin.Client, instanceARN, permissionSetARN string) error {
@@ -338,6 +362,34 @@ func newSSOAdminAccountAssignmentResource(instanceARN, permissionSetARN, targetI
 	)
 }
 
+func newSSOAdminInstanceAccessControlAttributesResource(instanceARN string, config *ssotypes.InstanceAccessControlAttributeConfiguration) terraformutils.Resource {
+	accessControlAttributes := ssoAdminAccessControlAttributes(config)
+	attributes := map[string]string{
+		"attribute.#":  strconv.Itoa(len(accessControlAttributes)),
+		"instance_arn": instanceARN,
+	}
+	for i, attribute := range accessControlAttributes {
+		attributePrefix := fmt.Sprintf("attribute.%d", i)
+		valuePrefix := attributePrefix + ".value.0"
+		sourcePrefix := valuePrefix + ".source"
+		attributes[attributePrefix+".key"] = attribute.key
+		attributes[attributePrefix+".value.#"] = "1"
+		attributes[sourcePrefix+".#"] = strconv.Itoa(len(attribute.sources))
+		for j, source := range attribute.sources {
+			attributes[fmt.Sprintf("%s.%d", sourcePrefix, j)] = source
+		}
+	}
+	return terraformutils.NewResource(
+		ssoAdminInstanceAccessControlAttributesResourceID(instanceARN),
+		ssoAdminInstanceAccessControlAttributesResourceName(instanceARN),
+		ssoAdminInstanceAccessControlAttributesResourceType,
+		"aws",
+		attributes,
+		ssoAdminAllowEmptyValues,
+		map[string]interface{}{},
+	)
+}
+
 func newSSOAdminManagedPolicyAttachmentResource(instanceARN, permissionSetARN string, policy ssotypes.AttachedManagedPolicy) terraformutils.Resource {
 	policyARN := StringValue(policy.Arn)
 	attributes := map[string]string{
@@ -428,6 +480,10 @@ func ssoAdminAccountAssignmentResourceID(principalID, principalType, targetID, t
 	return strings.Join([]string{principalID, principalType, targetID, targetType, permissionSetARN, instanceARN}, ssoAdminResourceIDSeparator)
 }
 
+func ssoAdminInstanceAccessControlAttributesResourceID(instanceARN string) string {
+	return instanceARN
+}
+
 func ssoAdminManagedPolicyAttachmentResourceID(managedPolicyARN, permissionSetARN, instanceARN string) string {
 	return strings.Join([]string{managedPolicyARN, permissionSetARN, instanceARN}, ssoAdminResourceIDSeparator)
 }
@@ -438,6 +494,10 @@ func ssoAdminCustomerManagedPolicyAttachmentResourceID(policyName, policyPath, p
 
 func ssoAdminAccountAssignmentResourceName(instanceARN, permissionSetARN, principalID, principalType, targetID, targetType string) string {
 	return ssoAdminResourceName(permissionSetARN, targetID, targetType, principalType, principalID, instanceARN)
+}
+
+func ssoAdminInstanceAccessControlAttributesResourceName(instanceARN string) string {
+	return ssoAdminResourceName("access-control-attributes", instanceARN)
 }
 
 func ssoAdminResourceName(parts ...string) string {
@@ -546,6 +606,50 @@ func ssoAdminPermissionsBoundaryConfigured(boundary *ssotypes.PermissionsBoundar
 
 func ssoAdminAccountAssignmentConfigured(targetID string, assignment ssotypes.AccountAssignment) bool {
 	return targetID != "" && StringValue(assignment.PrincipalId) != "" && string(assignment.PrincipalType) != ""
+}
+
+type ssoAdminAccessControlAttribute struct {
+	key     string
+	sources []string
+}
+
+func ssoAdminInstanceAccessControlAttributesConfigured(config *ssotypes.InstanceAccessControlAttributeConfiguration) bool {
+	return len(ssoAdminAccessControlAttributes(config)) > 0
+}
+
+func ssoAdminAccessControlAttributes(config *ssotypes.InstanceAccessControlAttributeConfiguration) []ssoAdminAccessControlAttribute {
+	if config == nil {
+		return nil
+	}
+	attributes := make([]ssoAdminAccessControlAttribute, 0, len(config.AccessControlAttributes))
+	for _, attribute := range config.AccessControlAttributes {
+		key := StringValue(attribute.Key)
+		if key == "" || attribute.Value == nil {
+			continue
+		}
+		sources := make([]string, 0, len(attribute.Value.Source))
+		for _, source := range attribute.Value.Source {
+			if source != "" {
+				sources = append(sources, source)
+			}
+		}
+		if len(sources) == 0 {
+			continue
+		}
+		sort.Strings(sources)
+		attributes = append(attributes, ssoAdminAccessControlAttribute{key: key, sources: sources})
+	}
+	sort.Slice(attributes, func(i, j int) bool {
+		if attributes[i].key != attributes[j].key {
+			return attributes[i].key < attributes[j].key
+		}
+		return strings.Join(attributes[i].sources, "\x00") < strings.Join(attributes[j].sources, "\x00")
+	})
+	return attributes
+}
+
+func ssoAdminInstanceAccessControlAttributesNotConfigured(err error) bool {
+	return ssoAdminResourceNotFound(err)
 }
 
 func ssoAdminCustomerManagedPolicyPath(path *string) string {

--- a/providers/aws/ssoadmin_test.go
+++ b/providers/aws/ssoadmin_test.go
@@ -52,6 +52,11 @@ func TestSSOAdminResourceIDs(t *testing.T) {
 			),
 			want: testSSOAdminPrincipalID + ",USER," + testSSOAdminAccountID + ",AWS_ACCOUNT," + testSSOAdminPermissionSetARN + "," + testSSOAdminInstanceARN,
 		},
+		{
+			name: "instance access control attributes",
+			got:  ssoAdminInstanceAccessControlAttributesResourceID(testSSOAdminInstanceARN),
+			want: testSSOAdminInstanceARN,
+		},
 	}
 
 	for _, tt := range tests {
@@ -60,6 +65,53 @@ func TestSSOAdminResourceIDs(t *testing.T) {
 				t.Fatalf("resource ID = %q, want %q", tt.got, tt.want)
 			}
 		})
+	}
+}
+
+func TestSSOAdminInstanceAccessControlAttributesResource(t *testing.T) {
+	resource := newSSOAdminInstanceAccessControlAttributesResource(
+		testSSOAdminInstanceARN,
+		&ssotypes.InstanceAccessControlAttributeConfiguration{
+			AccessControlAttributes: []ssotypes.AccessControlAttribute{
+				{
+					Key: aws.String("name"),
+					Value: &ssotypes.AccessControlAttributeValue{
+						Source: []string{"${path:name.preferredName}", "${path:name.givenName}"},
+					},
+				},
+				{
+					Key: aws.String("last"),
+					Value: &ssotypes.AccessControlAttributeValue{
+						Source: []string{"${path:name.familyName}"},
+					},
+				},
+			},
+		},
+	)
+
+	if got, want := resource.InstanceState.ID, testSSOAdminInstanceARN; got != want {
+		t.Fatalf("resource ID = %q, want %q", got, want)
+	}
+	if got, want := resource.InstanceInfo.Type, ssoAdminInstanceAccessControlAttributesResourceType; got != want {
+		t.Fatalf("resource type = %q, want %q", got, want)
+	}
+	attributes := resource.InstanceState.Attributes
+	for key, want := range map[string]string{
+		"attribute.#":                  "2",
+		"attribute.0.key":              "last",
+		"attribute.0.value.#":          "1",
+		"attribute.0.value.0.source.#": "1",
+		"attribute.0.value.0.source.0": "${path:name.familyName}",
+		"attribute.1.key":              "name",
+		"attribute.1.value.#":          "1",
+		"attribute.1.value.0.source.#": "2",
+		"attribute.1.value.0.source.0": "${path:name.givenName}",
+		"attribute.1.value.0.source.1": "${path:name.preferredName}",
+		"instance_arn":                 testSSOAdminInstanceARN,
+	} {
+		if got := attributes[key]; got != want {
+			t.Fatalf("%s = %q, want %q", key, got, want)
+		}
 	}
 }
 
@@ -440,6 +492,80 @@ func TestSSOAdminResourceNamesDoNotCollapseJoinedParts(t *testing.T) {
 	if left.ResourceName == right.ResourceName {
 		t.Fatalf("account assignment resource names collide: %q", left.ResourceName)
 	}
+
+	config := &ssotypes.InstanceAccessControlAttributeConfiguration{
+		AccessControlAttributes: []ssotypes.AccessControlAttribute{
+			{
+				Key: aws.String("name"),
+				Value: &ssotypes.AccessControlAttributeValue{
+					Source: []string{"${path:name.givenName}"},
+				},
+			},
+		},
+	}
+	left = newSSOAdminInstanceAccessControlAttributesResource("instance:a_b", config)
+	right = newSSOAdminInstanceAccessControlAttributesResource("instance:a:b", config)
+	if left.ResourceName == right.ResourceName {
+		t.Fatalf("instance access control attributes resource names collide: %q", left.ResourceName)
+	}
+}
+
+func TestSSOAdminInstanceAccessControlAttributesConfigured(t *testing.T) {
+	tests := []struct {
+		name   string
+		config *ssotypes.InstanceAccessControlAttributeConfiguration
+		want   bool
+	}{
+		{name: "nil", want: false},
+		{name: "empty", config: &ssotypes.InstanceAccessControlAttributeConfiguration{}, want: false},
+		{
+			name: "configured",
+			config: &ssotypes.InstanceAccessControlAttributeConfiguration{
+				AccessControlAttributes: []ssotypes.AccessControlAttribute{
+					{
+						Key: aws.String("name"),
+						Value: &ssotypes.AccessControlAttributeValue{
+							Source: []string{"${path:name.givenName}"},
+						},
+					},
+				},
+			},
+			want: true,
+		},
+		{
+			name: "missing key",
+			config: &ssotypes.InstanceAccessControlAttributeConfiguration{
+				AccessControlAttributes: []ssotypes.AccessControlAttribute{
+					{Value: &ssotypes.AccessControlAttributeValue{Source: []string{"${path:name.givenName}"}}},
+				},
+			},
+			want: false,
+		},
+		{
+			name: "missing value",
+			config: &ssotypes.InstanceAccessControlAttributeConfiguration{
+				AccessControlAttributes: []ssotypes.AccessControlAttribute{{Key: aws.String("name")}},
+			},
+			want: false,
+		},
+		{
+			name: "missing source",
+			config: &ssotypes.InstanceAccessControlAttributeConfiguration{
+				AccessControlAttributes: []ssotypes.AccessControlAttribute{
+					{Key: aws.String("name"), Value: &ssotypes.AccessControlAttributeValue{}},
+				},
+			},
+			want: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := ssoAdminInstanceAccessControlAttributesConfigured(tt.config); got != tt.want {
+				t.Fatalf("ssoAdminInstanceAccessControlAttributesConfigured() = %t, want %t", got, tt.want)
+			}
+		})
+	}
 }
 
 func TestSSOAdminAccountAssignmentConfigured(t *testing.T) {
@@ -520,6 +646,26 @@ func TestSSOAdminPermissionsBoundaryConfigured(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			if got := ssoAdminPermissionsBoundaryConfigured(tt.boundary); got != tt.want {
 				t.Fatalf("ssoAdminPermissionsBoundaryConfigured() = %t, want %t", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestSSOAdminInstanceAccessControlAttributesNotConfigured(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{name: "nil", want: false},
+		{name: "resource not found", err: &ssotypes.ResourceNotFoundException{}, want: true},
+		{name: "generic", err: errors.New("boom"), want: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := ssoAdminInstanceAccessControlAttributesNotConfigured(tt.err); got != tt.want {
+				t.Fatalf("ssoAdminInstanceAccessControlAttributesNotConfigured(%v) = %t, want %t", tt.err, got, tt.want)
 			}
 		})
 	}

--- a/providers/aws/ssoadmin_test.go
+++ b/providers/aws/ssoadmin_test.go
@@ -4,6 +4,7 @@ package aws
 
 import (
 	"errors"
+	"strings"
 	"testing"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
@@ -394,6 +395,81 @@ func TestSSOAdminPostConvertHookWrapsInlinePolicy(t *testing.T) {
 	want := "<<POLICY\n{\"Resource\":\"$" + "$" + "{aws:username}\"}\nPOLICY"
 	if got := g.Resources[0].Item["inline_policy"]; got != want {
 		t.Fatalf("inline_policy = %q, want %q", got, want)
+	}
+}
+
+func TestSSOAdminPostConvertHookEscapesInstanceAccessControlAttributeSources(t *testing.T) {
+	rawGivenNameSource := "$" + "{path:name.givenName}"
+	escapedGivenNameSource := "$" + "$" + "{path:name.givenName}"
+	escapedFamilyNameSource := "$" + "$" + "{path:name.familyName}"
+	rawDirectiveSource := "%" + "{if true}"
+	escapedDirectiveSource := "%" + "%" + "{if true}"
+	resource := newSSOAdminInstanceAccessControlAttributesResource(
+		testSSOAdminInstanceARN,
+		&ssotypes.InstanceAccessControlAttributeConfiguration{
+			AccessControlAttributes: []ssotypes.AccessControlAttribute{
+				{
+					Key: aws.String("name"),
+					Value: &ssotypes.AccessControlAttributeValue{
+						Source: []string{rawGivenNameSource},
+					},
+				},
+			},
+		},
+	)
+	resource.Item = map[string]interface{}{
+		"attribute": []interface{}{
+			map[string]interface{}{
+				"key": "name",
+				"value": []interface{}{
+					map[string]interface{}{
+						"source": []interface{}{
+							rawGivenNameSource,
+							escapedFamilyNameSource,
+							rawDirectiveSource,
+						},
+					},
+				},
+			},
+		},
+		"instance_arn": testSSOAdminInstanceARN,
+	}
+	g := &SSOAdminGenerator{}
+	g.Resources = append(g.Resources, resource)
+
+	if err := g.PostConvertHook(); err != nil {
+		t.Fatalf("PostConvertHook() error = %v", err)
+	}
+
+	attribute := g.Resources[0].Item["attribute"].([]interface{})[0].(map[string]interface{})
+	value := attribute["value"].([]interface{})[0].(map[string]interface{})
+	sources := value["source"].([]interface{})
+	for i, want := range []string{
+		escapedGivenNameSource,
+		escapedFamilyNameSource,
+		escapedDirectiveSource,
+	} {
+		if got := sources[i]; got != want {
+			t.Fatalf("source[%d] = %q, want %q", i, got, want)
+		}
+	}
+
+	data, err := terraformutils.HclPrintResource(g.Resources, map[string]interface{}{}, "hcl", true)
+	if err != nil {
+		t.Fatalf("HclPrintResource() error = %v", err)
+	}
+	output := string(data)
+	for _, want := range []string{
+		"\"" + escapedGivenNameSource + "\"",
+		"\"" + escapedFamilyNameSource + "\"",
+		"\"" + escapedDirectiveSource + "\"",
+	} {
+		if !strings.Contains(output, want) {
+			t.Fatalf("output does not contain %q:\n%s", want, output)
+		}
+	}
+	if strings.Contains(output, "\""+rawGivenNameSource+"\"") || strings.Contains(output, "\""+rawDirectiveSource+"\"") {
+		t.Fatalf("output contains unescaped Terraform template markers:\n%s", output)
 	}
 }
 


### PR DESCRIPTION
## Summary

- add SSO Admin instance access-control attributes import discovery
- seed import IDs as `instance_arn`
- seed nested `attribute` / `value` / `source` fields returned by SSO Admin
- update docs/aws.md for `aws_ssoadmin_instance_access_control_attributes`
- add unit tests for ID, resource construction, resource names, configured checks, and not-found skip behavior

## References

- #338

## Validation

```bash
go test ./providers/aws -run 'Test.*SSO|Test.*Sso|Test.*sso|Test.*IdentityStore'
go test ./providers/aws/... ./terraformutils/...
go run ./tools/aws-gap-inventory \
  -docs docs/aws.md \
  -aws-dir providers/aws \
  -skip-list providers/aws/unsupported_resources.json \
  -format markdown
git diff --check
golangci-lint run --new-from-rev=main
```

## Notes

Skipped/deferred resources:
- `aws_ssoadmin_application*`: deferred for a focused application-resource PR
- No unsupported-resource skip-list entries were added; unconfigured/deleted access-control attributes are skipped on SSO Admin `ResourceNotFoundException`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds import discovery for AWS SSO Admin instance access-control attributes, building `aws_ssoadmin_instance_access_control_attributes` from the instance config with IDs set to the `instance_arn`, stable names, and safe skips for unconfigured instances. Also escapes attribute source values to prevent Terraform template markers in generated HCL.

- **New Features**
  - Discover and import `ssoadmin` instance access-control attributes.
  - Populate sorted `attribute` → `value` → `source`.
  - Skip on `ResourceNotFoundException` when attributes aren’t configured.
  - Update `docs/aws.md`.
  - Add unit tests for IDs, names, resource build, skip behavior, and source escaping.

<sup>Written for commit de133e44106801fc5b7bf09e6ba513256f40f05f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

