### PR TITLE
aws(dms): add S3 endpoint imports

### DIFF
--- a/docs/aws.md
+++ b/docs/aws.md
@@ -223,6 +223,7 @@ For AWS provider gap audits and unsupported-resource skip-list maintenance, see 
     * `aws_dms_replication_instance`
     * `aws_dms_replication_subnet_group`
     * `aws_dms_replication_task`
+    * `aws_dms_s3_endpoint`
 *   `docdb`
     * `aws_docdb_cluster`
     * `aws_docdb_cluster_instance`

--- a/providers/aws/dms.go
+++ b/providers/aws/dms.go
@@ -24,6 +24,7 @@ const (
 	dmsReplicationSubnetGroupResourceType = "aws_dms_replication_subnet_group"
 	dmsEndpointResourceType               = "aws_dms_endpoint"
 	dmsReplicationTaskResourceType        = "aws_dms_replication_task"
+	dmsS3EndpointResourceType             = "aws_dms_s3_endpoint"
 
 	dmsEventSubscriptionStatusActive = "active"
 
@@ -39,6 +40,7 @@ const (
 )
 
 var dmsAllowEmptyValues = []string{"tags.", "^enabled$"}
+var dmsS3EndpointAllowEmptyValues = []string{"tags.", "^enable_statistics$", "^rfc_4180$"}
 
 type DmsGenerator struct {
 	AWSService
@@ -147,6 +149,9 @@ func (g *DmsGenerator) loadEndpoints(svc *databasemigrationservice.Client) error
 		}
 		for _, endpoint := range page.Endpoints {
 			if resource, ok := newDMSEndpointResource(endpoint); ok {
+				g.Resources = append(g.Resources, resource)
+			}
+			if resource, ok := newDMSS3EndpointResource(endpoint); ok {
 				g.Resources = append(g.Resources, resource)
 			}
 		}
@@ -315,6 +320,22 @@ func newDMSEndpointResource(endpoint dmstypes.Endpoint) (terraformutils.Resource
 	), true
 }
 
