### PR TITLE
aws(redshiftserverless): add Redshift Serverless core imports

### DIFF
--- a/docs/aws.md
+++ b/docs/aws.md
@@ -455,6 +455,9 @@ For AWS provider gap audits and unsupported-resource skip-list maintenance, see 
     * `aws_redshift_snapshot_schedule`
     * `aws_redshift_snapshot_schedule_association`
     * `aws_redshift_subnet_group`
+*   `redshiftserverless`
+    * `aws_redshiftserverless_namespace`
+    * `aws_redshiftserverless_workgroup`
 *   `resourcegroups`
     * `aws_resourcegroups_group`
 *   `route53`

--- a/go.mod
+++ b/go.mod
@@ -409,6 +409,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/directconnect v1.38.17
 	github.com/aws/aws-sdk-go-v2/service/mwaa v1.40.0
 	github.com/aws/aws-sdk-go-v2/service/pipes v1.23.22
+	github.com/aws/aws-sdk-go-v2/service/redshiftserverless v1.34.6
 	github.com/aws/aws-sdk-go-v2/service/s3control v1.70.1
 	github.com/aws/aws-sdk-go-v2/service/scheduler v1.17.24
 	github.com/aws/aws-sdk-go-v2/service/sesv2 v1.60.4

--- a/go.sum
+++ b/go.sum
@@ -341,6 +341,8 @@ github.com/aws/aws-sdk-go-v2/service/rds v1.118.2 h1:pkEeQneYFpTAnGhyqSbyp/DlCPP
 github.com/aws/aws-sdk-go-v2/service/rds v1.118.2/go.mod h1:7gS+cGrKF0mH253QHFlStmx79ws+DlNk+04ZRfmw3U0=
 github.com/aws/aws-sdk-go-v2/service/redshift v1.62.7 h1:6NCQBp9IIEs51YI9/jT5/ckSd6Ka9956gAGlw0a0yFI=
 github.com/aws/aws-sdk-go-v2/service/redshift v1.62.7/go.mod h1:uLWlNO4q8278lSx2iKIJZ09zSXNJ6uQTFM1jvZIZRf4=
+github.com/aws/aws-sdk-go-v2/service/redshiftserverless v1.34.6 h1:g+QhVVF4V03mgbtf6lLpvhLh0gf7mGMr+bFDMmKJvec=
+github.com/aws/aws-sdk-go-v2/service/redshiftserverless v1.34.6/go.mod h1:24tWvrWAt7wxYpXYPSmDyfyRWKGdz2glsgnLV9MSRq4=
 github.com/aws/aws-sdk-go-v2/service/resourcegroups v1.33.26 h1:HmcCtAaTeZTskXrcrdoioe6oDsQCbdGekBkLOCUE8F8=
 github.com/aws/aws-sdk-go-v2/service/resourcegroups v1.33.26/go.mod h1:nYctzUkOuHA0n6thF68Td93Mm8NJzAhWuhKOIqk5vW8=
 github.com/aws/aws-sdk-go-v2/service/route53 v1.62.7 h1:twRRMmtSITnt/rrp+D7UDLzE5pKMZe759aalkUdN+OY=

