### PR TITLE
aws(sesv2): add account settings imports

### DIFF
--- a/docs/aws.md
+++ b/docs/aws.md
@@ -505,6 +505,8 @@ For AWS provider gap audits and unsupported-resource skip-list maintenance, see 
     * `aws_ses_receipt_rule_set`
     * `aws_ses_template`
 *   `sesv2`
+    * `aws_sesv2_account_suppression_attributes`
+    * `aws_sesv2_account_vdm_attributes`
     * `aws_sesv2_configuration_set`
     * `aws_sesv2_configuration_set_event_destination`
     * `aws_sesv2_contact_list`

--- a/providers/aws/sesv2.go
+++ b/providers/aws/sesv2.go
@@ -6,16 +6,20 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"log"
 	"sort"
 	"strconv"
 	"strings"
 
+	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/sesv2"
 	sesv2types "github.com/aws/aws-sdk-go-v2/service/sesv2/types"
 	"github.com/chenrui333/terraformer/terraformutils"
 )
 
 const (
+	sesv2AccountSuppressionAttributesResourceType     = "aws_sesv2_account_suppression_attributes"
+	sesv2AccountVDMAttributesResourceType             = "aws_sesv2_account_vdm_attributes"
 	sesv2ConfigurationSetResourceType                 = "aws_sesv2_configuration_set"
 	sesv2ConfigurationSetEventDestinationResourceType = "aws_sesv2_configuration_set_event_destination"
 	sesv2ContactListResourceType                      = "aws_sesv2_contact_list"
@@ -25,6 +29,7 @@ const (
 	sesv2EmailIdentityFeedbackAttributesResourceType  = "aws_sesv2_email_identity_feedback_attributes"
 	sesv2EmailIdentityMailFromAttributesResourceType  = "aws_sesv2_email_identity_mail_from_attributes"
 	sesv2EmailIdentityPolicyResourceType              = "aws_sesv2_email_identity_policy"
+	sesv2AccountVDMAttributesImportIDValue            = "ses-account-vdm-attributes"
 	sesv2DefaultDedicatedIPPoolName                   = "ses-default-dedicated-pool"
 	sesv2DedicatedIPAssignmentIDSeparator             = ","
 	sesv2ResourceIDSeparator                          = "|"
@@ -43,6 +48,9 @@ func (g *SesV2Generator) InitResources() error {
 	}
 	svc := sesv2.NewFromConfig(config)
 
+	if err := g.loadAccountSettings(svc, config); err != nil {
+		log.Printf("Skipping SESv2 account settings: %v", err)
+	}
 	if err := g.loadConfigurationSets(svc); err != nil {
 		return err
 	}
@@ -72,6 +80,34 @@ func (g *SesV2Generator) PostConvertHook() error {
 			continue
 		}
 		g.Resources[i].Item["policy"] = fmt.Sprintf("<<POLICY\n%s\nPOLICY", g.escapeAwsInterpolation(policy))
+	}
+	return nil
+}
+
+func (g *SesV2Generator) loadAccountSettings(svc *sesv2.Client, config aws.Config) error {
+	output, err := svc.GetAccount(context.TODO(), &sesv2.GetAccountInput{})
+	if err != nil {
+		if sesv2NotFound(err) {
+			return nil
+		}
+		return err
+	}
+	if output == nil {
+		return nil
+	}
+	if output.SuppressionAttributes != nil && len(output.SuppressionAttributes.SuppressedReasons) > 0 {
+		accountID := ""
+		if account, err := g.getAccountNumber(config); err != nil {
+			log.Printf("Skipping SESv2 account suppression attributes: unable to get account ID: %v", err)
+		} else {
+			accountID = StringValue(account)
+		}
+		if resource, ok := newSESV2AccountSuppressionAttributesResource(accountID, output); ok {
+			g.Resources = append(g.Resources, resource)
+		}
+	}
+	if resource, ok := newSESV2AccountVDMAttributesResource(output); ok {
+		g.Resources = append(g.Resources, resource)
 	}
 	return nil
 }
@@ -283,6 +319,55 @@ func (g *SesV2Generator) loadEmailIdentityPolicies(svc *sesv2.Client, identityNa
 		}
 	}
 	return nil
