### PR TITLE
aws(mwaa): add MWAA environment imports

### DIFF
--- a/docs/aws.md
+++ b/docs/aws.md
@@ -402,6 +402,8 @@ For AWS provider gap audits and unsupported-resource skip-list maintenance, see 
     * `aws_msk_serverless_cluster`
     * `aws_msk_single_scram_secret_association`
     * `aws_msk_vpc_connection`
+*   `mwaa`
+    * `aws_mwaa_environment`
 *   `nacl`
     * `aws_default_network_acl`
     * `aws_network_acl`

--- a/go.mod
+++ b/go.mod
@@ -407,6 +407,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/backup v1.55.2
 	github.com/aws/aws-sdk-go-v2/service/bedrock v1.59.2
 	github.com/aws/aws-sdk-go-v2/service/directconnect v1.38.17
+	github.com/aws/aws-sdk-go-v2/service/mwaa v1.40.0
 	github.com/aws/aws-sdk-go-v2/service/pipes v1.23.22
 	github.com/aws/aws-sdk-go-v2/service/scheduler v1.17.24
 	github.com/aws/aws-sdk-go-v2/service/sesv2 v1.60.4

--- a/go.sum
+++ b/go.sum
@@ -327,6 +327,8 @@ github.com/aws/aws-sdk-go-v2/service/mediastore v1.29.23 h1:yxt0mlXvIz6tBqE6tE+8
 github.com/aws/aws-sdk-go-v2/service/mediastore v1.29.23/go.mod h1:8nxl+cuTs2USuUurU51GknJf37qAFtSRsrpSomYqqsA=
 github.com/aws/aws-sdk-go-v2/service/mq v1.34.22 h1:l7nzDTuFH15cvRIFo5cFokN5g+9sA/ZYUsiffFBTObk=
 github.com/aws/aws-sdk-go-v2/service/mq v1.34.22/go.mod h1:aWvcRNyk/LFb3R6xIJE1o4MDwJcLjXhpdlg8X4kW57k=
+github.com/aws/aws-sdk-go-v2/service/mwaa v1.40.0 h1:q5IvCkBGEnLV6lBBSFNxpZ3y0kqjF2HmY7cnKWtW2p8=
+github.com/aws/aws-sdk-go-v2/service/mwaa v1.40.0/go.mod h1:O2kdYrYDkdHdUpvYcrWQoYaJgPJCGHdaLF06ep3HzKI=
 github.com/aws/aws-sdk-go-v2/service/opsworks v1.31.0 h1:wTMEW5MX0+KDR2twK2UkdZ2AHItnab8/XFrM6bHYvtY=
 github.com/aws/aws-sdk-go-v2/service/opsworks v1.31.0/go.mod h1:pGgL2+mF6Gtjq9diAn/tVmvRqfFI+2/oyz3dENRCPXw=
 github.com/aws/aws-sdk-go-v2/service/organizations v1.51.3 h1:LWSmXWwYzR9yRcszxyqaKuPCO4E6g/iknZv1kQIkD7I=

--- a/providers/aws/aws_provider.go
+++ b/providers/aws/aws_provider.go
@@ -324,6 +324,7 @@ func (p *AWSProvider) GetSupportedService() map[string]terraformutils.ServiceGen
 		"medialive":         &AwsFacade{service: &MediaLiveGenerator{}},
 		"mq":                &AwsFacade{service: &MQGenerator{}},
 		"msk":               &AwsFacade{service: &MskGenerator{}},
+		"mwaa":              &AwsFacade{service: &MwaaGenerator{}},
 		"nacl":              &AwsFacade{service: &NaclGenerator{}},
 		"nat":               &AwsFacade{service: &NatGatewayGenerator{}},
 		"opsworks":          &AwsFacade{service: &OpsworksGenerator{}},

