### PR TITLE
aws(apigateway): add API Gateway follow-up imports

### DIFF
--- a/docs/aws.md
+++ b/docs/aws.md
@@ -48,9 +48,13 @@ For AWS provider gap audits and unsupported-resource skip-list maintenance, see 
     * `aws_lb_target_group`
     * `aws_lb_target_group_attachment`
 *   `api_gateway`
+    * `aws_api_gateway_account`
     * `aws_api_gateway_authorizer`
     * `aws_api_gateway_api_key`
+    * `aws_api_gateway_base_path_mapping`
+    * `aws_api_gateway_client_certificate`
     * `aws_api_gateway_documentation_part`
+    * `aws_api_gateway_documentation_version`
     * `aws_api_gateway_gateway_response`
     * `aws_api_gateway_integration`
     * `aws_api_gateway_integration_response`
@@ -59,8 +63,10 @@ For AWS provider gap audits and unsupported-resource skip-list maintenance, see 
     * `aws_api_gateway_model`
     * `aws_api_gateway_resource`
     * `aws_api_gateway_rest_api`
+    * `aws_api_gateway_request_validator`
     * `aws_api_gateway_stage`
     * `aws_api_gateway_usage_plan`
+    * `aws_api_gateway_usage_plan_key`
     * `aws_api_gateway_vpc_link`
 *   `api_gatewayv2`
     * `aws_apigatewayv2_api`

--- a/providers/aws/api_gateway.go
+++ b/providers/aws/api_gateway.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/aws/arn"
 	"github.com/aws/aws-sdk-go-v2/service/apigateway"
 	"github.com/aws/aws-sdk-go-v2/service/apigateway/types"
 	"github.com/chenrui333/terraformer/terraformutils"