+}
+
+func newSESV2AccountSuppressionAttributesResource(accountID string, output *sesv2.GetAccountOutput) (terraformutils.Resource, bool) {
+	if accountID == "" || output == nil || output.SuppressionAttributes == nil {
+		return terraformutils.Resource{}, false
+	}
+	attributes, ok := sesv2SuppressedReasonAttributes(output.SuppressionAttributes.SuppressedReasons)
+	if !ok {
+		return terraformutils.Resource{}, false
+	}
+	return terraformutils.NewResource(
+		sesv2AccountSuppressionAttributesImportID(accountID),
+		sesv2ResourceName("account_suppression_attributes", accountID),
+		sesv2AccountSuppressionAttributesResourceType,
+		"aws",
+		attributes,
+		sesv2AllowEmptyValues,
+		map[string]interface{}{},
+	), true
+}
+
+func newSESV2AccountVDMAttributesResource(output *sesv2.GetAccountOutput) (terraformutils.Resource, bool) {
+	if output == nil || !sesv2AccountVDMAttributesConfigured(output.VdmAttributes) {
+		return terraformutils.Resource{}, false
+	}
+	attributes := map[string]string{
+		"vdm_enabled": string(output.VdmAttributes.VdmEnabled),
+	}
+	if output.VdmAttributes.DashboardAttributes != nil {
+		if engagementMetrics := string(output.VdmAttributes.DashboardAttributes.EngagementMetrics); engagementMetrics != "" {
+			attributes["dashboard_attributes.#"] = "1"
+			attributes["dashboard_attributes.0.engagement_metrics"] = engagementMetrics
+		}
+	}
+	if output.VdmAttributes.GuardianAttributes != nil {
+		if optimizedSharedDelivery := string(output.VdmAttributes.GuardianAttributes.OptimizedSharedDelivery); optimizedSharedDelivery != "" {
+			attributes["guardian_attributes.#"] = "1"
+			attributes["guardian_attributes.0.optimized_shared_delivery"] = optimizedSharedDelivery
+		}
+	}
+	return terraformutils.NewResource(
+		sesv2AccountVDMAttributesImportID(),
+		sesv2ResourceName("account_vdm_attributes"),
+		sesv2AccountVDMAttributesResourceType,
+		"aws",
+		attributes,
+		sesv2AllowEmptyValues,
+		map[string]interface{}{},
+	), true
 }
 
 func newSESV2ConfigurationSetResource(configurationSetName string) (terraformutils.Resource, bool) {
@@ -523,9 +608,60 @@ func sesv2EmailIdentityImportable(output *sesv2.GetEmailIdentityOutput) bool {
 	return output.DkimAttributes.SigningAttributesOrigin != sesv2types.DkimSigningAttributesOriginExternal
 }
 
+func sesv2AccountVDMAttributesConfigured(attributes *sesv2types.VdmAttributes) bool {
+	if attributes == nil || attributes.VdmEnabled == "" {
+		return false
+	}
+	if attributes.VdmEnabled != sesv2types.FeatureStatusDisabled {
+		return true
+	}
+	return sesv2DashboardAttributesConfigured(attributes.DashboardAttributes) || sesv2GuardianAttributesConfigured(attributes.GuardianAttributes)
+}
+
+func sesv2DashboardAttributesConfigured(attributes *sesv2types.DashboardAttributes) bool {
+	return attributes != nil && attributes.EngagementMetrics != ""
+}
+
+func sesv2GuardianAttributesConfigured(attributes *sesv2types.GuardianAttributes) bool {
+	return attributes != nil && attributes.OptimizedSharedDelivery != ""
+}
+
+func sesv2SuppressedReasonAttributes(reasons []sesv2types.SuppressionListReason) (map[string]string, bool) {
+	if len(reasons) == 0 {
+		return nil, false
+	}
+	values := make([]string, 0, len(reasons))
+	for _, reason := range reasons {
+		if reason == "" {
+			return nil, false
+		}
+		values = append(values, string(reason))
+	}
+	sort.Strings(values)
+	return sesv2StringSliceAttributes("suppressed_reasons", values), true
+}
+
+func sesv2StringSliceAttributes(name string, values []string) map[string]string {
+	attributes := map[string]string{
+		name + ".#": strconv.Itoa(len(values)),
+	}
+	for i, value := range values {
+		attributes[name+"."+strconv.Itoa(i)] = value
+	}
+	return attributes
+}
+
 func sesv2NotFound(err error) bool {
 	var notFound *sesv2types.NotFoundException
 	return errors.As(err, &notFound)
+}
+
+func sesv2AccountSuppressionAttributesImportID(accountID string) string {
+	return accountID
+}
+
+func sesv2AccountVDMAttributesImportID() string {
+	return sesv2AccountVDMAttributesImportIDValue
 }
 
 func sesv2ConfigurationSetImportID(configurationSetName string) string {

--- a/providers/aws/sesv2_test.go
+++ b/providers/aws/sesv2_test.go
@@ -19,6 +19,8 @@ func TestSESV2ImportIDs(t *testing.T) {
 		got  string
 		want string
 	}{
+		{name: "account suppression attributes", got: sesv2AccountSuppressionAttributesImportID("123456789012"), want: "123456789012"},
+		{name: "account VDM attributes", got: sesv2AccountVDMAttributesImportID(), want: "ses-account-vdm-attributes"},
 		{name: "configuration set", got: sesv2ConfigurationSetImportID("config-set"), want: "config-set"},
 		{name: "configuration set event destination", got: sesv2ConfigurationSetEventDestinationImportID("config-set", "events"), want: "config-set|events"},
 		{name: "contact list", got: sesv2ContactListImportID("contacts"), want: "contacts"},
@@ -34,6 +36,112 @@ func TestSESV2ImportIDs(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			if tt.got != tt.want {
 				t.Fatalf("import ID = %q, want %q", tt.got, tt.want)
+			}
+		})
+	}
+}
+
+func TestNewSESV2AccountSuppressionAttributesResource(t *testing.T) {
+	resource, ok := newSESV2AccountSuppressionAttributesResource("123456789012", &sesv2.GetAccountOutput{
+		SuppressionAttributes: &sesv2types.SuppressionAttributes{
+			SuppressedReasons: []sesv2types.SuppressionListReason{
+				sesv2types.SuppressionListReasonComplaint,
+				sesv2types.SuppressionListReasonBounce,
+			},
+		},
+	})
+	if !ok {
+		t.Fatal("newSESV2AccountSuppressionAttributesResource() ok = false, want true")
+	}
+	assertSESV2ResourceAttributes(t, resource, sesv2AccountSuppressionAttributesResourceType, "123456789012",
+		[]string{"account_suppression_attributes", "123456789012"},
+		map[string]string{
+			"suppressed_reasons.#": "2",
+			"suppressed_reasons.0": "BOUNCE",
+			"suppressed_reasons.1": "COMPLAINT",
+		})
+
+	tests := []struct {
+		name      string
+		accountID string
+		output    *sesv2.GetAccountOutput
+	}{
+		{name: "empty account ID", output: &sesv2.GetAccountOutput{
+			SuppressionAttributes: &sesv2types.SuppressionAttributes{
+				SuppressedReasons: []sesv2types.SuppressionListReason{sesv2types.SuppressionListReasonComplaint},
+			},
+		}},
+		{name: "nil output", accountID: "123456789012"},
+		{name: "nil suppression attributes", accountID: "123456789012", output: &sesv2.GetAccountOutput{}},
+		{name: "empty suppressed reasons", accountID: "123456789012", output: &sesv2.GetAccountOutput{SuppressionAttributes: &sesv2types.SuppressionAttributes{}}},
+		{name: "empty suppressed reason", accountID: "123456789012", output: &sesv2.GetAccountOutput{
+			SuppressionAttributes: &sesv2types.SuppressionAttributes{
+				SuppressedReasons: []sesv2types.SuppressionListReason{""},
+			},
+		}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if _, ok := newSESV2AccountSuppressionAttributesResource(tt.accountID, tt.output); ok {
+				t.Fatal("newSESV2AccountSuppressionAttributesResource() ok = true, want false")
+			}
+		})
+	}
+}
+
+func TestNewSESV2AccountVDMAttributesResource(t *testing.T) {
+	resource, ok := newSESV2AccountVDMAttributesResource(&sesv2.GetAccountOutput{
+		VdmAttributes: &sesv2types.VdmAttributes{
+			VdmEnabled: sesv2types.FeatureStatusEnabled,
+			DashboardAttributes: &sesv2types.DashboardAttributes{
+				EngagementMetrics: sesv2types.FeatureStatusEnabled,
+			},
+			GuardianAttributes: &sesv2types.GuardianAttributes{
+				OptimizedSharedDelivery: sesv2types.FeatureStatusDisabled,
+			},
+		},
+	})
+	if !ok {
+		t.Fatal("newSESV2AccountVDMAttributesResource() ok = false, want true")
+	}
+	assertSESV2ResourceAttributes(t, resource, sesv2AccountVDMAttributesResourceType, "ses-account-vdm-attributes",
+		[]string{"account_vdm_attributes"},
+		map[string]string{
+			"dashboard_attributes.#":                          "1",
+			"dashboard_attributes.0.engagement_metrics":       "ENABLED",
+			"guardian_attributes.#":                           "1",
+			"guardian_attributes.0.optimized_shared_delivery": "DISABLED",
+			"vdm_enabled": "ENABLED",
+		})
+
+	resource, ok = newSESV2AccountVDMAttributesResource(&sesv2.GetAccountOutput{
+		VdmAttributes: &sesv2types.VdmAttributes{
+			VdmEnabled: sesv2types.FeatureStatusEnabled,
+		},
+	})
+	if !ok {
+		t.Fatal("newSESV2AccountVDMAttributesResource() ok = false for enabled VDM without optional attributes, want true")
+	}
+	if _, ok := resource.InstanceState.Attributes["dashboard_attributes.#"]; ok {
+		t.Fatal("newSESV2AccountVDMAttributesResource() seeded empty dashboard attributes, want omitted")
+	}
+	if _, ok := resource.InstanceState.Attributes["guardian_attributes.#"]; ok {
+		t.Fatal("newSESV2AccountVDMAttributesResource() seeded empty guardian attributes, want omitted")
+	}
+
+	tests := []struct {
+		name   string
+		output *sesv2.GetAccountOutput
+	}{
+		{name: "nil output"},
+		{name: "nil VDM attributes", output: &sesv2.GetAccountOutput{}},
+		{name: "empty VDM status", output: &sesv2.GetAccountOutput{VdmAttributes: &sesv2types.VdmAttributes{}}},
+		{name: "default disabled VDM", output: &sesv2.GetAccountOutput{VdmAttributes: &sesv2types.VdmAttributes{VdmEnabled: sesv2types.FeatureStatusDisabled}}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if _, ok := newSESV2AccountVDMAttributesResource(tt.output); ok {
+				t.Fatal("newSESV2AccountVDMAttributesResource() ok = true, want false")
 			}
 		})
 	}


