### PR TITLE
aws(s3control): add S3 Control access point imports

### DIFF
--- a/docs/aws.md
+++ b/docs/aws.md
@@ -474,6 +474,11 @@ For AWS provider gap audits and unsupported-resource skip-list maintenance, see 
     * `aws_s3_bucket_server_side_encryption_configuration`
     * `aws_s3_bucket_versioning`
     * `aws_s3_bucket_website_configuration`
+*   `s3control`
+    * `aws_s3_access_point`
+    * `aws_s3control_access_point_policy`
+    * `aws_s3control_object_lambda_access_point`
+    * `aws_s3control_object_lambda_access_point_policy`
 *   `scheduler`
     * `aws_scheduler_schedule`
     * `aws_scheduler_schedule_group`

--- a/go.mod
+++ b/go.mod
@@ -408,6 +408,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/bedrock v1.59.2
 	github.com/aws/aws-sdk-go-v2/service/directconnect v1.38.17
 	github.com/aws/aws-sdk-go-v2/service/pipes v1.23.22
+	github.com/aws/aws-sdk-go-v2/service/s3control v1.70.1
 	github.com/aws/aws-sdk-go-v2/service/scheduler v1.17.24
 	github.com/aws/aws-sdk-go-v2/service/sesv2 v1.60.4
 	github.com/gofrs/uuid/v3 v3.1.2

--- a/go.sum
+++ b/go.sum
@@ -345,6 +345,8 @@ github.com/aws/aws-sdk-go-v2/service/route53 v1.62.7 h1:twRRMmtSITnt/rrp+D7UDLzE
 github.com/aws/aws-sdk-go-v2/service/route53 v1.62.7/go.mod h1:ztM1lr+sRoCAI8336ZUvlRPbToue0d3gE/wd6jomSJ8=
 github.com/aws/aws-sdk-go-v2/service/s3 v1.101.0 h1:etqBTKY581iwLL/H/S2sVgk3C9lAsTJFeXWFDsDcWOU=
 github.com/aws/aws-sdk-go-v2/service/s3 v1.101.0/go.mod h1:L2dcoOgS2VSgbPLvpak2NyUPsO1TBN7M45Z4H7DlRc4=
+github.com/aws/aws-sdk-go-v2/service/s3control v1.70.1 h1:jbMg6zIdFawDnLhbzaLGUxaMN2H42wP4hKsjG0OuLmA=
+github.com/aws/aws-sdk-go-v2/service/s3control v1.70.1/go.mod h1:BJiTF1ijkh2XHYqan51v2pmnHyVFp1H31vqEuC/wEFw=
 github.com/aws/aws-sdk-go-v2/service/scheduler v1.17.24 h1:F4gvh9TJcEZVqirKpX/FBWEMK6tvnGSVf4FWDvFtSQw=
 github.com/aws/aws-sdk-go-v2/service/scheduler v1.17.24/go.mod h1:0/mvOL++cUfpS4KgHigHDo+x8KLYG/grOTyIOw3KCPM=
 github.com/aws/aws-sdk-go-v2/service/secretsmanager v1.41.7 h1:JUGKqUnJHbXpS8uyuICP/zpQ+vXUIXW2zTEqjMLCqrY=

--- a/providers/aws/aws_provider.go
+++ b/providers/aws/aws_provider.go
@@ -336,6 +336,7 @@ func (p *AWSProvider) GetSupportedService() map[string]terraformutils.ServiceGen
 		"route53":           &AwsFacade{service: &Route53Generator{}},
 		"route_table":       &AwsFacade{service: &RouteTableGenerator{}},
 		"s3":                &AwsFacade{service: &S3Generator{}},
+		"s3control":         &AwsFacade{service: &S3ControlGenerator{}},
 		"scheduler":         &AwsFacade{service: &SchedulerGenerator{}},
 		"secretsmanager":    &AwsFacade{service: &SecretsManagerGenerator{}},
 		"securityhub":       &AwsFacade{service: &SecurityhubGenerator{}},