+func newDMSS3EndpointResource(endpoint dmstypes.Endpoint) (terraformutils.Resource, bool) {
+	identifier := dmsS3EndpointImportID(endpoint)
+	if identifier == "" || !dmsS3EndpointImportable(endpoint) {
+		return terraformutils.Resource{}, false
+	}
+	return terraformutils.NewResource(
+		identifier,
+		dmsResourceName("s3-endpoint", identifier),
+		dmsS3EndpointResourceType,
+		"aws",
+		dmsS3EndpointAttributes(endpoint),
+		dmsS3EndpointAllowEmptyValues,
+		map[string]interface{}{},
+	), true
+}
+
 func newDMSReplicationTaskResource(task dmstypes.ReplicationTask) (terraformutils.Resource, bool) {
 	identifier := StringValue(task.ReplicationTaskIdentifier)
 	if identifier == "" || !dmsReplicationTaskImportable(task) {
@@ -349,6 +370,10 @@ func dmsReplicationConfigImportID(config dmstypes.ReplicationConfig) string {
 func dmsReplicationConfigResourceName(config dmstypes.ReplicationConfig) string {
 	arnSuffix := arnLastSegment(dmsReplicationConfigImportID(config), ":")
 	return dmsResourceName("replication-config", StringValue(config.ReplicationConfigIdentifier), arnSuffix)
+}
+
+func dmsS3EndpointImportID(endpoint dmstypes.Endpoint) string {
+	return StringValue(endpoint.EndpointIdentifier)
 }
 
 func dmsCertificateImportable(certificate dmstypes.Certificate) bool {
@@ -455,6 +480,63 @@ func dmsEndpointImportable(endpoint dmstypes.Endpoint) bool {
 		return false
 	}
 	return dmsStableStatusImportable(StringValue(endpoint.Status))
+}
+
+func dmsS3EndpointImportable(endpoint dmstypes.Endpoint) bool {
+	if !strings.EqualFold(StringValue(endpoint.EngineName), dmsEndpointEngineS3) {
+		return false
+	}
+	if endpoint.IsReadOnly != nil && *endpoint.IsReadOnly {
+		return false
+	}
+	if dmsS3EndpointImportID(endpoint) == "" ||
+		endpoint.EndpointType == "" ||
+		!dmsStableStatusImportable(StringValue(endpoint.Status)) ||
+		!dmsS3EndpointSettingsImportable(endpoint.S3Settings) {
+		return false
+	}
+	if strings.EqualFold(string(endpoint.EndpointType), string(dmstypes.ReplicationEndpointTypeValueSource)) {
+		return StringValue(endpoint.S3Settings.ExternalTableDefinition) != ""
+	}
+	return true
+}
+
+func dmsS3EndpointSettingsImportable(settings *dmstypes.S3Settings) bool {
+	return settings != nil &&
+		StringValue(settings.BucketName) != "" &&
+		StringValue(settings.ServiceAccessRoleArn) != ""
+}
+
+func dmsS3EndpointAttributes(endpoint dmstypes.Endpoint) map[string]string {
+	settings := endpoint.S3Settings
+	attributes := map[string]string{
+		"bucket_name":             StringValue(settings.BucketName),
+		"endpoint_id":             dmsS3EndpointImportID(endpoint),
+		"endpoint_type":           strings.ToLower(string(endpoint.EndpointType)),
+		"service_access_role_arn": StringValue(settings.ServiceAccessRoleArn),
+	}
+	if value := StringValue(endpoint.CertificateArn); value != "" {
+		attributes["certificate_arn"] = value
+	}
+	if value := StringValue(endpoint.KmsKeyId); value != "" {
+		attributes["kms_key_arn"] = value
+	}
+	if endpoint.SslMode != "" {
+		attributes["ssl_mode"] = string(endpoint.SslMode)
+	}
+	if value := StringValue(settings.BucketFolder); value != "" {
+		attributes["bucket_folder"] = value
+	}
+	if value := StringValue(settings.ExternalTableDefinition); value != "" {
+		attributes["external_table_definition"] = value
+	}
+	if settings.EnableStatistics != nil {
+		attributes["enable_statistics"] = strconv.FormatBool(*settings.EnableStatistics)
+	}
+	if settings.Rfc4180 != nil {
+		attributes["rfc_4180"] = strconv.FormatBool(*settings.Rfc4180)
+	}
+	return attributes
 }
 
 func dmsReplicationTaskImportable(task dmstypes.ReplicationTask) bool {

--- a/providers/aws/dms_test.go
+++ b/providers/aws/dms_test.go
@@ -33,9 +33,13 @@ func TestDMSResourceName(t *testing.T) {
 
 func TestDMSResourceNamesAvoidTypeCollisions(t *testing.T) {
 	endpoint := dmsResourceName("endpoint", "shared")
+	s3Endpoint := dmsResourceName("s3-endpoint", "shared")
 	task := dmsResourceName("replication-task", "shared")
 	if endpoint == task {
 		t.Fatalf("resource names collide: %q", endpoint)
+	}
+	if endpoint == s3Endpoint {
+		t.Fatalf("endpoint resource names collide: %q", endpoint)
 	}
 }
 
@@ -406,8 +410,13 @@ func TestNewDMSEndpointResource(t *testing.T) {
 	}
 	if _, ok := newDMSEndpointResource(dmstypes.Endpoint{
 		EndpointIdentifier: dmsString("s3-target"),
+		EndpointType:       dmstypes.ReplicationEndpointTypeValueTarget,
 		EngineName:         dmsString("s3"),
-		Status:             dmsString("active"),
+		S3Settings: &dmstypes.S3Settings{
+			BucketName:           dmsString("dms-export-bucket"),
+			ServiceAccessRoleArn: dmsString("arn:aws:iam::123456789012:role/dms-s3-role"),
+		},
+		Status: dmsString("active"),
 	}); ok {
 		t.Fatal("S3 endpoint should be skipped for aws_dms_endpoint")
 	}
@@ -417,6 +426,103 @@ func TestNewDMSEndpointResource(t *testing.T) {
 		Status:             dmsString("failed"),
 	}); ok {
 		t.Fatal("failed endpoint should be skipped")
+	}
+}
+
+func TestNewDMSS3EndpointResource(t *testing.T) {
+	resource, ok := newDMSS3EndpointResource(dmstypes.Endpoint{
+		CertificateArn:     dmsString("arn:aws:dms:us-east-1:123456789012:cert:ABC123"),
+		EndpointIdentifier: dmsString("s3-target"),
+		EndpointType:       dmstypes.ReplicationEndpointTypeValueTarget,
+		EngineName:         dmsString("S3"),
+		KmsKeyId:           dmsString("arn:aws:kms:us-east-1:123456789012:key/example"),
+		S3Settings: &dmstypes.S3Settings{
+			BucketFolder:         dmsString("exports"),
+			BucketName:           dmsString("dms-export-bucket"),
+			EnableStatistics:     dmsBool(false),
+			Rfc4180:              dmsBool(false),
+			ServiceAccessRoleArn: dmsString("arn:aws:iam::123456789012:role/dms-s3-role"),
+		},
+		SslMode: dmstypes.DmsSslModeValueNone,
+		Status:  dmsString("active"),
+	})
+	assertDMSResource(t, resource, ok, "s3-target", dmsResourceName("s3-endpoint", "s3-target"), dmsS3EndpointResourceType)
+	attributes := resource.InstanceState.Attributes
+	expected := map[string]string{
+		"bucket_folder":           "exports",
+		"bucket_name":             "dms-export-bucket",
+		"certificate_arn":         "arn:aws:dms:us-east-1:123456789012:cert:ABC123",
+		"enable_statistics":       "false",
+		"endpoint_id":             "s3-target",
+		"endpoint_type":           "target",
+		"kms_key_arn":             "arn:aws:kms:us-east-1:123456789012:key/example",
+		"rfc_4180":                "false",
+		"service_access_role_arn": "arn:aws:iam::123456789012:role/dms-s3-role",
+		"ssl_mode":                "none",
+	}
+	for key, want := range expected {
+		if got := attributes[key]; got != want {
+			t.Fatalf("%s = %q, want %q", key, got, want)
+		}
+	}
+	assertDMSAllowEmptyValue(t, resource, "enable_statistics")
+	assertDMSAllowEmptyValue(t, resource, "rfc_4180")
+
+	sourceResource, ok := newDMSS3EndpointResource(dmstypes.Endpoint{
+		EndpointIdentifier: dmsString("s3-source"),
+		EndpointType:       dmstypes.ReplicationEndpointTypeValueSource,
+		EngineName:         dmsString("s3"),
+		S3Settings: &dmstypes.S3Settings{
+			BucketName:              dmsString("dms-source-bucket"),
+			ExternalTableDefinition: dmsString("{\"TableCount\":1}"),
+			ServiceAccessRoleArn:    dmsString("arn:aws:iam::123456789012:role/dms-s3-role"),
+		},
+		Status: dmsString("active"),
+	})
+	assertDMSResource(t, sourceResource, ok, "s3-source", dmsResourceName("s3-endpoint", "s3-source"), dmsS3EndpointResourceType)
+	if got := sourceResource.InstanceState.Attributes["external_table_definition"]; got != "{\"TableCount\":1}" {
+		t.Fatalf("external_table_definition = %q, want source table definition", got)
+	}
+}
+
+func TestNewDMSS3EndpointResourceSkipsUnsafeEndpoints(t *testing.T) {
+	validEndpoint := func() dmstypes.Endpoint {
+		return dmstypes.Endpoint{
+			EndpointIdentifier: dmsString("s3-target"),
+			EndpointType:       dmstypes.ReplicationEndpointTypeValueTarget,
+			EngineName:         dmsString("s3"),
+			S3Settings: &dmstypes.S3Settings{
+				BucketName:           dmsString("dms-export-bucket"),
+				ServiceAccessRoleArn: dmsString("arn:aws:iam::123456789012:role/dms-s3-role"),
+			},
+			Status: dmsString("active"),
+		}
+	}
+
+	tests := []struct {
+		name   string
+		mutate func(*dmstypes.Endpoint)
+	}{
+		{name: "empty identifier", mutate: func(endpoint *dmstypes.Endpoint) { endpoint.EndpointIdentifier = nil }},
+		{name: "non-S3 engine", mutate: func(endpoint *dmstypes.Endpoint) { endpoint.EngineName = dmsString("postgres") }},
+		{name: "empty endpoint type", mutate: func(endpoint *dmstypes.Endpoint) { endpoint.EndpointType = "" }},
+		{name: "creating status", mutate: func(endpoint *dmstypes.Endpoint) { endpoint.Status = dmsString("creating") }},
+		{name: "missing S3 settings", mutate: func(endpoint *dmstypes.Endpoint) { endpoint.S3Settings = nil }},
+		{name: "missing bucket", mutate: func(endpoint *dmstypes.Endpoint) { endpoint.S3Settings.BucketName = nil }},
+		{name: "missing service role", mutate: func(endpoint *dmstypes.Endpoint) { endpoint.S3Settings.ServiceAccessRoleArn = nil }},
+		{name: "read-only", mutate: func(endpoint *dmstypes.Endpoint) { endpoint.IsReadOnly = dmsBool(true) }},
+		{name: "source missing external table definition", mutate: func(endpoint *dmstypes.Endpoint) {
+			endpoint.EndpointType = dmstypes.ReplicationEndpointTypeValueSource
+		}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			endpoint := validEndpoint()
+			tt.mutate(&endpoint)
+			if _, ok := newDMSS3EndpointResource(endpoint); ok {
+				t.Fatal("S3 endpoint should be skipped")
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
## Summary

- add DMS S3 endpoint import discovery for `aws_dms_s3_endpoint`
- seed import IDs as DMS endpoint identifiers
- build S3 endpoint resources from `DescribeEndpoints` results where `engine_name == "s3"`
- keep generic `aws_dms_endpoint` discovery skipping S3 endpoints
- update `docs/aws.md` for the supported DMS S3 endpoint resource
- add unit tests for DMS S3 endpoint helper behavior

## References

- #338

## Validation

```bash
go test ./providers/aws -run 'Test.*DMS|Test.*Dms|Test.*dms'
go test ./providers/aws/... ./terraformutils/...
go run ./tools/aws-gap-inventory \
  -docs docs/aws.md \
  -aws-dir providers/aws \
  -skip-list providers/aws/unsupported_resources.json \
  -format markdown
git diff --check
```

## Notes

Skipped/deferred resources:
- S3 endpoints missing returned `S3Settings.bucket_name` or `S3Settings.service_access_role_arn`: skipped because Terraform requires those fields
- S3 source endpoints missing `external_table_definition`: skipped because the provider docs require it for source endpoints
- read-only, creating, deleting, failed, or otherwise transient S3 endpoints: skipped for safe importability
- other DMS engine-specific endpoint resources: deferred for separate investigation

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add import discovery for AWS DMS S3 endpoints as `aws_dms_s3_endpoint`, with docs and tests. Addresses #338.

- **New Features**
  - Discover S3 endpoints via `DescribeEndpoints` and create `aws_dms_s3_endpoint` using the endpoint identifier.
  - Skip S3 endpoints in `aws_dms_endpoint` discovery to avoid duplicates.
  - Only import stable, non-read-only S3 endpoints with required `S3Settings` (bucket, role ARN); sources also require `external_table_definition`.
  - Map attributes: endpoint_id/type, bucket/folder, role ARN, cert/KMS, ssl_mode; include optional `enable_statistics` and `rfc_4180` (allowed empty). Updated `docs/aws.md` and added unit tests (including name collision and skip cases).

<sup>Written for commit 1d41d5dc3cd683a92db35ccff64d00dad1f6d5e4. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for importing AWS DMS S3 endpoints as Terraform resources with validation of required configuration fields including bucket, service role ARN, and endpoint status.

* **Documentation**
  * Updated AWS service documentation to list `aws_dms_s3_endpoint` as a newly supported resource.

* **Tests**
  * Added comprehensive test coverage for S3 endpoint resource creation and validation scenarios.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/chenrui333/terraformer/pull/414)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->