### PR TITLE
aws(bedrockagent): add Bedrock Agent core imports

### DIFF
--- a/docs/aws.md
+++ b/docs/aws.md
@@ -138,6 +138,9 @@ For AWS provider gap audits and unsupported-resource skip-list maintenance, see 
     * `aws_bedrock_inference_profile`
     * `aws_bedrock_model_invocation_logging_configuration`
     * `aws_bedrock_provisioned_model_throughput`
+*   `bedrockagent`
+    * `aws_bedrockagent_agent`
+    * `aws_bedrockagent_agent_alias`
 *   `budgets`
     * `aws_budgets_budget`
 *   `cloud9`

--- a/go.mod
+++ b/go.mod
@@ -406,6 +406,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/appstream v1.58.0
 	github.com/aws/aws-sdk-go-v2/service/backup v1.55.2
 	github.com/aws/aws-sdk-go-v2/service/bedrock v1.59.2
+	github.com/aws/aws-sdk-go-v2/service/bedrockagent v1.53.2
 	github.com/aws/aws-sdk-go-v2/service/directconnect v1.38.17
 	github.com/aws/aws-sdk-go-v2/service/pipes v1.23.22
 	github.com/aws/aws-sdk-go-v2/service/s3control v1.70.1

--- a/go.sum
+++ b/go.sum
@@ -223,6 +223,8 @@ github.com/aws/aws-sdk-go-v2/service/batch v1.64.1 h1:+Nm5tPlRgOVQB/uMvphSNyJI9W
 github.com/aws/aws-sdk-go-v2/service/batch v1.64.1/go.mod h1:EHhfaNTxntvYHmSdHGLLSxuerqkMIlXY9lWjl+CJJxg=
 github.com/aws/aws-sdk-go-v2/service/bedrock v1.59.2 h1:TdYgGWLuNqQGNNVHzMwBEkg1fsyoaOfd+aP3xKfIeDM=
 github.com/aws/aws-sdk-go-v2/service/bedrock v1.59.2/go.mod h1:v/+a2bHvfo04yQC/p2HOK1iJF6V59OwCfCSf4iYgob4=
+github.com/aws/aws-sdk-go-v2/service/bedrockagent v1.53.2 h1:5WfuuVf0Mie5g3ibps8fgYDrlTVMc7PQpdycZmI1R+k=
+github.com/aws/aws-sdk-go-v2/service/bedrockagent v1.53.2/go.mod h1:zue4MN4ji6nlKYQYwVLmaPXJ66wB9JnIePX1e1yg5MU=
 github.com/aws/aws-sdk-go-v2/service/budgets v1.43.6 h1:2C1Fx5PAPB+8Se7nwnxAElSMW5KxuDVwzBu6t2qtlfg=
 github.com/aws/aws-sdk-go-v2/service/budgets v1.43.6/go.mod h1:W/ACxHO2V65T11t9KLLG+pQytcYk206Ff5b5lbGeMF8=
 github.com/aws/aws-sdk-go-v2/service/cloud9 v1.33.22 h1:NiWafOOhAC6Wcnj9L/xd371nvXMuoSqblNzRJ2vB2nE=

--- a/providers/aws/aws_provider.go
+++ b/providers/aws/aws_provider.go
@@ -275,6 +275,7 @@ func (p *AWSProvider) GetSupportedService() map[string]terraformutils.ServiceGen
 		"backup":            &AwsFacade{service: &BackupGenerator{}},
 		"batch":             &AwsFacade{service: &BatchGenerator{}},
 		"bedrock":           &AwsFacade{service: &BedrockGenerator{}},
+		"bedrockagent":      &AwsFacade{service: &BedrockAgentGenerator{}},
 		"budgets":           &AwsFacade{service: &BudgetsGenerator{}},
 		"cloud9":            &AwsFacade{service: &Cloud9Generator{}},
 		"cloudformation":    &AwsFacade{service: &CloudFormationGenerator{}},