--- a/providers/aws/s3control.go
+++ b/providers/aws/s3control.go
@@ -1,0 +1,469 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package aws
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log"
+	"strconv"
+	"strings"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/aws/arn"
+	"github.com/aws/aws-sdk-go-v2/service/s3control"
+	s3controltypes "github.com/aws/aws-sdk-go-v2/service/s3control/types"
+	"github.com/aws/smithy-go"
+	"github.com/chenrui333/terraformer/terraformutils"
+)
+
+const (
+	s3ControlAccessPointResourceType                   = "aws_s3_access_point"
+	s3ControlAccessPointPolicyResourceType             = "aws_s3control_access_point_policy"
+	s3ControlObjectLambdaAccessPointResourceType       = "aws_s3control_object_lambda_access_point"
+	s3ControlObjectLambdaAccessPointPolicyResourceType = "aws_s3control_object_lambda_access_point_policy"
+	s3ControlAccessPointIDSeparator                    = ":"
+)
+
+var s3ControlAllowEmptyValues = []string{"tags."}
+
+type S3ControlGenerator struct {
+	AWSService
+}
+
+func (g *S3ControlGenerator) InitResources() error {
+	config, e := g.generateConfig()
+	if e != nil {
+		return e
+	}
+	accountID, err := g.getAccountNumber(config)
+	if err != nil {
+		return err
+	}
+	if accountID == nil || *accountID == "" {
+		return nil
+	}
+
+	svc := s3control.NewFromConfig(config)
+	if err := g.loadAccessPoints(svc, *accountID); err != nil {
+		return err
+	}
+	return g.loadObjectLambdaAccessPoints(svc, *accountID)
+}
+
+func (g *S3ControlGenerator) PostConvertHook() error {
+	splitPolicyIDs := s3ControlSplitAccessPointPolicyIDs(g.Resources)
+	for i, resource := range g.Resources {
+		if resource.InstanceInfo == nil {
+			continue
+		}
+		switch resource.InstanceInfo.Type {
+		case s3ControlAccessPointResourceType:
+			if resource.InstanceState != nil && splitPolicyIDs[resource.InstanceState.ID] {
+				if g.Resources[i].Item != nil {
+					delete(g.Resources[i].Item, "policy")
+				}
+				if g.Resources[i].InstanceState != nil {
+					deleteFlatmapAttribute(g.Resources[i].InstanceState.Attributes, "policy")
+				}
+			}
+			wrapS3ControlPolicyHeredoc(g, &g.Resources[i])
+		case s3ControlAccessPointPolicyResourceType,
+			s3ControlObjectLambdaAccessPointPolicyResourceType:
+			wrapS3ControlPolicyHeredoc(g, &g.Resources[i])
+		}
+	}
+	return nil
+}
+
+func (g *S3ControlGenerator) loadAccessPoints(svc *s3control.Client, accountID string) error {
+	if accountID == "" {
+		return nil
+	}
+	p := s3control.NewListAccessPointsPaginator(svc, &s3control.ListAccessPointsInput{
+		AccountId: aws.String(accountID),
+	})
+	for p.HasMorePages() {
+		page, err := p.NextPage(context.TODO())
+		if s3ControlResourceNotFound(err) {
+			return nil
+		}
+		if err != nil {
+			return err
+		}
+		for _, listedAccessPoint := range page.AccessPointList {
+			apiName := s3ControlAccessPointAPIName(StringValue(listedAccessPoint.Name), StringValue(listedAccessPoint.AccessPointArn))
+			if apiName == "" {
+				continue
+			}
+			accessPoint, err := svc.GetAccessPoint(context.TODO(), &s3control.GetAccessPointInput{
+				AccountId: aws.String(accountID),
+				Name:      aws.String(apiName),
+			})
+			if s3ControlResourceNotFound(err) {
+				continue
+			}
+			if err != nil {
+				return err
+			}
+			if resource, ok := newS3ControlAccessPointResource(accountID, accessPoint); ok {
+				g.Resources = append(g.Resources, resource)
+			}
+			g.addAccessPointPolicy(svc, accountID, apiName, accessPoint)
+		}
+	}
+	return nil
+}
+
+func (g *S3ControlGenerator) addAccessPointPolicy(svc *s3control.Client, accountID, apiName string, accessPoint *s3control.GetAccessPointOutput) {
+	if accessPoint == nil {
+		return
+	}
+	accessPointName := StringValue(accessPoint.Name)
+	accessPointARN := StringValue(accessPoint.AccessPointArn)
+	policy, ok := getS3ControlAccessPointPolicy(svc, accountID, apiName)
+	if !ok {
+		return
+	}
+	if resource, ok := newS3ControlAccessPointPolicyResource(accountID, accessPointName, accessPointARN, policy); ok {
+		g.Resources = append(g.Resources, resource)
+	}
+}
+
+func (g *S3ControlGenerator) loadObjectLambdaAccessPoints(svc *s3control.Client, accountID string) error {
+	if accountID == "" {
+		return nil
+	}
+	p := s3control.NewListAccessPointsForObjectLambdaPaginator(svc, &s3control.ListAccessPointsForObjectLambdaInput{
+		AccountId: aws.String(accountID),
+	})
+	for p.HasMorePages() {
+		page, err := p.NextPage(context.TODO())
+		if s3ControlResourceNotFound(err) {
+			return nil
+		}
+		if err != nil {
+			return err
+		}
+		for _, accessPoint := range page.ObjectLambdaAccessPointList {
+			name := StringValue(accessPoint.Name)
+			if name == "" {
+				continue
+			}
+			configuration, err := svc.GetAccessPointConfigurationForObjectLambda(context.TODO(), &s3control.GetAccessPointConfigurationForObjectLambdaInput{
+				AccountId: aws.String(accountID),
+				Name:      aws.String(name),
+			})
+			if s3ControlResourceNotFound(err) {
+				continue
+			}
+			if err != nil {
+				return err
+			}
+			if resource, ok := newS3ControlObjectLambdaAccessPointResource(accountID, accessPoint, configuration); ok {
+				g.Resources = append(g.Resources, resource)
+			}
+			g.addObjectLambdaAccessPointPolicy(svc, accountID, name)
+		}
+	}
+	return nil
+}
+
+func (g *S3ControlGenerator) addObjectLambdaAccessPointPolicy(svc *s3control.Client, accountID, name string) {
+	policy, ok := getS3ControlObjectLambdaAccessPointPolicy(svc, accountID, name)
+	if !ok {
+		return
+	}
+	if resource, ok := newS3ControlObjectLambdaAccessPointPolicyResource(accountID, name, policy); ok {
+		g.Resources = append(g.Resources, resource)
+	}
+}
+
+func newS3ControlAccessPointResource(accountID string, accessPoint *s3control.GetAccessPointOutput) (terraformutils.Resource, bool) {
+	if accessPoint == nil {
+		return terraformutils.Resource{}, false
+	}
+	name := StringValue(accessPoint.Name)
+	bucket := StringValue(accessPoint.Bucket)
+	accessPointARN := StringValue(accessPoint.AccessPointArn)
+	if accountID == "" || name == "" || bucket == "" {
+		return terraformutils.Resource{}, false
+	}
+	attributes := map[string]string{
+		"account_id": accountID,
+		"bucket":     bucket,
+		"name":       name,
+	}
+	if bucketAccountID := StringValue(accessPoint.BucketAccountId); bucketAccountID != "" {
+		attributes["bucket_account_id"] = bucketAccountID
+	}
+	return terraformutils.NewResource(
+		s3ControlAccessPointImportID(accountID, name, accessPointARN),
+		s3ControlResourceName("access_point", accountID, name, accessPointARN),
+		s3ControlAccessPointResourceType,
+		"aws",
+		attributes,
+		s3ControlAllowEmptyValues,
+		map[string]interface{}{},
+	), true
+}
+
+func newS3ControlAccessPointPolicyResource(accountID, accessPointName, accessPointARN, policy string) (terraformutils.Resource, bool) {
+	if accountID == "" || accessPointName == "" || accessPointARN == "" || policy == "" {
+		return terraformutils.Resource{}, false
+	}
+	return terraformutils.NewResource(
+		s3ControlAccessPointImportID(accountID, accessPointName, accessPointARN),
+		s3ControlResourceName("access_point_policy", accountID, accessPointName, accessPointARN),
+		s3ControlAccessPointPolicyResourceType,
+		"aws",
+		map[string]string{
+			"access_point_arn": accessPointARN,
+			"policy":           policy,
+		},
+		s3ControlAllowEmptyValues,
+		map[string]interface{}{},
+	), true
+}
+
+func newS3ControlObjectLambdaAccessPointResource(accountID string, accessPoint s3controltypes.ObjectLambdaAccessPoint, configuration *s3control.GetAccessPointConfigurationForObjectLambdaOutput) (terraformutils.Resource, bool) {
+	name := StringValue(accessPoint.Name)
+	if accountID == "" || name == "" || !s3ControlObjectLambdaAccessPointImportable(configuration) {
+		return terraformutils.Resource{}, false
+	}
+	return terraformutils.NewResource(
+		s3ControlObjectLambdaAccessPointImportID(accountID, name),
+		s3ControlResourceName("object_lambda_access_point", accountID, name, StringValue(accessPoint.ObjectLambdaAccessPointArn)),
+		s3ControlObjectLambdaAccessPointResourceType,
+		"aws",
+		map[string]string{
+			"account_id": accountID,
+			"name":       name,
+		},
+		s3ControlAllowEmptyValues,
+		map[string]interface{}{},
+	), true
+}
+
+func newS3ControlObjectLambdaAccessPointPolicyResource(accountID, name, policy string) (terraformutils.Resource, bool) {
+	if accountID == "" || name == "" || policy == "" {
+		return terraformutils.Resource{}, false
+	}
+	return terraformutils.NewResource(
+		s3ControlObjectLambdaAccessPointImportID(accountID, name),
+		s3ControlResourceName("object_lambda_access_point_policy", accountID, name),
+		s3ControlObjectLambdaAccessPointPolicyResourceType,
+		"aws",
+		map[string]string{
+			"account_id": accountID,
+			"name":       name,
+			"policy":     policy,
+		},
+		s3ControlAllowEmptyValues,
+		map[string]interface{}{},
+	), true
+}
+
+func getS3ControlAccessPointPolicy(svc *s3control.Client, accountID, apiName string) (string, bool) {
+	if accountID == "" || apiName == "" {
+		return "", false
+	}
+	policyOutput, err := svc.GetAccessPointPolicy(context.TODO(), &s3control.GetAccessPointPolicyInput{
+		AccountId: aws.String(accountID),
+		Name:      aws.String(apiName),
+	})
+	if s3ControlResourceNotFound(err) {
+		return "", false
+	}
+	if err != nil {
+		log.Printf("skipping S3 Control access point policy discovery for %s: %v", apiName, err)
+		return "", false
+	}
+	if policyOutput == nil {
+		return "", false
+	}
+	policy := StringValue(policyOutput.Policy)
+	if policy == "" {
+		return "", false
+	}
+	if _, ok := getS3ControlAccessPointPolicyStatus(svc, accountID, apiName); !ok {
+		return "", false
+	}
+	return policy, true
+}
+
+func getS3ControlAccessPointPolicyStatus(svc *s3control.Client, accountID, apiName string) (*s3controltypes.PolicyStatus, bool) {
+	statusOutput, err := svc.GetAccessPointPolicyStatus(context.TODO(), &s3control.GetAccessPointPolicyStatusInput{
+		AccountId: aws.String(accountID),
+		Name:      aws.String(apiName),
+	})
+	if s3ControlResourceNotFound(err) {
+		return nil, false
+	}
+	if s3ControlDirectoryBucketPolicyStatusUnsupported(err) {
+		return &s3controltypes.PolicyStatus{IsPublic: false}, true
+	}
+	if err != nil {
+		log.Printf("skipping S3 Control access point policy status discovery for %s: %v", apiName, err)
+		return nil, false
+	}
+	if statusOutput == nil || statusOutput.PolicyStatus == nil {
+		return nil, false
+	}
+	return statusOutput.PolicyStatus, true
+}
+
+func getS3ControlObjectLambdaAccessPointPolicy(svc *s3control.Client, accountID, name string) (string, bool) {
+	if accountID == "" || name == "" {
+		return "", false
+	}
+	policyOutput, err := svc.GetAccessPointPolicyForObjectLambda(context.TODO(), &s3control.GetAccessPointPolicyForObjectLambdaInput{
+		AccountId: aws.String(accountID),
+		Name:      aws.String(name),
+	})
+	if s3ControlResourceNotFound(err) {
+		return "", false
+	}
+	if err != nil {
+		log.Printf("skipping S3 Control Object Lambda access point policy discovery for %s: %v", name, err)
+		return "", false
+	}
+	if policyOutput == nil {
+		return "", false
+	}
+	policy := StringValue(policyOutput.Policy)
+	if policy == "" {
+		return "", false
+	}
+	statusOutput, err := svc.GetAccessPointPolicyStatusForObjectLambda(context.TODO(), &s3control.GetAccessPointPolicyStatusForObjectLambdaInput{
+		AccountId: aws.String(accountID),
+		Name:      aws.String(name),
+	})
+	if s3ControlResourceNotFound(err) {
+		return "", false
+	}
+	if err != nil {
+		log.Printf("skipping S3 Control Object Lambda access point policy status discovery for %s: %v", name, err)
+		return "", false
+	}
+	if statusOutput == nil || statusOutput.PolicyStatus == nil {
+		return "", false
+	}
+	return policy, true
+}
+
+func s3ControlAccessPointImportID(accountID, accessPointName, accessPointARN string) string {
+	if s3ControlARNService(accessPointARN) == "s3-outposts" {
+		return accessPointARN
+	}
+	return strings.Join([]string{accountID, accessPointName}, s3ControlAccessPointIDSeparator)
+}
+
+func s3ControlObjectLambdaAccessPointImportID(accountID, accessPointName string) string {
+	return strings.Join([]string{accountID, accessPointName}, s3ControlAccessPointIDSeparator)
+}
+
+func s3ControlAccessPointAPIName(accessPointName, accessPointARN string) string {
+	if s3ControlARNService(accessPointARN) == "s3-outposts" {
+		return accessPointARN
+	}
+	return accessPointName
+}
+
+func s3ControlARNService(value string) string {
+	parsedARN, err := arn.Parse(value)
+	if err != nil {
+		return ""
+	}
+	return parsedARN.Service
+}
+
+func s3ControlObjectLambdaAccessPointImportable(configuration *s3control.GetAccessPointConfigurationForObjectLambdaOutput) bool {
+	if configuration == nil || configuration.Configuration == nil {
+		return false
+	}
+	return StringValue(configuration.Configuration.SupportingAccessPoint) != "" &&
+		len(configuration.Configuration.TransformationConfigurations) > 0
+}
+
+func s3ControlResourceName(parts ...string) string {
+	var name strings.Builder
+	for _, part := range parts {
+		if part == "" {
+			continue
+		}
+		if name.Len() > 0 {
+			name.WriteString("_")
+		}
+		name.WriteString(strconv.Itoa(len(part)))
+		name.WriteString("_")
+		name.WriteString(part)
+	}
+	return name.String()
+}
+
+func s3ControlResourceNotFound(err error) bool {
+	if err == nil {
+		return false
+	}
+	var notFound *s3controltypes.NotFoundException
+	if errors.As(err, &notFound) {
+		return true
+	}
+	var apiErr smithy.APIError
+	if !errors.As(err, &apiErr) {
+		return false
+	}
+	switch apiErr.ErrorCode() {
+	case "NoSuchAccessPoint",
+		"NoSuchAccessPointPolicy",
+		"NoSuchBucket",
+		"NotFound",
+		"NotFoundException":
+		return true
+	default:
+		return false
+	}
+}
+
+func s3ControlDirectoryBucketPolicyStatusUnsupported(err error) bool {
+	if err == nil {
+		return false
+	}
+	var apiErr smithy.APIError
+	if !errors.As(err, &apiErr) {
+		return false
+	}
+	switch apiErr.ErrorCode() {
+	case "MethodNotAllowed", "UnknownError":
+		return true
+	default:
+		return false
+	}
+}
+
+func s3ControlSplitAccessPointPolicyIDs(resources []terraformutils.Resource) map[string]bool {
+	ids := map[string]bool{}
+	for _, resource := range resources {
+		if resource.InstanceInfo == nil || resource.InstanceInfo.Type != s3ControlAccessPointPolicyResourceType {
+			continue
+		}
+		if resource.InstanceState == nil || resource.InstanceState.ID == "" {
+			continue
+		}
+		ids[resource.InstanceState.ID] = true
+	}
+	return ids
+}
+
+func wrapS3ControlPolicyHeredoc(g *S3ControlGenerator, resource *terraformutils.Resource) {
+	if resource == nil || resource.Item == nil {
+		return
+	}
+	policy, ok := resource.Item["policy"].(string)
+	if !ok || policy == "" {
+		return
+	}
+	resource.Item["policy"] = fmt.Sprintf("<<POLICY\n%s\nPOLICY", g.escapeAwsInterpolation(policy))
+}