--- a/providers/aws/aws_provider.go
+++ b/providers/aws/aws_provider.go
@@ -261,7 +261,7 @@ func (p *AWSProvider) InitService(serviceName string, verbose bool) error {
 
 // GetAWSSupportService return map of support service for AWS
 func (p *AWSProvider) GetSupportedService() map[string]terraformutils.ServiceGenerator {
-	return map[string]terraformutils.ServiceGenerator{
+	services := map[string]terraformutils.ServiceGenerator{
 		"accessanalyzer":    &AwsFacade{service: &AccessAnalyzerGenerator{}},
 		"acm":               &AwsFacade{service: &ACMGenerator{}},
 		"alb":               &AwsFacade{service: &AlbGenerator{}},
@@ -365,6 +365,8 @@ func (p *AWSProvider) GetSupportedService() map[string]terraformutils.ServiceGen
 		"workspaces":        &AwsFacade{service: &WorkspacesGenerator{}},
 		"xray":              &AwsFacade{service: &XrayGenerator{}},
 	}
+	services["redshiftserverless"] = &AwsFacade{service: &RedshiftServerlessGenerator{}}
+	return services
 }
 
 func StringValue(value *string) string {

--- a/providers/aws/redshiftserverless.go
+++ b/providers/aws/redshiftserverless.go
@@ -84,14 +84,18 @@ func newRedshiftServerlessNamespaceResource(namespace redshiftserverlesstypes.Na
 	if importID == "" || !redshiftServerlessNamespaceImportable(namespace) {
 		return terraformutils.Resource{}, false
 	}
+	attributes := map[string]string{
+		"namespace_name": importID,
+	}
+	if StringValue(namespace.AdminPasswordSecretArn) != "" {
+		attributes["manage_admin_password"] = "true"
+	}
 	return terraformutils.NewResource(
 		importID,
 		redshiftServerlessResourceName("namespace", importID),
 		redshiftServerlessNamespaceResourceType,
 		"aws",
-		map[string]string{
-			"namespace_name": importID,
-		},
+		attributes,
 		redshiftServerlessAllowEmptyValues,
 		map[string]interface{}{},
 	), true
@@ -136,13 +140,21 @@ func redshiftServerlessResourceName(parts ...string) string {
 
 func redshiftServerlessNamespaceImportable(namespace redshiftserverlesstypes.Namespace) bool {
 	return redshiftServerlessNamespaceImportID(namespace) != "" &&
-		namespace.Status == redshiftserverlesstypes.NamespaceStatusAvailable
+		redshiftServerlessNamespaceStatusImportable(namespace.Status)
 }
 
 func redshiftServerlessWorkgroupImportable(workgroup redshiftserverlesstypes.Workgroup) bool {
 	return redshiftServerlessWorkgroupImportID(workgroup) != "" &&
 		StringValue(workgroup.NamespaceName) != "" &&
-		workgroup.Status == redshiftserverlesstypes.WorkgroupStatusAvailable
+		redshiftServerlessWorkgroupStatusImportable(workgroup.Status)
+}
+
+func redshiftServerlessNamespaceStatusImportable(status redshiftserverlesstypes.NamespaceStatus) bool {
+	return status != "" && status != redshiftserverlesstypes.NamespaceStatusDeleting
+}
+
+func redshiftServerlessWorkgroupStatusImportable(status redshiftserverlesstypes.WorkgroupStatus) bool {
+	return status != "" && status != redshiftserverlesstypes.WorkgroupStatusDeleting
 }
 
 func redshiftServerlessWorkgroupAttributes(workgroup redshiftserverlesstypes.Workgroup) map[string]string {

--- a/providers/aws/redshiftserverless.go
+++ b/providers/aws/redshiftserverless.go
@@ -1,0 +1,204 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package aws
+
+import (
+	"context"
+	"strconv"
+	"strings"
+
+	"github.com/aws/aws-sdk-go-v2/service/redshiftserverless"
+	redshiftserverlesstypes "github.com/aws/aws-sdk-go-v2/service/redshiftserverless/types"
+	"github.com/chenrui333/terraformer/terraformutils"
+)
+
+const (
+	redshiftServerlessNamespaceResourceType = "aws_redshiftserverless_namespace"
+	redshiftServerlessWorkgroupResourceType = "aws_redshiftserverless_workgroup"
+
+	redshiftServerlessResourceNameFallback = "redshiftserverless-resource"
+)
+
+var redshiftServerlessAllowEmptyValues = []string{
+	"tags.",
+	"^enhanced_vpc_routing$",
+	`^price_performance_target\.\d+\.enabled$`,
+	"^publicly_accessible$",
+}
+
+type RedshiftServerlessGenerator struct {
+	AWSService
+}
+
+func (g *RedshiftServerlessGenerator) InitResources() error {
+	config, err := g.generateConfig()
+	if err != nil {
+		return err
+	}
+	svc := redshiftserverless.NewFromConfig(config)
+
+	if err := g.loadNamespaces(svc); err != nil {
+		return err
+	}
+	if err := g.loadWorkgroups(svc); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (g *RedshiftServerlessGenerator) loadNamespaces(svc *redshiftserverless.Client) error {
+	p := redshiftserverless.NewListNamespacesPaginator(svc, &redshiftserverless.ListNamespacesInput{})
+	for p.HasMorePages() {
+		page, err := p.NextPage(context.TODO())
+		if err != nil {
+			return err
+		}
+		for _, namespace := range page.Namespaces {
+			if resource, ok := newRedshiftServerlessNamespaceResource(namespace); ok {
+				g.Resources = append(g.Resources, resource)
+			}
+		}
+	}
+	return nil
+}
+
+func (g *RedshiftServerlessGenerator) loadWorkgroups(svc *redshiftserverless.Client) error {
+	p := redshiftserverless.NewListWorkgroupsPaginator(svc, &redshiftserverless.ListWorkgroupsInput{})
+	for p.HasMorePages() {
+		page, err := p.NextPage(context.TODO())
+		if err != nil {
+			return err
+		}
+		for _, workgroup := range page.Workgroups {
+			if resource, ok := newRedshiftServerlessWorkgroupResource(workgroup); ok {
+				g.Resources = append(g.Resources, resource)
+			}
+		}
+	}
+	return nil
+}
+
+func newRedshiftServerlessNamespaceResource(namespace redshiftserverlesstypes.Namespace) (terraformutils.Resource, bool) {
+	importID := redshiftServerlessNamespaceImportID(namespace)
+	if importID == "" || !redshiftServerlessNamespaceImportable(namespace) {
+		return terraformutils.Resource{}, false
+	}
+	return terraformutils.NewResource(
+		importID,
+		redshiftServerlessResourceName("namespace", importID),
+		redshiftServerlessNamespaceResourceType,
+		"aws",
+		map[string]string{
+			"namespace_name": importID,
+		},
+		redshiftServerlessAllowEmptyValues,
+		map[string]interface{}{},
+	), true
+}
+
+func newRedshiftServerlessWorkgroupResource(workgroup redshiftserverlesstypes.Workgroup) (terraformutils.Resource, bool) {
+	importID := redshiftServerlessWorkgroupImportID(workgroup)
+	if importID == "" || !redshiftServerlessWorkgroupImportable(workgroup) {
+		return terraformutils.Resource{}, false
+	}
+	return terraformutils.NewResource(
+		importID,
+		redshiftServerlessResourceName("workgroup", StringValue(workgroup.NamespaceName), importID),
+		redshiftServerlessWorkgroupResourceType,
+		"aws",
+		redshiftServerlessWorkgroupAttributes(workgroup),
+		redshiftServerlessAllowEmptyValues,
+		map[string]interface{}{},
+	), true
+}
+
+func redshiftServerlessNamespaceImportID(namespace redshiftserverlesstypes.Namespace) string {
+	return StringValue(namespace.NamespaceName)
+}
+
+func redshiftServerlessWorkgroupImportID(workgroup redshiftserverlesstypes.Workgroup) string {
+	return StringValue(workgroup.WorkgroupName)
+}
+
+func redshiftServerlessResourceName(parts ...string) string {
+	var cleanParts []string
+	for _, part := range parts {
+		if part != "" {
+			cleanParts = append(cleanParts, part)
+		}
+	}
+	if len(cleanParts) == 0 {
+		return redshiftServerlessResourceNameFallback
+	}
+	return strings.Join(cleanParts, "/")
+}
+
+func redshiftServerlessNamespaceImportable(namespace redshiftserverlesstypes.Namespace) bool {
+	return redshiftServerlessNamespaceImportID(namespace) != "" &&
+		namespace.Status == redshiftserverlesstypes.NamespaceStatusAvailable
+}
+
+func redshiftServerlessWorkgroupImportable(workgroup redshiftserverlesstypes.Workgroup) bool {
+	return redshiftServerlessWorkgroupImportID(workgroup) != "" &&
+		StringValue(workgroup.NamespaceName) != "" &&
+		workgroup.Status == redshiftserverlesstypes.WorkgroupStatusAvailable
+}
+
+func redshiftServerlessWorkgroupAttributes(workgroup redshiftserverlesstypes.Workgroup) map[string]string {
+	attributes := map[string]string{
+		"namespace_name": StringValue(workgroup.NamespaceName),
+		"workgroup_name": redshiftServerlessWorkgroupImportID(workgroup),
+	}
+	if workgroup.BaseCapacity != nil {
+		attributes["base_capacity"] = strconv.Itoa(int(*workgroup.BaseCapacity))
+	}
+	if workgroup.EnhancedVpcRouting != nil {
+		attributes["enhanced_vpc_routing"] = strconv.FormatBool(*workgroup.EnhancedVpcRouting)
+	}
+	if workgroup.MaxCapacity != nil {
+		attributes["max_capacity"] = strconv.Itoa(int(*workgroup.MaxCapacity))
+	}
+	if workgroup.Port != nil {
+		attributes["port"] = strconv.Itoa(int(*workgroup.Port))
+	}
+	if workgroup.PricePerformanceTarget != nil {
+		for key, value := range redshiftServerlessPricePerformanceTargetAttributes("price_performance_target", workgroup.PricePerformanceTarget) {
+			attributes[key] = value
+		}
+	}
+	if workgroup.PubliclyAccessible != nil {
+		attributes["publicly_accessible"] = strconv.FormatBool(*workgroup.PubliclyAccessible)
+	}
+	for key, value := range redshiftServerlessStringSliceAttributes("security_group_ids", workgroup.SecurityGroupIds) {
+		attributes[key] = value
+	}
+	for key, value := range redshiftServerlessStringSliceAttributes("subnet_ids", workgroup.SubnetIds) {
+		attributes[key] = value
+	}
+	if value := StringValue(workgroup.TrackName); value != "" {
+		attributes["track_name"] = value
+	}
+	return attributes
+}
+
+func redshiftServerlessPricePerformanceTargetAttributes(prefix string, target *redshiftserverlesstypes.PerformanceTarget) map[string]string {
+	attributes := map[string]string{
+		prefix + ".#":         "1",
+		prefix + ".0.enabled": strconv.FormatBool(target.Status == redshiftserverlesstypes.PerformanceTargetStatusEnabled),
+	}
+	if target.Level != nil {
+		attributes[prefix+".0.level"] = strconv.Itoa(int(*target.Level))
+	}
+	return attributes
+}
+
+func redshiftServerlessStringSliceAttributes(prefix string, values []string) map[string]string {
+	attributes := map[string]string{
+		prefix + ".#": strconv.Itoa(len(values)),
+	}
+	for i, value := range values {
+		attributes[prefix+"."+strconv.Itoa(i)] = value
+	}
+	return attributes
+}

--- a/providers/aws/redshiftserverless_test.go
+++ b/providers/aws/redshiftserverless_test.go
@@ -51,8 +51,9 @@ func TestRedshiftServerlessImportIDs(t *testing.T) {
 
 func TestNewRedshiftServerlessNamespaceResource(t *testing.T) {
 	resource, ok := newRedshiftServerlessNamespaceResource(redshiftserverlesstypes.Namespace{
-		NamespaceName: redshiftServerlessString("analytics"),
-		Status:        redshiftserverlesstypes.NamespaceStatusAvailable,
+		AdminPasswordSecretArn: redshiftServerlessString("arn:aws:secretsmanager:us-east-1:123456789012:secret:redshift-serverless-admin"),
+		NamespaceName:          redshiftServerlessString("analytics"),
+		Status:                 redshiftserverlesstypes.NamespaceStatusAvailable,
 	})
 	assertRedshiftServerlessResource(
 		t,
@@ -63,17 +64,30 @@ func TestNewRedshiftServerlessNamespaceResource(t *testing.T) {
 		redshiftServerlessNamespaceResourceType,
 	)
 	assertRedshiftServerlessAttribute(t, resource, "namespace_name", "analytics")
+	assertRedshiftServerlessAttribute(t, resource, "manage_admin_password", "true")
 
 	if _, ok := newRedshiftServerlessNamespaceResource(redshiftserverlesstypes.Namespace{
 		Status: redshiftserverlesstypes.NamespaceStatusAvailable,
 	}); ok {
 		t.Fatal("namespace with empty name should be skipped")
 	}
-	if _, ok := newRedshiftServerlessNamespaceResource(redshiftserverlesstypes.Namespace{
+	resource, ok = newRedshiftServerlessNamespaceResource(redshiftserverlesstypes.Namespace{
 		NamespaceName: redshiftServerlessString("analytics"),
 		Status:        redshiftserverlesstypes.NamespaceStatusModifying,
+	})
+	assertRedshiftServerlessResource(
+		t,
+		resource,
+		ok,
+		"analytics",
+		redshiftServerlessResourceName("namespace", "analytics"),
+		redshiftServerlessNamespaceResourceType,
+	)
+	if _, ok := newRedshiftServerlessNamespaceResource(redshiftserverlesstypes.Namespace{
+		NamespaceName: redshiftServerlessString("analytics"),
+		Status:        redshiftserverlesstypes.NamespaceStatusDeleting,
 	}); ok {
-		t.Fatal("modifying namespace should be skipped")
+		t.Fatal("deleting namespace should be skipped")
 	}
 }
 
@@ -143,12 +157,6 @@ func TestNewRedshiftServerlessWorkgroupResourceSkipsUnsafeWorkgroups(t *testing.
 	}{
 		{name: "empty workgroup name", mutate: func(workgroup *redshiftserverlesstypes.Workgroup) { workgroup.WorkgroupName = nil }},
 		{name: "empty namespace name", mutate: func(workgroup *redshiftserverlesstypes.Workgroup) { workgroup.NamespaceName = nil }},
-		{name: "creating status", mutate: func(workgroup *redshiftserverlesstypes.Workgroup) {
-			workgroup.Status = redshiftserverlesstypes.WorkgroupStatusCreating
-		}},
-		{name: "modifying status", mutate: func(workgroup *redshiftserverlesstypes.Workgroup) {
-			workgroup.Status = redshiftserverlesstypes.WorkgroupStatusModifying
-		}},
 		{name: "deleting status", mutate: func(workgroup *redshiftserverlesstypes.Workgroup) {
 			workgroup.Status = redshiftserverlesstypes.WorkgroupStatusDeleting
 		}},
@@ -172,7 +180,13 @@ func TestRedshiftServerlessStatusImportability(t *testing.T) {
 	}) {
 		t.Fatal("available namespace should be importable")
 	}
-	for _, status := range []redshiftserverlesstypes.NamespaceStatus{"", redshiftserverlesstypes.NamespaceStatusModifying, redshiftserverlesstypes.NamespaceStatusDeleting} {
+	if !redshiftServerlessNamespaceImportable(redshiftserverlesstypes.Namespace{
+		NamespaceName: redshiftServerlessString("analytics"),
+		Status:        redshiftserverlesstypes.NamespaceStatusModifying,
+	}) {
+		t.Fatal("modifying namespace should be importable")
+	}
+	for _, status := range []redshiftserverlesstypes.NamespaceStatus{"", redshiftserverlesstypes.NamespaceStatusDeleting} {
 		if redshiftServerlessNamespaceImportable(redshiftserverlesstypes.Namespace{
 			NamespaceName: redshiftServerlessString("analytics"),
 			Status:        status,
@@ -188,7 +202,16 @@ func TestRedshiftServerlessStatusImportability(t *testing.T) {
 	}) {
 		t.Fatal("available workgroup should be importable")
 	}
-	for _, status := range []redshiftserverlesstypes.WorkgroupStatus{"", redshiftserverlesstypes.WorkgroupStatusCreating, redshiftserverlesstypes.WorkgroupStatusModifying, redshiftserverlesstypes.WorkgroupStatusDeleting} {
+	for _, status := range []redshiftserverlesstypes.WorkgroupStatus{redshiftserverlesstypes.WorkgroupStatusCreating, redshiftserverlesstypes.WorkgroupStatusModifying} {
+		if !redshiftServerlessWorkgroupImportable(redshiftserverlesstypes.Workgroup{
+			NamespaceName: redshiftServerlessString("analytics"),
+			Status:        status,
+			WorkgroupName: redshiftServerlessString("reporting"),
+		}) {
+			t.Fatalf("workgroup status %q should be importable", status)
+		}
+	}
+	for _, status := range []redshiftserverlesstypes.WorkgroupStatus{"", redshiftserverlesstypes.WorkgroupStatusDeleting} {
 		if redshiftServerlessWorkgroupImportable(redshiftserverlesstypes.Workgroup{
 			NamespaceName: redshiftServerlessString("analytics"),
 			Status:        status,

--- a/providers/aws/redshiftserverless_test.go
+++ b/providers/aws/redshiftserverless_test.go
@@ -1,0 +1,241 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package aws
+
+import (
+	"testing"
+
+	redshiftserverlesstypes "github.com/aws/aws-sdk-go-v2/service/redshiftserverless/types"
+	"github.com/chenrui333/terraformer/terraformutils"
+)
+
+func TestRedshiftServerlessResourceName(t *testing.T) {
+	tests := []struct {
+		name  string
+		parts []string
+		want  string
+	}{
+		{name: "filters empty parts", parts: []string{"", "workgroup", "", "analytics", "reporting"}, want: "workgroup/analytics/reporting"},
+		{name: "preserves segment boundaries", parts: []string{"namespace", "analytics"}, want: "namespace/analytics"},
+		{name: "fallback", parts: nil, want: redshiftServerlessResourceNameFallback},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := redshiftServerlessResourceName(tt.parts...)
+			if got != tt.want {
+				t.Fatalf("redshiftServerlessResourceName() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestRedshiftServerlessResourceNameUniqueness(t *testing.T) {
+	first := terraformutils.TfSanitize(redshiftServerlessResourceName("workgroup", "ab", "c"))
+	second := terraformutils.TfSanitize(redshiftServerlessResourceName("workgroup", "a", "bc"))
+	if first == second {
+		t.Fatalf("redshiftServerlessResourceName() collision after sanitize: %q", first)
+	}
+}
+
+func TestRedshiftServerlessImportIDs(t *testing.T) {
+	namespace := redshiftserverlesstypes.Namespace{NamespaceName: redshiftServerlessString("analytics")}
+	if got := redshiftServerlessNamespaceImportID(namespace); got != "analytics" {
+		t.Fatalf("namespace import ID = %q, want analytics", got)
+	}
+
+	workgroup := redshiftserverlesstypes.Workgroup{WorkgroupName: redshiftServerlessString("reporting")}
+	if got := redshiftServerlessWorkgroupImportID(workgroup); got != "reporting" {
+		t.Fatalf("workgroup import ID = %q, want reporting", got)
+	}
+}
+
+func TestNewRedshiftServerlessNamespaceResource(t *testing.T) {
+	resource, ok := newRedshiftServerlessNamespaceResource(redshiftserverlesstypes.Namespace{
+		NamespaceName: redshiftServerlessString("analytics"),
+		Status:        redshiftserverlesstypes.NamespaceStatusAvailable,
+	})
+	assertRedshiftServerlessResource(
+		t,
+		resource,
+		ok,
+		"analytics",
+		redshiftServerlessResourceName("namespace", "analytics"),
+		redshiftServerlessNamespaceResourceType,
+	)
+	assertRedshiftServerlessAttribute(t, resource, "namespace_name", "analytics")
+
+	if _, ok := newRedshiftServerlessNamespaceResource(redshiftserverlesstypes.Namespace{
+		Status: redshiftserverlesstypes.NamespaceStatusAvailable,
+	}); ok {
+		t.Fatal("namespace with empty name should be skipped")
+	}
+	if _, ok := newRedshiftServerlessNamespaceResource(redshiftserverlesstypes.Namespace{
+		NamespaceName: redshiftServerlessString("analytics"),
+		Status:        redshiftserverlesstypes.NamespaceStatusModifying,
+	}); ok {
+		t.Fatal("modifying namespace should be skipped")
+	}
+}
+
+func TestNewRedshiftServerlessWorkgroupResource(t *testing.T) {
+	enhancedVPCRouting := false
+	publiclyAccessible := false
+	resource, ok := newRedshiftServerlessWorkgroupResource(redshiftserverlesstypes.Workgroup{
+		BaseCapacity:           redshiftServerlessInt32(32),
+		EnhancedVpcRouting:     &enhancedVPCRouting,
+		MaxCapacity:            redshiftServerlessInt32(128),
+		NamespaceName:          redshiftServerlessString("analytics"),
+		Port:                   redshiftServerlessInt32(5439),
+		PricePerformanceTarget: &redshiftserverlesstypes.PerformanceTarget{Status: redshiftserverlesstypes.PerformanceTargetStatusDisabled, Level: redshiftServerlessInt32(50)},
+		PubliclyAccessible:     &publiclyAccessible,
+		SecurityGroupIds:       []string{"sg-1", "sg-2"},
+		Status:                 redshiftserverlesstypes.WorkgroupStatusAvailable,
+		SubnetIds:              []string{"subnet-1", "subnet-2"},
+		TrackName:              redshiftServerlessString("current"),
+		WorkgroupName:          redshiftServerlessString("reporting"),
+	})
+	assertRedshiftServerlessResource(
+		t,
+		resource,
+		ok,
+		"reporting",
+		redshiftServerlessResourceName("workgroup", "analytics", "reporting"),
+		redshiftServerlessWorkgroupResourceType,
+	)
+
+	expected := map[string]string{
+		"base_capacity":                      "32",
+		"enhanced_vpc_routing":               "false",
+		"max_capacity":                       "128",
+		"namespace_name":                     "analytics",
+		"port":                               "5439",
+		"price_performance_target.#":         "1",
+		"price_performance_target.0.enabled": "false",
+		"price_performance_target.0.level":   "50",
+		"publicly_accessible":                "false",
+		"security_group_ids.#":               "2",
+		"security_group_ids.1":               "sg-2",
+		"subnet_ids.#":                       "2",
+		"subnet_ids.1":                       "subnet-2",
+		"track_name":                         "current",
+		"workgroup_name":                     "reporting",
+	}
+	for key, want := range expected {
+		assertRedshiftServerlessAttribute(t, resource, key, want)
+	}
+	assertRedshiftServerlessAllowEmptyValue(t, resource, `^price_performance_target\.\d+\.enabled$`)
+	assertRedshiftServerlessAllowEmptyValue(t, resource, "^enhanced_vpc_routing$")
+	assertRedshiftServerlessAllowEmptyValue(t, resource, "^publicly_accessible$")
+}
+
+func TestNewRedshiftServerlessWorkgroupResourceSkipsUnsafeWorkgroups(t *testing.T) {
+	validWorkgroup := func() redshiftserverlesstypes.Workgroup {
+		return redshiftserverlesstypes.Workgroup{
+			NamespaceName: redshiftServerlessString("analytics"),
+			Status:        redshiftserverlesstypes.WorkgroupStatusAvailable,
+			WorkgroupName: redshiftServerlessString("reporting"),
+		}
+	}
+
+	tests := []struct {
+		name   string
+		mutate func(*redshiftserverlesstypes.Workgroup)
+	}{
+		{name: "empty workgroup name", mutate: func(workgroup *redshiftserverlesstypes.Workgroup) { workgroup.WorkgroupName = nil }},
+		{name: "empty namespace name", mutate: func(workgroup *redshiftserverlesstypes.Workgroup) { workgroup.NamespaceName = nil }},
+		{name: "creating status", mutate: func(workgroup *redshiftserverlesstypes.Workgroup) {
+			workgroup.Status = redshiftserverlesstypes.WorkgroupStatusCreating
+		}},
+		{name: "modifying status", mutate: func(workgroup *redshiftserverlesstypes.Workgroup) {
+			workgroup.Status = redshiftserverlesstypes.WorkgroupStatusModifying
+		}},
+		{name: "deleting status", mutate: func(workgroup *redshiftserverlesstypes.Workgroup) {
+			workgroup.Status = redshiftserverlesstypes.WorkgroupStatusDeleting
+		}},
+		{name: "empty status", mutate: func(workgroup *redshiftserverlesstypes.Workgroup) { workgroup.Status = "" }},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			workgroup := validWorkgroup()
+			tt.mutate(&workgroup)
+			if _, ok := newRedshiftServerlessWorkgroupResource(workgroup); ok {
+				t.Fatal("workgroup should be skipped")
+			}
+		})
+	}
+}
+
+func TestRedshiftServerlessStatusImportability(t *testing.T) {
+	if !redshiftServerlessNamespaceImportable(redshiftserverlesstypes.Namespace{
+		NamespaceName: redshiftServerlessString("analytics"),
+		Status:        redshiftserverlesstypes.NamespaceStatusAvailable,
+	}) {
+		t.Fatal("available namespace should be importable")
+	}
+	for _, status := range []redshiftserverlesstypes.NamespaceStatus{"", redshiftserverlesstypes.NamespaceStatusModifying, redshiftserverlesstypes.NamespaceStatusDeleting} {
+		if redshiftServerlessNamespaceImportable(redshiftserverlesstypes.Namespace{
+			NamespaceName: redshiftServerlessString("analytics"),
+			Status:        status,
+		}) {
+			t.Fatalf("namespace status %q should not be importable", status)
+		}
+	}
+
+	if !redshiftServerlessWorkgroupImportable(redshiftserverlesstypes.Workgroup{
+		NamespaceName: redshiftServerlessString("analytics"),
+		Status:        redshiftserverlesstypes.WorkgroupStatusAvailable,
+		WorkgroupName: redshiftServerlessString("reporting"),
+	}) {
+		t.Fatal("available workgroup should be importable")
+	}
+	for _, status := range []redshiftserverlesstypes.WorkgroupStatus{"", redshiftserverlesstypes.WorkgroupStatusCreating, redshiftserverlesstypes.WorkgroupStatusModifying, redshiftserverlesstypes.WorkgroupStatusDeleting} {
+		if redshiftServerlessWorkgroupImportable(redshiftserverlesstypes.Workgroup{
+			NamespaceName: redshiftServerlessString("analytics"),
+			Status:        status,
+			WorkgroupName: redshiftServerlessString("reporting"),
+		}) {
+			t.Fatalf("workgroup status %q should not be importable", status)
+		}
+	}
+}
+
+func assertRedshiftServerlessResource(t *testing.T, resource terraformutils.Resource, ok bool, wantID, wantName, wantType string) {
+	t.Helper()
+	if !ok {
+		t.Fatal("resource was skipped")
+	}
+	if got := resource.InstanceState.ID; got != wantID {
+		t.Fatalf("resource ID = %q, want %q", got, wantID)
+	}
+	if got := resource.ResourceName; got != terraformutils.TfSanitize(wantName) {
+		t.Fatalf("resource name = %q, want %q", got, terraformutils.TfSanitize(wantName))
+	}
+	if got := resource.InstanceInfo.Type; got != wantType {
+		t.Fatalf("resource type = %q, want %q", got, wantType)
+	}
+}
+
+func assertRedshiftServerlessAttribute(t *testing.T, resource terraformutils.Resource, key, want string) {
+	t.Helper()
+	if got := resource.InstanceState.Attributes[key]; got != want {
+		t.Fatalf("resource attribute %q = %q, want %q", key, got, want)
+	}
+}
+
+func assertRedshiftServerlessAllowEmptyValue(t *testing.T, resource terraformutils.Resource, want string) {
+	t.Helper()
+	for _, value := range resource.AllowEmptyValues {
+		if value == want {
+			return
+		}
+	}
+	t.Fatalf("AllowEmptyValues = %v, want %q", resource.AllowEmptyValues, want)
+}
+
+func redshiftServerlessString(value string) *string {
+	return &value
+}
+
+func redshiftServerlessInt32(value int32) *int32 {
+	return &value
+}


### PR DESCRIPTION
## Summary

- add Redshift Serverless import discovery for `aws_redshiftserverless_namespace` and `aws_redshiftserverless_workgroup`
- register the `redshiftserverless` AWS service
- seed import IDs as namespace and workgroup names
- update `docs/aws.md` for supported Redshift Serverless resources
- add unit tests for Redshift Serverless helper behavior

## References

- #338

## Validation

```bash
go test ./providers/aws -run 'Test.*RedshiftServerless|Test.*Redshiftserverless|Test.*redshiftserverless'
go test ./providers/aws/... ./terraformutils/...
go run ./tools/aws-gap-inventory \
  -docs docs/aws.md \
  -aws-dir providers/aws \
  -skip-list providers/aws/unsupported_resources.json \
  -format markdown
git diff --check
```

## Notes

Skipped/deferred resources:
- `aws_redshiftserverless_snapshot`: deferred for a separate snapshot/lifecycle follow-up
- `aws_redshiftserverless_usage_limit`: deferred for a focused usage-limit follow-up
- `aws_redshiftserverless_custom_domain_association`: deferred for custom-domain follow-up
- `aws_redshiftserverless_endpoint_access`: deferred for endpoint/networking follow-up
- `aws_redshiftserverless_resource_policy`: deferred for policy-resource follow-up
- `aws_redshiftserverless_scheduled_action`: not present in the current Terraform AWS provider resource source inspected for this PR

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds Redshift Serverless import support for namespaces and workgroups by registering the `redshiftserverless` service. Preserves importable states and skips only deleting resources.

- **New Features**
  - Discover and import `aws_redshiftserverless_namespace` and `aws_redshiftserverless_workgroup` using names as import IDs.
  - Register `redshiftserverless` in the AWS provider; list namespaces/workgroups via the SDK.
  - Update `docs/aws.md` to include supported Redshift Serverless resources.
  - Add unit tests for naming, importability (including creating/modifying states), and attribute mapping.

- **Dependencies**
  - Add `github.com/aws/aws-sdk-go-v2/service/redshiftserverless v1.34.6`.

<sup>Written for commit 927bd1c6fcb47c71626d338f313fefa9774dc02b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

