### PR TITLE
aws(guardduty): add GuardDuty core resource imports

### DIFF
--- a/docs/aws.md
+++ b/docs/aws.md
@@ -323,6 +323,11 @@ For AWS provider gap audits and unsupported-resource skip-list maintenance, see 
     * `aws_glue_trigger`
     * `aws_glue_user_defined_function`
     * `aws_glue_workflow`
+*   `guardduty`
+    * `aws_guardduty_detector`
+    * `aws_guardduty_filter`
+    * `aws_guardduty_ipset`
+    * `aws_guardduty_threatintelset`
 *   `iam`
     * `aws_iam_access_key`
     * `aws_iam_account_alias`

--- a/go.mod
+++ b/go.mod
@@ -408,6 +408,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/bedrock v1.59.2
 	github.com/aws/aws-sdk-go-v2/service/bedrockagent v1.53.2
 	github.com/aws/aws-sdk-go-v2/service/directconnect v1.38.17
+	github.com/aws/aws-sdk-go-v2/service/guardduty v1.75.4
 	github.com/aws/aws-sdk-go-v2/service/ivs v1.50.1
 	github.com/aws/aws-sdk-go-v2/service/ivschat v1.21.22
 	github.com/aws/aws-sdk-go-v2/service/mwaa v1.40.0

--- a/go.sum
+++ b/go.sum
@@ -297,6 +297,8 @@ github.com/aws/aws-sdk-go-v2/service/firehose v1.42.16 h1:nSg1UAENCjuryTr9JMPMOP
 github.com/aws/aws-sdk-go-v2/service/firehose v1.42.16/go.mod h1:8atLs+8lOWcDaxiD+suvyvt63IuwLbT8zlU6Ti9qZiY=
 github.com/aws/aws-sdk-go-v2/service/glue v1.141.0 h1:QeZdzcEB+eB76YvIHqZyxsmxH+f9f2kKDdz48UC4HCM=
 github.com/aws/aws-sdk-go-v2/service/glue v1.141.0/go.mod h1:FZCvt95CcJWRkZNRcmMW1uQkpDHmyUSkZfz3awyZgqg=
+github.com/aws/aws-sdk-go-v2/service/guardduty v1.75.4 h1:i/lHZlUwCvEiFU0Qbw2unKW4JsPezrIQEJe7K0dKVo8=
+github.com/aws/aws-sdk-go-v2/service/guardduty v1.75.4/go.mod h1:kCpMuo4vLtzUaugNCZGCkVtdehl2YvoSd73Jmiuh1M0=
 github.com/aws/aws-sdk-go-v2/service/iam v1.53.10 h1:kcN3I3llO7VwIY5w3Pc5FmEonpsr23Ou7Cwk4qf7dik=
 github.com/aws/aws-sdk-go-v2/service/iam v1.53.10/go.mod h1:1vkJzjCYC3byO0kIrBqLPzvZpuvYhPXkuyARs6E7tM4=
 github.com/aws/aws-sdk-go-v2/service/identitystore v1.36.7 h1:GsxxFPzdMhDGsNrTacu/ofQWLJRGCl3nwCS+Z0+rwQM=

--- a/providers/aws/aws_provider.go
+++ b/providers/aws/aws_provider.go
@@ -312,6 +312,7 @@ func (p *AWSProvider) GetSupportedService() map[string]terraformutils.ServiceGen
 		"es":                &AwsFacade{service: &EsGenerator{}},
 		"firehose":          &AwsFacade{service: &FirehoseGenerator{}},
 		"glue":              &AwsFacade{service: &GlueGenerator{}},
+		"guardduty":         &AwsFacade{service: &GuardDutyGenerator{}},
 		"iam":               &AwsFacade{service: &IamGenerator{}},
 		"identitystore":     &AwsFacade{service: &IdentityStoreGenerator{}},
 		"igw":               &AwsFacade{service: &IgwGenerator{}},

