### PR TITLE
aws(s3tables): add S3 Tables resource imports

### DIFF
--- a/docs/aws.md
+++ b/docs/aws.md
@@ -489,6 +489,7 @@ For AWS provider gap audits and unsupported-resource skip-list maintenance, see 
     * `aws_s3tables_namespace`
     * `aws_s3tables_table`
     * `aws_s3tables_table_bucket_policy`
+    * `aws_s3tables_table_policy`
 *   `scheduler`
     * `aws_scheduler_schedule`
     * `aws_scheduler_schedule_group`

--- a/docs/aws.md
+++ b/docs/aws.md
@@ -484,6 +484,11 @@ For AWS provider gap audits and unsupported-resource skip-list maintenance, see 
     * `aws_s3control_access_point_policy`
     * `aws_s3control_object_lambda_access_point`
     * `aws_s3control_object_lambda_access_point_policy`
+*   `s3tables`
+    * `aws_s3tables_table_bucket`
+    * `aws_s3tables_namespace`
+    * `aws_s3tables_table`
+    * `aws_s3tables_table_bucket_policy`
 *   `scheduler`
     * `aws_scheduler_schedule`
     * `aws_scheduler_schedule_group`

--- a/go.mod
+++ b/go.mod
@@ -409,6 +409,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/directconnect v1.38.17
 	github.com/aws/aws-sdk-go-v2/service/pipes v1.23.22
 	github.com/aws/aws-sdk-go-v2/service/s3control v1.70.1
+	github.com/aws/aws-sdk-go-v2/service/s3tables v1.15.2
 	github.com/aws/aws-sdk-go-v2/service/scheduler v1.17.24
 	github.com/aws/aws-sdk-go-v2/service/sesv2 v1.60.4
 	github.com/gofrs/uuid/v3 v3.1.2

--- a/go.sum
+++ b/go.sum
@@ -347,6 +347,8 @@ github.com/aws/aws-sdk-go-v2/service/s3 v1.101.0 h1:etqBTKY581iwLL/H/S2sVgk3C9lA
 github.com/aws/aws-sdk-go-v2/service/s3 v1.101.0/go.mod h1:L2dcoOgS2VSgbPLvpak2NyUPsO1TBN7M45Z4H7DlRc4=
 github.com/aws/aws-sdk-go-v2/service/s3control v1.70.1 h1:jbMg6zIdFawDnLhbzaLGUxaMN2H42wP4hKsjG0OuLmA=
 github.com/aws/aws-sdk-go-v2/service/s3control v1.70.1/go.mod h1:BJiTF1ijkh2XHYqan51v2pmnHyVFp1H31vqEuC/wEFw=
+github.com/aws/aws-sdk-go-v2/service/s3tables v1.15.2 h1:a3XYwgDb0SnjQD5TqEOi+9pwOOxXWnoVpqHAn9Vz4Eo=
+github.com/aws/aws-sdk-go-v2/service/s3tables v1.15.2/go.mod h1:eppybYlnphhnRlQ92dS4ENotpFE2OmwyJsVIICCOjW8=
 github.com/aws/aws-sdk-go-v2/service/scheduler v1.17.24 h1:F4gvh9TJcEZVqirKpX/FBWEMK6tvnGSVf4FWDvFtSQw=
 github.com/aws/aws-sdk-go-v2/service/scheduler v1.17.24/go.mod h1:0/mvOL++cUfpS4KgHigHDo+x8KLYG/grOTyIOw3KCPM=
 github.com/aws/aws-sdk-go-v2/service/secretsmanager v1.41.7 h1:JUGKqUnJHbXpS8uyuICP/zpQ+vXUIXW2zTEqjMLCqrY=

--- a/providers/aws/aws_provider.go
+++ b/providers/aws/aws_provider.go
@@ -337,6 +337,7 @@ func (p *AWSProvider) GetSupportedService() map[string]terraformutils.ServiceGen
 		"route_table":       &AwsFacade{service: &RouteTableGenerator{}},
 		"s3":                &AwsFacade{service: &S3Generator{}},
 		"s3control":         &AwsFacade{service: &S3ControlGenerator{}},
+		"s3tables":          &AwsFacade{service: &S3TablesGenerator{}},
 		"scheduler":         &AwsFacade{service: &SchedulerGenerator{}},
 		"secretsmanager":    &AwsFacade{service: &SecretsManagerGenerator{}},
 		"securityhub":       &AwsFacade{service: &SecurityhubGenerator{}},