--- a/providers/aws/bedrockagent.go
+++ b/providers/aws/bedrockagent.go
@@ -1,0 +1,241 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package aws
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/aws/aws-sdk-go-v2/service/bedrockagent"
+	bedrockagenttypes "github.com/aws/aws-sdk-go-v2/service/bedrockagent/types"
+	"github.com/chenrui333/terraformer/terraformutils"
+)
+
+const (
+	bedrockAgentAgentResourceType      = "aws_bedrockagent_agent"
+	bedrockAgentAgentAliasResourceType = "aws_bedrockagent_agent_alias"
+	bedrockAgentImportIDSeparator      = ","
+	bedrockAgentResourceNameFallback   = "bedrockagent-resource"
+)
+
+var (
+	bedrockAgentAllowEmptyValues = []string{"tags."}
+	bedrockAgentResourceTypes    = []string{
+		bedrockAgentServiceName(bedrockAgentAgentResourceType),
+		bedrockAgentServiceName(bedrockAgentAgentAliasResourceType),
+	}
+)
+
+type BedrockAgentGenerator struct {
+	AWSService
+}
+
+func (g *BedrockAgentGenerator) InitialCleanup() {
+	if len(g.Filter) == 0 {
+		return
+	}
+	filteredResources := []terraformutils.Resource{}
+	for _, resource := range g.Resources {
+		serviceName := bedrockAgentServiceName(resource.InstanceInfo.Type)
+		if g.hasTypedBedrockAgentFilter() && !g.hasTypedFilterFor(serviceName) && !g.hasUntypedFilter() {
+			continue
+		}
+		allPredicatesTrue := true
+		for _, filter := range g.Filter {
+			if filter.FieldPath != "id" {
+				continue
+			}
+			allPredicatesTrue = allPredicatesTrue && filter.Filter(resource)
+		}
+		if allPredicatesTrue && !terraformutils.ContainsResource(filteredResources, resource) {
+			filteredResources = append(filteredResources, resource)
+		}
+	}
+	g.Resources = filteredResources
+}
+
+func (g *BedrockAgentGenerator) InitResources() error {
+	config, e := g.generateConfig()
+	if e != nil {
+		return e
+	}
+	svc := bedrockagent.NewFromConfig(config)
+
+	loadAgents := g.shouldLoadBedrockAgentResource(bedrockAgentServiceName(bedrockAgentAgentResourceType))
+	loadAgentAliases := g.shouldLoadBedrockAgentResource(bedrockAgentServiceName(bedrockAgentAgentAliasResourceType))
+	if loadAgents || loadAgentAliases {
+		agents, err := listBedrockAgentAgents(svc)
+		if err != nil {
+			return err
+		}
+		if loadAgents {
+			g.loadAgents(agents)
+		}
+		if loadAgentAliases {
+			if err := g.loadAgentAliases(svc, agents); err != nil {
+				return err
+			}
+		}
+	}
+
+	return nil
+}
+
+func (g *BedrockAgentGenerator) shouldLoadBedrockAgentResource(serviceName string) bool {
+	if !g.hasTypedBedrockAgentFilter() {
+		return true
+	}
+	return g.hasTypedFilterFor(serviceName) || g.hasUntypedFilter()
+}
+
+func (g *BedrockAgentGenerator) hasTypedBedrockAgentFilter() bool {
+	for _, serviceName := range bedrockAgentResourceTypes {
+		if g.hasTypedFilterFor(serviceName) {
+			return true
+		}
+	}
+	return false
+}
+
+func (g *BedrockAgentGenerator) hasTypedFilterFor(serviceName string) bool {
+	for _, filter := range g.Filter {
+		if filter.ServiceName == serviceName {
+			return true
+		}
+	}
+	return false
+}
+
+func (g *BedrockAgentGenerator) hasUntypedFilter() bool {
+	for _, filter := range g.Filter {
+		if filter.ServiceName == "" {
+			return true
+		}
+	}
+	return false
+}
+
+func bedrockAgentServiceName(resourceType string) string {
+	return strings.TrimPrefix(resourceType, "aws_")
+}
+
+func listBedrockAgentAgents(svc *bedrockagent.Client) ([]bedrockagenttypes.AgentSummary, error) {
+	p := bedrockagent.NewListAgentsPaginator(svc, &bedrockagent.ListAgentsInput{})
+	agents := []bedrockagenttypes.AgentSummary{}
+	for p.HasMorePages() {
+		page, err := p.NextPage(context.TODO())
+		if err != nil {
+			return nil, err
+		}
+		agents = append(agents, page.AgentSummaries...)
+	}
+	return agents, nil
+}
+
+func (g *BedrockAgentGenerator) loadAgents(agents []bedrockagenttypes.AgentSummary) {
+	for _, agent := range agents {
+		if resource, ok := newBedrockAgentAgentResource(agent); ok {
+			g.Resources = append(g.Resources, resource)
+		}
+	}
+}
+
+func (g *BedrockAgentGenerator) loadAgentAliases(svc *bedrockagent.Client, agents []bedrockagenttypes.AgentSummary) error {
+	for _, agent := range agents {
+		agentID := StringValue(agent.AgentId)
+		if agentID == "" || !bedrockAgentAgentImportable(agent.AgentStatus) {
+			continue
+		}
+		p := bedrockagent.NewListAgentAliasesPaginator(svc, &bedrockagent.ListAgentAliasesInput{
+			AgentId: &agentID,
+		})
+		for p.HasMorePages() {
+			page, err := p.NextPage(context.TODO())
+			if err != nil {
+				if bedrockAgentResourceNotFound(err) {
+					break
+				}
+				return err
+			}
+			for _, alias := range page.AgentAliasSummaries {
+				if resource, ok := newBedrockAgentAgentAliasResource(agentID, alias); ok {
+					g.Resources = append(g.Resources, resource)
+				}
+			}
+		}
+	}
+	return nil
+}
+
+func newBedrockAgentAgentResource(agent bedrockagenttypes.AgentSummary) (terraformutils.Resource, bool) {
+	agentID := StringValue(agent.AgentId)
+	agentName := StringValue(agent.AgentName)
+	if agentID == "" || agentName == "" || !bedrockAgentAgentImportable(agent.AgentStatus) {
+		return terraformutils.Resource{}, false
+	}
+	return terraformutils.NewResource(
+		agentID,
+		bedrockAgentResourceName("agent", agentName, agentID),
+		bedrockAgentAgentResourceType,
+		"aws",
+		map[string]string{
+			"agent_id":   agentID,
+			"agent_name": agentName,
+		},
+		bedrockAgentAllowEmptyValues,
+		map[string]interface{}{},
+	), true
+}
+
+func newBedrockAgentAgentAliasResource(agentID string, alias bedrockagenttypes.AgentAliasSummary) (terraformutils.Resource, bool) {
+	agentAliasID := StringValue(alias.AgentAliasId)
+	agentAliasName := StringValue(alias.AgentAliasName)
+	if agentID == "" || agentAliasID == "" || agentAliasName == "" || !bedrockAgentAgentAliasImportable(alias.AgentAliasStatus) {
+		return terraformutils.Resource{}, false
+	}
+	return terraformutils.NewResource(
+		bedrockAgentAgentAliasImportID(agentAliasID, agentID),
+		bedrockAgentResourceName("agent-alias", agentID, agentAliasName, agentAliasID),
+		bedrockAgentAgentAliasResourceType,
+		"aws",
+		map[string]string{
+			"agent_alias_id":   agentAliasID,
+			"agent_alias_name": agentAliasName,
+			"agent_id":         agentID,
+		},
+		bedrockAgentAllowEmptyValues,
+		map[string]interface{}{},
+	), true
+}
+
+func bedrockAgentAgentAliasImportID(agentAliasID, agentID string) string {
+	return agentAliasID + bedrockAgentImportIDSeparator + agentID
+}
+
+func bedrockAgentResourceName(parts ...string) string {
+	var cleanParts []string
+	for _, part := range parts {
+		if part != "" {
+			cleanParts = append(cleanParts, fmt.Sprintf("%d-%s", len(part), part))
+		}
+	}
+	if len(cleanParts) == 0 {
+		return bedrockAgentResourceNameFallback
+	}
+	return strings.Join(cleanParts, "/")
+}
+
+func bedrockAgentAgentImportable(status bedrockagenttypes.AgentStatus) bool {
+	return status == bedrockagenttypes.AgentStatusPrepared || status == bedrockagenttypes.AgentStatusNotPrepared
+}
+
+func bedrockAgentAgentAliasImportable(status bedrockagenttypes.AgentAliasStatus) bool {
+	return status == bedrockagenttypes.AgentAliasStatusPrepared
+}
+
+func bedrockAgentResourceNotFound(err error) bool {
+	var notFound *bedrockagenttypes.ResourceNotFoundException
+	return errors.As(err, &notFound)
+}