--- a/providers/aws/s3control.go
+++ b/providers/aws/s3control.go
@@ -161,6 +161,19 @@ func (g *S3ControlGenerator) loadObjectLambdaAccessPoints(svc *s3control.Client,
 			if err != nil {
 				return err
 			}
+			details, err := svc.GetAccessPointForObjectLambda(context.TODO(), &s3control.GetAccessPointForObjectLambdaInput{
+				AccountId: aws.String(accountID),
+				Name:      aws.String(name),
+			})
+			if s3ControlResourceNotFound(err) {
+				continue
+			}
+			if err != nil {
+				return err
+			}
+			if !s3ControlObjectLambdaAccessPointReadable(details) {
+				continue
+			}
 			if resource, ok := newS3ControlObjectLambdaAccessPointResource(accountID, accessPoint, configuration); ok {
 				g.Resources = append(g.Resources, resource)
 			}
@@ -385,6 +398,10 @@ func s3ControlObjectLambdaAccessPointImportable(configuration *s3control.GetAcce
 	}
 	return StringValue(configuration.Configuration.SupportingAccessPoint) != "" &&
 		len(configuration.Configuration.TransformationConfigurations) > 0
+}
+
+func s3ControlObjectLambdaAccessPointReadable(accessPoint *s3control.GetAccessPointForObjectLambdaOutput) bool {
+	return accessPoint != nil && accessPoint.Alias != nil
 }
 
 func s3ControlResourceName(parts ...string) string {

--- a/providers/aws/s3control.go
+++ b/providers/aws/s3control.go
@@ -227,7 +227,7 @@ func newS3ControlAccessPointPolicyResource(accountID, accessPointName, accessPoi
 		return terraformutils.Resource{}, false
 	}
 	return terraformutils.NewResource(
-		s3ControlAccessPointImportID(accountID, accessPointName, accessPointARN),
+		accessPointARN,
 		s3ControlResourceName("access_point_policy", accountID, accessPointName, accessPointARN),
 		s3ControlAccessPointPolicyResourceType,
 		"aws",
@@ -373,6 +373,25 @@ func s3ControlAccessPointImportID(accountID, accessPointName, accessPointARN str
 	return strings.Join([]string{accountID, accessPointName}, s3ControlAccessPointIDSeparator)
 }
 
+func s3ControlAccessPointImportIDFromARN(accessPointARN string) (string, bool) {
+	parsedARN, err := arn.Parse(accessPointARN)
+	if err != nil {
+		return "", false
+	}
+	switch parsedARN.Service {
+	case "s3", "s3express":
+		accessPointName := strings.TrimPrefix(parsedARN.Resource, "accesspoint/")
+		if accessPointName == parsedARN.Resource || parsedARN.AccountID == "" || accessPointName == "" {
+			return "", false
+		}
+		return s3ControlAccessPointImportID(parsedARN.AccountID, accessPointName, accessPointARN), true
+	case "s3-outposts":
+		return accessPointARN, true
+	default:
+		return "", false
+	}
+}
+
 func s3ControlObjectLambdaAccessPointImportID(accountID, accessPointName string) string {
 	return strings.Join([]string{accountID, accessPointName}, s3ControlAccessPointIDSeparator)
 }
@@ -470,6 +489,11 @@ func s3ControlSplitAccessPointPolicyIDs(resources []terraformutils.Resource) map
 			continue
 		}
 		ids[resource.InstanceState.ID] = true
+		if resource.InstanceState.Attributes != nil {
+			if id, ok := s3ControlAccessPointImportIDFromARN(resource.InstanceState.Attributes["access_point_arn"]); ok {
+				ids[id] = true
+			}
+		}
 	}
 	return ids
 }