--- a/providers/aws/mwaa.go
+++ b/providers/aws/mwaa.go
@@ -97,8 +97,7 @@ func mwaaEnvironmentImportable(environment *mwaatypes.Environment) bool {
 	if StringValue(environment.Name) == "" ||
 		StringValue(environment.DagS3Path) == "" ||
 		StringValue(environment.ExecutionRoleArn) == "" ||
-		StringValue(environment.SourceBucketArn) == "" ||
-		environment.LastUpdate == nil {
+		StringValue(environment.SourceBucketArn) == "" {
 		return false
 	}
 	return mwaaEnvironmentNetworkConfigurationComplete(environment.NetworkConfiguration)

--- a/providers/aws/mwaa.go
+++ b/providers/aws/mwaa.go
@@ -1,0 +1,149 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package aws
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/mwaa"
+	mwaatypes "github.com/aws/aws-sdk-go-v2/service/mwaa/types"
+	"github.com/chenrui333/terraformer/terraformutils"
+)
+
+const mwaaEnvironmentResourceType = "aws_mwaa_environment"
+
+var mwaaAllowEmptyValues = []string{"tags."}
+
+type MwaaGenerator struct {
+	AWSService
+}
+
+func (g *MwaaGenerator) InitResources() error {
+	config, e := g.generateConfig()
+	if e != nil {
+		return e
+	}
+	svc := mwaa.NewFromConfig(config)
+
+	return g.loadEnvironments(svc)
+}
+
+func (g *MwaaGenerator) loadEnvironments(svc *mwaa.Client) error {
+	paginator := mwaa.NewListEnvironmentsPaginator(svc, &mwaa.ListEnvironmentsInput{})
+	for paginator.HasMorePages() {
+		page, err := paginator.NextPage(context.TODO())
+		if mwaaResourceNotFound(err) {
+			return nil
+		}
+		if err != nil {
+			return err
+		}
+		for _, name := range page.Environments {
+			environment, err := getMwaaEnvironment(svc, name)
+			if mwaaResourceNotFound(err) {
+				continue
+			}
+			if err != nil {
+				return err
+			}
+			if resource, ok := newMwaaEnvironmentResource(environment); ok {
+				g.Resources = append(g.Resources, resource)
+			}
+		}
+	}
+	return nil
+}
+
+func getMwaaEnvironment(svc *mwaa.Client, name string) (*mwaatypes.Environment, error) {
+	if name == "" {
+		return nil, nil
+	}
+	output, err := svc.GetEnvironment(context.TODO(), &mwaa.GetEnvironmentInput{
+		Name: aws.String(name),
+	})
+	if err != nil {
+		return nil, err
+	}
+	if output == nil {
+		return nil, nil
+	}
+	return output.Environment, nil
+}
+
+func newMwaaEnvironmentResource(environment *mwaatypes.Environment) (terraformutils.Resource, bool) {
+	if !mwaaEnvironmentImportable(environment) {
+		return terraformutils.Resource{}, false
+	}
+	name := StringValue(environment.Name)
+	return terraformutils.NewResource(
+		mwaaEnvironmentImportID(name),
+		mwaaResourceName("environment", name),
+		mwaaEnvironmentResourceType,
+		"aws",
+		mwaaEnvironmentAttributes(environment),
+		mwaaAllowEmptyValues,
+		map[string]interface{}{},
+	), true
+}
+
+func mwaaEnvironmentImportable(environment *mwaatypes.Environment) bool {
+	if environment == nil || !mwaaEnvironmentStatusImportable(environment.Status) {
+		return false
+	}
+	if StringValue(environment.Name) == "" ||
+		StringValue(environment.DagS3Path) == "" ||
+		StringValue(environment.ExecutionRoleArn) == "" ||
+		StringValue(environment.SourceBucketArn) == "" ||
+		environment.LastUpdate == nil {
+		return false
+	}
+	return mwaaEnvironmentNetworkConfigurationComplete(environment.NetworkConfiguration)
+}
+
+func mwaaEnvironmentNetworkConfigurationComplete(config *mwaatypes.NetworkConfiguration) bool {
+	return config != nil && len(config.SecurityGroupIds) > 0 && len(config.SubnetIds) > 1
+}
+
+func mwaaEnvironmentAttributes(environment *mwaatypes.Environment) map[string]string {
+	return map[string]string{
+		"dag_s3_path":        StringValue(environment.DagS3Path),
+		"execution_role_arn": StringValue(environment.ExecutionRoleArn),
+		"name":               StringValue(environment.Name),
+		"source_bucket_arn":  StringValue(environment.SourceBucketArn),
+	}
+}
+
+func mwaaEnvironmentImportID(name string) string {
+	return name
+}
+
+func mwaaEnvironmentStatusImportable(status mwaatypes.EnvironmentStatus) bool {
+	switch status {
+	case "", mwaatypes.EnvironmentStatusDeleting, mwaatypes.EnvironmentStatusDeleted:
+		return false
+	default:
+		return true
+	}
+}
+
+func mwaaResourceName(parts ...string) string {
+	cleanParts := []string{}
+	for _, part := range parts {
+		if part != "" {
+			cleanParts = append(cleanParts, fmt.Sprintf("%d/%s", len(part), part))
+		}
+	}
+	if len(cleanParts) == 0 {
+		return "mwaa-resource"
+	}
+	return strings.Join(cleanParts, "/")
+}
+
+func mwaaResourceNotFound(err error) bool {
+	var notFound *mwaatypes.ResourceNotFoundException
+	return errors.As(err, &notFound)
+}

--- a/providers/aws/mwaa.go
+++ b/providers/aws/mwaa.go
@@ -94,10 +94,12 @@ func mwaaEnvironmentImportable(environment *mwaatypes.Environment) bool {
 	if environment == nil || !mwaaEnvironmentStatusImportable(environment.Status) {
 		return false
 	}
+	// Terraform AWS provider v6.43/v6.44 dereference LastUpdate during Read.
 	if StringValue(environment.Name) == "" ||
 		StringValue(environment.DagS3Path) == "" ||
 		StringValue(environment.ExecutionRoleArn) == "" ||
-		StringValue(environment.SourceBucketArn) == "" {
+		StringValue(environment.SourceBucketArn) == "" ||
+		environment.LastUpdate == nil {
 		return false
 	}
 	return mwaaEnvironmentNetworkConfigurationComplete(environment.NetworkConfiguration)

--- a/providers/aws/mwaa_test.go
+++ b/providers/aws/mwaa_test.go
@@ -20,14 +20,6 @@ func TestNewMwaaEnvironmentResource(t *testing.T) {
 	assertMwaaAttribute(t, resource, "source_bucket_arn", "arn:aws:s3:::mwaa-source")
 }
 
-func TestNewMwaaEnvironmentResourceAllowsMissingLastUpdate(t *testing.T) {
-	environment := validMwaaEnvironment("prod-airflow")
-	environment.LastUpdate = nil
-
-	resource, ok := newMwaaEnvironmentResource(environment)
-	assertMwaaResource(t, resource, ok, "prod-airflow", mwaaResourceName("environment", "prod-airflow"), mwaaEnvironmentResourceType)
-}
-
 func TestNewMwaaEnvironmentResourceSkipsIncompleteEnvironments(t *testing.T) {
 	tests := []struct {
 		name   string
@@ -79,6 +71,12 @@ func TestNewMwaaEnvironmentResourceSkipsIncompleteEnvironments(t *testing.T) {
 			name: "single subnet",
 			mutate: func(environment *mwaatypes.Environment) {
 				environment.NetworkConfiguration.SubnetIds = []string{"subnet-1"}
+			},
+		},
+		{
+			name: "missing last update",
+			mutate: func(environment *mwaatypes.Environment) {
+				environment.LastUpdate = nil
 			},
 		},
 		{

--- a/providers/aws/mwaa_test.go
+++ b/providers/aws/mwaa_test.go
@@ -20,6 +20,14 @@ func TestNewMwaaEnvironmentResource(t *testing.T) {
 	assertMwaaAttribute(t, resource, "source_bucket_arn", "arn:aws:s3:::mwaa-source")
 }
 
+func TestNewMwaaEnvironmentResourceAllowsMissingLastUpdate(t *testing.T) {
+	environment := validMwaaEnvironment("prod-airflow")
+	environment.LastUpdate = nil
+
+	resource, ok := newMwaaEnvironmentResource(environment)
+	assertMwaaResource(t, resource, ok, "prod-airflow", mwaaResourceName("environment", "prod-airflow"), mwaaEnvironmentResourceType)
+}
+
 func TestNewMwaaEnvironmentResourceSkipsIncompleteEnvironments(t *testing.T) {
 	tests := []struct {
 		name   string
@@ -71,12 +79,6 @@ func TestNewMwaaEnvironmentResourceSkipsIncompleteEnvironments(t *testing.T) {
 			name: "single subnet",
 			mutate: func(environment *mwaatypes.Environment) {
 				environment.NetworkConfiguration.SubnetIds = []string{"subnet-1"}
-			},
-		},
-		{
-			name: "missing last update",
-			mutate: func(environment *mwaatypes.Environment) {
-				environment.LastUpdate = nil
 			},
 		},
 		{

--- a/providers/aws/mwaa_test.go
+++ b/providers/aws/mwaa_test.go
@@ -1,0 +1,230 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package aws
+
+import (
+	"errors"
+	"testing"
+
+	mwaatypes "github.com/aws/aws-sdk-go-v2/service/mwaa/types"
+	"github.com/chenrui333/terraformer/terraformutils"
+)
+
+func TestNewMwaaEnvironmentResource(t *testing.T) {
+	environment := validMwaaEnvironment("prod-airflow")
+	resource, ok := newMwaaEnvironmentResource(environment)
+	assertMwaaResource(t, resource, ok, "prod-airflow", mwaaResourceName("environment", "prod-airflow"), mwaaEnvironmentResourceType)
+	assertMwaaAttribute(t, resource, "dag_s3_path", "dags")
+	assertMwaaAttribute(t, resource, "execution_role_arn", "arn:aws:iam::123456789012:role/mwaa-execution")
+	assertMwaaAttribute(t, resource, "name", "prod-airflow")
+	assertMwaaAttribute(t, resource, "source_bucket_arn", "arn:aws:s3:::mwaa-source")
+}
+
+func TestNewMwaaEnvironmentResourceSkipsIncompleteEnvironments(t *testing.T) {
+	tests := []struct {
+		name   string
+		mutate func(*mwaatypes.Environment)
+	}{
+		{
+			name: "nil environment",
+			mutate: func(environment *mwaatypes.Environment) {
+				*environment = mwaatypes.Environment{}
+			},
+		},
+		{
+			name: "empty name",
+			mutate: func(environment *mwaatypes.Environment) {
+				environment.Name = nil
+			},
+		},
+		{
+			name: "empty DAG path",
+			mutate: func(environment *mwaatypes.Environment) {
+				environment.DagS3Path = nil
+			},
+		},
+		{
+			name: "empty execution role ARN",
+			mutate: func(environment *mwaatypes.Environment) {
+				environment.ExecutionRoleArn = nil
+			},
+		},
+		{
+			name: "empty source bucket ARN",
+			mutate: func(environment *mwaatypes.Environment) {
+				environment.SourceBucketArn = nil
+			},
+		},
+		{
+			name: "missing network configuration",
+			mutate: func(environment *mwaatypes.Environment) {
+				environment.NetworkConfiguration = nil
+			},
+		},
+		{
+			name: "empty security groups",
+			mutate: func(environment *mwaatypes.Environment) {
+				environment.NetworkConfiguration.SecurityGroupIds = nil
+			},
+		},
+		{
+			name: "single subnet",
+			mutate: func(environment *mwaatypes.Environment) {
+				environment.NetworkConfiguration.SubnetIds = []string{"subnet-1"}
+			},
+		},
+		{
+			name: "missing last update",
+			mutate: func(environment *mwaatypes.Environment) {
+				environment.LastUpdate = nil
+			},
+		},
+		{
+			name: "empty status",
+			mutate: func(environment *mwaatypes.Environment) {
+				environment.Status = ""
+			},
+		},
+		{
+			name: "deleting status",
+			mutate: func(environment *mwaatypes.Environment) {
+				environment.Status = mwaatypes.EnvironmentStatusDeleting
+			},
+		},
+		{
+			name: "deleted status",
+			mutate: func(environment *mwaatypes.Environment) {
+				environment.Status = mwaatypes.EnvironmentStatusDeleted
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			environment := validMwaaEnvironment("prod-airflow")
+			tt.mutate(environment)
+			if _, ok := newMwaaEnvironmentResource(environment); ok {
+				t.Fatal("incomplete environment should be skipped")
+			}
+		})
+	}
+
+	if _, ok := newMwaaEnvironmentResource(nil); ok {
+		t.Fatal("nil environment should be skipped")
+	}
+}
+
+func TestMwaaEnvironmentImportID(t *testing.T) {
+	got := mwaaEnvironmentImportID("prod-airflow")
+	want := "prod-airflow"
+	if got != want {
+		t.Fatalf("environment import ID = %q, want %q", got, want)
+	}
+}
+
+func TestMwaaEnvironmentStatusImportable(t *testing.T) {
+	tests := []struct {
+		name   string
+		status mwaatypes.EnvironmentStatus
+		want   bool
+	}{
+		{name: "creating", status: mwaatypes.EnvironmentStatusCreating, want: true},
+		{name: "create failed", status: mwaatypes.EnvironmentStatusCreateFailed, want: true},
+		{name: "available", status: mwaatypes.EnvironmentStatusAvailable, want: true},
+		{name: "updating", status: mwaatypes.EnvironmentStatusUpdating, want: true},
+		{name: "unavailable", status: mwaatypes.EnvironmentStatusUnavailable, want: true},
+		{name: "update failed", status: mwaatypes.EnvironmentStatusUpdateFailed, want: true},
+		{name: "rolling back", status: mwaatypes.EnvironmentStatusRollingBack, want: true},
+		{name: "creating snapshot", status: mwaatypes.EnvironmentStatusCreatingSnapshot, want: true},
+		{name: "pending", status: mwaatypes.EnvironmentStatusPending, want: true},
+		{name: "maintenance", status: mwaatypes.EnvironmentStatusMaintenance, want: true},
+		{name: "empty", want: false},
+		{name: "deleting", status: mwaatypes.EnvironmentStatusDeleting, want: false},
+		{name: "deleted", status: mwaatypes.EnvironmentStatusDeleted, want: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := mwaaEnvironmentStatusImportable(tt.status); got != tt.want {
+				t.Fatalf("mwaaEnvironmentStatusImportable(%q) = %t, want %t", tt.status, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestMwaaResourceNamesPreserveSegmentBoundaries(t *testing.T) {
+	left, ok := newMwaaEnvironmentResource(validMwaaEnvironment("a/b_c"))
+	if !ok {
+		t.Fatal("left environment should be importable")
+	}
+	right, ok := newMwaaEnvironmentResource(validMwaaEnvironment("a-002F-b_c"))
+	if !ok {
+		t.Fatal("right environment should be importable")
+	}
+	if left.ResourceName == right.ResourceName {
+		t.Fatalf("environment resource names collide: %q", left.ResourceName)
+	}
+}
+
+func TestMwaaResourceNotFound(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{name: "nil", want: false},
+		{name: "resource not found", err: &mwaatypes.ResourceNotFoundException{}, want: true},
+		{name: "wrapped resource not found", err: errors.Join(errors.New("lookup failed"), &mwaatypes.ResourceNotFoundException{}), want: true},
+		{name: "generic", err: errors.New("boom"), want: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := mwaaResourceNotFound(tt.err); got != tt.want {
+				t.Fatalf("mwaaResourceNotFound(%v) = %t, want %t", tt.err, got, tt.want)
+			}
+		})
+	}
+}
+
+func assertMwaaResource(t *testing.T, resource terraformutils.Resource, ok bool, wantID, wantName, wantType string) {
+	t.Helper()
+	if !ok {
+		t.Fatal("resource was skipped")
+	}
+	if got := resource.InstanceState.ID; got != wantID {
+		t.Fatalf("resource ID = %q, want %q", got, wantID)
+	}
+	if got := resource.ResourceName; got != terraformutils.TfSanitize(wantName) {
+		t.Fatalf("resource name = %q, want %q", got, terraformutils.TfSanitize(wantName))
+	}
+	if got := resource.InstanceInfo.Type; got != wantType {
+		t.Fatalf("resource type = %q, want %q", got, wantType)
+	}
+}
+
+func assertMwaaAttribute(t *testing.T, resource terraformutils.Resource, key, want string) {
+	t.Helper()
+	if got := resource.InstanceState.Attributes[key]; got != want {
+		t.Fatalf("resource attribute %q = %q, want %q", key, got, want)
+	}
+}
+
+func validMwaaEnvironment(name string) *mwaatypes.Environment {
+	return &mwaatypes.Environment{
+		DagS3Path:        mwaaString("dags"),
+		ExecutionRoleArn: mwaaString("arn:aws:iam::123456789012:role/mwaa-execution"),
+		LastUpdate:       &mwaatypes.LastUpdate{},
+		Name:             mwaaString(name),
+		NetworkConfiguration: &mwaatypes.NetworkConfiguration{
+			SecurityGroupIds: []string{"sg-1"},
+			SubnetIds:        []string{"subnet-1", "subnet-2"},
+		},
+		SourceBucketArn: mwaaString("arn:aws:s3:::mwaa-source"),
+		Status:          mwaatypes.EnvironmentStatusAvailable,
+	}
+}
+
+func mwaaString(value string) *string {
+	return &value
+}


### PR DESCRIPTION
## Summary

- add MWAA environment import discovery
- register the `mwaa` AWS service
- seed import IDs as MWAA environment names
- update docs/aws.md for `aws_mwaa_environment`
- add unit tests for MWAA environment helper behavior

## References

- #338

## Validation

```bash
go test ./providers/aws -run 'Test.*MWAA|Test.*Mwaa|Test.*mwaa'
go test ./providers/aws/... ./terraformutils/...
go run ./tools/aws-gap-inventory \
  -docs docs/aws.md \
  -aws-dir providers/aws \
  -skip-list providers/aws/unsupported_resources.json \
  -format markdown
git diff --check
```

## Notes

Skipped/deferred resources:
- AppStream follow-ups, media services, Device Farm, QLDB, SWF, and MQ are outside this MWAA-only PR.
- Other MWAA resources: none found in Terraform AWS provider v6.44.0 schema; `aws_mwaa_environment` is the only MWAA provider resource in this pass.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds Amazon MWAA environment import support to the AWS provider, generating `aws_mwaa_environment` resources from discovered environments. Skips environments the current provider cannot refresh to avoid import errors.

- **New Features**
  - Discover and import MWAA environments using `ListEnvironments` and `GetEnvironment`.
  - Register `mwaa` and generate `aws_mwaa_environment` only when environments are valid (not deleted/deleting, required fields set, network config complete).
  - Update `docs/aws.md` and add unit tests for importability and naming.

- **Bug Fixes**
  - Skip environments the current provider can’t refresh (e.g., missing `LastUpdate`) so imports don’t fail.

<sup>Written for commit 81a4a10401783d42454215fa7ee9d5586417d9ef. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for AWS MWAA (Managed Workflows for Apache Airflow) environment resources, enabling import into Terraform.

* **Documentation**
  * Updated supported services list to include MWAA as an importable Terraform resource.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/chenrui333/terraformer/pull/415)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->