@@ -48,7 +49,7 @@ func (g *APIGatewayGenerator) InitResources() error {
 	svc := apigateway.NewFromConfig(config)
 
 	g.loadOptionalResources([]apiGatewayOptionalResourceLoader{
-		{name: "account", load: func() error { return g.loadAccount(svc, config) }},
+		{name: "account", load: func() error { return g.loadAccount(svc) }},
 		{name: "client certificates", load: func() error { return g.loadClientCertificates(svc) }},
 	})
 
@@ -181,20 +182,24 @@ func (g *APIGatewayGenerator) shouldFilterBasePathMapping(mapping types.BasePath
 	return !ok
 }
 
-func (g *APIGatewayGenerator) loadAccount(svc *apigateway.Client, config aws.Config) error {
+func (g *APIGatewayGenerator) loadAccount(svc *apigateway.Client) error {
 	output, err := svc.GetAccount(context.TODO(), &apigateway.GetAccountInput{})
 	if err != nil {
 		return err
 	}
-	if output == nil || StringValue(output.CloudwatchRoleArn) == "" {
+	cloudwatchRoleARN := ""
+	if output != nil {
+		cloudwatchRoleARN = StringValue(output.CloudwatchRoleArn)
+	}
+	if cloudwatchRoleARN == "" {
 		return nil
 	}
-	account, err := g.getAccountNumber(config)
-	if err != nil {
-		log.Printf("Skipping API Gateway account: unable to get account ID: %v", err)
+	accountID, ok := apiGatewayAccountIDFromRoleARN(cloudwatchRoleARN)
+	if !ok {
+		log.Printf("Skipping API Gateway account: unable to parse account ID from CloudWatch role ARN %q", cloudwatchRoleARN)
 		return nil
 	}
-	if resource, ok := newAPIGatewayAccountResource(StringValue(account), output); ok {
+	if resource, ok := newAPIGatewayAccountResource(accountID, output); ok {
 		g.Resources = append(g.Resources, resource)
 	}
 	return nil
@@ -839,6 +844,26 @@ func apiGatewayAccountImportID(accountID string) string {
 	return accountID
 }
 
+func apiGatewayAccountIDFromRoleARN(roleARN string) (string, bool) {
+	parsedARN, err := arn.Parse(roleARN)
+	if err != nil || !apiGatewayAWSAccountID(parsedARN.AccountID) {
+		return "", false
+	}
+	return parsedARN.AccountID, true
+}
+
+func apiGatewayAWSAccountID(accountID string) bool {
+	if len(accountID) != 12 {
+		return false
+	}
+	for _, r := range accountID {
+		if r < '0' || r > '9' {
+			return false
+		}
+	}
+	return true
+}
+
 func apiGatewayBasePathMappingImportID(domainName, basePath, domainNameID string) string {
 	parts := []string{domainName, basePath}
 	if domainNameID != "" {
@@ -859,6 +884,9 @@ func apiGatewayRequestValidatorImportID(restAPIID, validatorID string) string {
 	return strings.Join([]string{restAPIID, validatorID}, apiGatewayResourceIDSeparator)
 }
 
+// Terraformer seeds provider state directly before refresh. These IDs match the
+// Terraform AWS provider read IDs after its importers parse composite import IDs
+// and seed the required parent attributes.
 func apiGatewayRequestValidatorStateID(validatorID string) string {
 	return validatorID
 }

--- a/providers/aws/api_gateway.go
+++ b/providers/aws/api_gateway.go
@@ -37,6 +37,7 @@ type apiGatewayOptionalResourceLoader struct {
 
 type APIGatewayGenerator struct {
 	AWSService
+	acceptedRestAPIIDs map[string]struct{}
 }
 
 func (g *APIGatewayGenerator) InitResources() error {
@@ -48,13 +49,15 @@ func (g *APIGatewayGenerator) InitResources() error {
 
 	g.loadOptionalResources([]apiGatewayOptionalResourceLoader{
 		{name: "account", load: func() error { return g.loadAccount(svc, config) }},
-		{name: "base path mappings", load: func() error { return g.loadDomainBasePathMappings(svc) }},
 		{name: "client certificates", load: func() error { return g.loadClientCertificates(svc) }},
 	})
 
 	if err := g.loadRestApis(svc); err != nil {
 		return err
 	}
+	g.loadOptionalResources([]apiGatewayOptionalResourceLoader{
+		{name: "base path mappings", load: func() error { return g.loadDomainBasePathMappings(svc) }},
+	})
 	if err := g.loadVpcLinks(svc); err != nil {
 		return err
 	}
@@ -90,9 +93,18 @@ func (g *APIGatewayGenerator) loadRestApis(svc *apigateway.Client) error {
 			if g.shouldFilterRestAPI(restAPI.Tags) {
 				continue
 			}
+			restAPIID := StringValue(restAPI.Id)
+			if restAPIID == "" {
+				continue
+			}
+			restAPIName := StringValue(restAPI.Name)
+			if restAPIName == "" {
+				restAPIName = restAPIID
+			}
+			g.rememberAcceptedRestAPIID(restAPIID)
 			g.Resources = append(g.Resources, terraformutils.NewSimpleResource(
-				*restAPI.Id,
-				*restAPI.Id+"_"+*restAPI.Name,
+				restAPIID,
+				restAPIID+"_"+restAPIName,
 				"aws_api_gateway_rest_api",
 				"aws",
 				apiGatewayAllowEmptyValues))
@@ -136,6 +148,37 @@ func (g *APIGatewayGenerator) shouldFilterRestAPI(tags map[string]string) bool {
 		}
 	}
 	return false
+}
+
+func (g *APIGatewayGenerator) hasRestAPITagFilter() bool {
+	for _, filter := range g.Filter {
+		if strings.HasPrefix(filter.FieldPath, "tags.") && filter.IsApplicable("api_gateway_rest_api") {
+			return true
+		}
+	}
+	return false
+}
+
+func (g *APIGatewayGenerator) rememberAcceptedRestAPIID(restAPIID string) {
+	if restAPIID == "" {
+		return
+	}
+	if g.acceptedRestAPIIDs == nil {
+		g.acceptedRestAPIIDs = map[string]struct{}{}
+	}
+	g.acceptedRestAPIIDs[restAPIID] = struct{}{}
+}
+
+func (g *APIGatewayGenerator) shouldFilterBasePathMapping(mapping types.BasePathMapping) bool {
+	if !g.hasRestAPITagFilter() {
+		return false
+	}
+	restAPIID := StringValue(mapping.RestApiId)
+	if restAPIID == "" {
+		return true
+	}
+	_, ok := g.acceptedRestAPIIDs[restAPIID]
+	return !ok
 }
 
 func (g *APIGatewayGenerator) loadAccount(svc *apigateway.Client, config aws.Config) error {
@@ -619,6 +662,9 @@ func (g *APIGatewayGenerator) loadBasePathMappings(svc *apigateway.Client, domai
 			return err
 		}
 		for _, mapping := range page.Items {
+			if g.shouldFilterBasePathMapping(mapping) {
+				continue
+			}
 			if resource, ok := newAPIGatewayBasePathMappingResource(domainName, domainNameID, mapping); ok {
 				g.Resources = append(g.Resources, resource)
 			}

--- a/providers/aws/api_gateway.go
+++ b/providers/aws/api_gateway.go
@@ -4,15 +4,36 @@ package aws
 
 import (
 	"context"
+	"errors"
+	"log"
+	"strconv"
 	"strings"
 
+	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/apigateway"
 	"github.com/aws/aws-sdk-go-v2/service/apigateway/types"
 	"github.com/chenrui333/terraformer/terraformutils"
 	"github.com/chenrui333/terraformer/terraformutils/terraformerstring"
 )
 
-var apiGatewayAllowEmptyValues = []string{"tags.", "parent_id", "path_part"}
+const (
+	apiGatewayAccountResourceType              = "aws_api_gateway_account"
+	apiGatewayBasePathMappingResourceType      = "aws_api_gateway_base_path_mapping"
+	apiGatewayClientCertificateResourceType    = "aws_api_gateway_client_certificate"
+	apiGatewayDocumentationVersionResourceType = "aws_api_gateway_documentation_version"
+	apiGatewayRequestValidatorResourceType     = "aws_api_gateway_request_validator"
+	apiGatewayResourceResourceType             = "aws_api_gateway_resource"
+	apiGatewayUsagePlanKeyResourceType         = "aws_api_gateway_usage_plan_key"
+	apiGatewayEmptyBasePathMappingValue        = "(none)"
+	apiGatewayResourceIDSeparator              = "/"
+)
+
+var apiGatewayAllowEmptyValues = []string{"tags.", "base_path", "parent_id", "path_part"}
+
+type apiGatewayOptionalResourceLoader struct {
+	name string
+	load func() error
+}
 
 type APIGatewayGenerator struct {
 	AWSService
@@ -24,6 +45,12 @@ func (g *APIGatewayGenerator) InitResources() error {
 		return e
 	}
 	svc := apigateway.NewFromConfig(config)
+
+	g.loadOptionalResources([]apiGatewayOptionalResourceLoader{
+		{name: "account", load: func() error { return g.loadAccount(svc, config) }},
+		{name: "base path mappings", load: func() error { return g.loadDomainBasePathMappings(svc) }},
+		{name: "client certificates", load: func() error { return g.loadClientCertificates(svc) }},
+	})
 
 	if err := g.loadRestApis(svc); err != nil {
 		return err
@@ -39,6 +66,17 @@ func (g *APIGatewayGenerator) InitResources() error {
 	}
 
 	return nil
+}
+
+func (g *APIGatewayGenerator) loadOptionalResources(loaders []apiGatewayOptionalResourceLoader) {
+	for _, loader := range loaders {
+		if err := loader.load(); err != nil {
+			if apiGatewayResourceMissing(err) {
+				continue
+			}
+			log.Printf("Skipping API Gateway %s: %v", loader.name, err)
+		}
+	}
 }
 
 func (g *APIGatewayGenerator) loadRestApis(svc *apigateway.Client) error {
@@ -73,7 +111,13 @@ func (g *APIGatewayGenerator) loadRestApis(svc *apigateway.Client) error {
 			if err := g.loadDocumentationParts(svc, restAPI.Id); err != nil {
 				return err
 			}
+			if err := g.loadDocumentationVersions(svc, restAPI.Id); err != nil {
+				return err
+			}
 			if err := g.loadAuthorizers(svc, restAPI.Id); err != nil {
+				return err
+			}
+			if err := g.loadRequestValidators(svc, restAPI.Id); err != nil {
 				return err
 			}
 		}
@@ -92,6 +136,25 @@ func (g *APIGatewayGenerator) shouldFilterRestAPI(tags map[string]string) bool {
 		}
 	}
 	return false
+}
+
+func (g *APIGatewayGenerator) loadAccount(svc *apigateway.Client, config aws.Config) error {
+	output, err := svc.GetAccount(context.TODO(), &apigateway.GetAccountInput{})
+	if err != nil {
+		return err
+	}
+	if output == nil || StringValue(output.CloudwatchRoleArn) == "" {
+		return nil
+	}
+	account, err := g.getAccountNumber(config)
+	if err != nil {
+		log.Printf("Skipping API Gateway account: unable to get account ID: %v", err)
+		return nil
+	}
+	if resource, ok := newAPIGatewayAccountResource(StringValue(account), output); ok {
+		g.Resources = append(g.Resources, resource)
+	}
+	return nil
 }
 
 func (g *APIGatewayGenerator) loadStages(svc *apigateway.Client, restAPIID *string) error {
@@ -129,21 +192,9 @@ func (g *APIGatewayGenerator) loadResources(svc *apigateway.Client, restAPIID *s
 			return err
 		}
 		for _, resource := range page.Items {
-			resourceID := *restAPIID + "/" + *resource.Id
-			g.Resources = append(g.Resources, terraformutils.NewResource(
-				resourceID,
-				resourceID,
-				"aws_api_gateway_resource",
-				"aws",
-				map[string]string{
-					"path":        StringValue(resource.Path),
-					"path_part":   StringValue(resource.PathPart),
-					"partent_id":  StringValue(resource.ParentId),
-					"rest_api_id": StringValue(restAPIID),
-				},
-				apiGatewayAllowEmptyValues,
-				map[string]interface{}{},
-			))
+			if tfResource, ok := newAPIGatewayResourceResource(StringValue(restAPIID), resource); ok {
+				g.Resources = append(g.Resources, tfResource)
+			}
 			err := g.loadResourceMethods(svc, restAPIID, resource)
 			if err != nil {
 				return err
@@ -345,6 +396,29 @@ func (g *APIGatewayGenerator) loadDocumentationParts(svc *apigateway.Client, res
 	return nil
 }
 
+func (g *APIGatewayGenerator) loadDocumentationVersions(svc *apigateway.Client, restAPIID *string) error {
+	var position *string
+	for {
+		response, err := svc.GetDocumentationVersions(context.TODO(), &apigateway.GetDocumentationVersionsInput{
+			RestApiId: restAPIID,
+			Position:  position,
+		})
+		if err != nil {
+			return err
+		}
+		for _, documentationVersion := range response.Items {
+			if resource, ok := newAPIGatewayDocumentationVersionResource(StringValue(restAPIID), documentationVersion); ok {
+				g.Resources = append(g.Resources, resource)
+			}
+		}
+		position = response.Position
+		if position == nil {
+			break
+		}
+	}
+	return nil
+}
+
 func (g *APIGatewayGenerator) loadAuthorizers(svc *apigateway.Client, restAPIID *string) error {
 	var position *string
 	for {
@@ -368,6 +442,29 @@ func (g *APIGatewayGenerator) loadAuthorizers(svc *apigateway.Client, restAPIID 
 				apiGatewayAllowEmptyValues,
 				map[string]interface{}{},
 			))
+		}
+		position = response.Position
+		if position == nil {
+			break
+		}
+	}
+	return nil
+}
+
+func (g *APIGatewayGenerator) loadRequestValidators(svc *apigateway.Client, restAPIID *string) error {
+	var position *string
+	for {
+		response, err := svc.GetRequestValidators(context.TODO(), &apigateway.GetRequestValidatorsInput{
+			RestApiId: restAPIID,
+			Position:  position,
+		})
+		if err != nil {
+			return err
+		}
+		for _, validator := range response.Items {
+			if resource, ok := newAPIGatewayRequestValidatorResource(StringValue(restAPIID), validator); ok {
+				g.Resources = append(g.Resources, resource)
+			}
 		}
 		position = response.Position
 		if position == nil {
@@ -404,12 +501,47 @@ func (g *APIGatewayGenerator) loadUsagePlans(svc *apigateway.Client) error {
 			return err
 		}
 		for _, usagePlan := range page.Items {
+			usagePlanID := StringValue(usagePlan.Id)
+			if usagePlanID == "" {
+				continue
+			}
+			usagePlanName := StringValue(usagePlan.Name)
+			if usagePlanName == "" {
+				usagePlanName = usagePlanID
+			}
 			g.Resources = append(g.Resources, terraformutils.NewSimpleResource(
-				*usagePlan.Id,
-				*usagePlan.Name,
+				usagePlanID,
+				usagePlanName,
 				"aws_api_gateway_usage_plan",
 				"aws",
 				apiGatewayAllowEmptyValues))
+			if err := g.loadUsagePlanKeys(svc, aws.String(usagePlanID)); err != nil {
+				if !apiGatewayResourceMissing(err) {
+					log.Printf("Skipping API Gateway usage plan keys for %s: %v", usagePlanID, err)
+				}
+			}
+		}
+	}
+	return nil
+}
+
+func (g *APIGatewayGenerator) loadUsagePlanKeys(svc *apigateway.Client, usagePlanID *string) error {
+	usagePlanIDValue := StringValue(usagePlanID)
+	if usagePlanIDValue == "" {
+		return nil
+	}
+	p := apigateway.NewGetUsagePlanKeysPaginator(svc, &apigateway.GetUsagePlanKeysInput{
+		UsagePlanId: aws.String(usagePlanIDValue),
+	})
+	for p.HasMorePages() {
+		page, err := p.NextPage(context.TODO())
+		if err != nil {
+			return err
+		}
+		for _, usagePlanKey := range page.Items {
+			if resource, ok := newAPIGatewayUsagePlanKeyResource(usagePlanIDValue, usagePlanKey); ok {
+				g.Resources = append(g.Resources, resource)
+			}
 		}
 	}
 	return nil
@@ -433,4 +565,293 @@ func (g *APIGatewayGenerator) loadAPIKeys(svc *apigateway.Client) error {
 	}
 
 	return nil
+}
+
+func (g *APIGatewayGenerator) loadClientCertificates(svc *apigateway.Client) error {
+	p := apigateway.NewGetClientCertificatesPaginator(svc, &apigateway.GetClientCertificatesInput{})
+	for p.HasMorePages() {
+		page, err := p.NextPage(context.TODO())
+		if err != nil {
+			return err
+		}
+		for _, certificate := range page.Items {
+			if resource, ok := newAPIGatewayClientCertificateResource(certificate); ok {
+				g.Resources = append(g.Resources, resource)
+			}
+		}
+	}
+	return nil
+}
+
+func (g *APIGatewayGenerator) loadDomainBasePathMappings(svc *apigateway.Client) error {
+	p := apigateway.NewGetDomainNamesPaginator(svc, &apigateway.GetDomainNamesInput{})
+	for p.HasMorePages() {
+		page, err := p.NextPage(context.TODO())
+		if err != nil {
+			return err
+		}
+		for _, domainName := range page.Items {
+			domainNameValue := StringValue(domainName.DomainName)
+			if domainNameValue == "" {
+				continue
+			}
+			if err := g.loadBasePathMappings(svc, domainNameValue, StringValue(domainName.DomainNameId)); err != nil {
+				if !apiGatewayResourceMissing(err) {
+					log.Printf("Skipping API Gateway base path mappings for %s: %v", domainNameValue, err)
+				}
+			}
+		}
+	}
+	return nil
+}
+
+func (g *APIGatewayGenerator) loadBasePathMappings(svc *apigateway.Client, domainName, domainNameID string) error {
+	input := &apigateway.GetBasePathMappingsInput{
+		DomainName: aws.String(domainName),
+	}
+	if domainNameID != "" {
+		input.DomainNameId = aws.String(domainNameID)
+	}
+	p := apigateway.NewGetBasePathMappingsPaginator(svc, input)
+	for p.HasMorePages() {
+		page, err := p.NextPage(context.TODO())
+		if err != nil {
+			return err
+		}
+		for _, mapping := range page.Items {
+			if resource, ok := newAPIGatewayBasePathMappingResource(domainName, domainNameID, mapping); ok {
+				g.Resources = append(g.Resources, resource)
+			}
+		}
+	}
+	return nil
+}
+
+func newAPIGatewayAccountResource(accountID string, output *apigateway.GetAccountOutput) (terraformutils.Resource, bool) {
+	cloudwatchRoleARN := ""
+	if output != nil {
+		cloudwatchRoleARN = StringValue(output.CloudwatchRoleArn)
+	}
+	if accountID == "" || cloudwatchRoleARN == "" {
+		return terraformutils.Resource{}, false
+	}
+	return terraformutils.NewResource(
+		apiGatewayAccountImportID(accountID),
+		apiGatewayResourceName("account", accountID),
+		apiGatewayAccountResourceType,
+		"aws",
+		map[string]string{
+			"cloudwatch_role_arn": cloudwatchRoleARN,
+		},
+		apiGatewayAllowEmptyValues,
+		map[string]interface{}{},
+	), true
+}
+
+func newAPIGatewayBasePathMappingResource(domainName, domainNameID string, mapping types.BasePathMapping) (terraformutils.Resource, bool) {
+	basePath := apiGatewayNormalizeBasePathMappingValue(StringValue(mapping.BasePath))
+	if domainName == "" || StringValue(mapping.RestApiId) == "" || !apiGatewayBasePathMappingImportable(basePath) {
+		return terraformutils.Resource{}, false
+	}
+	attributes := map[string]string{
+		"api_id":      StringValue(mapping.RestApiId),
+		"base_path":   basePath,
+		"domain_name": domainName,
+	}
+	if domainNameID != "" {
+		attributes["domain_name_id"] = domainNameID
+	}
+	if stageName := StringValue(mapping.Stage); stageName != "" {
+		attributes["stage_name"] = stageName
+	}
+	return terraformutils.NewResource(
+		apiGatewayBasePathMappingImportID(domainName, basePath, domainNameID),
+		apiGatewayResourceName("base_path_mapping", domainName, basePath, domainNameID),
+		apiGatewayBasePathMappingResourceType,
+		"aws",
+		attributes,
+		apiGatewayAllowEmptyValues,
+		map[string]interface{}{},
+	), true
+}
+
+func newAPIGatewayClientCertificateResource(certificate types.ClientCertificate) (terraformutils.Resource, bool) {
+	certificateID := StringValue(certificate.ClientCertificateId)
+	if certificateID == "" {
+		return terraformutils.Resource{}, false
+	}
+	attributes := map[string]string{}
+	if description := StringValue(certificate.Description); description != "" {
+		attributes["description"] = description
+	}
+	return terraformutils.NewResource(
+		apiGatewayClientCertificateImportID(certificateID),
+		apiGatewayResourceName("client_certificate", certificateID),
+		apiGatewayClientCertificateResourceType,
+		"aws",
+		attributes,
+		apiGatewayAllowEmptyValues,
+		map[string]interface{}{},
+	), true
+}
+
+func newAPIGatewayDocumentationVersionResource(restAPIID string, documentationVersion types.DocumentationVersion) (terraformutils.Resource, bool) {
+	version := StringValue(documentationVersion.Version)
+	if restAPIID == "" || version == "" {
+		return terraformutils.Resource{}, false
+	}
+	attributes := map[string]string{
+		"rest_api_id": restAPIID,
+		"version":     version,
+	}
+	if description := StringValue(documentationVersion.Description); description != "" {
+		attributes["description"] = description
+	}
+	return terraformutils.NewResource(
+		apiGatewayDocumentationVersionImportID(restAPIID, version),
+		apiGatewayResourceName("documentation_version", restAPIID, version),
+		apiGatewayDocumentationVersionResourceType,
+		"aws",
+		attributes,
+		apiGatewayAllowEmptyValues,
+		map[string]interface{}{},
+	), true
+}
+
+func newAPIGatewayRequestValidatorResource(restAPIID string, validator types.RequestValidator) (terraformutils.Resource, bool) {
+	validatorID := StringValue(validator.Id)
+	validatorName := StringValue(validator.Name)
+	if restAPIID == "" || validatorID == "" || validatorName == "" {
+		return terraformutils.Resource{}, false
+	}
+	return terraformutils.NewResource(
+		apiGatewayRequestValidatorStateID(validatorID),
+		apiGatewayResourceName("request_validator", restAPIID, validatorID),
+		apiGatewayRequestValidatorResourceType,
+		"aws",
+		map[string]string{
+			"name":                        validatorName,
+			"rest_api_id":                 restAPIID,
+			"validate_request_body":       strconv.FormatBool(validator.ValidateRequestBody),
+			"validate_request_parameters": strconv.FormatBool(validator.ValidateRequestParameters),
+		},
+		apiGatewayAllowEmptyValues,
+		map[string]interface{}{},
+	), true
+}
+
+func newAPIGatewayResourceResource(restAPIID string, resource types.Resource) (terraformutils.Resource, bool) {
+	resourceID := StringValue(resource.Id)
+	parentID := StringValue(resource.ParentId)
+	pathPart := StringValue(resource.PathPart)
+	if restAPIID == "" || resourceID == "" || parentID == "" || pathPart == "" {
+		return terraformutils.Resource{}, false
+	}
+	return terraformutils.NewResource(
+		apiGatewayResourceStateID(resourceID),
+		apiGatewayResourceName("resource", restAPIID, resourceID),
+		apiGatewayResourceResourceType,
+		"aws",
+		map[string]string{
+			"path":        StringValue(resource.Path),
+			"path_part":   pathPart,
+			"parent_id":   parentID,
+			"rest_api_id": restAPIID,
+		},
+		apiGatewayAllowEmptyValues,
+		map[string]interface{}{},
+	), true
+}
+
+func newAPIGatewayUsagePlanKeyResource(usagePlanID string, usagePlanKey types.UsagePlanKey) (terraformutils.Resource, bool) {
+	keyID := StringValue(usagePlanKey.Id)
+	keyType := StringValue(usagePlanKey.Type)
+	if usagePlanID == "" || keyID == "" || keyType == "" {
+		return terraformutils.Resource{}, false
+	}
+	return terraformutils.NewResource(
+		apiGatewayUsagePlanKeyStateID(keyID),
+		apiGatewayResourceName("usage_plan_key", usagePlanID, keyID),
+		apiGatewayUsagePlanKeyResourceType,
+		"aws",
+		map[string]string{
+			"key_id":        keyID,
+			"key_type":      keyType,
+			"usage_plan_id": usagePlanID,
+		},
+		apiGatewayAllowEmptyValues,
+		map[string]interface{}{},
+	), true
+}
+
+func apiGatewayResourceMissing(err error) bool {
+	var notFound *types.NotFoundException
+	return errors.As(err, &notFound)
+}
+
+func apiGatewayAccountImportID(accountID string) string {
+	return accountID
+}
+
+func apiGatewayBasePathMappingImportID(domainName, basePath, domainNameID string) string {
+	parts := []string{domainName, basePath}
+	if domainNameID != "" {
+		parts = append(parts, domainNameID)
+	}
+	return strings.Join(parts, apiGatewayResourceIDSeparator)
+}
+
+func apiGatewayClientCertificateImportID(certificateID string) string {
+	return certificateID
+}
+
+func apiGatewayDocumentationVersionImportID(restAPIID, version string) string {
+	return strings.Join([]string{restAPIID, version}, apiGatewayResourceIDSeparator)
+}
+
+func apiGatewayRequestValidatorImportID(restAPIID, validatorID string) string {
+	return strings.Join([]string{restAPIID, validatorID}, apiGatewayResourceIDSeparator)
+}
+
+func apiGatewayRequestValidatorStateID(validatorID string) string {
+	return validatorID
+}
+
+func apiGatewayResourceStateID(resourceID string) string {
+	return resourceID
+}
+
+func apiGatewayUsagePlanKeyImportID(usagePlanID, keyID string) string {
+	return strings.Join([]string{usagePlanID, keyID}, apiGatewayResourceIDSeparator)
+}
+
+func apiGatewayUsagePlanKeyStateID(keyID string) string {
+	return keyID
+}
+
+func apiGatewayNormalizeBasePathMappingValue(basePath string) string {
+	if basePath == apiGatewayEmptyBasePathMappingValue {
+		return ""
+	}
+	return basePath
+}
+
+func apiGatewayBasePathMappingImportable(basePath string) bool {
+	return !strings.Contains(basePath, apiGatewayResourceIDSeparator)
+}
+
+func apiGatewayResourceName(parts ...string) string {
+	var name strings.Builder
+	for _, part := range parts {
+		if part == "" {
+			continue
+		}
+		if name.Len() > 0 {
+			name.WriteString("_")
+		}
+		name.WriteString(strconv.Itoa(len(part)))
+		name.WriteString("_")
+		name.WriteString(part)
+	}
+	return name.String()
 }

--- a/providers/aws/api_gateway.go
+++ b/providers/aws/api_gateway.go
@@ -91,7 +91,7 @@ func (g *APIGatewayGenerator) loadRestApis(svc *apigateway.Client) error {
 			return err
 		}
 		for _, restAPI := range page.Items {
-			if g.shouldFilterRestAPI(restAPI.Tags) {
+			if g.shouldFilterRestAPI(restAPI) {
 				continue
 			}
 			restAPIID := StringValue(restAPI.Id)
@@ -138,22 +138,32 @@ func (g *APIGatewayGenerator) loadRestApis(svc *apigateway.Client) error {
 	return nil
 }
 
-func (g *APIGatewayGenerator) shouldFilterRestAPI(tags map[string]string) bool {
+func (g *APIGatewayGenerator) shouldFilterRestAPI(restAPI types.RestApi) bool {
 	for _, filter := range g.Filter {
+		if filter.FieldPath == "id" && filter.IsApplicable("api_gateway_rest_api") {
+			if !terraformerstring.ContainsString(filter.AcceptableValues, StringValue(restAPI.Id)) {
+				return true
+			}
+			continue
+		}
 		if strings.HasPrefix(filter.FieldPath, "tags.") && filter.IsApplicable("api_gateway_rest_api") {
 			tagName := strings.Replace(filter.FieldPath, "tags.", "", 1)
-			if val, ok := tags[tagName]; ok {
-				return !terraformerstring.ContainsString(filter.AcceptableValues, val)
+			if val, ok := restAPI.Tags[tagName]; ok {
+				if !terraformerstring.ContainsString(filter.AcceptableValues, val) {
+					return true
+				}
+			} else {
+				return true
 			}
-			return true
 		}
 	}
 	return false
 }
 
-func (g *APIGatewayGenerator) hasRestAPITagFilter() bool {
+func (g *APIGatewayGenerator) hasRestAPIFilter() bool {
 	for _, filter := range g.Filter {
-		if strings.HasPrefix(filter.FieldPath, "tags.") && filter.IsApplicable("api_gateway_rest_api") {
+		if filter.IsApplicable("api_gateway_rest_api") &&
+			(filter.FieldPath == "id" || strings.HasPrefix(filter.FieldPath, "tags.")) {
 			return true
 		}
 	}
@@ -171,7 +181,7 @@ func (g *APIGatewayGenerator) rememberAcceptedRestAPIID(restAPIID string) {
 }
 
 func (g *APIGatewayGenerator) shouldFilterBasePathMapping(mapping types.BasePathMapping) bool {
-	if !g.hasRestAPITagFilter() {
+	if !g.hasRestAPIFilter() {
 		return false
 	}
 	restAPIID := StringValue(mapping.RestApiId)

--- a/providers/aws/api_gateway_test.go
+++ b/providers/aws/api_gateway_test.go
@@ -37,6 +37,52 @@ func TestAPIGatewayImportIDs(t *testing.T) {
 	}
 }
 
+func TestAPIGatewayProviderRefreshStateIDs(t *testing.T) {
+	tests := []struct {
+		name string
+		got  string
+		want string
+	}{
+		{name: "request validator", got: apiGatewayRequestValidatorStateID("validator-456"), want: "validator-456"},
+		{name: "resource", got: apiGatewayResourceStateID("resource-456"), want: "resource-456"},
+		{name: "usage plan key", got: apiGatewayUsagePlanKeyStateID("key-456"), want: "key-456"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.got != tt.want {
+				t.Fatalf("provider refresh state ID = %q, want %q", tt.got, tt.want)
+			}
+		})
+	}
+}
+
+func TestAPIGatewayAccountIDFromRoleARN(t *testing.T) {
+	tests := []struct {
+		name    string
+		roleARN string
+		want    string
+		wantOK  bool
+	}{
+		{name: "standard partition", roleARN: "arn:aws:iam::123456789012:role/apigw-cloudwatch", want: "123456789012", wantOK: true},
+		{name: "gov partition", roleARN: "arn:aws-us-gov:iam::210987654321:role/apigw-cloudwatch", want: "210987654321", wantOK: true},
+		{name: "invalid arn", roleARN: "not-an-arn"},
+		{name: "missing account", roleARN: "arn:aws:iam:::role/apigw-cloudwatch"},
+		{name: "non-numeric account", roleARN: "arn:aws:iam::12345678901x:role/apigw-cloudwatch"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, ok := apiGatewayAccountIDFromRoleARN(tt.roleARN)
+			if ok != tt.wantOK {
+				t.Fatalf("ok = %t, want %t", ok, tt.wantOK)
+			}
+			if got != tt.want {
+				t.Fatalf("account ID = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
 func TestNewAPIGatewayAccountResource(t *testing.T) {
 	resource, ok := newAPIGatewayAccountResource("123456789012", &apigateway.GetAccountOutput{
 		CloudwatchRoleArn: aws.String("arn:aws:iam::123456789012:role/apigw-cloudwatch"),

--- a/providers/aws/api_gateway_test.go
+++ b/providers/aws/api_gateway_test.go
@@ -158,28 +158,52 @@ func TestNewAPIGatewayBasePathMappingResource(t *testing.T) {
 	}
 }
 
-func TestAPIGatewayBasePathMappingsRespectRestAPITagFilters(t *testing.T) {
+func TestAPIGatewayBasePathMappingsRespectRestAPIFilters(t *testing.T) {
 	noFilter := &APIGatewayGenerator{}
 	if noFilter.shouldFilterBasePathMapping(types.BasePathMapping{RestApiId: aws.String("api-excluded")}) {
-		t.Fatal("shouldFilterBasePathMapping() = true without REST API tag filter, want false")
+		t.Fatal("shouldFilterBasePathMapping() = true without REST API filter, want false")
 	}
 
-	filtered := &APIGatewayGenerator{}
-	filtered.Filter = []terraformutils.ResourceFilter{{
+	tagFiltered := &APIGatewayGenerator{}
+	tagFiltered.Filter = []terraformutils.ResourceFilter{{
 		ServiceName:      "api_gateway_rest_api",
 		FieldPath:        "tags.Environment",
 		AcceptableValues: []string{"prod"},
 	}}
-	filtered.rememberAcceptedRestAPIID("api-allowed")
+	tagFiltered.rememberAcceptedRestAPIID("api-allowed")
 
-	if filtered.shouldFilterBasePathMapping(types.BasePathMapping{RestApiId: aws.String("api-allowed")}) {
-		t.Fatal("shouldFilterBasePathMapping() = true for accepted REST API, want false")
+	if tagFiltered.shouldFilterBasePathMapping(types.BasePathMapping{RestApiId: aws.String("api-allowed")}) {
+		t.Fatal("shouldFilterBasePathMapping() = true for tag-accepted REST API, want false")
 	}
-	if !filtered.shouldFilterBasePathMapping(types.BasePathMapping{RestApiId: aws.String("api-excluded")}) {
-		t.Fatal("shouldFilterBasePathMapping() = false for filtered REST API, want true")
+	if !tagFiltered.shouldFilterBasePathMapping(types.BasePathMapping{RestApiId: aws.String("api-excluded")}) {
+		t.Fatal("shouldFilterBasePathMapping() = false for tag-filtered REST API, want true")
 	}
-	if !filtered.shouldFilterBasePathMapping(types.BasePathMapping{}) {
+	if !tagFiltered.shouldFilterBasePathMapping(types.BasePathMapping{}) {
 		t.Fatal("shouldFilterBasePathMapping() = false for empty REST API ID under tag filter, want true")
+	}
+
+	idFiltered := &APIGatewayGenerator{}
+	idFiltered.Filter = []terraformutils.ResourceFilter{{
+		ServiceName:      "api_gateway_rest_api",
+		FieldPath:        "id",
+		AcceptableValues: []string{"api-allowed"},
+	}}
+	idFiltered.rememberAcceptedRestAPIID("api-allowed")
+
+	if idFiltered.shouldFilterRestAPI(types.RestApi{Id: aws.String("api-allowed")}) {
+		t.Fatal("shouldFilterRestAPI() = true for accepted REST API ID, want false")
+	}
+	if !idFiltered.shouldFilterRestAPI(types.RestApi{Id: aws.String("api-excluded")}) {
+		t.Fatal("shouldFilterRestAPI() = false for excluded REST API ID, want true")
+	}
+	if idFiltered.shouldFilterBasePathMapping(types.BasePathMapping{RestApiId: aws.String("api-allowed")}) {
+		t.Fatal("shouldFilterBasePathMapping() = true for ID-accepted REST API, want false")
+	}
+	if !idFiltered.shouldFilterBasePathMapping(types.BasePathMapping{RestApiId: aws.String("api-excluded")}) {
+		t.Fatal("shouldFilterBasePathMapping() = false for ID-filtered REST API, want true")
+	}
+	if !idFiltered.shouldFilterBasePathMapping(types.BasePathMapping{}) {
+		t.Fatal("shouldFilterBasePathMapping() = false for empty REST API ID under ID filter, want true")
 	}
 }
 

--- a/providers/aws/api_gateway_test.go
+++ b/providers/aws/api_gateway_test.go
@@ -112,6 +112,31 @@ func TestNewAPIGatewayBasePathMappingResource(t *testing.T) {
 	}
 }
 
+func TestAPIGatewayBasePathMappingsRespectRestAPITagFilters(t *testing.T) {
+	noFilter := &APIGatewayGenerator{}
+	if noFilter.shouldFilterBasePathMapping(types.BasePathMapping{RestApiId: aws.String("api-excluded")}) {
+		t.Fatal("shouldFilterBasePathMapping() = true without REST API tag filter, want false")
+	}
+
+	filtered := &APIGatewayGenerator{}
+	filtered.Filter = []terraformutils.ResourceFilter{{
+		ServiceName:      "api_gateway_rest_api",
+		FieldPath:        "tags.Environment",
+		AcceptableValues: []string{"prod"},
+	}}
+	filtered.rememberAcceptedRestAPIID("api-allowed")
+
+	if filtered.shouldFilterBasePathMapping(types.BasePathMapping{RestApiId: aws.String("api-allowed")}) {
+		t.Fatal("shouldFilterBasePathMapping() = true for accepted REST API, want false")
+	}
+	if !filtered.shouldFilterBasePathMapping(types.BasePathMapping{RestApiId: aws.String("api-excluded")}) {
+		t.Fatal("shouldFilterBasePathMapping() = false for filtered REST API, want true")
+	}
+	if !filtered.shouldFilterBasePathMapping(types.BasePathMapping{}) {
+		t.Fatal("shouldFilterBasePathMapping() = false for empty REST API ID under tag filter, want true")
+	}
+}
+
 func TestNewAPIGatewayClientCertificateResource(t *testing.T) {
 	resource, ok := newAPIGatewayClientCertificateResource(types.ClientCertificate{
 		ClientCertificateId: aws.String("cert-123"),

--- a/providers/aws/api_gateway_test.go
+++ b/providers/aws/api_gateway_test.go
@@ -1,0 +1,298 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package aws
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/apigateway"
+	"github.com/aws/aws-sdk-go-v2/service/apigateway/types"
+	"github.com/chenrui333/terraformer/terraformutils"
+)
+
+func TestAPIGatewayImportIDs(t *testing.T) {
+	tests := []struct {
+		name string
+		got  string
+		want string
+	}{
+		{name: "account", got: apiGatewayAccountImportID("123456789012"), want: "123456789012"},
+		{name: "base path mapping", got: apiGatewayBasePathMappingImportID("api.example.com", "v1", ""), want: "api.example.com/v1"},
+		{name: "root base path mapping", got: apiGatewayBasePathMappingImportID("api.example.com", "", ""), want: "api.example.com/"},
+		{name: "private domain base path mapping", got: apiGatewayBasePathMappingImportID("api.example.com", "v1", "domain-id"), want: "api.example.com/v1/domain-id"},
+		{name: "client certificate", got: apiGatewayClientCertificateImportID("cert-123"), want: "cert-123"},
+		{name: "documentation version", got: apiGatewayDocumentationVersionImportID("api-123", "v1"), want: "api-123/v1"},
+		{name: "request validator", got: apiGatewayRequestValidatorImportID("api-123", "validator-456"), want: "api-123/validator-456"},
+		{name: "usage plan key", got: apiGatewayUsagePlanKeyImportID("plan-123", "key-456"), want: "plan-123/key-456"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.got != tt.want {
+				t.Fatalf("import ID = %q, want %q", tt.got, tt.want)
+			}
+		})
+	}
+}
+
+func TestNewAPIGatewayAccountResource(t *testing.T) {
+	resource, ok := newAPIGatewayAccountResource("123456789012", &apigateway.GetAccountOutput{
+		CloudwatchRoleArn: aws.String("arn:aws:iam::123456789012:role/apigw-cloudwatch"),
+	})
+	if !ok {
+		t.Fatal("newAPIGatewayAccountResource() ok = false, want true")
+	}
+	assertAPIGatewayResourceAttributes(t, resource, apiGatewayAccountResourceType, "123456789012",
+		[]string{"account", "123456789012"},
+		map[string]string{
+			"cloudwatch_role_arn": "arn:aws:iam::123456789012:role/apigw-cloudwatch",
+		})
+
+	if _, ok := newAPIGatewayAccountResource("", &apigateway.GetAccountOutput{CloudwatchRoleArn: aws.String("arn")}); ok {
+		t.Fatal("newAPIGatewayAccountResource() ok = true for empty account ID, want false")
+	}
+	if _, ok := newAPIGatewayAccountResource("123456789012", nil); ok {
+		t.Fatal("newAPIGatewayAccountResource() ok = true for nil output, want false")
+	}
+	if _, ok := newAPIGatewayAccountResource("123456789012", &apigateway.GetAccountOutput{}); ok {
+		t.Fatal("newAPIGatewayAccountResource() ok = true for unconfigured account, want false")
+	}
+}
+
+func TestNewAPIGatewayBasePathMappingResource(t *testing.T) {
+	resource, ok := newAPIGatewayBasePathMappingResource("api.example.com", "domain-id", types.BasePathMapping{
+		BasePath:  aws.String("v1"),
+		RestApiId: aws.String("api-123"),
+		Stage:     aws.String("prod"),
+	})
+	if !ok {
+		t.Fatal("newAPIGatewayBasePathMappingResource() ok = false, want true")
+	}
+	assertAPIGatewayResourceAttributes(t, resource, apiGatewayBasePathMappingResourceType, "api.example.com/v1/domain-id",
+		[]string{"base_path_mapping", "api.example.com", "v1", "domain-id"},
+		map[string]string{
+			"api_id":         "api-123",
+			"base_path":      "v1",
+			"domain_name":    "api.example.com",
+			"domain_name_id": "domain-id",
+			"stage_name":     "prod",
+		})
+
+	resource, ok = newAPIGatewayBasePathMappingResource("api.example.com", "", types.BasePathMapping{
+		BasePath:  aws.String(apiGatewayEmptyBasePathMappingValue),
+		RestApiId: aws.String("api-123"),
+	})
+	if !ok {
+		t.Fatal("newAPIGatewayBasePathMappingResource() ok = false for root mapping, want true")
+	}
+	assertAPIGatewayResourceAttributes(t, resource, apiGatewayBasePathMappingResourceType, "api.example.com/",
+		[]string{"base_path_mapping", "api.example.com"},
+		map[string]string{
+			"api_id":      "api-123",
+			"base_path":   "",
+			"domain_name": "api.example.com",
+		})
+	if _, ok := resource.InstanceState.Attributes["stage_name"]; ok {
+		t.Fatal("newAPIGatewayBasePathMappingResource() seeded empty stage_name, want omitted")
+	}
+
+	if _, ok := newAPIGatewayBasePathMappingResource("", "", types.BasePathMapping{RestApiId: aws.String("api-123")}); ok {
+		t.Fatal("newAPIGatewayBasePathMappingResource() ok = true for empty domain name, want false")
+	}
+	if _, ok := newAPIGatewayBasePathMappingResource("api.example.com", "", types.BasePathMapping{}); ok {
+		t.Fatal("newAPIGatewayBasePathMappingResource() ok = true without rest API ID, want false")
+	}
+	if _, ok := newAPIGatewayBasePathMappingResource("api.example.com", "", types.BasePathMapping{
+		BasePath:  aws.String("v1/orders"),
+		RestApiId: aws.String("api-123"),
+	}); ok {
+		t.Fatal("newAPIGatewayBasePathMappingResource() ok = true for slash-delimited base path, want false")
+	}
+}
+
+func TestNewAPIGatewayClientCertificateResource(t *testing.T) {
+	resource, ok := newAPIGatewayClientCertificateResource(types.ClientCertificate{
+		ClientCertificateId: aws.String("cert-123"),
+		Description:         aws.String("backend mTLS"),
+	})
+	if !ok {
+		t.Fatal("newAPIGatewayClientCertificateResource() ok = false, want true")
+	}
+	assertAPIGatewayResourceAttributes(t, resource, apiGatewayClientCertificateResourceType, "cert-123",
+		[]string{"client_certificate", "cert-123"},
+		map[string]string{
+			"description": "backend mTLS",
+		})
+
+	if _, ok := newAPIGatewayClientCertificateResource(types.ClientCertificate{}); ok {
+		t.Fatal("newAPIGatewayClientCertificateResource() ok = true for empty certificate ID, want false")
+	}
+}
+
+func TestNewAPIGatewayDocumentationVersionResource(t *testing.T) {
+	resource, ok := newAPIGatewayDocumentationVersionResource("api-123", types.DocumentationVersion{
+		Description: aws.String("public docs"),
+		Version:     aws.String("v1"),
+	})
+	if !ok {
+		t.Fatal("newAPIGatewayDocumentationVersionResource() ok = false, want true")
+	}
+	assertAPIGatewayResourceAttributes(t, resource, apiGatewayDocumentationVersionResourceType, "api-123/v1",
+		[]string{"documentation_version", "api-123", "v1"},
+		map[string]string{
+			"description": "public docs",
+			"rest_api_id": "api-123",
+			"version":     "v1",
+		})
+
+	if _, ok := newAPIGatewayDocumentationVersionResource("", types.DocumentationVersion{Version: aws.String("v1")}); ok {
+		t.Fatal("newAPIGatewayDocumentationVersionResource() ok = true for empty rest API ID, want false")
+	}
+	if _, ok := newAPIGatewayDocumentationVersionResource("api-123", types.DocumentationVersion{}); ok {
+		t.Fatal("newAPIGatewayDocumentationVersionResource() ok = true for empty version, want false")
+	}
+}
+
+func TestNewAPIGatewayRequestValidatorResource(t *testing.T) {
+	resource, ok := newAPIGatewayRequestValidatorResource("api-123", types.RequestValidator{
+		Id:                        aws.String("validator-456"),
+		Name:                      aws.String("body-and-params"),
+		ValidateRequestBody:       true,
+		ValidateRequestParameters: true,
+	})
+	if !ok {
+		t.Fatal("newAPIGatewayRequestValidatorResource() ok = false, want true")
+	}
+	assertAPIGatewayResourceAttributes(t, resource, apiGatewayRequestValidatorResourceType, "validator-456",
+		[]string{"request_validator", "api-123", "validator-456"},
+		map[string]string{
+			"name":                        "body-and-params",
+			"rest_api_id":                 "api-123",
+			"validate_request_body":       "true",
+			"validate_request_parameters": "true",
+		})
+
+	if _, ok := newAPIGatewayRequestValidatorResource("", types.RequestValidator{Id: aws.String("validator-456"), Name: aws.String("validator")}); ok {
+		t.Fatal("newAPIGatewayRequestValidatorResource() ok = true for empty rest API ID, want false")
+	}
+	if _, ok := newAPIGatewayRequestValidatorResource("api-123", types.RequestValidator{Name: aws.String("validator")}); ok {
+		t.Fatal("newAPIGatewayRequestValidatorResource() ok = true for empty validator ID, want false")
+	}
+	if _, ok := newAPIGatewayRequestValidatorResource("api-123", types.RequestValidator{Id: aws.String("validator-456")}); ok {
+		t.Fatal("newAPIGatewayRequestValidatorResource() ok = true for empty validator name, want false")
+	}
+}
+
+func TestNewAPIGatewayResourceResource(t *testing.T) {
+	resource, ok := newAPIGatewayResourceResource("api-123", types.Resource{
+		Id:       aws.String("resource-456"),
+		ParentId: aws.String("parent-123"),
+		Path:     aws.String("/pets/{petId}"),
+		PathPart: aws.String("{petId}"),
+	})
+	if !ok {
+		t.Fatal("newAPIGatewayResourceResource() ok = false, want true")
+	}
+	assertAPIGatewayResourceAttributes(t, resource, apiGatewayResourceResourceType, "resource-456",
+		[]string{"resource", "api-123", "resource-456"},
+		map[string]string{
+			"parent_id":   "parent-123",
+			"path":        "/pets/{petId}",
+			"path_part":   "{petId}",
+			"rest_api_id": "api-123",
+		})
+	if _, ok := resource.InstanceState.Attributes["partent_id"]; ok {
+		t.Fatal("newAPIGatewayResourceResource() seeded misspelled partent_id, want parent_id only")
+	}
+
+	if _, ok := newAPIGatewayResourceResource("", types.Resource{Id: aws.String("resource-456")}); ok {
+		t.Fatal("newAPIGatewayResourceResource() ok = true for empty rest API ID, want false")
+	}
+	if _, ok := newAPIGatewayResourceResource("api-123", types.Resource{
+		ParentId: aws.String("parent-123"),
+		PathPart: aws.String("pets"),
+	}); ok {
+		t.Fatal("newAPIGatewayResourceResource() ok = true for empty resource ID, want false")
+	}
+	if _, ok := newAPIGatewayResourceResource("api-123", types.Resource{
+		Id:       aws.String("resource-456"),
+		PathPart: aws.String("pets"),
+	}); ok {
+		t.Fatal("newAPIGatewayResourceResource() ok = true for empty parent ID, want false")
+	}
+	if _, ok := newAPIGatewayResourceResource("api-123", types.Resource{
+		Id:       aws.String("resource-456"),
+		ParentId: aws.String("parent-123"),
+	}); ok {
+		t.Fatal("newAPIGatewayResourceResource() ok = true for empty path part, want false")
+	}
+}
+
+func TestNewAPIGatewayUsagePlanKeyResource(t *testing.T) {
+	resource, ok := newAPIGatewayUsagePlanKeyResource("plan-123", types.UsagePlanKey{
+		Id:   aws.String("key-456"),
+		Type: aws.String("API_KEY"),
+	})
+	if !ok {
+		t.Fatal("newAPIGatewayUsagePlanKeyResource() ok = false, want true")
+	}
+	assertAPIGatewayResourceAttributes(t, resource, apiGatewayUsagePlanKeyResourceType, "key-456",
+		[]string{"usage_plan_key", "plan-123", "key-456"},
+		map[string]string{
+			"key_id":        "key-456",
+			"key_type":      "API_KEY",
+			"usage_plan_id": "plan-123",
+		})
+
+	if _, ok := newAPIGatewayUsagePlanKeyResource("", types.UsagePlanKey{Id: aws.String("key-456"), Type: aws.String("API_KEY")}); ok {
+		t.Fatal("newAPIGatewayUsagePlanKeyResource() ok = true for empty usage plan ID, want false")
+	}
+	if _, ok := newAPIGatewayUsagePlanKeyResource("plan-123", types.UsagePlanKey{Type: aws.String("API_KEY")}); ok {
+		t.Fatal("newAPIGatewayUsagePlanKeyResource() ok = true for empty key ID, want false")
+	}
+	if _, ok := newAPIGatewayUsagePlanKeyResource("plan-123", types.UsagePlanKey{Id: aws.String("key-456")}); ok {
+		t.Fatal("newAPIGatewayUsagePlanKeyResource() ok = true for empty key type, want false")
+	}
+}
+
+func TestAPIGatewayResourceNameIsCollisionResistant(t *testing.T) {
+	first := terraformutils.TfSanitize(apiGatewayResourceName("base_path_mapping", "a/b", "c"))
+	second := terraformutils.TfSanitize(apiGatewayResourceName("base_path_mapping", "a", "b/c"))
+	if first == second {
+		t.Fatalf("apiGatewayResourceName() generated duplicate sanitized names %q", first)
+	}
+}
+
+func TestAPIGatewayResourceMissing(t *testing.T) {
+	if !apiGatewayResourceMissing(&types.NotFoundException{}) {
+		t.Fatal("apiGatewayResourceMissing() = false for NotFoundException, want true")
+	}
+	if apiGatewayResourceMissing(errors.New("boom")) {
+		t.Fatal("apiGatewayResourceMissing() = true for generic error, want false")
+	}
+	if apiGatewayResourceMissing(nil) {
+		t.Fatal("apiGatewayResourceMissing() = true for nil error, want false")
+	}
+}
+
+func assertAPIGatewayResourceAttributes(t *testing.T, resource terraformutils.Resource, resourceType, resourceID string, nameParts []string, attributes map[string]string) {
+	t.Helper()
+
+	if resource.InstanceInfo.Type != resourceType {
+		t.Fatalf("resource type = %q, want %q", resource.InstanceInfo.Type, resourceType)
+	}
+	if resource.InstanceState.ID != resourceID {
+		t.Fatalf("resource ID = %q, want %q", resource.InstanceState.ID, resourceID)
+	}
+	for name, want := range attributes {
+		if got := resource.InstanceState.Attributes[name]; got != want {
+			t.Fatalf("attribute %q = %q, want %q", name, got, want)
+		}
+	}
+	wantName := terraformutils.TfSanitize(apiGatewayResourceName(nameParts...))
+	if resource.ResourceName != wantName {
+		t.Fatalf("resource name = %q, want %q", resource.ResourceName, wantName)
+	}
+}


### PR DESCRIPTION
## Summary

- add REST API Gateway import discovery for account settings, base path mappings, client certificates, documentation versions, request validators, and usage plan keys
- seed child resources with provider-refresh IDs and required parent attributes
- skip unsafe/default cases such as unconfigured account settings, root API resources, and slash-delimited base path mappings the provider import ID cannot represent
- update docs/aws.md and add unit tests for API Gateway helper behavior

## References

- #338

## Validation

```bash
go test ./providers/aws -run 'Test.*APIGateway|Test.*ApiGateway|Test.*apiGateway|Test.*APIGatewayV2|Test.*ApiGatewayV2|Test.*apigateway'
go test ./providers/aws/... ./terraformutils/...
go run ./tools/aws-gap-inventory \
  -docs docs/aws.md \
  -aws-dir providers/aws \
  -skip-list providers/aws/unsupported_resources.json \
  -format markdown
git diff --check
```

## Notes

Skipped/deferred resources:
- aws_api_gateway_account: emits only when a CloudWatch role ARN is configured; default account settings are skipped.
- aws_api_gateway_base_path_mapping: skips base paths containing "/" because the Terraform provider's slash-delimited import ID cannot represent them safely.
- aws_api_gateway_deployment: deferred because REST deployments are snapshot-like and need separate refresh/import review.
- aws_api_gateway_domain_name: deferred because uploaded certificate private key material is not returned by AWS; ACM-only import needs a separate scoped PR.
- aws_api_gateway_method_settings: deferred because method-path import behavior needs separate coverage.
- API Gateway v2 candidate resources were already supported on main; this PR keeps v2 unchanged.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Expand API Gateway REST import coverage with safety checks and correct account ID parsing from the CloudWatch role ARN. Base path mappings now respect REST API tag and id filters to avoid unrelated imports.

- **New Features**
  - Import discovery for `aws_api_gateway_account`, `aws_api_gateway_base_path_mapping`, `aws_api_gateway_client_certificate`, `aws_api_gateway_documentation_version`, `aws_api_gateway_request_validator`, `aws_api_gateway_usage_plan_key`.
  - Seed required parent fields and provider-refresh IDs for child resources (e.g., `rest_api_id`, `parent_id`, `path_part`, `base_path`).
  - Skip unsafe/default cases the provider cannot represent: unconfigured account settings, root API resources, and base paths containing "/". API Gateway v2 remains unchanged.
  - Update `docs/aws.md` and add unit tests for helper behavior.

- **Bug Fixes**
  - Base path mappings are filtered by accepted `aws_api_gateway_rest_api` tag and id filters to prevent cross-API imports.
  - Parse API Gateway account ID from the CloudWatch role ARN to build a stable `aws_api_gateway_account` import.

<sup>Written for commit bb7f8339a66e5629381cf23fd1f3c38f647f7999. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for many additional AWS API Gateway resource types (accounts, API keys, base path mappings, client certificates, documentation versions, request validators, stages, usage plans, usage plan keys, etc.).

* **Bug Fixes**
  * Improved discovery/import behavior (skip blank IDs, filter mappings by discovered APIs) and corrected attribute wiring for API Gateway resources.

* **Documentation**
  * Updated AWS provider docs to list the newly supported API Gateway resources.

* **Tests**
  * Added comprehensive tests for new resources, import/ID utilities, and discovery/filtering behavior.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/chenrui333/terraformer/pull/421)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->