--- a/providers/aws/s3control_test.go
+++ b/providers/aws/s3control_test.go
@@ -1,0 +1,347 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package aws
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/s3control"
+	s3controltypes "github.com/aws/aws-sdk-go-v2/service/s3control/types"
+	"github.com/aws/smithy-go"
+	"github.com/chenrui333/terraformer/terraformutils"
+)
+
+const (
+	testS3ControlAccountID      = "123456789012"
+	testS3ControlAccessPointARN = "arn:aws:s3:us-east-1:123456789012:accesspoint/core-ap"
+)
+
+func TestS3ControlAccessPointImportIDs(t *testing.T) {
+	outpostsARN := "arn:aws:s3-outposts:us-east-1:123456789012:outpost/op-1234567890123456/accesspoint/core-ap"
+	tests := []struct {
+		name string
+		got  string
+		want string
+	}{
+		{
+			name: "access point",
+			got:  s3ControlAccessPointImportID(testS3ControlAccountID, "core-ap", testS3ControlAccessPointARN),
+			want: "123456789012:core-ap",
+		},
+		{
+			name: "outposts access point",
+			got:  s3ControlAccessPointImportID(testS3ControlAccountID, "core-ap", outpostsARN),
+			want: outpostsARN,
+		},
+		{
+			name: "object lambda access point",
+			got:  s3ControlObjectLambdaAccessPointImportID(testS3ControlAccountID, "core-olap"),
+			want: "123456789012:core-olap",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.got != tt.want {
+				t.Fatalf("import ID = %q, want %q", tt.got, tt.want)
+			}
+		})
+	}
+}
+
+func TestS3ControlAccessPointAPIName(t *testing.T) {
+	outpostsARN := "arn:aws:s3-outposts:us-east-1:123456789012:outpost/op-1234567890123456/accesspoint/core-ap"
+	if got := s3ControlAccessPointAPIName("core-ap", testS3ControlAccessPointARN); got != "core-ap" {
+		t.Fatalf("regular access point API name = %q, want %q", got, "core-ap")
+	}
+	if got := s3ControlAccessPointAPIName("core-ap", outpostsARN); got != outpostsARN {
+		t.Fatalf("outposts access point API name = %q, want %q", got, outpostsARN)
+	}
+}
+
+func TestNewS3ControlAccessPointResource(t *testing.T) {
+	resource, ok := newS3ControlAccessPointResource(testS3ControlAccountID, &s3control.GetAccessPointOutput{
+		AccessPointArn:  aws.String(testS3ControlAccessPointARN),
+		Bucket:          aws.String("core-bucket"),
+		BucketAccountId: aws.String(testS3ControlAccountID),
+		Name:            aws.String("core-ap"),
+	})
+	assertS3ControlResourceAttributes(t, resource, ok, s3ControlAccessPointResourceType, "123456789012:core-ap",
+		[]string{"access_point", testS3ControlAccountID, "core-ap", testS3ControlAccessPointARN},
+		map[string]string{
+			"account_id":        testS3ControlAccountID,
+			"bucket":            "core-bucket",
+			"bucket_account_id": testS3ControlAccountID,
+			"name":              "core-ap",
+		})
+
+	if _, ok := newS3ControlAccessPointResource("", &s3control.GetAccessPointOutput{
+		Bucket: aws.String("core-bucket"),
+		Name:   aws.String("core-ap"),
+	}); ok {
+		t.Fatal("access point with empty account ID should be skipped")
+	}
+	if _, ok := newS3ControlAccessPointResource(testS3ControlAccountID, &s3control.GetAccessPointOutput{
+		Name: aws.String("core-ap"),
+	}); ok {
+		t.Fatal("access point with empty bucket should be skipped")
+	}
+	if _, ok := newS3ControlAccessPointResource(testS3ControlAccountID, &s3control.GetAccessPointOutput{
+		Bucket: aws.String("core-bucket"),
+	}); ok {
+		t.Fatal("access point with empty name should be skipped")
+	}
+	if _, ok := newS3ControlAccessPointResource(testS3ControlAccountID, nil); ok {
+		t.Fatal("nil access point should be skipped")
+	}
+}
+
+func TestNewS3ControlOutpostsAccessPointResource(t *testing.T) {
+	outpostsARN := "arn:aws:s3-outposts:us-east-1:123456789012:outpost/op-1234567890123456/accesspoint/core-ap"
+	resource, ok := newS3ControlAccessPointResource(testS3ControlAccountID, &s3control.GetAccessPointOutput{
+		AccessPointArn: aws.String(outpostsARN),
+		Bucket:         aws.String("arn:aws:s3-outposts:us-east-1:123456789012:outpost/op-1234567890123456/bucket/core-bucket"),
+		Name:           aws.String("core-ap"),
+	})
+	assertS3ControlResourceAttributes(t, resource, ok, s3ControlAccessPointResourceType, outpostsARN,
+		[]string{"access_point", testS3ControlAccountID, "core-ap", outpostsARN},
+		map[string]string{
+			"account_id": testS3ControlAccountID,
+			"bucket":     "arn:aws:s3-outposts:us-east-1:123456789012:outpost/op-1234567890123456/bucket/core-bucket",
+			"name":       "core-ap",
+		})
+}
+
+func TestNewS3ControlAccessPointPolicyResource(t *testing.T) {
+	policy := `{"Version":"2012-10-17"}`
+	resource, ok := newS3ControlAccessPointPolicyResource(testS3ControlAccountID, "core-ap", testS3ControlAccessPointARN, policy)
+	assertS3ControlResourceAttributes(t, resource, ok, s3ControlAccessPointPolicyResourceType, "123456789012:core-ap",
+		[]string{"access_point_policy", testS3ControlAccountID, "core-ap", testS3ControlAccessPointARN},
+		map[string]string{
+			"access_point_arn": testS3ControlAccessPointARN,
+			"policy":           policy,
+		})
+
+	if _, ok := newS3ControlAccessPointPolicyResource("", "core-ap", testS3ControlAccessPointARN, policy); ok {
+		t.Fatal("policy with empty account ID should be skipped")
+	}
+	if _, ok := newS3ControlAccessPointPolicyResource(testS3ControlAccountID, "", testS3ControlAccessPointARN, policy); ok {
+		t.Fatal("policy with empty access point name should be skipped")
+	}
+	if _, ok := newS3ControlAccessPointPolicyResource(testS3ControlAccountID, "core-ap", "", policy); ok {
+		t.Fatal("policy with empty access point ARN should be skipped")
+	}
+	if _, ok := newS3ControlAccessPointPolicyResource(testS3ControlAccountID, "core-ap", testS3ControlAccessPointARN, ""); ok {
+		t.Fatal("policy with empty policy body should be skipped")
+	}
+}
+
+func TestNewS3ControlObjectLambdaAccessPointResource(t *testing.T) {
+	configuration := testS3ControlObjectLambdaConfiguration()
+	objectLambdaARN := "arn:aws:s3-object-lambda:us-east-1:123456789012:accesspoint/core-olap"
+	resource, ok := newS3ControlObjectLambdaAccessPointResource(testS3ControlAccountID, s3controltypes.ObjectLambdaAccessPoint{
+		Name:                       aws.String("core-olap"),
+		ObjectLambdaAccessPointArn: aws.String(objectLambdaARN),
+	}, configuration)
+	assertS3ControlResourceAttributes(t, resource, ok, s3ControlObjectLambdaAccessPointResourceType, "123456789012:core-olap",
+		[]string{"object_lambda_access_point", testS3ControlAccountID, "core-olap", objectLambdaARN},
+		map[string]string{
+			"account_id": testS3ControlAccountID,
+			"name":       "core-olap",
+		})
+
+	if _, ok := newS3ControlObjectLambdaAccessPointResource("", s3controltypes.ObjectLambdaAccessPoint{Name: aws.String("core-olap")}, configuration); ok {
+		t.Fatal("object lambda access point with empty account ID should be skipped")
+	}
+	if _, ok := newS3ControlObjectLambdaAccessPointResource(testS3ControlAccountID, s3controltypes.ObjectLambdaAccessPoint{}, configuration); ok {
+		t.Fatal("object lambda access point with empty name should be skipped")
+	}
+	if _, ok := newS3ControlObjectLambdaAccessPointResource(testS3ControlAccountID, s3controltypes.ObjectLambdaAccessPoint{Name: aws.String("core-olap")}, nil); ok {
+		t.Fatal("object lambda access point with empty configuration should be skipped")
+	}
+}
+
+func TestNewS3ControlObjectLambdaAccessPointPolicyResource(t *testing.T) {
+	policy := `{"Version":"2012-10-17"}`
+	resource, ok := newS3ControlObjectLambdaAccessPointPolicyResource(testS3ControlAccountID, "core-olap", policy)
+	assertS3ControlResourceAttributes(t, resource, ok, s3ControlObjectLambdaAccessPointPolicyResourceType, "123456789012:core-olap",
+		[]string{"object_lambda_access_point_policy", testS3ControlAccountID, "core-olap"},
+		map[string]string{
+			"account_id": testS3ControlAccountID,
+			"name":       "core-olap",
+			"policy":     policy,
+		})
+
+	if _, ok := newS3ControlObjectLambdaAccessPointPolicyResource("", "core-olap", policy); ok {
+		t.Fatal("object lambda policy with empty account ID should be skipped")
+	}
+	if _, ok := newS3ControlObjectLambdaAccessPointPolicyResource(testS3ControlAccountID, "", policy); ok {
+		t.Fatal("object lambda policy with empty name should be skipped")
+	}
+	if _, ok := newS3ControlObjectLambdaAccessPointPolicyResource(testS3ControlAccountID, "core-olap", ""); ok {
+		t.Fatal("object lambda policy with empty policy body should be skipped")
+	}
+}
+
+func TestS3ControlObjectLambdaAccessPointImportable(t *testing.T) {
+	tests := []struct {
+		name          string
+		configuration *s3control.GetAccessPointConfigurationForObjectLambdaOutput
+		want          bool
+	}{
+		{name: "valid", configuration: testS3ControlObjectLambdaConfiguration(), want: true},
+		{name: "nil output", want: false},
+		{name: "nil configuration", configuration: &s3control.GetAccessPointConfigurationForObjectLambdaOutput{}, want: false},
+		{name: "empty supporting access point", configuration: &s3control.GetAccessPointConfigurationForObjectLambdaOutput{
+			Configuration: &s3controltypes.ObjectLambdaConfiguration{
+				TransformationConfigurations: []s3controltypes.ObjectLambdaTransformationConfiguration{{}},
+			},
+		}, want: false},
+		{name: "empty transformations", configuration: &s3control.GetAccessPointConfigurationForObjectLambdaOutput{
+			Configuration: &s3controltypes.ObjectLambdaConfiguration{
+				SupportingAccessPoint: aws.String(testS3ControlAccessPointARN),
+			},
+		}, want: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := s3ControlObjectLambdaAccessPointImportable(tt.configuration); got != tt.want {
+				t.Fatalf("importable = %t, want %t", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestS3ControlResourceNameAvoidsSanitizedCollisions(t *testing.T) {
+	left := terraformutils.TfSanitize(s3ControlResourceName("access_point", testS3ControlAccountID, "a_b", "c"))
+	right := terraformutils.TfSanitize(s3ControlResourceName("access_point", testS3ControlAccountID, "a", "b_c"))
+	if left == right {
+		t.Fatalf("resource names collide: %q", left)
+	}
+}
+
+func TestS3ControlResourceNotFound(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{name: "nil", want: false},
+		{name: "typed not found", err: &s3controltypes.NotFoundException{}, want: true},
+		{name: "no such access point", err: &smithy.GenericAPIError{Code: "NoSuchAccessPoint"}, want: true},
+		{name: "no such policy", err: &smithy.GenericAPIError{Code: "NoSuchAccessPointPolicy"}, want: true},
+		{name: "wrapped not found", err: errors.Join(errors.New("lookup failed"), &s3controltypes.NotFoundException{}), want: true},
+		{name: "access denied", err: &smithy.GenericAPIError{Code: "AccessDenied"}, want: false},
+		{name: "generic", err: errors.New("boom"), want: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := s3ControlResourceNotFound(tt.err); got != tt.want {
+				t.Fatalf("not found = %t, want %t", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestS3ControlDirectoryBucketPolicyStatusUnsupported(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{name: "nil", want: false},
+		{name: "method not allowed", err: &smithy.GenericAPIError{Code: "MethodNotAllowed"}, want: true},
+		{name: "unknown error", err: &smithy.GenericAPIError{Code: "UnknownError"}, want: true},
+		{name: "access denied", err: &smithy.GenericAPIError{Code: "AccessDenied"}, want: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := s3ControlDirectoryBucketPolicyStatusUnsupported(tt.err); got != tt.want {
+				t.Fatalf("unsupported = %t, want %t", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestS3ControlPostConvertHookWrapsSplitPolicies(t *testing.T) {
+	accessPoint, ok := newS3ControlAccessPointResource(testS3ControlAccountID, &s3control.GetAccessPointOutput{
+		AccessPointArn: aws.String(testS3ControlAccessPointARN),
+		Bucket:         aws.String("core-bucket"),
+		Name:           aws.String("core-ap"),
+	})
+	if !ok {
+		t.Fatal("access point should be importable")
+	}
+	accessPoint.Item = map[string]interface{}{
+		"name":   "core-ap",
+		"policy": `{"Resource":"${aws:username}"}`,
+	}
+	accessPoint.InstanceState.Attributes["policy"] = `{"Resource":"${aws:username}"}`
+
+	policyResource, ok := newS3ControlAccessPointPolicyResource(testS3ControlAccountID, "core-ap", testS3ControlAccessPointARN, `{"Resource":"${aws:username}"}`)
+	if !ok {
+		t.Fatal("access point policy should be importable")
+	}
+	policyResource.Item = map[string]interface{}{
+		"policy": `{"Resource":"${aws:username}"}`,
+	}
+
+	generator := S3ControlGenerator{
+		AWSService: AWSService{
+			Service: terraformutils.Service{
+				Resources: []terraformutils.Resource{accessPoint, policyResource},
+			},
+		},
+	}
+	if err := generator.PostConvertHook(); err != nil {
+		t.Fatalf("PostConvertHook() error = %v", err)
+	}
+	if _, ok := generator.Resources[0].Item["policy"]; ok {
+		t.Fatal("inline access point policy was not removed when split policy resource exists")
+	}
+	if _, ok := generator.Resources[0].InstanceState.Attributes["policy"]; ok {
+		t.Fatal("inline access point policy flatmap attribute was not removed")
+	}
+	want := "<<POLICY\n{\"Resource\":\"$" + "$" + "{aws:username}\"}\nPOLICY"
+	if got := generator.Resources[1].Item["policy"]; got != want {
+		t.Fatalf("split policy = %q, want %q", got, want)
+	}
+}
+
+func assertS3ControlResourceAttributes(t *testing.T, resource terraformutils.Resource, ok bool, resourceType, resourceID string, nameParts []string, attributes map[string]string) {
+	t.Helper()
+	if !ok {
+		t.Fatal("resource was skipped")
+	}
+	if resource.InstanceInfo.Type != resourceType {
+		t.Fatalf("resource type = %q, want %q", resource.InstanceInfo.Type, resourceType)
+	}
+	if resource.InstanceState.ID != resourceID {
+		t.Fatalf("resource ID = %q, want %q", resource.InstanceState.ID, resourceID)
+	}
+	for name, want := range attributes {
+		if got := resource.InstanceState.Attributes[name]; got != want {
+			t.Fatalf("attribute %q = %q, want %q", name, got, want)
+		}
+	}
+	wantName := terraformutils.TfSanitize(s3ControlResourceName(nameParts...))
+	if resource.ResourceName != wantName {
+		t.Fatalf("resource name = %q, want %q", resource.ResourceName, wantName)
+	}
+}
+
+func testS3ControlObjectLambdaConfiguration() *s3control.GetAccessPointConfigurationForObjectLambdaOutput {
+	return &s3control.GetAccessPointConfigurationForObjectLambdaOutput{
+		Configuration: &s3controltypes.ObjectLambdaConfiguration{
+			SupportingAccessPoint: aws.String(testS3ControlAccessPointARN),
+			TransformationConfigurations: []s3controltypes.ObjectLambdaTransformationConfiguration{
+				{},
+			},
+		},
+	}
+}

--- a/providers/aws/s3control_test.go
+++ b/providers/aws/s3control_test.go
@@ -215,6 +215,26 @@ func TestS3ControlObjectLambdaAccessPointImportable(t *testing.T) {
 	}
 }
 
+func TestS3ControlObjectLambdaAccessPointReadable(t *testing.T) {
+	tests := []struct {
+		name        string
+		accessPoint *s3control.GetAccessPointForObjectLambdaOutput
+		want        bool
+	}{
+		{name: "valid", accessPoint: &s3control.GetAccessPointForObjectLambdaOutput{Alias: &s3controltypes.ObjectLambdaAccessPointAlias{}}, want: true},
+		{name: "nil output", want: false},
+		{name: "nil alias", accessPoint: &s3control.GetAccessPointForObjectLambdaOutput{}, want: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := s3ControlObjectLambdaAccessPointReadable(tt.accessPoint); got != tt.want {
+				t.Fatalf("readable = %t, want %t", got, tt.want)
+			}
+		})
+	}
+}
+
 func TestS3ControlResourceNameAvoidsSanitizedCollisions(t *testing.T) {
 	left := terraformutils.TfSanitize(s3ControlResourceName("access_point", testS3ControlAccountID, "a_b", "c"))
 	right := terraformutils.TfSanitize(s3ControlResourceName("access_point", testS3ControlAccountID, "a", "b_c"))

--- a/providers/aws/s3control_test.go
+++ b/providers/aws/s3control_test.go
@@ -117,7 +117,7 @@ func TestNewS3ControlOutpostsAccessPointResource(t *testing.T) {
 func TestNewS3ControlAccessPointPolicyResource(t *testing.T) {
 	policy := `{"Version":"2012-10-17"}`
 	resource, ok := newS3ControlAccessPointPolicyResource(testS3ControlAccountID, "core-ap", testS3ControlAccessPointARN, policy)
-	assertS3ControlResourceAttributes(t, resource, ok, s3ControlAccessPointPolicyResourceType, "123456789012:core-ap",
+	assertS3ControlResourceAttributes(t, resource, ok, s3ControlAccessPointPolicyResourceType, testS3ControlAccessPointARN,
 		[]string{"access_point_policy", testS3ControlAccountID, "core-ap", testS3ControlAccessPointARN},
 		map[string]string{
 			"access_point_arn": testS3ControlAccessPointARN,
@@ -182,6 +182,35 @@ func TestNewS3ControlObjectLambdaAccessPointPolicyResource(t *testing.T) {
 	}
 	if _, ok := newS3ControlObjectLambdaAccessPointPolicyResource(testS3ControlAccountID, "core-olap", ""); ok {
 		t.Fatal("object lambda policy with empty policy body should be skipped")
+	}
+}
+
+func TestS3ControlAccessPointImportIDFromARN(t *testing.T) {
+	outpostsARN := "arn:aws:s3-outposts:us-east-1:123456789012:outpost/op-1234567890123456/accesspoint/core-ap"
+	tests := []struct {
+		name string
+		arn  string
+		want string
+		ok   bool
+	}{
+		{name: "regular access point", arn: testS3ControlAccessPointARN, want: "123456789012:core-ap", ok: true},
+		{name: "s3 express access point", arn: "arn:aws:s3express:us-east-1:123456789012:accesspoint/core-ap", want: "123456789012:core-ap", ok: true},
+		{name: "outposts access point", arn: outpostsARN, want: outpostsARN, ok: true},
+		{name: "invalid arn", arn: "not-an-arn", ok: false},
+		{name: "wrong service", arn: "arn:aws:sqs:us-east-1:123456789012:queue/core", ok: false},
+		{name: "wrong resource", arn: "arn:aws:s3:us-east-1:123456789012:bucket/core", ok: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, ok := s3ControlAccessPointImportIDFromARN(tt.arn)
+			if ok != tt.ok {
+				t.Fatalf("ok = %t, want %t", ok, tt.ok)
+			}
+			if got != tt.want {
+				t.Fatalf("import ID = %q, want %q", got, tt.want)
+			}
+		})
 	}
 }
 
@@ -330,6 +359,21 @@ func TestS3ControlPostConvertHookWrapsSplitPolicies(t *testing.T) {
 	want := "<<POLICY\n{\"Resource\":\"$" + "$" + "{aws:username}\"}\nPOLICY"
 	if got := generator.Resources[1].Item["policy"]; got != want {
 		t.Fatalf("split policy = %q, want %q", got, want)
+	}
+}
+
+func TestS3ControlSplitAccessPointPolicyIDsIncludesImportedARN(t *testing.T) {
+	policyResource, ok := newS3ControlAccessPointPolicyResource(testS3ControlAccountID, "core-ap", testS3ControlAccessPointARN, "{\"Version\":\"2012-10-17\"}")
+	if !ok {
+		t.Fatal("access point policy should be importable")
+	}
+
+	ids := s3ControlSplitAccessPointPolicyIDs([]terraformutils.Resource{policyResource})
+	if !ids[testS3ControlAccessPointARN] {
+		t.Fatalf("split policy IDs did not include policy import ARN: %#v", ids)
+	}
+	if !ids["123456789012:core-ap"] {
+		t.Fatalf("split policy IDs did not include provider read ID derived from access_point_arn: %#v", ids)
 	}
 }
 


### PR DESCRIPTION
## Summary

- add S3 Control import discovery for access points, access point policies, Object Lambda access points, and Object Lambda access point policies
- register the `s3control` AWS service and update `docs/aws.md`
- seed access point IDs as `account_id:name` for regular access points and the access point ARN for S3 on Outposts
- add unit tests for S3 Control resource helper behavior

## References

- #338

## Validation

```bash
go test ./providers/aws -run 'Test.*S3|Test.*s3|Test.*S3Control|Test.*s3control'
go test ./providers/aws/... ./terraformutils/... ./tools/aws-gap-inventory/...
go run ./tools/aws-gap-inventory \
  -docs docs/aws.md \
  -aws-dir providers/aws \
  -skip-list providers/aws/unsupported_resources.json \
  -format markdown
git diff --check
```

## Notes

Skipped/deferred resources:
- `aws_s3_object` / `aws_s3_bucket_object`: high-cardinality content resources; not suitable for broad default discovery
- S3 bucket table/metadata resources: deferred to a separate focused PR
- S3 Outposts-specific resources beyond S3 access point ARN import handling: deferred to a separate focused PR

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds S3 Control import discovery for access points and Object Lambda access points (and their policies) so `s3control` resources can be generated and managed. Also ensures Object Lambda access points are readable before import and imports access point policies by ARN to avoid mismatches.

- **New Features**
  - Discover and import `aws_s3_access_point`, `aws_s3control_access_point_policy`, `aws_s3control_object_lambda_access_point`, and `aws_s3control_object_lambda_access_point_policy`.
  - Register `s3control` in the AWS provider and document supported resources.
  - Import IDs: use `account_id:name` for standard access points and Object Lambda; use the access point ARN for S3 on Outposts.
  - Post-convert: wrap policy JSON in heredocs and strip inline policies when a split policy resource exists.
  - Unit tests added for generators and helpers.

- **Bug Fixes**
  - Import access point policies by access point ARN.
  - Check that Object Lambda access points are readable (alias present) before importing; skip if not to prevent failures.

<sup>Written for commit 503decf0115741cabc75c1748822c173e03bc57b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for AWS S3 Control service, including access points, access point policies, object lambda access points, and object lambda access point policies

* **Documentation**
  * Updated supported services list to include S3 Control resources

* **Tests**
  * Added comprehensive test coverage for S3 Control resource operations

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/chenrui333/terraformer/pull/411)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->