--- a/providers/aws/bedrockagent.go
+++ b/providers/aws/bedrockagent.go
@@ -175,15 +175,19 @@ func newBedrockAgentAgentResource(agent bedrockagenttypes.AgentSummary) (terrafo
 	if agentID == "" || agentName == "" || !bedrockAgentAgentImportable(agent.AgentStatus) {
 		return terraformutils.Resource{}, false
 	}
+	attributes := map[string]string{
+		"agent_id":   agentID,
+		"agent_name": agentName,
+	}
+	if agent.AgentStatus == bedrockagenttypes.AgentStatusNotPrepared {
+		attributes["prepare_agent"] = "false"
+	}
 	return terraformutils.NewResource(
 		agentID,
 		bedrockAgentResourceName("agent", agentName, agentID),
 		bedrockAgentAgentResourceType,
 		"aws",
-		map[string]string{
-			"agent_id":   agentID,
-			"agent_name": agentName,
-		},
+		attributes,
 		bedrockAgentAllowEmptyValues,
 		map[string]interface{}{},
 	), true
@@ -232,7 +236,7 @@ func bedrockAgentAgentImportable(status bedrockagenttypes.AgentStatus) bool {
 }
 
 func bedrockAgentAgentAliasImportable(status bedrockagenttypes.AgentAliasStatus) bool {
-	return status == bedrockagenttypes.AgentAliasStatusPrepared
+	return status == bedrockagenttypes.AgentAliasStatusPrepared || status == bedrockagenttypes.AgentAliasStatusDissociated
 }
 
 func bedrockAgentResourceNotFound(err error) bool {

--- a/providers/aws/bedrockagent_test.go
+++ b/providers/aws/bedrockagent_test.go
@@ -127,6 +127,19 @@ func TestNewBedrockAgentAgentResource(t *testing.T) {
 	if got := resource.InstanceState.Attributes["agent_name"]; got != "support-agent" {
 		t.Fatalf("agent_name attribute = %q, want support-agent", got)
 	}
+	if _, ok := resource.InstanceState.Attributes["prepare_agent"]; ok {
+		t.Fatal("prepared agent should not force prepare_agent")
+	}
+
+	unprepared, ok := newBedrockAgentAgentResource(bedrockagenttypes.AgentSummary{
+		AgentId:     aws.String("ABCDEFGHIJ"),
+		AgentName:   aws.String("draft-agent"),
+		AgentStatus: bedrockagenttypes.AgentStatusNotPrepared,
+	})
+	assertBedrockAgentResource(t, unprepared, ok, "ABCDEFGHIJ", bedrockAgentAgentResourceType)
+	if got := unprepared.InstanceState.Attributes["prepare_agent"]; got != "false" {
+		t.Fatalf("prepare_agent attribute = %q, want false", got)
+	}
 
 	if _, ok := newBedrockAgentAgentResource(bedrockagenttypes.AgentSummary{
 		AgentName:   aws.String("support-agent"),
@@ -165,6 +178,13 @@ func TestNewBedrockAgentAgentAliasResource(t *testing.T) {
 	if got := resource.InstanceState.Attributes["agent_id"]; got != "GGRRAED6JP" {
 		t.Fatalf("agent_id attribute = %q, want GGRRAED6JP", got)
 	}
+
+	dissociated, ok := newBedrockAgentAgentAliasResource("GGRRAED6JP", bedrockagenttypes.AgentAliasSummary{
+		AgentAliasId:     aws.String("11AA22BB33"),
+		AgentAliasName:   aws.String("offline"),
+		AgentAliasStatus: bedrockagenttypes.AgentAliasStatusDissociated,
+	})
+	assertBedrockAgentResource(t, dissociated, ok, "11AA22BB33,GGRRAED6JP", bedrockAgentAgentAliasResourceType)
 
 	if _, ok := newBedrockAgentAgentAliasResource("", bedrockagenttypes.AgentAliasSummary{
 		AgentAliasId:     aws.String("66IVY0GUTF"),
@@ -216,15 +236,19 @@ func TestBedrockAgentImportableStatuses(t *testing.T) {
 		}
 	}
 
-	if !bedrockAgentAgentAliasImportable(bedrockagenttypes.AgentAliasStatusPrepared) {
-		t.Fatal("PREPARED agent alias should be importable")
+	for _, status := range []bedrockagenttypes.AgentAliasStatus{
+		bedrockagenttypes.AgentAliasStatusPrepared,
+		bedrockagenttypes.AgentAliasStatusDissociated,
+	} {
+		if !bedrockAgentAgentAliasImportable(status) {
+			t.Fatalf("%s agent alias should be importable", status)
+		}
 	}
 	for _, status := range []bedrockagenttypes.AgentAliasStatus{
 		bedrockagenttypes.AgentAliasStatusCreating,
 		bedrockagenttypes.AgentAliasStatusUpdating,
 		bedrockagenttypes.AgentAliasStatusDeleting,
 		bedrockagenttypes.AgentAliasStatusFailed,
-		bedrockagenttypes.AgentAliasStatusDissociated,
 	} {
 		if bedrockAgentAgentAliasImportable(status) {
 			t.Fatalf("%s agent alias should not be importable", status)

--- a/providers/aws/bedrockagent_test.go
+++ b/providers/aws/bedrockagent_test.go
@@ -1,0 +1,325 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package aws
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	bedrockagenttypes "github.com/aws/aws-sdk-go-v2/service/bedrockagent/types"
+	"github.com/chenrui333/terraformer/terraformutils"
+)
+
+func TestBedrockAgentAgentAliasImportID(t *testing.T) {
+	got := bedrockAgentAgentAliasImportID("66IVY0GUTF", "GGRRAED6JP")
+	want := "66IVY0GUTF,GGRRAED6JP"
+	if got != want {
+		t.Fatalf("bedrockAgentAgentAliasImportID() = %q, want %q", got, want)
+	}
+}
+
+func TestBedrockAgentResourceNameFallback(t *testing.T) {
+	if got := bedrockAgentResourceName("", ""); got != bedrockAgentResourceNameFallback {
+		t.Fatalf("bedrockAgentResourceName() = %q, want %q", got, bedrockAgentResourceNameFallback)
+	}
+}
+
+func TestBedrockAgentResourceNameUniqueness(t *testing.T) {
+	first := terraformutils.TfSanitize(bedrockAgentResourceName("ab", "c"))
+	second := terraformutils.TfSanitize(bedrockAgentResourceName("a", "bc"))
+	if first == second {
+		t.Fatalf("bedrockAgentResourceName() collision after sanitize: %q", first)
+	}
+	aliasFirst := terraformutils.TfSanitize(bedrockAgentResourceName("agent-alias", "agent-a", "prod", "alias-1"))
+	aliasSecond := terraformutils.TfSanitize(bedrockAgentResourceName("agent-alias", "agent-b", "prod", "alias-1"))
+	if aliasFirst == aliasSecond {
+		t.Fatalf("agent alias resource names should include parent agent identity: %q", aliasFirst)
+	}
+}
+
+func TestBedrockAgentShouldLoadResourceHonorsTypedFilters(t *testing.T) {
+	g := BedrockAgentGenerator{}
+	if !g.shouldLoadBedrockAgentResource("bedrockagent_agent") ||
+		!g.shouldLoadBedrockAgentResource("bedrockagent_agent_alias") {
+		t.Fatal("without typed filters, all Bedrock Agent resource families should be loaded")
+	}
+
+	g.Filter = []terraformutils.ResourceFilter{{
+		ServiceName:      "bedrockagent_agent",
+		FieldPath:        "id",
+		AcceptableValues: []string{"GGRRAED6JP"},
+	}}
+	if !g.shouldLoadBedrockAgentResource("bedrockagent_agent") {
+		t.Fatal("typed agent filter should load agents")
+	}
+	if g.shouldLoadBedrockAgentResource("bedrockagent_agent_alias") {
+		t.Fatal("typed agent filter should not load agent aliases")
+	}
+
+	g.Filter = []terraformutils.ResourceFilter{{
+		ServiceName:      "bedrockagent_agent_alias",
+		FieldPath:        "id",
+		AcceptableValues: []string{"66IVY0GUTF,GGRRAED6JP"},
+	}}
+	if !g.shouldLoadBedrockAgentResource("bedrockagent_agent_alias") {
+		t.Fatal("typed agent alias filter should load agent aliases")
+	}
+	if g.shouldLoadBedrockAgentResource("bedrockagent_agent") {
+		t.Fatal("typed agent alias filter should not emit agent resources")
+	}
+}
+
+func TestBedrockAgentShouldLoadResourceAllowsUntypedFilters(t *testing.T) {
+	tests := []struct {
+		name   string
+		filter terraformutils.ResourceFilter
+	}{
+		{
+			name: "id",
+			filter: terraformutils.ResourceFilter{
+				FieldPath:        "id",
+				AcceptableValues: []string{"66IVY0GUTF,GGRRAED6JP"},
+			},
+		},
+		{
+			name: "post-refresh attribute",
+			filter: terraformutils.ResourceFilter{
+				FieldPath:        "tags.env",
+				AcceptableValues: []string{"prod"},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := BedrockAgentGenerator{
+				AWSService: AWSService{
+					Service: terraformutils.Service{
+						Filter: []terraformutils.ResourceFilter{
+							{
+								ServiceName:      "bedrockagent_agent",
+								FieldPath:        "id",
+								AcceptableValues: []string{"GGRRAED6JP"},
+							},
+							tt.filter,
+						},
+					},
+				},
+			}
+			if !g.shouldLoadBedrockAgentResource("bedrockagent_agent_alias") {
+				t.Fatal("untyped filter should keep agent alias discovery available")
+			}
+		})
+	}
+}
+
+func TestNewBedrockAgentAgentResource(t *testing.T) {
+	resource, ok := newBedrockAgentAgentResource(bedrockagenttypes.AgentSummary{
+		AgentId:     aws.String("GGRRAED6JP"),
+		AgentName:   aws.String("support-agent"),
+		AgentStatus: bedrockagenttypes.AgentStatusPrepared,
+	})
+	assertBedrockAgentResource(t, resource, ok, "GGRRAED6JP", bedrockAgentAgentResourceType)
+	if got := resource.InstanceState.Attributes["agent_id"]; got != "GGRRAED6JP" {
+		t.Fatalf("agent_id attribute = %q, want GGRRAED6JP", got)
+	}
+	if got := resource.InstanceState.Attributes["agent_name"]; got != "support-agent" {
+		t.Fatalf("agent_name attribute = %q, want support-agent", got)
+	}
+
+	if _, ok := newBedrockAgentAgentResource(bedrockagenttypes.AgentSummary{
+		AgentName:   aws.String("support-agent"),
+		AgentStatus: bedrockagenttypes.AgentStatusPrepared,
+	}); ok {
+		t.Fatal("agent without ID should be skipped")
+	}
+	if _, ok := newBedrockAgentAgentResource(bedrockagenttypes.AgentSummary{
+		AgentId:     aws.String("GGRRAED6JP"),
+		AgentStatus: bedrockagenttypes.AgentStatusPrepared,
+	}); ok {
+		t.Fatal("agent without name should be skipped")
+	}
+	if _, ok := newBedrockAgentAgentResource(bedrockagenttypes.AgentSummary{
+		AgentId:     aws.String("GGRRAED6JP"),
+		AgentName:   aws.String("support-agent"),
+		AgentStatus: bedrockagenttypes.AgentStatusCreating,
+	}); ok {
+		t.Fatal("creating agent should be skipped")
+	}
+}
+
+func TestNewBedrockAgentAgentAliasResource(t *testing.T) {
+	resource, ok := newBedrockAgentAgentAliasResource("GGRRAED6JP", bedrockagenttypes.AgentAliasSummary{
+		AgentAliasId:     aws.String("66IVY0GUTF"),
+		AgentAliasName:   aws.String("prod"),
+		AgentAliasStatus: bedrockagenttypes.AgentAliasStatusPrepared,
+	})
+	assertBedrockAgentResource(t, resource, ok, "66IVY0GUTF,GGRRAED6JP", bedrockAgentAgentAliasResourceType)
+	if got := resource.InstanceState.Attributes["agent_alias_id"]; got != "66IVY0GUTF" {
+		t.Fatalf("agent_alias_id attribute = %q, want 66IVY0GUTF", got)
+	}
+	if got := resource.InstanceState.Attributes["agent_alias_name"]; got != "prod" {
+		t.Fatalf("agent_alias_name attribute = %q, want prod", got)
+	}
+	if got := resource.InstanceState.Attributes["agent_id"]; got != "GGRRAED6JP" {
+		t.Fatalf("agent_id attribute = %q, want GGRRAED6JP", got)
+	}
+
+	if _, ok := newBedrockAgentAgentAliasResource("", bedrockagenttypes.AgentAliasSummary{
+		AgentAliasId:     aws.String("66IVY0GUTF"),
+		AgentAliasName:   aws.String("prod"),
+		AgentAliasStatus: bedrockagenttypes.AgentAliasStatusPrepared,
+	}); ok {
+		t.Fatal("alias without parent agent ID should be skipped")
+	}
+	if _, ok := newBedrockAgentAgentAliasResource("GGRRAED6JP", bedrockagenttypes.AgentAliasSummary{
+		AgentAliasName:   aws.String("prod"),
+		AgentAliasStatus: bedrockagenttypes.AgentAliasStatusPrepared,
+	}); ok {
+		t.Fatal("alias without ID should be skipped")
+	}
+	if _, ok := newBedrockAgentAgentAliasResource("GGRRAED6JP", bedrockagenttypes.AgentAliasSummary{
+		AgentAliasId:     aws.String("66IVY0GUTF"),
+		AgentAliasStatus: bedrockagenttypes.AgentAliasStatusPrepared,
+	}); ok {
+		t.Fatal("alias without name should be skipped")
+	}
+	if _, ok := newBedrockAgentAgentAliasResource("GGRRAED6JP", bedrockagenttypes.AgentAliasSummary{
+		AgentAliasId:     aws.String("66IVY0GUTF"),
+		AgentAliasName:   aws.String("prod"),
+		AgentAliasStatus: bedrockagenttypes.AgentAliasStatusFailed,
+	}); ok {
+		t.Fatal("failed alias should be skipped")
+	}
+}
+
+func TestBedrockAgentImportableStatuses(t *testing.T) {
+	for _, status := range []bedrockagenttypes.AgentStatus{
+		bedrockagenttypes.AgentStatusPrepared,
+		bedrockagenttypes.AgentStatusNotPrepared,
+	} {
+		if !bedrockAgentAgentImportable(status) {
+			t.Fatalf("%s agent should be importable", status)
+		}
+	}
+	for _, status := range []bedrockagenttypes.AgentStatus{
+		bedrockagenttypes.AgentStatusCreating,
+		bedrockagenttypes.AgentStatusPreparing,
+		bedrockagenttypes.AgentStatusUpdating,
+		bedrockagenttypes.AgentStatusVersioning,
+		bedrockagenttypes.AgentStatusDeleting,
+		bedrockagenttypes.AgentStatusFailed,
+	} {
+		if bedrockAgentAgentImportable(status) {
+			t.Fatalf("%s agent should not be importable", status)
+		}
+	}
+
+	if !bedrockAgentAgentAliasImportable(bedrockagenttypes.AgentAliasStatusPrepared) {
+		t.Fatal("PREPARED agent alias should be importable")
+	}
+	for _, status := range []bedrockagenttypes.AgentAliasStatus{
+		bedrockagenttypes.AgentAliasStatusCreating,
+		bedrockagenttypes.AgentAliasStatusUpdating,
+		bedrockagenttypes.AgentAliasStatusDeleting,
+		bedrockagenttypes.AgentAliasStatusFailed,
+		bedrockagenttypes.AgentAliasStatusDissociated,
+	} {
+		if bedrockAgentAgentAliasImportable(status) {
+			t.Fatalf("%s agent alias should not be importable", status)
+		}
+	}
+}
+
+func TestBedrockAgentResourceNotFound(t *testing.T) {
+	if !bedrockAgentResourceNotFound(&bedrockagenttypes.ResourceNotFoundException{}) {
+		t.Fatal("ResourceNotFoundException should be detected")
+	}
+	if !bedrockAgentResourceNotFound(errors.Join(errors.New("lookup failed"), &bedrockagenttypes.ResourceNotFoundException{})) {
+		t.Fatal("wrapped ResourceNotFoundException should be detected")
+	}
+	if bedrockAgentResourceNotFound(errors.New("other error")) {
+		t.Fatal("non-not-found error should not be detected")
+	}
+}
+
+func TestBedrockAgentInitialCleanupHonorsTypedFilters(t *testing.T) {
+	agent, alias := bedrockAgentTestResources(t)
+	g := BedrockAgentGenerator{}
+	g.Resources = []terraformutils.Resource{agent, alias}
+	g.Filter = []terraformutils.ResourceFilter{{
+		ServiceName:      "bedrockagent_agent_alias",
+		FieldPath:        "id",
+		AcceptableValues: []string{"66IVY0GUTF,GGRRAED6JP"},
+	}}
+
+	g.InitialCleanup()
+
+	if len(g.Resources) != 1 {
+		t.Fatalf("InitialCleanup() resources len = %d, want 1", len(g.Resources))
+	}
+	if got := g.Resources[0].InstanceInfo.Type; got != bedrockAgentAgentAliasResourceType {
+		t.Fatalf("InitialCleanup() kept resource type = %q, want %s", got, bedrockAgentAgentAliasResourceType)
+	}
+}
+
+func TestBedrockAgentInitialCleanupPreservesGlobalFilters(t *testing.T) {
+	agent, alias := bedrockAgentTestResources(t)
+	g := BedrockAgentGenerator{}
+	g.Resources = []terraformutils.Resource{agent, alias}
+	g.Filter = []terraformutils.ResourceFilter{
+		{
+			ServiceName:      "bedrockagent_agent",
+			FieldPath:        "id",
+			AcceptableValues: []string{"GGRRAED6JP"},
+		},
+		{
+			FieldPath:        "tags.env",
+			AcceptableValues: []string{"prod"},
+		},
+	}
+
+	g.InitialCleanup()
+
+	if len(g.Resources) != 2 {
+		t.Fatalf("InitialCleanup() resources len = %d, want 2", len(g.Resources))
+	}
+}
+
+func assertBedrockAgentResource(t *testing.T, resource terraformutils.Resource, ok bool, wantID, wantType string) {
+	t.Helper()
+	if !ok {
+		t.Fatal("resource should be created")
+	}
+	if got := resource.InstanceState.ID; got != wantID {
+		t.Fatalf("resource ID = %q, want %q", got, wantID)
+	}
+	if got := resource.InstanceInfo.Type; got != wantType {
+		t.Fatalf("resource type = %q, want %q", got, wantType)
+	}
+	if resource.ResourceName == "" {
+		t.Fatal("resource name should not be empty")
+	}
+}
+
+func bedrockAgentTestResources(t *testing.T) (terraformutils.Resource, terraformutils.Resource) {
+	t.Helper()
+	agent, ok := newBedrockAgentAgentResource(bedrockagenttypes.AgentSummary{
+		AgentId:     aws.String("GGRRAED6JP"),
+		AgentName:   aws.String("support-agent"),
+		AgentStatus: bedrockagenttypes.AgentStatusPrepared,
+	})
+	if !ok {
+		t.Fatal("newBedrockAgentAgentResource() should create agent")
+	}
+	alias, ok := newBedrockAgentAgentAliasResource("GGRRAED6JP", bedrockagenttypes.AgentAliasSummary{
+		AgentAliasId:     aws.String("66IVY0GUTF"),
+		AgentAliasName:   aws.String("prod"),
+		AgentAliasStatus: bedrockagenttypes.AgentAliasStatusPrepared,
+	})
+	if !ok {
+		t.Fatal("newBedrockAgentAgentAliasResource() should create alias")
+	}
+	return agent, alias
+}


### PR DESCRIPTION
## Summary

- add Bedrock Agent import discovery for `aws_bedrockagent_agent` and `aws_bedrockagent_agent_alias`
- register the `bedrockagent` AWS service and add the AWS SDK v2 Bedrock Agent module
- seed import IDs as `agent_id` for agents and `agent_alias_id,agent_id` for aliases
- update docs/aws.md for supported Bedrock Agent resources
- add unit tests for Bedrock Agent helper behavior, status filtering, typed filters, and alias parent attributes

## References

- #338

## Validation

```bash
go test ./providers/aws -run 'Test.*BedrockAgent|Test.*Bedrockagent|Test.*bedrockagent'
go test ./providers/aws/... ./terraformutils/...
go run ./tools/aws-gap-inventory \
  -docs docs/aws.md \
  -aws-dir providers/aws \
  -skip-list providers/aws/unsupported_resources.json \
  -format markdown
git diff --check
```

## Notes

Skipped/deferred resources:
- aws_bedrock_custom_model: deferred for customization-job-based discovery
- aws_bedrockagent_knowledge_base: deferred for a focused knowledge-base PR because the provider schema spans multiple storage/query backends and required credential-secret ARN fields that need separate validation
- aws_bedrockagent_agent_action_group: deferred for child-resource PR
- aws_bedrockagent_agent_collaborator: deferred for child-resource PR
- aws_bedrockagent_agent_knowledge_base_association: deferred for association-resource PR
- aws_bedrockagent_data_source: deferred until knowledge-base support is validated
- aws_bedrockagent_flow* / aws_bedrockagent_prompt*: deferred for separate flow/prompt PRs
- aws_bedrockagentcore_*: deferred for separate Agent Core service-family PR

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds discovery and import for `aws_bedrockagent_agent` and `aws_bedrockagent_agent_alias`, registers the `bedrockagent` service, and updates docs. Preserves import state for unprepared agents and allows importing dissociated aliases.

- **New Features**
  - Discover and generate `aws_bedrockagent_agent` and `aws_bedrockagent_agent_alias`; import IDs: agents use `agent_id`, aliases use `agent_alias_id,agent_id`.
  - Status rules: agents import when PREPARED or NOT_PREPARED; aliases when PREPARED or DISSOCIATED. For NOT_PREPARED agents, set `prepare_agent=false` to avoid side effects.
  - Support typed and untyped filters; alias resources include parent agent attributes.

- **Dependencies**
  - Add `github.com/aws/aws-sdk-go-v2/service/bedrockagent`.

<sup>Written for commit 0504945dd2c22e5e5f25cd9a4b12b04f755d5780. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for AWS Bedrock Agent service, enabling import of Bedrock agents and agent aliases into Terraform.

* **Documentation**
  * Updated supported services list to include Bedrock Agent service.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/chenrui333/terraformer/pull/417)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->