### PR DESCRIPTION
## Summary

- add SESv2 account setting import discovery for account suppression and VDM attributes
- seed import IDs as the AWS account ID for suppression attributes and `ses-account-vdm-attributes` for VDM attributes
- update docs/aws.md for supported SESv2 account setting resources
- add unit tests for account setting import IDs, resource construction, field seeding, and default skip behavior

## References

- #338

## Validation

```bash
go test ./providers/aws -run 'Test.*SES|Test.*Ses|Test.*ses'
go test ./providers/aws/... ./terraformutils/...
go run ./tools/aws-gap-inventory \
  -docs docs/aws.md \
  -aws-dir providers/aws \
  -skip-list providers/aws/unsupported_resources.json \
  -format markdown
git diff --check
```

## Notes

Skipped/deferred resources:
- aws_sesv2_account_suppression_attributes with no suppressed reasons: skipped as an unconfigured/default singleton
- aws_sesv2_account_vdm_attributes with only default DISABLED state: skipped as an unconfigured/default singleton
- aws_sesv2_tenant / aws_sesv2_tenant_resource_association: deferred for tenant-specific PR
- contact/subscriber entries: not in scope


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds SESv2 account settings imports for account suppression and VDM attributes, with deterministic import IDs and sensible defaults to reduce noise. Updates docs and adds tests.

- **New Features**
  - Import `aws_sesv2_account_suppression_attributes` when suppressed reasons exist; import ID = AWS account ID.
  - Import `aws_sesv2_account_vdm_attributes` when configured/enabled; import ID = `ses-account-vdm-attributes`.
  - Skip unconfigured defaults (no suppressed reasons; VDM disabled with defaults).
  - Update `docs/aws.md` and add unit tests for import IDs, resource construction, attribute seeding, and skip behavior.

<sup>Written for commit ab5348c0f541fa28cf1eba8ef50dea2a3e6e707b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