--- a/providers/aws/s3tables.go
+++ b/providers/aws/s3tables.go
@@ -1,0 +1,400 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package aws
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log"
+	"strconv"
+	"strings"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/s3tables"
+	s3tablestypes "github.com/aws/aws-sdk-go-v2/service/s3tables/types"
+	"github.com/aws/smithy-go"
+	"github.com/chenrui333/terraformer/terraformutils"
+	"github.com/chenrui333/terraformer/terraformutils/tfcompat"
+)
+
+const (
+	s3TablesTableBucketResourceType       = "aws_s3tables_table_bucket"
+	s3TablesNamespaceResourceType         = "aws_s3tables_namespace"
+	s3TablesTableResourceType             = "aws_s3tables_table"
+	s3TablesTableBucketPolicyResourceType = "aws_s3tables_table_bucket_policy"
+	s3TablesIDSeparator                   = ";"
+)
+
+var s3TablesAllowEmptyValues = []string{"tags."}
+
+type S3TablesGenerator struct {
+	AWSService
+}
+
+func (g *S3TablesGenerator) InitResources() error {
+	config, err := g.generateConfig()
+	if err != nil {
+		return err
+	}
+
+	svc := s3tables.NewFromConfig(config)
+	return g.loadTableBuckets(svc)
+}
+
+func (g *S3TablesGenerator) PostConvertHook() error {
+	for i := range g.Resources {
+		if g.Resources[i].InstanceInfo == nil {
+			continue
+		}
+		if g.Resources[i].InstanceInfo.Type == s3TablesTableBucketPolicyResourceType {
+			wrapS3TablesPolicyHeredoc(g, &g.Resources[i])
+		}
+	}
+	return nil
+}
+
+func (g *S3TablesGenerator) loadTableBuckets(svc *s3tables.Client) error {
+	paginator := s3tables.NewListTableBucketsPaginator(svc, &s3tables.ListTableBucketsInput{
+		Type: s3tablestypes.TableBucketTypeCustomer,
+	})
+	for paginator.HasMorePages() {
+		page, err := paginator.NextPage(context.TODO())
+		if s3TablesResourceNotFound(err) {
+			return nil
+		}
+		if err != nil {
+			return err
+		}
+		for _, bucketSummary := range page.TableBuckets {
+			tableBucketARN := StringValue(bucketSummary.Arn)
+			if tableBucketARN == "" {
+				continue
+			}
+			tableBucket, err := svc.GetTableBucket(context.TODO(), &s3tables.GetTableBucketInput{
+				TableBucketARN: aws.String(tableBucketARN),
+			})
+			if s3TablesResourceNotFound(err) {
+				continue
+			}
+			if err != nil {
+				return err
+			}
+			if resource, ok := newS3TablesTableBucketResource(tableBucket); ok {
+				g.Resources = append(g.Resources, resource)
+			}
+			g.addTableBucketPolicy(svc, tableBucketARN)
+			if err := g.loadNamespaces(svc, tableBucketARN); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+func (g *S3TablesGenerator) addTableBucketPolicy(svc *s3tables.Client, tableBucketARN string) {
+	policy, ok := getS3TablesTableBucketPolicy(svc, tableBucketARN)
+	if !ok {
+		return
+	}
+	if resource, ok := newS3TablesTableBucketPolicyResource(tableBucketARN, policy); ok {
+		g.Resources = append(g.Resources, resource)
+	}
+}
+
+func (g *S3TablesGenerator) loadNamespaces(svc *s3tables.Client, tableBucketARN string) error {
+	if tableBucketARN == "" {
+		return nil
+	}
+	paginator := s3tables.NewListNamespacesPaginator(svc, &s3tables.ListNamespacesInput{
+		TableBucketARN: aws.String(tableBucketARN),
+	})
+	for paginator.HasMorePages() {
+		page, err := paginator.NextPage(context.TODO())
+		if s3TablesResourceNotFound(err) {
+			return nil
+		}
+		if err != nil {
+			return err
+		}
+		for _, namespaceSummary := range page.Namespaces {
+			namespace, ok := s3TablesNamespaceName(namespaceSummary.Namespace)
+			if !ok {
+				continue
+			}
+			namespaceOutput, err := svc.GetNamespace(context.TODO(), &s3tables.GetNamespaceInput{
+				Namespace:      aws.String(namespace),
+				TableBucketARN: aws.String(tableBucketARN),
+			})
+			if s3TablesResourceNotFound(err) {
+				continue
+			}
+			if err != nil {
+				return err
+			}
+			if resource, ok := newS3TablesNamespaceResource(tableBucketARN, namespaceOutput); ok {
+				g.Resources = append(g.Resources, resource)
+			}
+			if err := g.loadTables(svc, tableBucketARN, namespace); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+func (g *S3TablesGenerator) loadTables(svc *s3tables.Client, tableBucketARN, namespace string) error {
+	if tableBucketARN == "" || namespace == "" {
+		return nil
+	}
+	paginator := s3tables.NewListTablesPaginator(svc, &s3tables.ListTablesInput{
+		Namespace:      aws.String(namespace),
+		TableBucketARN: aws.String(tableBucketARN),
+	})
+	for paginator.HasMorePages() {
+		page, err := paginator.NextPage(context.TODO())
+		if s3TablesResourceNotFound(err) {
+			return nil
+		}
+		if err != nil {
+			return err
+		}
+		for _, tableSummary := range page.Tables {
+			tableName := StringValue(tableSummary.Name)
+			if tableName == "" {
+				continue
+			}
+			table, err := svc.GetTable(context.TODO(), &s3tables.GetTableInput{
+				Name:           aws.String(tableName),
+				Namespace:      aws.String(namespace),
+				TableBucketARN: aws.String(tableBucketARN),
+			})
+			if s3TablesResourceNotFound(err) {
+				continue
+			}
+			if err != nil {
+				return err
+			}
+			if resource, ok := newS3TablesTableResource(tableBucketARN, table); ok {
+				g.Resources = append(g.Resources, resource)
+			}
+		}
+	}
+	return nil
+}
+
+func newS3TablesTableBucketResource(tableBucket *s3tables.GetTableBucketOutput) (terraformutils.Resource, bool) {
+	if !s3TablesTableBucketImportable(tableBucket) {
+		return terraformutils.Resource{}, false
+	}
+	tableBucketARN := StringValue(tableBucket.Arn)
+	name := StringValue(tableBucket.Name)
+	if tableBucketARN == "" || name == "" {
+		return terraformutils.Resource{}, false
+	}
+	resource := terraformutils.NewResource(
+		tableBucketARN,
+		s3TablesResourceName("table_bucket", name, tableBucketARN),
+		s3TablesTableBucketResourceType,
+		"aws",
+		map[string]string{
+			"arn":           tableBucketARN,
+			"force_destroy": "false",
+			"name":          name,
+		},
+		s3TablesAllowEmptyValues,
+		map[string]interface{}{},
+	)
+	setS3TablesPreserveIDAfterRefresh(&resource)
+	return resource, true
+}
+
+func newS3TablesNamespaceResource(tableBucketARN string, namespaceOutput *s3tables.GetNamespaceOutput) (terraformutils.Resource, bool) {
+	if namespaceOutput == nil {
+		return terraformutils.Resource{}, false
+	}
+	namespace, ok := s3TablesNamespaceName(namespaceOutput.Namespace)
+	if !ok || tableBucketARN == "" {
+		return terraformutils.Resource{}, false
+	}
+	resource := terraformutils.NewResource(
+		s3TablesNamespaceImportID(tableBucketARN, namespace),
+		s3TablesResourceName("namespace", tableBucketARN, namespace),
+		s3TablesNamespaceResourceType,
+		"aws",
+		map[string]string{
+			"namespace":        namespace,
+			"table_bucket_arn": tableBucketARN,
+		},
+		s3TablesAllowEmptyValues,
+		map[string]interface{}{},
+	)
+	setS3TablesPreserveIDAfterRefresh(&resource)
+	return resource, true
+}
+
+func newS3TablesTableResource(tableBucketARN string, table *s3tables.GetTableOutput) (terraformutils.Resource, bool) {
+	if !s3TablesTableImportable(table) {
+		return terraformutils.Resource{}, false
+	}
+	name := StringValue(table.Name)
+	namespace, ok := s3TablesNamespaceName(table.Namespace)
+	tableARN := StringValue(table.TableARN)
+	format := string(table.Format)
+	if !ok || tableBucketARN == "" || name == "" || tableARN == "" || format == "" {
+		return terraformutils.Resource{}, false
+	}
+	resource := terraformutils.NewResource(
+		s3TablesTableImportID(tableBucketARN, namespace, name),
+		s3TablesResourceName("table", tableBucketARN, namespace, name, tableARN),
+		s3TablesTableResourceType,
+		"aws",
+		map[string]string{
+			"arn":              tableARN,
+			"format":           format,
+			"name":             name,
+			"namespace":        namespace,
+			"table_bucket_arn": tableBucketARN,
+		},
+		s3TablesAllowEmptyValues,
+		map[string]interface{}{},
+	)
+	setS3TablesPreserveIDAfterRefresh(&resource)
+	return resource, true
+}
+
+func newS3TablesTableBucketPolicyResource(tableBucketARN, policy string) (terraformutils.Resource, bool) {
+	if tableBucketARN == "" || policy == "" {
+		return terraformutils.Resource{}, false
+	}
+	resource := terraformutils.NewResource(
+		tableBucketARN,
+		s3TablesResourceName("table_bucket_policy", tableBucketARN),
+		s3TablesTableBucketPolicyResourceType,
+		"aws",
+		map[string]string{
+			"resource_policy":  policy,
+			"table_bucket_arn": tableBucketARN,
+		},
+		s3TablesAllowEmptyValues,
+		map[string]interface{}{},
+	)
+	setS3TablesPreserveIDAfterRefresh(&resource)
+	return resource, true
+}
+
+func getS3TablesTableBucketPolicy(svc *s3tables.Client, tableBucketARN string) (string, bool) {
+	if tableBucketARN == "" {
+		return "", false
+	}
+	policyOutput, err := svc.GetTableBucketPolicy(context.TODO(), &s3tables.GetTableBucketPolicyInput{
+		TableBucketARN: aws.String(tableBucketARN),
+	})
+	if s3TablesResourceNotFound(err) {
+		return "", false
+	}
+	if err != nil {
+		log.Printf("skipping S3 Tables table bucket policy discovery for %s: %v", tableBucketARN, err)
+		return "", false
+	}
+	if policyOutput == nil {
+		return "", false
+	}
+	policy := StringValue(policyOutput.ResourcePolicy)
+	if policy == "" {
+		return "", false
+	}
+	return policy, true
+}
+
+func s3TablesNamespaceImportID(tableBucketARN, namespace string) string {
+	return strings.Join([]string{tableBucketARN, namespace}, s3TablesIDSeparator)
+}
+
+func s3TablesTableImportID(tableBucketARN, namespace, name string) string {
+	return strings.Join([]string{tableBucketARN, namespace, name}, s3TablesIDSeparator)
+}
+
+func s3TablesNamespaceName(parts []string) (string, bool) {
+	if len(parts) != 1 || parts[0] == "" {
+		return "", false
+	}
+	return parts[0], true
+}
+
+func s3TablesTableBucketImportable(tableBucket *s3tables.GetTableBucketOutput) bool {
+	if tableBucket == nil {
+		return false
+	}
+	return tableBucket.Type == "" || tableBucket.Type == s3tablestypes.TableBucketTypeCustomer
+}
+
+func s3TablesTableImportable(table *s3tables.GetTableOutput) bool {
+	if table == nil {
+		return false
+	}
+	if StringValue(table.ManagedByService) != "" {
+		return false
+	}
+	return table.Type == "" || table.Type == s3tablestypes.TableTypeCustomer
+}
+
+func s3TablesResourceName(parts ...string) string {
+	var name strings.Builder
+	for _, part := range parts {
+		if part == "" {
+			continue
+		}
+		if name.Len() > 0 {
+			name.WriteString("_")
+		}
+		name.WriteString(strconv.Itoa(len(part)))
+		name.WriteString("_")
+		name.WriteString(part)
+	}
+	return name.String()
+}
+
+func s3TablesResourceNotFound(err error) bool {
+	if err == nil {
+		return false
+	}
+	var notFound *s3tablestypes.NotFoundException
+	if errors.As(err, &notFound) {
+		return true
+	}
+	var apiErr smithy.APIError
+	if !errors.As(err, &apiErr) {
+		return false
+	}
+	switch apiErr.ErrorCode() {
+	case "NotFound",
+		"NotFoundException",
+		"NoSuchResource",
+		"ResourceNotFoundException":
+		return true
+	default:
+		return false
+	}
+}
+
+func setS3TablesPreserveIDAfterRefresh(resource *terraformutils.Resource) {
+	if resource == nil || resource.InstanceState == nil {
+		return
+	}
+	if resource.InstanceState.Meta == nil {
+		resource.InstanceState.Meta = map[string]interface{}{}
+	}
+	resource.InstanceState.Meta[tfcompat.MetaKeyPreserveIDAfterRefresh] = true
+}
+
+func wrapS3TablesPolicyHeredoc(g *S3TablesGenerator, resource *terraformutils.Resource) {
+	if resource == nil || resource.Item == nil {
+		return
+	}
+	policy, ok := resource.Item["resource_policy"].(string)
+	if !ok || policy == "" {
+		return
+	}
+	resource.Item["resource_policy"] = fmt.Sprintf("<<POLICY\n%s\nPOLICY", g.escapeAwsInterpolation(policy))
+}

--- a/providers/aws/s3tables.go
+++ b/providers/aws/s3tables.go
@@ -23,6 +23,7 @@ const (
 	s3TablesNamespaceResourceType         = "aws_s3tables_namespace"
 	s3TablesTableResourceType             = "aws_s3tables_table"
 	s3TablesTableBucketPolicyResourceType = "aws_s3tables_table_bucket_policy"
+	s3TablesTablePolicyResourceType       = "aws_s3tables_table_policy"
 	s3TablesIDSeparator                   = ";"
 )
 
@@ -47,7 +48,8 @@ func (g *S3TablesGenerator) PostConvertHook() error {
 		if g.Resources[i].InstanceInfo == nil {
 			continue
 		}
-		if g.Resources[i].InstanceInfo.Type == s3TablesTableBucketPolicyResourceType {
+		if g.Resources[i].InstanceInfo.Type == s3TablesTableBucketPolicyResourceType ||
+			g.Resources[i].InstanceInfo.Type == s3TablesTablePolicyResourceType {
 			wrapS3TablesPolicyHeredoc(g, &g.Resources[i])
 		}
 	}
@@ -177,6 +179,7 @@ func (g *S3TablesGenerator) loadTables(svc *s3tables.Client, tableBucketARN, nam
 			}
 			if resource, ok := newS3TablesTableResource(tableBucketARN, table); ok {
 				g.Resources = append(g.Resources, resource)
+				g.addTablePolicy(svc, tableBucketARN, namespace, tableName)
 			}
 		}
 	}
@@ -283,6 +286,38 @@ func newS3TablesTableBucketPolicyResource(tableBucketARN, policy string) (terraf
 	return resource, true
 }
 
+func newS3TablesTablePolicyResource(tableBucketARN, namespace, name, policy string) (terraformutils.Resource, bool) {
+	if tableBucketARN == "" || namespace == "" || name == "" || policy == "" {
+		return terraformutils.Resource{}, false
+	}
+	resource := terraformutils.NewResource(
+		s3TablesTableImportID(tableBucketARN, namespace, name),
+		s3TablesResourceName("table_policy", tableBucketARN, namespace, name),
+		s3TablesTablePolicyResourceType,
+		"aws",
+		map[string]string{
+			"name":             name,
+			"namespace":        namespace,
+			"resource_policy":  policy,
+			"table_bucket_arn": tableBucketARN,
+		},
+		s3TablesAllowEmptyValues,
+		map[string]interface{}{},
+	)
+	setS3TablesPreserveIDAfterRefresh(&resource)
+	return resource, true
+}
+
+func (g *S3TablesGenerator) addTablePolicy(svc *s3tables.Client, tableBucketARN, namespace, name string) {
+	policy, ok := getS3TablesTablePolicy(svc, tableBucketARN, namespace, name)
+	if !ok {
+		return
+	}
+	if resource, ok := newS3TablesTablePolicyResource(tableBucketARN, namespace, name, policy); ok {
+		g.Resources = append(g.Resources, resource)
+	}
+}
+
 func getS3TablesTableBucketPolicy(svc *s3tables.Client, tableBucketARN string) (string, bool) {
 	if tableBucketARN == "" {
 		return "", false
@@ -295,6 +330,32 @@ func getS3TablesTableBucketPolicy(svc *s3tables.Client, tableBucketARN string) (
 	}
 	if err != nil {
 		log.Printf("skipping S3 Tables table bucket policy discovery for %s: %v", tableBucketARN, err)
+		return "", false
+	}
+	if policyOutput == nil {
+		return "", false
+	}
+	policy := StringValue(policyOutput.ResourcePolicy)
+	if policy == "" {
+		return "", false
+	}
+	return policy, true
+}
+
+func getS3TablesTablePolicy(svc *s3tables.Client, tableBucketARN, namespace, name string) (string, bool) {
+	if tableBucketARN == "" || namespace == "" || name == "" {
+		return "", false
+	}
+	policyOutput, err := svc.GetTablePolicy(context.TODO(), &s3tables.GetTablePolicyInput{
+		Name:           aws.String(name),
+		Namespace:      aws.String(namespace),
+		TableBucketARN: aws.String(tableBucketARN),
+	})
+	if s3TablesResourceNotFound(err) {
+		return "", false
+	}
+	if err != nil {
+		log.Printf("skipping S3 Tables table policy discovery for %s: %v", s3TablesTableImportID(tableBucketARN, namespace, name), err)
 		return "", false
 	}
 	if policyOutput == nil {

--- a/providers/aws/s3tables_test.go
+++ b/providers/aws/s3tables_test.go
@@ -1,0 +1,339 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package aws
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/s3tables"
+	s3tablestypes "github.com/aws/aws-sdk-go-v2/service/s3tables/types"
+	"github.com/aws/smithy-go"
+	"github.com/chenrui333/terraformer/terraformutils"
+	"github.com/chenrui333/terraformer/terraformutils/tfcompat"
+)
+
+const (
+	testS3TablesTableBucketARN = "arn:aws:s3tables:us-east-1:123456789012:bucket/core-bucket"
+	testS3TablesTableARN       = "arn:aws:s3tables:us-east-1:123456789012:bucket/core-bucket/table/12345678-1234-1234-1234-123456789012"
+)
+
+func TestS3TablesImportIDs(t *testing.T) {
+	tests := []struct {
+		name string
+		got  string
+		want string
+	}{
+		{
+			name: "namespace",
+			got:  s3TablesNamespaceImportID(testS3TablesTableBucketARN, "core_namespace"),
+			want: testS3TablesTableBucketARN + ";core_namespace",
+		},
+		{
+			name: "table",
+			got:  s3TablesTableImportID(testS3TablesTableBucketARN, "core_namespace", "core_table"),
+			want: testS3TablesTableBucketARN + ";core_namespace;core_table",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.got != tt.want {
+				t.Fatalf("import ID = %q, want %q", tt.got, tt.want)
+			}
+		})
+	}
+}
+
+func TestNewS3TablesTableBucketResource(t *testing.T) {
+	resource, ok := newS3TablesTableBucketResource(&s3tables.GetTableBucketOutput{
+		Arn:  aws.String(testS3TablesTableBucketARN),
+		Name: aws.String("core-bucket"),
+		Type: s3tablestypes.TableBucketTypeCustomer,
+	})
+	assertS3TablesResourceAttributes(t, resource, ok, s3TablesTableBucketResourceType, testS3TablesTableBucketARN,
+		[]string{"table_bucket", "core-bucket", testS3TablesTableBucketARN},
+		map[string]string{
+			"arn":           testS3TablesTableBucketARN,
+			"force_destroy": "false",
+			"name":          "core-bucket",
+		})
+	assertS3TablesPreservesID(t, resource)
+
+	if _, ok := newS3TablesTableBucketResource(nil); ok {
+		t.Fatal("nil table bucket should be skipped")
+	}
+	if _, ok := newS3TablesTableBucketResource(&s3tables.GetTableBucketOutput{Name: aws.String("core-bucket")}); ok {
+		t.Fatal("table bucket with empty ARN should be skipped")
+	}
+	if _, ok := newS3TablesTableBucketResource(&s3tables.GetTableBucketOutput{Arn: aws.String(testS3TablesTableBucketARN)}); ok {
+		t.Fatal("table bucket with empty name should be skipped")
+	}
+	if _, ok := newS3TablesTableBucketResource(&s3tables.GetTableBucketOutput{
+		Arn:  aws.String(testS3TablesTableBucketARN),
+		Name: aws.String("core-bucket"),
+		Type: s3tablestypes.TableBucketTypeAws,
+	}); ok {
+		t.Fatal("AWS-managed table bucket should be skipped")
+	}
+}
+
+func TestNewS3TablesNamespaceResource(t *testing.T) {
+	resource, ok := newS3TablesNamespaceResource(testS3TablesTableBucketARN, &s3tables.GetNamespaceOutput{
+		Namespace: []string{"core_namespace"},
+	})
+	assertS3TablesResourceAttributes(t, resource, ok, s3TablesNamespaceResourceType, testS3TablesTableBucketARN+";core_namespace",
+		[]string{"namespace", testS3TablesTableBucketARN, "core_namespace"},
+		map[string]string{
+			"namespace":        "core_namespace",
+			"table_bucket_arn": testS3TablesTableBucketARN,
+		})
+	assertS3TablesPreservesID(t, resource)
+
+	if _, ok := newS3TablesNamespaceResource("", &s3tables.GetNamespaceOutput{Namespace: []string{"core_namespace"}}); ok {
+		t.Fatal("namespace with empty table bucket ARN should be skipped")
+	}
+	if _, ok := newS3TablesNamespaceResource(testS3TablesTableBucketARN, nil); ok {
+		t.Fatal("nil namespace output should be skipped")
+	}
+	if _, ok := newS3TablesNamespaceResource(testS3TablesTableBucketARN, &s3tables.GetNamespaceOutput{}); ok {
+		t.Fatal("namespace with empty name should be skipped")
+	}
+	if _, ok := newS3TablesNamespaceResource(testS3TablesTableBucketARN, &s3tables.GetNamespaceOutput{Namespace: []string{"core", "nested"}}); ok {
+		t.Fatal("multi-part namespace should be skipped")
+	}
+}
+
+func TestNewS3TablesTableResource(t *testing.T) {
+	resource, ok := newS3TablesTableResource(testS3TablesTableBucketARN, &s3tables.GetTableOutput{
+		Format:    s3tablestypes.OpenTableFormatIceberg,
+		Name:      aws.String("core_table"),
+		Namespace: []string{"core_namespace"},
+		TableARN:  aws.String(testS3TablesTableARN),
+		Type:      s3tablestypes.TableTypeCustomer,
+	})
+	assertS3TablesResourceAttributes(t, resource, ok, s3TablesTableResourceType, testS3TablesTableBucketARN+";core_namespace;core_table",
+		[]string{"table", testS3TablesTableBucketARN, "core_namespace", "core_table", testS3TablesTableARN},
+		map[string]string{
+			"arn":              testS3TablesTableARN,
+			"format":           "ICEBERG",
+			"name":             "core_table",
+			"namespace":        "core_namespace",
+			"table_bucket_arn": testS3TablesTableBucketARN,
+		})
+	assertS3TablesPreservesID(t, resource)
+
+	if _, ok := newS3TablesTableResource("", &s3tables.GetTableOutput{
+		Format:    s3tablestypes.OpenTableFormatIceberg,
+		Name:      aws.String("core_table"),
+		Namespace: []string{"core_namespace"},
+		TableARN:  aws.String(testS3TablesTableARN),
+	}); ok {
+		t.Fatal("table with empty table bucket ARN should be skipped")
+	}
+	if _, ok := newS3TablesTableResource(testS3TablesTableBucketARN, nil); ok {
+		t.Fatal("nil table should be skipped")
+	}
+	if _, ok := newS3TablesTableResource(testS3TablesTableBucketARN, &s3tables.GetTableOutput{
+		Name:      aws.String("core_table"),
+		Namespace: []string{"core_namespace"},
+		TableARN:  aws.String(testS3TablesTableARN),
+	}); ok {
+		t.Fatal("table with empty format should be skipped")
+	}
+	if _, ok := newS3TablesTableResource(testS3TablesTableBucketARN, &s3tables.GetTableOutput{
+		Format:    s3tablestypes.OpenTableFormatIceberg,
+		Namespace: []string{"core_namespace"},
+		TableARN:  aws.String(testS3TablesTableARN),
+	}); ok {
+		t.Fatal("table with empty name should be skipped")
+	}
+	if _, ok := newS3TablesTableResource(testS3TablesTableBucketARN, &s3tables.GetTableOutput{
+		Format:    s3tablestypes.OpenTableFormatIceberg,
+		Name:      aws.String("core_table"),
+		Namespace: []string{"core", "nested"},
+		TableARN:  aws.String(testS3TablesTableARN),
+	}); ok {
+		t.Fatal("table with multi-part namespace should be skipped")
+	}
+	if _, ok := newS3TablesTableResource(testS3TablesTableBucketARN, &s3tables.GetTableOutput{
+		Format:    s3tablestypes.OpenTableFormatIceberg,
+		Name:      aws.String("core_table"),
+		Namespace: []string{"core_namespace"},
+	}); ok {
+		t.Fatal("table with empty ARN should be skipped")
+	}
+	if _, ok := newS3TablesTableResource(testS3TablesTableBucketARN, &s3tables.GetTableOutput{
+		Format:    s3tablestypes.OpenTableFormatIceberg,
+		Name:      aws.String("core_table"),
+		Namespace: []string{"core_namespace"},
+		TableARN:  aws.String(testS3TablesTableARN),
+		Type:      s3tablestypes.TableTypeAws,
+	}); ok {
+		t.Fatal("AWS-managed table should be skipped")
+	}
+	if _, ok := newS3TablesTableResource(testS3TablesTableBucketARN, &s3tables.GetTableOutput{
+		Format:           s3tablestypes.OpenTableFormatIceberg,
+		ManagedByService: aws.String("s3.amazonaws.com"),
+		Name:             aws.String("core_table"),
+		Namespace:        []string{"core_namespace"},
+		TableARN:         aws.String(testS3TablesTableARN),
+		Type:             s3tablestypes.TableTypeCustomer,
+	}); ok {
+		t.Fatal("service-managed table should be skipped")
+	}
+}
+
+func TestNewS3TablesTableBucketPolicyResource(t *testing.T) {
+	policy := `{"Version":"2012-10-17"}`
+	resource, ok := newS3TablesTableBucketPolicyResource(testS3TablesTableBucketARN, policy)
+	assertS3TablesResourceAttributes(t, resource, ok, s3TablesTableBucketPolicyResourceType, testS3TablesTableBucketARN,
+		[]string{"table_bucket_policy", testS3TablesTableBucketARN},
+		map[string]string{
+			"resource_policy":  policy,
+			"table_bucket_arn": testS3TablesTableBucketARN,
+		})
+	assertS3TablesPreservesID(t, resource)
+
+	if _, ok := newS3TablesTableBucketPolicyResource("", policy); ok {
+		t.Fatal("policy with empty table bucket ARN should be skipped")
+	}
+	if _, ok := newS3TablesTableBucketPolicyResource(testS3TablesTableBucketARN, ""); ok {
+		t.Fatal("policy with empty policy body should be skipped")
+	}
+}
+
+func TestS3TablesNamespaceName(t *testing.T) {
+	tests := []struct {
+		name  string
+		parts []string
+		want  string
+		ok    bool
+	}{
+		{name: "single", parts: []string{"core_namespace"}, want: "core_namespace", ok: true},
+		{name: "empty slice", ok: false},
+		{name: "empty value", parts: []string{""}, ok: false},
+		{name: "multi part", parts: []string{"core", "nested"}, ok: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, ok := s3TablesNamespaceName(tt.parts)
+			if ok != tt.ok {
+				t.Fatalf("ok = %t, want %t", ok, tt.ok)
+			}
+			if got != tt.want {
+				t.Fatalf("namespace = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestS3TablesImportablePredicates(t *testing.T) {
+	if !s3TablesTableBucketImportable(&s3tables.GetTableBucketOutput{Type: s3tablestypes.TableBucketTypeCustomer}) {
+		t.Fatal("customer table bucket should be importable")
+	}
+	if s3TablesTableBucketImportable(&s3tables.GetTableBucketOutput{Type: s3tablestypes.TableBucketTypeAws}) {
+		t.Fatal("AWS-managed table bucket should not be importable")
+	}
+	if !s3TablesTableImportable(&s3tables.GetTableOutput{Type: s3tablestypes.TableTypeCustomer}) {
+		t.Fatal("customer table should be importable")
+	}
+	if s3TablesTableImportable(&s3tables.GetTableOutput{Type: s3tablestypes.TableTypeAws}) {
+		t.Fatal("AWS-managed table should not be importable")
+	}
+	if s3TablesTableImportable(&s3tables.GetTableOutput{
+		ManagedByService: aws.String("s3.amazonaws.com"),
+		Type:             s3tablestypes.TableTypeCustomer,
+	}) {
+		t.Fatal("service-managed table should not be importable")
+	}
+}
+
+func TestS3TablesResourceNameAvoidsSanitizedCollisions(t *testing.T) {
+	left := terraformutils.TfSanitize(s3TablesResourceName("table", "a_b", "c"))
+	right := terraformutils.TfSanitize(s3TablesResourceName("table", "a", "b_c"))
+	if left == right {
+		t.Fatalf("resource names collide: %q", left)
+	}
+}
+
+func TestS3TablesResourceNotFound(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{name: "nil", want: false},
+		{name: "typed not found", err: &s3tablestypes.NotFoundException{}, want: true},
+		{name: "generic not found", err: &smithy.GenericAPIError{Code: "NotFoundException"}, want: true},
+		{name: "resource not found", err: &smithy.GenericAPIError{Code: "ResourceNotFoundException"}, want: true},
+		{name: "wrapped not found", err: errors.Join(errors.New("lookup failed"), &s3tablestypes.NotFoundException{}), want: true},
+		{name: "access denied", err: &smithy.GenericAPIError{Code: "AccessDenied"}, want: false},
+		{name: "generic", err: errors.New("boom"), want: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := s3TablesResourceNotFound(tt.err); got != tt.want {
+				t.Fatalf("not found = %t, want %t", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestS3TablesPostConvertHookWrapsPolicy(t *testing.T) {
+	policyResource, ok := newS3TablesTableBucketPolicyResource(testS3TablesTableBucketARN, `{"Resource":"${aws:username}"}`)
+	if !ok {
+		t.Fatal("table bucket policy should be importable")
+	}
+	policyResource.Item = map[string]interface{}{
+		"resource_policy": `{"Resource":"${aws:username}"}`,
+	}
+
+	generator := S3TablesGenerator{
+		AWSService: AWSService{
+			Service: terraformutils.Service{
+				Resources: []terraformutils.Resource{policyResource},
+			},
+		},
+	}
+	if err := generator.PostConvertHook(); err != nil {
+		t.Fatalf("PostConvertHook() error = %v", err)
+	}
+	want := "<<POLICY\n{\"Resource\":\"$" + "$" + "{aws:username}\"}\nPOLICY"
+	if got := generator.Resources[0].Item["resource_policy"]; got != want {
+		t.Fatalf("resource_policy = %q, want %q", got, want)
+	}
+}
+
+func assertS3TablesResourceAttributes(t *testing.T, resource terraformutils.Resource, ok bool, resourceType, resourceID string, nameParts []string, attributes map[string]string) {
+	t.Helper()
+	if !ok {
+		t.Fatal("resource was skipped")
+	}
+	if resource.InstanceInfo.Type != resourceType {
+		t.Fatalf("resource type = %q, want %q", resource.InstanceInfo.Type, resourceType)
+	}
+	if resource.InstanceState.ID != resourceID {
+		t.Fatalf("resource ID = %q, want %q", resource.InstanceState.ID, resourceID)
+	}
+	for name, want := range attributes {
+		if got := resource.InstanceState.Attributes[name]; got != want {
+			t.Fatalf("attribute %q = %q, want %q", name, got, want)
+		}
+	}
+	wantName := terraformutils.TfSanitize(s3TablesResourceName(nameParts...))
+	if resource.ResourceName != wantName {
+		t.Fatalf("resource name = %q, want %q", resource.ResourceName, wantName)
+	}
+}
+
+func assertS3TablesPreservesID(t *testing.T, resource terraformutils.Resource) {
+	t.Helper()
+	preserveID, ok := resource.InstanceState.Meta[tfcompat.MetaKeyPreserveIDAfterRefresh].(bool)
+	if !ok || !preserveID {
+		t.Fatalf("preserve ID metadata = %#v, want true", resource.InstanceState.Meta[tfcompat.MetaKeyPreserveIDAfterRefresh])
+	}
+}

--- a/providers/aws/s3tables_test.go
+++ b/providers/aws/s3tables_test.go
@@ -35,6 +35,11 @@ func TestS3TablesImportIDs(t *testing.T) {
 			got:  s3TablesTableImportID(testS3TablesTableBucketARN, "core_namespace", "core_table"),
 			want: testS3TablesTableBucketARN + ";core_namespace;core_table",
 		},
+		{
+			name: "table policy",
+			got:  s3TablesTableImportID(testS3TablesTableBucketARN, "core_namespace", "core_table"),
+			want: testS3TablesTableBucketARN + ";core_namespace;core_table",
+		},
 	}
 
 	for _, tt := range tests {
@@ -204,6 +209,33 @@ func TestNewS3TablesTableBucketPolicyResource(t *testing.T) {
 	}
 }
 
+func TestNewS3TablesTablePolicyResource(t *testing.T) {
+	policy := `{"Version":"2012-10-17"}`
+	resource, ok := newS3TablesTablePolicyResource(testS3TablesTableBucketARN, "core_namespace", "core_table", policy)
+	assertS3TablesResourceAttributes(t, resource, ok, s3TablesTablePolicyResourceType, testS3TablesTableBucketARN+";core_namespace;core_table",
+		[]string{"table_policy", testS3TablesTableBucketARN, "core_namespace", "core_table"},
+		map[string]string{
+			"name":             "core_table",
+			"namespace":        "core_namespace",
+			"resource_policy":  policy,
+			"table_bucket_arn": testS3TablesTableBucketARN,
+		})
+	assertS3TablesPreservesID(t, resource)
+
+	if _, ok := newS3TablesTablePolicyResource("", "core_namespace", "core_table", policy); ok {
+		t.Fatal("table policy with empty table bucket ARN should be skipped")
+	}
+	if _, ok := newS3TablesTablePolicyResource(testS3TablesTableBucketARN, "", "core_table", policy); ok {
+		t.Fatal("table policy with empty namespace should be skipped")
+	}
+	if _, ok := newS3TablesTablePolicyResource(testS3TablesTableBucketARN, "core_namespace", "", policy); ok {
+		t.Fatal("table policy with empty name should be skipped")
+	}
+	if _, ok := newS3TablesTablePolicyResource(testS3TablesTableBucketARN, "core_namespace", "core_table", ""); ok {
+		t.Fatal("table policy with empty policy body should be skipped")
+	}
+}
+
 func TestS3TablesNamespaceName(t *testing.T) {
 	tests := []struct {
 		name  string
@@ -284,18 +316,25 @@ func TestS3TablesResourceNotFound(t *testing.T) {
 }
 
 func TestS3TablesPostConvertHookWrapsPolicy(t *testing.T) {
-	policyResource, ok := newS3TablesTableBucketPolicyResource(testS3TablesTableBucketARN, `{"Resource":"${aws:username}"}`)
+	tableBucketPolicyResource, ok := newS3TablesTableBucketPolicyResource(testS3TablesTableBucketARN, `{"Resource":"${aws:username}"}`)
 	if !ok {
 		t.Fatal("table bucket policy should be importable")
 	}
-	policyResource.Item = map[string]interface{}{
+	tableBucketPolicyResource.Item = map[string]interface{}{
+		"resource_policy": `{"Resource":"${aws:username}"}`,
+	}
+	tablePolicyResource, ok := newS3TablesTablePolicyResource(testS3TablesTableBucketARN, "core_namespace", "core_table", `{"Resource":"${aws:username}"}`)
+	if !ok {
+		t.Fatal("table policy should be importable")
+	}
+	tablePolicyResource.Item = map[string]interface{}{
 		"resource_policy": `{"Resource":"${aws:username}"}`,
 	}
 
 	generator := S3TablesGenerator{
 		AWSService: AWSService{
 			Service: terraformutils.Service{
-				Resources: []terraformutils.Resource{policyResource},
+				Resources: []terraformutils.Resource{tableBucketPolicyResource, tablePolicyResource},
 			},
 		},
 	}
@@ -303,8 +342,10 @@ func TestS3TablesPostConvertHookWrapsPolicy(t *testing.T) {
 		t.Fatalf("PostConvertHook() error = %v", err)
 	}
 	want := "<<POLICY\n{\"Resource\":\"$" + "$" + "{aws:username}\"}\nPOLICY"
-	if got := generator.Resources[0].Item["resource_policy"]; got != want {
-		t.Fatalf("resource_policy = %q, want %q", got, want)
+	for _, resource := range generator.Resources {
+		if got := resource.Item["resource_policy"]; got != want {
+			t.Fatalf("resource_policy = %q, want %q", got, want)
+		}
 	}
 }
 


### PR DESCRIPTION
## Summary

- add S3 Tables import discovery for table buckets, namespaces, tables, table bucket policies, and table policies
- register `s3tables` and add the AWS SDK S3 Tables dependency
- seed import IDs as table bucket ARNs or semicolon-delimited parent identifiers
- preserve framework import IDs after refresh and heredoc-wrap S3 Tables policy resources

## References

- #338

## Validation

```bash
go test ./providers/aws -run 'Test.*S3|Test.*s3|Test.*S3Control|Test.*s3control|Test.*S3Tables|Test.*s3tables'
go test ./providers/aws/... ./terraformutils/...
go run ./tools/aws-gap-inventory \
  -docs docs/aws.md \
  -aws-dir providers/aws \
  -skip-list providers/aws/unsupported_resources.json \
  -format markdown
git diff --check
```

## Notes

Skipped/deferred resources:
- `aws_s3_bucket_metadata_table_configuration`: not present in the current Terraform AWS provider source/docs under that name.
- `aws_s3_bucket_metadata_configuration`: deferred for a focused S3 bucket metadata configuration PR because it needs nested `metadata_configuration` state seeding.
- `aws_s3tables_table_bucket_replication` and `aws_s3tables_table_replication`: deferred to keep this PR to the table bucket, namespace, table, and policy subset.
- AWS service-managed S3 Tables buckets/tables are intentionally filtered or skipped so bucket metadata-managed tables are not emitted as customer-managed S3 Tables resources.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced support for AWS S3Tables resources, enabling automatic discovery and Terraform code generation for table buckets, namespaces, tables, and associated bucket/table policies.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/chenrui333/terraformer/pull/418)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->