--- a/providers/aws/guardduty.go
+++ b/providers/aws/guardduty.go
@@ -1,0 +1,428 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package aws
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/guardduty"
+	guarddutytypes "github.com/aws/aws-sdk-go-v2/service/guardduty/types"
+	"github.com/chenrui333/terraformer/terraformutils"
+)
+
+const (
+	guardDutyDetectorResourceType       = "aws_guardduty_detector"
+	guardDutyFilterResourceType         = "aws_guardduty_filter"
+	guardDutyIPSetResourceType          = "aws_guardduty_ipset"
+	guardDutyThreatIntelSetResourceType = "aws_guardduty_threatintelset"
+
+	guardDutyResourceIDSeparator   = ":"
+	guardDutyResourceNameSeparator = ":"
+)
+
+var guardDutyAllowEmptyValues = []string{"tags."}
+
+// GuardDutyGenerator generates GuardDuty resources.
+type GuardDutyGenerator struct {
+	AWSService
+}
+
+// InitResources generates Terraform resources from the GuardDuty API.
+func (g *GuardDutyGenerator) InitResources() error {
+	config, e := g.generateConfig()
+	if e != nil {
+		return e
+	}
+	svc := guardduty.NewFromConfig(config)
+	detectors, e := listGuardDutyDetectors(svc)
+	if e != nil {
+		return e
+	}
+
+	for _, detectorID := range detectors {
+		if detectorID == "" {
+			continue
+		}
+		resourceStart := len(g.Resources)
+		detector, err := svc.GetDetector(context.TODO(), &guardduty.GetDetectorInput{
+			DetectorId: aws.String(detectorID),
+		})
+		if guardDutyResourceNotFound(err) {
+			continue
+		}
+		if err != nil {
+			return err
+		}
+		resource, ok := newGuardDutyDetectorResource(detectorID, detector)
+		if !ok {
+			continue
+		}
+		g.Resources = append(g.Resources, resource)
+
+		if err := g.loadDetectorChildren(svc, detectorID); err != nil {
+			if guardDutyResourceNotFound(err) {
+				g.Resources = g.Resources[:resourceStart]
+				continue
+			}
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (g *GuardDutyGenerator) loadDetectorChildren(svc *guardduty.Client, detectorID string) error {
+	if err := g.loadFilters(svc, detectorID); err != nil {
+		return err
+	}
+	if err := g.loadIPSets(svc, detectorID); err != nil {
+		return err
+	}
+	return g.loadThreatIntelSets(svc, detectorID)
+}
+
+func (g *GuardDutyGenerator) loadFilters(svc *guardduty.Client, detectorID string) error {
+	paginator := guardduty.NewListFiltersPaginator(svc, &guardduty.ListFiltersInput{
+		DetectorId: aws.String(detectorID),
+	})
+	for paginator.HasMorePages() {
+		page, err := paginator.NextPage(context.TODO())
+		if err != nil {
+			return err
+		}
+		for _, filterName := range page.FilterNames {
+			if filterName == "" {
+				continue
+			}
+			filter, err := svc.GetFilter(context.TODO(), &guardduty.GetFilterInput{
+				DetectorId: aws.String(detectorID),
+				FilterName: aws.String(filterName),
+			})
+			if guardDutyResourceNotFound(err) {
+				continue
+			}
+			if err != nil {
+				return err
+			}
+			resource, ok := newGuardDutyFilterResource(detectorID, filterName, filter)
+			if !ok {
+				continue
+			}
+			g.Resources = append(g.Resources, resource)
+		}
+	}
+	return nil
+}
+
+func (g *GuardDutyGenerator) loadIPSets(svc *guardduty.Client, detectorID string) error {
+	paginator := guardduty.NewListIPSetsPaginator(svc, &guardduty.ListIPSetsInput{
+		DetectorId: aws.String(detectorID),
+	})
+	for paginator.HasMorePages() {
+		page, err := paginator.NextPage(context.TODO())
+		if err != nil {
+			return err
+		}
+		for _, ipSetID := range page.IpSetIds {
+			if ipSetID == "" {
+				continue
+			}
+			ipSet, err := svc.GetIPSet(context.TODO(), &guardduty.GetIPSetInput{
+				DetectorId: aws.String(detectorID),
+				IpSetId:    aws.String(ipSetID),
+			})
+			if guardDutyResourceNotFound(err) {
+				continue
+			}
+			if err != nil {
+				return err
+			}
+			resource, ok := newGuardDutyIPSetResource(detectorID, ipSetID, ipSet)
+			if !ok {
+				continue
+			}
+			g.Resources = append(g.Resources, resource)
+		}
+	}
+	return nil
+}
+
+func (g *GuardDutyGenerator) loadThreatIntelSets(svc *guardduty.Client, detectorID string) error {
+	paginator := guardduty.NewListThreatIntelSetsPaginator(svc, &guardduty.ListThreatIntelSetsInput{
+		DetectorId: aws.String(detectorID),
+	})
+	for paginator.HasMorePages() {
+		page, err := paginator.NextPage(context.TODO())
+		if err != nil {
+			return err
+		}
+		for _, threatIntelSetID := range page.ThreatIntelSetIds {
+			if threatIntelSetID == "" {
+				continue
+			}
+			threatIntelSet, err := svc.GetThreatIntelSet(context.TODO(), &guardduty.GetThreatIntelSetInput{
+				DetectorId:       aws.String(detectorID),
+				ThreatIntelSetId: aws.String(threatIntelSetID),
+			})
+			if guardDutyResourceNotFound(err) {
+				continue
+			}
+			if err != nil {
+				return err
+			}
+			resource, ok := newGuardDutyThreatIntelSetResource(detectorID, threatIntelSetID, threatIntelSet)
+			if !ok {
+				continue
+			}
+			g.Resources = append(g.Resources, resource)
+		}
+	}
+	return nil
+}
+
+func listGuardDutyDetectors(svc *guardduty.Client) ([]string, error) {
+	var detectors []string
+	paginator := guardduty.NewListDetectorsPaginator(svc, &guardduty.ListDetectorsInput{})
+	for paginator.HasMorePages() {
+		page, err := paginator.NextPage(context.TODO())
+		if err != nil {
+			return nil, err
+		}
+		detectors = append(detectors, page.DetectorIds...)
+	}
+	return detectors, nil
+}
+
+func newGuardDutyDetectorResource(detectorID string, detector *guardduty.GetDetectorOutput) (terraformutils.Resource, bool) {
+	if detectorID == "" || detector == nil {
+		return terraformutils.Resource{}, false
+	}
+	attributes := map[string]string{
+		"enable": strconv.FormatBool(detector.Status == guarddutytypes.DetectorStatusEnabled),
+	}
+	if detector.FindingPublishingFrequency != "" {
+		attributes["finding_publishing_frequency"] = string(detector.FindingPublishingFrequency)
+	}
+	addGuardDutyDataSources(attributes, detector.DataSources)
+
+	return terraformutils.NewResource(
+		detectorID,
+		guardDutyResourceName("detector", detectorID),
+		guardDutyDetectorResourceType,
+		"aws",
+		attributes,
+		guardDutyAllowEmptyValues,
+		map[string]interface{}{},
+	), true
+}
+
+func newGuardDutyFilterResource(detectorID, filterName string, filter *guardduty.GetFilterOutput) (terraformutils.Resource, bool) {
+	if detectorID == "" || filter == nil {
+		return terraformutils.Resource{}, false
+	}
+	name := StringValue(filter.Name)
+	if name == "" {
+		name = filterName
+	}
+	if name == "" || filter.Action == "" || filter.Rank == nil {
+		return terraformutils.Resource{}, false
+	}
+
+	attributes, ok := guardDutyFindingCriteriaAttributes(filter.FindingCriteria)
+	if !ok {
+		return terraformutils.Resource{}, false
+	}
+	attributes["action"] = string(filter.Action)
+	attributes["detector_id"] = detectorID
+	attributes["name"] = name
+	attributes["rank"] = strconv.Itoa(int(*filter.Rank))
+	if description := StringValue(filter.Description); description != "" {
+		attributes["description"] = description
+	}
+
+	return terraformutils.NewResource(
+		guardDutyChildResourceID(detectorID, name),
+		guardDutyResourceName("filter", detectorID, name),
+		guardDutyFilterResourceType,
+		"aws",
+		attributes,
+		guardDutyAllowEmptyValues,
+		map[string]interface{}{},
+	), true
+}
+
+func newGuardDutyIPSetResource(detectorID, ipSetID string, ipSet *guardduty.GetIPSetOutput) (terraformutils.Resource, bool) {
+	if detectorID == "" || ipSetID == "" || ipSet == nil || ipSet.Status == guarddutytypes.IpSetStatusDeleted {
+		return terraformutils.Resource{}, false
+	}
+	name := StringValue(ipSet.Name)
+	if name == "" || ipSet.Format == "" || StringValue(ipSet.Location) == "" {
+		return terraformutils.Resource{}, false
+	}
+	attributes := map[string]string{
+		"activate":    strconv.FormatBool(ipSet.Status == guarddutytypes.IpSetStatusActive),
+		"detector_id": detectorID,
+		"format":      string(ipSet.Format),
+		"location":    StringValue(ipSet.Location),
+		"name":        name,
+	}
+
+	return terraformutils.NewResource(
+		guardDutyChildResourceID(detectorID, ipSetID),
+		guardDutyResourceName("ipset", detectorID, name, ipSetID),
+		guardDutyIPSetResourceType,
+		"aws",
+		attributes,
+		guardDutyAllowEmptyValues,
+		map[string]interface{}{},
+	), true
+}
+
+func newGuardDutyThreatIntelSetResource(detectorID, threatIntelSetID string, threatIntelSet *guardduty.GetThreatIntelSetOutput) (terraformutils.Resource, bool) {
+	if detectorID == "" || threatIntelSetID == "" || threatIntelSet == nil || threatIntelSet.Status == guarddutytypes.ThreatIntelSetStatusDeleted {
+		return terraformutils.Resource{}, false
+	}
+	name := StringValue(threatIntelSet.Name)
+	if name == "" || threatIntelSet.Format == "" || StringValue(threatIntelSet.Location) == "" {
+		return terraformutils.Resource{}, false
+	}
+	attributes := map[string]string{
+		"activate":    strconv.FormatBool(threatIntelSet.Status == guarddutytypes.ThreatIntelSetStatusActive),
+		"detector_id": detectorID,
+		"format":      string(threatIntelSet.Format),
+		"location":    StringValue(threatIntelSet.Location),
+		"name":        name,
+	}
+
+	return terraformutils.NewResource(
+		guardDutyChildResourceID(detectorID, threatIntelSetID),
+		guardDutyResourceName("threatintelset", detectorID, name, threatIntelSetID),
+		guardDutyThreatIntelSetResourceType,
+		"aws",
+		attributes,
+		guardDutyAllowEmptyValues,
+		map[string]interface{}{},
+	), true
+}
+
+func addGuardDutyDataSources(attributes map[string]string, dataSources *guarddutytypes.DataSourceConfigurationsResult) {
+	if dataSources == nil {
+		return
+	}
+	attributes["datasources.#"] = "1"
+	if dataSources.S3Logs != nil {
+		attributes["datasources.0.s3_logs.#"] = "1"
+		attributes["datasources.0.s3_logs.0.enable"] = strconv.FormatBool(dataSources.S3Logs.Status == guarddutytypes.DataSourceStatusEnabled)
+	}
+	if dataSources.Kubernetes != nil && dataSources.Kubernetes.AuditLogs != nil {
+		attributes["datasources.0.kubernetes.#"] = "1"
+		attributes["datasources.0.kubernetes.0.audit_logs.#"] = "1"
+		attributes["datasources.0.kubernetes.0.audit_logs.0.enable"] = strconv.FormatBool(dataSources.Kubernetes.AuditLogs.Status == guarddutytypes.DataSourceStatusEnabled)
+	}
+	if dataSources.MalwareProtection != nil && dataSources.MalwareProtection.ScanEc2InstanceWithFindings != nil && dataSources.MalwareProtection.ScanEc2InstanceWithFindings.EbsVolumes != nil {
+		attributes["datasources.0.malware_protection.#"] = "1"
+		attributes["datasources.0.malware_protection.0.scan_ec2_instance_with_findings.#"] = "1"
+		attributes["datasources.0.malware_protection.0.scan_ec2_instance_with_findings.0.ebs_volumes.#"] = "1"
+		attributes["datasources.0.malware_protection.0.scan_ec2_instance_with_findings.0.ebs_volumes.0.enable"] = strconv.FormatBool(dataSources.MalwareProtection.ScanEc2InstanceWithFindings.EbsVolumes.Status == guarddutytypes.DataSourceStatusEnabled)
+	}
+}
+
+func guardDutyFindingCriteriaAttributes(criteria *guarddutytypes.FindingCriteria) (map[string]string, bool) {
+	if criteria == nil || len(criteria.Criterion) == 0 {
+		return nil, false
+	}
+	fields := make([]string, 0, len(criteria.Criterion))
+	for field, condition := range criteria.Criterion {
+		if field == "" || !guardDutyConditionConfigured(condition) {
+			continue
+		}
+		fields = append(fields, field)
+	}
+	if len(fields) == 0 {
+		return nil, false
+	}
+	sort.Strings(fields)
+
+	attributes := map[string]string{
+		"finding_criteria.#":             "1",
+		"finding_criteria.0.criterion.#": strconv.Itoa(len(fields)),
+	}
+	for i, field := range fields {
+		condition := criteria.Criterion[field]
+		prefix := fmt.Sprintf("finding_criteria.0.criterion.%d", i)
+		attributes[prefix+".field"] = field
+		guardDutyListAttributes(attributes, prefix+".equals", condition.Equals)
+		guardDutyListAttributes(attributes, prefix+".not_equals", condition.NotEquals)
+		guardDutyListAttributes(attributes, prefix+".matches", condition.Matches)
+		guardDutyListAttributes(attributes, prefix+".not_matches", condition.NotMatches)
+		guardDutyConditionIntAttribute(attributes, prefix+".greater_than", field, condition.GreaterThan)
+		guardDutyConditionIntAttribute(attributes, prefix+".greater_than_or_equal", field, condition.GreaterThanOrEqual)
+		guardDutyConditionIntAttribute(attributes, prefix+".less_than", field, condition.LessThan)
+		guardDutyConditionIntAttribute(attributes, prefix+".less_than_or_equal", field, condition.LessThanOrEqual)
+	}
+	return attributes, true
+}
+
+func guardDutyConditionConfigured(condition guarddutytypes.Condition) bool {
+	return len(condition.Equals) > 0 ||
+		len(condition.NotEquals) > 0 ||
+		len(condition.Matches) > 0 ||
+		len(condition.NotMatches) > 0 ||
+		condition.GreaterThan != nil ||
+		condition.GreaterThanOrEqual != nil ||
+		condition.LessThan != nil ||
+		condition.LessThanOrEqual != nil
+}
+
+func guardDutyListAttributes(attributes map[string]string, prefix string, values []string) {
+	if len(values) == 0 {
+		return
+	}
+	attributes[prefix+".#"] = strconv.Itoa(len(values))
+	for i, value := range values {
+		attributes[fmt.Sprintf("%s.%d", prefix, i)] = value
+	}
+}
+
+func guardDutyConditionIntAttribute(attributes map[string]string, key, field string, value *int64) {
+	if value == nil || *value <= 0 {
+		return
+	}
+	attributes[key] = guardDutyConditionIntValue(field, *value)
+}
+
+func guardDutyConditionIntValue(field string, value int64) string {
+	if field == "updatedAt" {
+		return time.Unix(value/1000, value%1000).UTC().Format(time.RFC3339)
+	}
+	return strconv.FormatInt(value, 10)
+}
+
+func guardDutyChildResourceID(detectorID, resourceID string) string {
+	return strings.Join([]string{detectorID, resourceID}, guardDutyResourceIDSeparator)
+}
+
+func guardDutyResourceName(parts ...string) string {
+	return strings.Join(parts, guardDutyResourceNameSeparator)
+}
+
+func guardDutyResourceNotFound(err error) bool {
+	if err == nil {
+		return false
+	}
+	var badRequest *guarddutytypes.BadRequestException
+	if !errors.As(err, &badRequest) {
+		return false
+	}
+	message := strings.ToLower(badRequest.ErrorMessage())
+	return strings.Contains(message, "no such resource found") ||
+		strings.Contains(message, "input detectorid is not owned by the current account") ||
+		strings.Contains(message, "input detectorid is not owned by current account")
+}

--- a/providers/aws/guardduty.go
+++ b/providers/aws/guardduty.go
@@ -400,7 +400,7 @@ func guardDutyConditionIntAttribute(attributes map[string]string, key, field str
 
 func guardDutyConditionIntValue(field string, value int64) string {
 	if field == "updatedAt" {
-		return time.Unix(value/1000, value%1000).UTC().Format(time.RFC3339)
+		return time.UnixMilli(value).UTC().Format(time.RFC3339Nano)
 	}
 	return strconv.FormatInt(value, 10)
 }

--- a/providers/aws/guardduty.go
+++ b/providers/aws/guardduty.go
@@ -4,6 +4,7 @@ package aws
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"sort"
@@ -15,6 +16,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/guardduty"
 	guarddutytypes "github.com/aws/aws-sdk-go-v2/service/guardduty/types"
 	"github.com/chenrui333/terraformer/terraformutils"
+	"github.com/chenrui333/terraformer/terraformutils/tfcompat"
 )
 
 const (
@@ -88,7 +90,7 @@ func (g *GuardDutyGenerator) PostConvertHook() error {
 			continue
 		}
 		updatedAtCriteria := guardDutyUpdatedAtCriteriaFromAdditionalFields(resource.AdditionalFields)
-		guardDutyRestoreUpdatedAtCriteria(resource.Item, updatedAtCriteria)
+		guardDutyRestoreUpdatedAtCriteria(resource, updatedAtCriteria)
 	}
 	return nil
 }
@@ -225,7 +227,7 @@ func newGuardDutyDetectorResource(detectorID string, detector *guardduty.GetDete
 	if detector.FindingPublishingFrequency != "" {
 		attributes["finding_publishing_frequency"] = string(detector.FindingPublishingFrequency)
 	}
-	addGuardDutyDataSources(attributes, detector.DataSources)
+	addGuardDutyDataSources(attributes, detector.DataSources) //nolint:staticcheck // DataSources backs Terraform's deprecated datasources block.
 
 	return terraformutils.NewResource(
 		detectorID,
@@ -468,7 +470,19 @@ func guardDutyUpdatedAtCriteriaFromAdditionalFields(additionalFields map[string]
 	}
 }
 
-func guardDutyRestoreUpdatedAtCriteria(item map[string]interface{}, updatedAtCriteria map[string]string) {
+func guardDutyRestoreUpdatedAtCriteria(resource *terraformutils.Resource, updatedAtCriteria map[string]string) {
+	if resource == nil {
+		return
+	}
+	guardDutyRestoreUpdatedAtCriteriaItem(resource.Item, updatedAtCriteria)
+	if resource.InstanceState == nil {
+		return
+	}
+	guardDutyRestoreUpdatedAtCriteriaAttributes(resource.InstanceState.Attributes, updatedAtCriteria)
+	guardDutyRestoreUpdatedAtCriteriaTypedAttributes(resource.InstanceState, updatedAtCriteria)
+}
+
+func guardDutyRestoreUpdatedAtCriteriaItem(item map[string]interface{}, updatedAtCriteria map[string]string) {
 	if item == nil {
 		return
 	}
@@ -494,6 +508,40 @@ func guardDutyRestoreUpdatedAtCriteria(item map[string]interface{}, updatedAtCri
 			}
 		}
 	}
+}
+
+func guardDutyRestoreUpdatedAtCriteriaAttributes(attributes map[string]string, updatedAtCriteria map[string]string) {
+	if len(attributes) == 0 || len(updatedAtCriteria) == 0 {
+		return
+	}
+	for key, value := range attributes {
+		if value != guardDutyUpdatedAtField || !strings.HasPrefix(key, "finding_criteria.") || !strings.HasSuffix(key, ".field") {
+			continue
+		}
+		criterionPrefix := strings.TrimSuffix(key, ".field")
+		for conditionKey, conditionValue := range updatedAtCriteria {
+			attributeKey := criterionPrefix + "." + conditionKey
+			if _, ok := attributes[attributeKey]; ok {
+				attributes[attributeKey] = conditionValue
+			}
+		}
+	}
+}
+
+func guardDutyRestoreUpdatedAtCriteriaTypedAttributes(state *tfcompat.InstanceState, updatedAtCriteria map[string]string) {
+	if state == nil || len(state.TypedAttributes) == 0 || len(updatedAtCriteria) == 0 {
+		return
+	}
+	var attributes map[string]interface{}
+	if err := json.Unmarshal(state.TypedAttributes, &attributes); err != nil {
+		return
+	}
+	guardDutyRestoreUpdatedAtCriteriaItem(attributes, updatedAtCriteria)
+	raw, err := json.Marshal(attributes)
+	if err != nil {
+		return
+	}
+	state.SetTypedAttributes(raw)
 }
 
 func guardDutyInterfaceSlice(value interface{}) []interface{} {

--- a/providers/aws/guardduty.go
+++ b/providers/aws/guardduty.go
@@ -25,6 +25,9 @@ const (
 
 	guardDutyResourceIDSeparator   = ":"
 	guardDutyResourceNameSeparator = ":"
+	guardDutyUpdatedAtField        = "updatedAt"
+
+	guardDutyFilterUpdatedAtCriteriaAdditionalField = "__guardduty_filter_updated_at_criteria"
 )
 
 var guardDutyAllowEmptyValues = []string{"tags."}
@@ -75,6 +78,18 @@ func (g *GuardDutyGenerator) InitResources() error {
 		}
 	}
 
+	return nil
+}
+
+func (g *GuardDutyGenerator) PostConvertHook() error {
+	for i := range g.Resources {
+		resource := &g.Resources[i]
+		if resource.InstanceInfo == nil || resource.InstanceInfo.Type != guardDutyFilterResourceType {
+			continue
+		}
+		updatedAtCriteria := guardDutyUpdatedAtCriteriaFromAdditionalFields(resource.AdditionalFields)
+		guardDutyRestoreUpdatedAtCriteria(resource.Item, updatedAtCriteria)
+	}
 	return nil
 }
 
@@ -246,6 +261,10 @@ func newGuardDutyFilterResource(detectorID, filterName string, filter *guardduty
 	if description := StringValue(filter.Description); description != "" {
 		attributes["description"] = description
 	}
+	additionalFields := map[string]interface{}{}
+	if updatedAtCriteria := guardDutyUpdatedAtCriteria(filter.FindingCriteria); len(updatedAtCriteria) > 0 {
+		additionalFields[guardDutyFilterUpdatedAtCriteriaAdditionalField] = updatedAtCriteria
+	}
 
 	return terraformutils.NewResource(
 		guardDutyChildResourceID(detectorID, name),
@@ -254,7 +273,7 @@ func newGuardDutyFilterResource(detectorID, filterName string, filter *guardduty
 		"aws",
 		attributes,
 		guardDutyAllowEmptyValues,
-		map[string]interface{}{},
+		additionalFields,
 	), true
 }
 
@@ -399,10 +418,97 @@ func guardDutyConditionIntAttribute(attributes map[string]string, key, field str
 }
 
 func guardDutyConditionIntValue(field string, value int64) string {
-	if field == "updatedAt" {
+	if field == guardDutyUpdatedAtField {
 		return time.UnixMilli(value).UTC().Format(time.RFC3339Nano)
 	}
 	return strconv.FormatInt(value, 10)
+}
+
+func guardDutyUpdatedAtCriteria(criteria *guarddutytypes.FindingCriteria) map[string]string {
+	if criteria == nil {
+		return nil
+	}
+	condition, ok := criteria.Criterion[guardDutyUpdatedAtField]
+	if !ok {
+		return nil
+	}
+	updatedAtCriteria := map[string]string{}
+	guardDutyUpdatedAtCriteriaValue(updatedAtCriteria, "greater_than", condition.GreaterThan)
+	guardDutyUpdatedAtCriteriaValue(updatedAtCriteria, "greater_than_or_equal", condition.GreaterThanOrEqual)
+	guardDutyUpdatedAtCriteriaValue(updatedAtCriteria, "less_than", condition.LessThan)
+	guardDutyUpdatedAtCriteriaValue(updatedAtCriteria, "less_than_or_equal", condition.LessThanOrEqual)
+	return updatedAtCriteria
+}
+
+func guardDutyUpdatedAtCriteriaValue(criteria map[string]string, key string, value *int64) {
+	if value == nil || *value <= 0 {
+		return
+	}
+	criteria[key] = guardDutyConditionIntValue(guardDutyUpdatedAtField, *value)
+}
+
+func guardDutyUpdatedAtCriteriaFromAdditionalFields(additionalFields map[string]interface{}) map[string]string {
+	raw, ok := additionalFields[guardDutyFilterUpdatedAtCriteriaAdditionalField]
+	if !ok {
+		return nil
+	}
+	switch criteria := raw.(type) {
+	case map[string]string:
+		return criteria
+	case map[string]interface{}:
+		updatedAtCriteria := map[string]string{}
+		for key, value := range criteria {
+			if text, ok := value.(string); ok {
+				updatedAtCriteria[key] = text
+			}
+		}
+		return updatedAtCriteria
+	default:
+		return nil
+	}
+}
+
+func guardDutyRestoreUpdatedAtCriteria(item map[string]interface{}, updatedAtCriteria map[string]string) {
+	if item == nil {
+		return
+	}
+	delete(item, guardDutyFilterUpdatedAtCriteriaAdditionalField)
+	if len(updatedAtCriteria) == 0 {
+		return
+	}
+
+	for _, findingCriteria := range guardDutyInterfaceSlice(item["finding_criteria"]) {
+		findingCriteriaMap, ok := findingCriteria.(map[string]interface{})
+		if !ok {
+			continue
+		}
+		for _, criterion := range guardDutyInterfaceSlice(findingCriteriaMap["criterion"]) {
+			criterionMap, ok := criterion.(map[string]interface{})
+			if !ok || criterionMap["field"] != guardDutyUpdatedAtField {
+				continue
+			}
+			for key, value := range updatedAtCriteria {
+				if _, ok := criterionMap[key]; ok {
+					criterionMap[key] = value
+				}
+			}
+		}
+	}
+}
+
+func guardDutyInterfaceSlice(value interface{}) []interface{} {
+	switch values := value.(type) {
+	case []interface{}:
+		return values
+	case []map[string]interface{}:
+		result := make([]interface{}, 0, len(values))
+		for _, value := range values {
+			result = append(result, value)
+		}
+		return result
+	default:
+		return nil
+	}
 }
 
 func guardDutyChildResourceID(detectorID, resourceID string) string {

--- a/providers/aws/guardduty_test.go
+++ b/providers/aws/guardduty_test.go
@@ -153,6 +153,61 @@ func TestGuardDutyFilterResource(t *testing.T) {
 			t.Fatalf("%s = %q, want %q", key, got, want)
 		}
 	}
+	updatedAtCriteria, ok := resource.AdditionalFields[guardDutyFilterUpdatedAtCriteriaAdditionalField].(map[string]string)
+	if !ok {
+		t.Fatalf("missing updatedAt criteria metadata in %#v", resource.AdditionalFields)
+	}
+	if got, want := updatedAtCriteria["greater_than"], "2024-03-09T16:00:00.123Z"; got != want {
+		t.Fatalf("updatedAt greater_than metadata = %q, want %q", got, want)
+	}
+}
+
+func TestGuardDutyPostConvertHookPreservesUpdatedAtMillisecondsAfterRefresh(t *testing.T) {
+	rank := int32(7)
+	greaterThan := int64(1710000000123)
+	resource, ok := newGuardDutyFilterResource(testGuardDutyDetectorID, testGuardDutyFilterName, &guardduty.GetFilterOutput{
+		Action: guarddutytypes.FilterActionArchive,
+		FindingCriteria: &guarddutytypes.FindingCriteria{
+			Criterion: map[string]guarddutytypes.Condition{
+				"updatedAt": {
+					GreaterThan: &greaterThan,
+				},
+			},
+		},
+		Name: aws.String(testGuardDutyFilterName),
+		Rank: &rank,
+	})
+	if !ok {
+		t.Fatal("expected filter resource")
+	}
+	resource.Item = map[string]interface{}{
+		guardDutyFilterUpdatedAtCriteriaAdditionalField: resource.AdditionalFields[guardDutyFilterUpdatedAtCriteriaAdditionalField],
+		"finding_criteria": []interface{}{
+			map[string]interface{}{
+				"criterion": []interface{}{
+					map[string]interface{}{
+						"field":        "updatedAt",
+						"greater_than": "2024-03-09T16:00:00Z",
+					},
+				},
+			},
+		},
+	}
+
+	g := GuardDutyGenerator{}
+	g.Resources = append(g.Resources, resource)
+	if err := g.PostConvertHook(); err != nil {
+		t.Fatalf("PostConvertHook() error = %v", err)
+	}
+
+	if _, ok := g.Resources[0].Item[guardDutyFilterUpdatedAtCriteriaAdditionalField]; ok {
+		t.Fatalf("unexpected metadata in item: %#v", g.Resources[0].Item)
+	}
+	findingCriteria := g.Resources[0].Item["finding_criteria"].([]interface{})[0].(map[string]interface{})
+	criterion := findingCriteria["criterion"].([]interface{})[0].(map[string]interface{})
+	if got, want := criterion["greater_than"], "2024-03-09T16:00:00.123Z"; got != want {
+		t.Fatalf("greater_than = %q, want %q", got, want)
+	}
 }
 
 func TestGuardDutyIPSetResource(t *testing.T) {

--- a/providers/aws/guardduty_test.go
+++ b/providers/aws/guardduty_test.go
@@ -104,7 +104,7 @@ func TestGuardDutyDetectorResource(t *testing.T) {
 
 func TestGuardDutyFilterResource(t *testing.T) {
 	rank := int32(7)
-	greaterThan := int64(1710000000000)
+	greaterThan := int64(1710000000123)
 	lessThan := int64(5)
 	resource, ok := newGuardDutyFilterResource(testGuardDutyDetectorID, testGuardDutyFilterName, &guardduty.GetFilterOutput{
 		Action:      guarddutytypes.FilterActionArchive,
@@ -147,7 +147,7 @@ func TestGuardDutyFilterResource(t *testing.T) {
 		"finding_criteria.0.criterion.0.not_equals.#":          "1",
 		"finding_criteria.0.criterion.0.not_equals.0":          "1",
 		"finding_criteria.0.criterion.1.field":                 "updatedAt",
-		"finding_criteria.0.criterion.1.greater_than":          "2024-03-09T16:00:00Z",
+		"finding_criteria.0.criterion.1.greater_than":          "2024-03-09T16:00:00.123Z",
 	} {
 		if got := attributes[key]; got != want {
 			t.Fatalf("%s = %q, want %q", key, got, want)

--- a/providers/aws/guardduty_test.go
+++ b/providers/aws/guardduty_test.go
@@ -3,6 +3,7 @@
 package aws
 
 import (
+	"encoding/json"
 	"errors"
 	"testing"
 
@@ -180,6 +181,8 @@ func TestGuardDutyPostConvertHookPreservesUpdatedAtMillisecondsAfterRefresh(t *t
 	if !ok {
 		t.Fatal("expected filter resource")
 	}
+	resource.InstanceState.Attributes["finding_criteria.0.criterion.0.greater_than"] = "2024-03-09T16:00:00Z"
+	resource.InstanceState.SetTypedAttributes(json.RawMessage(`{"finding_criteria":[{"criterion":[{"field":"updatedAt","greater_than":"2024-03-09T16:00:00Z"}]}]}`))
 	resource.Item = map[string]interface{}{
 		guardDutyFilterUpdatedAtCriteriaAdditionalField: resource.AdditionalFields[guardDutyFilterUpdatedAtCriteriaAdditionalField],
 		"finding_criteria": []interface{}{
@@ -207,6 +210,21 @@ func TestGuardDutyPostConvertHookPreservesUpdatedAtMillisecondsAfterRefresh(t *t
 	criterion := findingCriteria["criterion"].([]interface{})[0].(map[string]interface{})
 	if got, want := criterion["greater_than"], "2024-03-09T16:00:00.123Z"; got != want {
 		t.Fatalf("greater_than = %q, want %q", got, want)
+	}
+	if got, want := g.Resources[0].InstanceState.Attributes["finding_criteria.0.criterion.0.greater_than"], "2024-03-09T16:00:00.123Z"; got != want {
+		t.Fatalf("state greater_than = %q, want %q", got, want)
+	}
+	var typedAttributes map[string]interface{}
+	if err := json.Unmarshal(g.Resources[0].InstanceState.TypedAttributes, &typedAttributes); err != nil {
+		t.Fatalf("TypedAttributes unmarshal error: %v", err)
+	}
+	typedFindingCriteria := typedAttributes["finding_criteria"].([]interface{})[0].(map[string]interface{})
+	typedCriterion := typedFindingCriteria["criterion"].([]interface{})[0].(map[string]interface{})
+	if got, want := typedCriterion["greater_than"], "2024-03-09T16:00:00.123Z"; got != want {
+		t.Fatalf("typed greater_than = %q, want %q", got, want)
+	}
+	if !g.Resources[0].InstanceState.HasCurrentTypedAttributes() {
+		t.Fatal("typed attributes should track patched flat state")
 	}
 }
 

--- a/providers/aws/guardduty_test.go
+++ b/providers/aws/guardduty_test.go
@@ -1,0 +1,328 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package aws
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/guardduty"
+	guarddutytypes "github.com/aws/aws-sdk-go-v2/service/guardduty/types"
+)
+
+const (
+	testGuardDutyDetectorID       = "12abc34d567e8fa901bc2d34e56789f0"
+	testGuardDutyFilterName       = "CriticalFindings"
+	testGuardDutyIPSetID          = "ipset-1234567890abcdef"
+	testGuardDutyThreatIntelSetID = "threatintelset-1234567890abcdef"
+)
+
+func TestGuardDutyResourceIDs(t *testing.T) {
+	tests := []struct {
+		name string
+		got  string
+		want string
+	}{
+		{
+			name: "detector",
+			got:  testGuardDutyDetectorID,
+			want: testGuardDutyDetectorID,
+		},
+		{
+			name: "filter",
+			got:  guardDutyChildResourceID(testGuardDutyDetectorID, testGuardDutyFilterName),
+			want: testGuardDutyDetectorID + ":" + testGuardDutyFilterName,
+		},
+		{
+			name: "ip set",
+			got:  guardDutyChildResourceID(testGuardDutyDetectorID, testGuardDutyIPSetID),
+			want: testGuardDutyDetectorID + ":" + testGuardDutyIPSetID,
+		},
+		{
+			name: "threat intel set",
+			got:  guardDutyChildResourceID(testGuardDutyDetectorID, testGuardDutyThreatIntelSetID),
+			want: testGuardDutyDetectorID + ":" + testGuardDutyThreatIntelSetID,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.got != tt.want {
+				t.Fatalf("resource ID = %q, want %q", tt.got, tt.want)
+			}
+		})
+	}
+}
+
+func TestGuardDutyDetectorResource(t *testing.T) {
+	resource, ok := newGuardDutyDetectorResource(testGuardDutyDetectorID, &guardduty.GetDetectorOutput{
+		FindingPublishingFrequency: guarddutytypes.FindingPublishingFrequencyFifteenMinutes,
+		Status:                     guarddutytypes.DetectorStatusEnabled,
+		DataSources: &guarddutytypes.DataSourceConfigurationsResult{
+			S3Logs: &guarddutytypes.S3LogsConfigurationResult{Status: guarddutytypes.DataSourceStatusEnabled},
+			Kubernetes: &guarddutytypes.KubernetesConfigurationResult{
+				AuditLogs: &guarddutytypes.KubernetesAuditLogsConfigurationResult{Status: guarddutytypes.DataSourceStatusDisabled},
+			},
+			MalwareProtection: &guarddutytypes.MalwareProtectionConfigurationResult{
+				ScanEc2InstanceWithFindings: &guarddutytypes.ScanEc2InstanceWithFindingsResult{
+					EbsVolumes: &guarddutytypes.EbsVolumesResult{Status: guarddutytypes.DataSourceStatusEnabled},
+				},
+			},
+		},
+	})
+	if !ok {
+		t.Fatal("expected detector resource")
+	}
+
+	if got, want := resource.InstanceState.ID, testGuardDutyDetectorID; got != want {
+		t.Fatalf("resource ID = %q, want %q", got, want)
+	}
+	if got, want := resource.InstanceInfo.Type, guardDutyDetectorResourceType; got != want {
+		t.Fatalf("resource type = %q, want %q", got, want)
+	}
+	attributes := resource.InstanceState.Attributes
+	for key, want := range map[string]string{
+		"enable":                                         "true",
+		"finding_publishing_frequency":                   "FIFTEEN_MINUTES",
+		"datasources.#":                                  "1",
+		"datasources.0.s3_logs.#":                        "1",
+		"datasources.0.s3_logs.0.enable":                 "true",
+		"datasources.0.kubernetes.#":                     "1",
+		"datasources.0.kubernetes.0.audit_logs.#":        "1",
+		"datasources.0.kubernetes.0.audit_logs.0.enable": "false",
+		"datasources.0.malware_protection.#":             "1",
+		"datasources.0.malware_protection.0.scan_ec2_instance_with_findings.#":                      "1",
+		"datasources.0.malware_protection.0.scan_ec2_instance_with_findings.0.ebs_volumes.#":        "1",
+		"datasources.0.malware_protection.0.scan_ec2_instance_with_findings.0.ebs_volumes.0.enable": "true",
+	} {
+		if got := attributes[key]; got != want {
+			t.Fatalf("%s = %q, want %q", key, got, want)
+		}
+	}
+}
+
+func TestGuardDutyFilterResource(t *testing.T) {
+	rank := int32(7)
+	greaterThan := int64(1710000000000)
+	lessThan := int64(5)
+	resource, ok := newGuardDutyFilterResource(testGuardDutyDetectorID, testGuardDutyFilterName, &guardduty.GetFilterOutput{
+		Action:      guarddutytypes.FilterActionArchive,
+		Description: aws.String("archive known findings"),
+		FindingCriteria: &guarddutytypes.FindingCriteria{
+			Criterion: map[string]guarddutytypes.Condition{
+				"severity": {
+					GreaterThanOrEqual: &lessThan,
+					NotEquals:          []string{"1"},
+				},
+				"updatedAt": {
+					GreaterThan: &greaterThan,
+				},
+			},
+		},
+		Name: aws.String(testGuardDutyFilterName),
+		Rank: &rank,
+	})
+	if !ok {
+		t.Fatal("expected filter resource")
+	}
+
+	if got, want := resource.InstanceState.ID, testGuardDutyDetectorID+":"+testGuardDutyFilterName; got != want {
+		t.Fatalf("resource ID = %q, want %q", got, want)
+	}
+	if got, want := resource.InstanceInfo.Type, guardDutyFilterResourceType; got != want {
+		t.Fatalf("resource type = %q, want %q", got, want)
+	}
+	attributes := resource.InstanceState.Attributes
+	for key, want := range map[string]string{
+		"action":                               "ARCHIVE",
+		"description":                          "archive known findings",
+		"detector_id":                          testGuardDutyDetectorID,
+		"name":                                 testGuardDutyFilterName,
+		"rank":                                 "7",
+		"finding_criteria.#":                   "1",
+		"finding_criteria.0.criterion.#":       "2",
+		"finding_criteria.0.criterion.0.field": "severity",
+		"finding_criteria.0.criterion.0.greater_than_or_equal": "5",
+		"finding_criteria.0.criterion.0.not_equals.#":          "1",
+		"finding_criteria.0.criterion.0.not_equals.0":          "1",
+		"finding_criteria.0.criterion.1.field":                 "updatedAt",
+		"finding_criteria.0.criterion.1.greater_than":          "2024-03-09T16:00:00Z",
+	} {
+		if got := attributes[key]; got != want {
+			t.Fatalf("%s = %q, want %q", key, got, want)
+		}
+	}
+}
+
+func TestGuardDutyIPSetResource(t *testing.T) {
+	resource, ok := newGuardDutyIPSetResource(testGuardDutyDetectorID, testGuardDutyIPSetID, &guardduty.GetIPSetOutput{
+		Format:   guarddutytypes.IpSetFormatTxt,
+		Location: aws.String("s3://example-bucket/ipset.txt"),
+		Name:     aws.String("trusted-ipset"),
+		Status:   guarddutytypes.IpSetStatusActive,
+	})
+	if !ok {
+		t.Fatal("expected ipset resource")
+	}
+
+	if got, want := resource.InstanceState.ID, testGuardDutyDetectorID+":"+testGuardDutyIPSetID; got != want {
+		t.Fatalf("resource ID = %q, want %q", got, want)
+	}
+	if got, want := resource.InstanceInfo.Type, guardDutyIPSetResourceType; got != want {
+		t.Fatalf("resource type = %q, want %q", got, want)
+	}
+	attributes := resource.InstanceState.Attributes
+	for key, want := range map[string]string{
+		"activate":    "true",
+		"detector_id": testGuardDutyDetectorID,
+		"format":      "TXT",
+		"location":    "s3://example-bucket/ipset.txt",
+		"name":        "trusted-ipset",
+	} {
+		if got := attributes[key]; got != want {
+			t.Fatalf("%s = %q, want %q", key, got, want)
+		}
+	}
+	if _, ok := attributes["ip_set_id"]; ok {
+		t.Fatalf("unexpected ip_set_id attribute in %#v", attributes)
+	}
+}
+
+func TestGuardDutyThreatIntelSetResource(t *testing.T) {
+	resource, ok := newGuardDutyThreatIntelSetResource(testGuardDutyDetectorID, testGuardDutyThreatIntelSetID, &guardduty.GetThreatIntelSetOutput{
+		Format:   guarddutytypes.ThreatIntelSetFormatStix,
+		Location: aws.String("s3://example-bucket/threats.stix"),
+		Name:     aws.String("known-threats"),
+		Status:   guarddutytypes.ThreatIntelSetStatusInactive,
+	})
+	if !ok {
+		t.Fatal("expected threat intel set resource")
+	}
+
+	if got, want := resource.InstanceState.ID, testGuardDutyDetectorID+":"+testGuardDutyThreatIntelSetID; got != want {
+		t.Fatalf("resource ID = %q, want %q", got, want)
+	}
+	if got, want := resource.InstanceInfo.Type, guardDutyThreatIntelSetResourceType; got != want {
+		t.Fatalf("resource type = %q, want %q", got, want)
+	}
+	attributes := resource.InstanceState.Attributes
+	for key, want := range map[string]string{
+		"activate":    "false",
+		"detector_id": testGuardDutyDetectorID,
+		"format":      "STIX",
+		"location":    "s3://example-bucket/threats.stix",
+		"name":        "known-threats",
+	} {
+		if got := attributes[key]; got != want {
+			t.Fatalf("%s = %q, want %q", key, got, want)
+		}
+	}
+	if _, ok := attributes["threat_intel_set_id"]; ok {
+		t.Fatalf("unexpected threat_intel_set_id attribute in %#v", attributes)
+	}
+}
+
+func TestGuardDutyEmptyIdentifierSkipBehavior(t *testing.T) {
+	if _, ok := newGuardDutyDetectorResource("", &guardduty.GetDetectorOutput{}); ok {
+		t.Fatal("expected empty detector ID to skip")
+	}
+	if _, ok := newGuardDutyFilterResource(testGuardDutyDetectorID, "", &guardduty.GetFilterOutput{}); ok {
+		t.Fatal("expected empty filter to skip")
+	}
+	if _, ok := newGuardDutyIPSetResource(testGuardDutyDetectorID, "", &guardduty.GetIPSetOutput{}); ok {
+		t.Fatal("expected empty ipset ID to skip")
+	}
+	if _, ok := newGuardDutyThreatIntelSetResource(testGuardDutyDetectorID, "", &guardduty.GetThreatIntelSetOutput{}); ok {
+		t.Fatal("expected empty threat intel set ID to skip")
+	}
+}
+
+func TestGuardDutyDeletedResourcesAreSkipped(t *testing.T) {
+	if _, ok := newGuardDutyIPSetResource(testGuardDutyDetectorID, testGuardDutyIPSetID, &guardduty.GetIPSetOutput{
+		Format:   guarddutytypes.IpSetFormatTxt,
+		Location: aws.String("s3://example-bucket/ipset.txt"),
+		Name:     aws.String("trusted-ipset"),
+		Status:   guarddutytypes.IpSetStatusDeleted,
+	}); ok {
+		t.Fatal("expected deleted ipset to skip")
+	}
+	if _, ok := newGuardDutyThreatIntelSetResource(testGuardDutyDetectorID, testGuardDutyThreatIntelSetID, &guardduty.GetThreatIntelSetOutput{
+		Format:   guarddutytypes.ThreatIntelSetFormatStix,
+		Location: aws.String("s3://example-bucket/threats.stix"),
+		Name:     aws.String("known-threats"),
+		Status:   guarddutytypes.ThreatIntelSetStatusDeleted,
+	}); ok {
+		t.Fatal("expected deleted threat intel set to skip")
+	}
+}
+
+func TestGuardDutyResourceNamesDoNotCollapseJoinedParts(t *testing.T) {
+	one := guardDutyResourceName("filter", "detector_a", "b")
+	two := guardDutyResourceName("filter", "detector", "a_b")
+	if one == two {
+		t.Fatalf("resource names collapsed before sanitize: %q", one)
+	}
+	resourceOne, ok := newGuardDutyFilterResource("detector_a", "b", guardDutyTestFilter("b"))
+	if !ok {
+		t.Fatal("expected first filter resource")
+	}
+	resourceTwo, ok := newGuardDutyFilterResource("detector", "a_b", guardDutyTestFilter("a_b"))
+	if !ok {
+		t.Fatal("expected second filter resource")
+	}
+	if resourceOne.ResourceName == resourceTwo.ResourceName {
+		t.Fatalf("resource names collapsed after sanitize: %q", resourceOne.ResourceName)
+	}
+}
+
+func TestGuardDutyResourceNotFound(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{
+			name: "no such resource",
+			err:  &guarddutytypes.BadRequestException{Message: aws.String("The request is rejected since no such resource found.")},
+			want: true,
+		},
+		{
+			name: "detector not owned",
+			err:  &guarddutytypes.BadRequestException{Message: aws.String("The request is rejected because the input detectorId is not owned by the current account.")},
+			want: true,
+		},
+		{
+			name: "other bad request",
+			err:  &guarddutytypes.BadRequestException{Message: aws.String("The request is rejected because a parameter is invalid.")},
+			want: false,
+		},
+		{
+			name: "other error type",
+			err:  errors.New("boom"),
+			want: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := guardDutyResourceNotFound(tt.err); got != tt.want {
+				t.Fatalf("not found = %t, want %t", got, tt.want)
+			}
+		})
+	}
+}
+
+func guardDutyTestFilter(name string) *guardduty.GetFilterOutput {
+	rank := int32(1)
+	return &guardduty.GetFilterOutput{
+		Action: guarddutytypes.FilterActionNoop,
+		FindingCriteria: &guarddutytypes.FindingCriteria{
+			Criterion: map[string]guarddutytypes.Condition{
+				"severity": {Equals: []string{"8"}},
+			},
+		},
+		Name: aws.String(name),
+		Rank: &rank,
+	}
+}


### PR DESCRIPTION
## Summary

- add GuardDuty import discovery for detectors, filters, IP sets, and threat intel sets
- register the `guardduty` AWS service and AWS SDK module
- seed import IDs as `detector_id` and `detector_id:child_resource_id`
- update docs/aws.md for supported GuardDuty resources
- add unit tests for GuardDuty helper behavior

## References

- #338

## Validation

```bash
go test ./providers/aws -run 'Test.*GuardDuty|Test.*Guardduty|Test.*guardduty'
go test ./providers/aws/... ./terraformutils/...
go run ./tools/aws-gap-inventory \
  -docs docs/aws.md \
  -aws-dir providers/aws \
  -skip-list providers/aws/unsupported_resources.json \
  -format markdown
git diff --check origin/main...HEAD
```

## Notes

Skipped/deferred resources:
- aws_guardduty_member: deferred for account/member relationship PR
- aws_guardduty_organization_*: deferred for organization-admin/configuration PR
- aws_guardduty_publishing_destination: deferred for focused destination PR
- aws_guardduty_malware_protection_plan: deferred for newer-feature PR
- aws_guardduty_detector_feature: deferred for detector feature PR
- aws_guardduty_invite_accepter: deferred because invitation acceptance is account-relationship state and should not be guessed

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds GuardDuty core imports to the AWS provider and preserves filter `updatedAt` millisecond precision on import and after refresh. Supports importing `aws_guardduty_detector`, `aws_guardduty_filter`, `aws_guardduty_ipset`, and `aws_guardduty_threatintelset`.

- **New Features**
  - Register `guardduty` service with discovery; add `github.com/aws/aws-sdk-go-v2/service/guardduty` v1.75.4.
  - Seed import IDs as `detector_id` and `detector_id:child_resource_id`; update `docs/aws.md` and add unit tests.

- **Bug Fixes**
  - Preserve `finding_criteria.updatedAt` millisecond precision in filter state (attributes and typed attributes) during import and after refresh.

<sup>Written for commit 60d1eaf7f062e1d9b88008bc7ebd6cae1555f8ba. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added AWS GuardDuty support: automatic detection and generation of Terraform resources for detectors, filters, IP sets, and threat intel sets; preserves timestamp precision in generated filter criteria.

* **Documentation**
  * Updated docs to list GuardDuty as a supported service and enumerate its Terraform resource types.

* **Tests**
  * Added tests covering GuardDuty resource generation, naming, skipping deleted/missing resources, and error classification.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/chenrui333/terraformer/pull/416)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->