### PR TITLE
aws(media): add media service imports

### DIFF
--- a/docs/aws.md
+++ b/docs/aws.md
@@ -349,6 +349,12 @@ For AWS provider gap audits and unsupported-resource skip-list maintenance, see 
     * `aws_iot_thing_type`
     * `aws_iot_topic_rule`
     * `aws_iot_role_alias`
+*   `ivs`
+    * `aws_ivs_channel`
+    * `aws_ivs_recording_configuration`
+*   `ivschat`
+    * `aws_ivschat_logging_configuration`
+    * `aws_ivschat_room`
 *   `kinesis`
     * `aws_kinesis_resource_policy`
     * `aws_kinesis_stream`
@@ -390,6 +396,7 @@ For AWS provider gap audits and unsupported-resource skip-list maintenance, see 
     * `aws_media_package_channel`
 *   `media_store`
     * `aws_media_store_container`
+    * `aws_media_store_container_policy`
 *   `medialive`
     * `aws_medialive_channel`
     * `aws_medialive_input`

--- a/go.mod
+++ b/go.mod
@@ -407,6 +407,8 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/backup v1.55.2
 	github.com/aws/aws-sdk-go-v2/service/bedrock v1.59.2
 	github.com/aws/aws-sdk-go-v2/service/directconnect v1.38.17
+	github.com/aws/aws-sdk-go-v2/service/ivs v1.50.1
+	github.com/aws/aws-sdk-go-v2/service/ivschat v1.21.22
 	github.com/aws/aws-sdk-go-v2/service/mwaa v1.40.0
 	github.com/aws/aws-sdk-go-v2/service/pipes v1.23.22
 	github.com/aws/aws-sdk-go-v2/service/s3control v1.70.1

--- a/go.sum
+++ b/go.sum
@@ -311,6 +311,10 @@ github.com/aws/aws-sdk-go-v2/service/internal/s3shared v1.19.23 h1:03xatSQO4+AM1
 github.com/aws/aws-sdk-go-v2/service/internal/s3shared v1.19.23/go.mod h1:M8l3mwgx5ToK7wot2sBBce/ojzgnPzZXUV445gTSyE8=
 github.com/aws/aws-sdk-go-v2/service/iot v1.73.0 h1:7ZI147ei1koJE5dnfus8cfMOp2CRxsMgORp6hmewV9I=
 github.com/aws/aws-sdk-go-v2/service/iot v1.73.0/go.mod h1:9OGjPSOz2OZbObVfBcn110WPW/XZ1k6rSCpky8EvfHQ=
+github.com/aws/aws-sdk-go-v2/service/ivs v1.50.1 h1:H/tTA4a7nmiFacIKeQjK/S8m7Ah/OXzSSLwPXEtD3l8=
+github.com/aws/aws-sdk-go-v2/service/ivs v1.50.1/go.mod h1:bu+KAqMu3i8tSo+e5AT3LriDJ6miYVK1E3hVqBXFA/k=
+github.com/aws/aws-sdk-go-v2/service/ivschat v1.21.22 h1:A6xe0lDrslLJw1krOhqfEdCGdeqCJHseKGjHvZPXl1s=
+github.com/aws/aws-sdk-go-v2/service/ivschat v1.21.22/go.mod h1:YtV5J3V6kO+ZIYpVSbdQhq3lrEFxQLDtqRNptC+rlGg=
 github.com/aws/aws-sdk-go-v2/service/kafka v1.51.0 h1:ovcPO5rh87iOWFMLAwtgyHEzZOCx0WYemd7thWdnXME=
 github.com/aws/aws-sdk-go-v2/service/kafka v1.51.0/go.mod h1:pW4pYNuVeScl13yqwsjLY0F/7g2YD8E0AvR6SOQsJZE=
 github.com/aws/aws-sdk-go-v2/service/kinesis v1.43.7 h1:9FvrpWzkSPbm995UGQ4jOdRDuhQLmwgh/5t8UoosTdY=

--- a/providers/aws/aws_provider.go
+++ b/providers/aws/aws_provider.go
@@ -315,6 +315,8 @@ func (p *AWSProvider) GetSupportedService() map[string]terraformutils.ServiceGen
 		"identitystore":     &AwsFacade{service: &IdentityStoreGenerator{}},
 		"igw":               &AwsFacade{service: &IgwGenerator{}},
 		"iot":               &AwsFacade{service: &IotGenerator{}},
+		"ivs":               &AwsFacade{service: &IvsGenerator{}},
+		"ivschat":           &AwsFacade{service: &IvsChatGenerator{}},
 		"kinesis":           &AwsFacade{service: &KinesisGenerator{}},
 		"kms":               &AwsFacade{service: &KmsGenerator{}},
 		"lambda":            &AwsFacade{service: &LambdaGenerator{}},

--- a/providers/aws/ivs.go
+++ b/providers/aws/ivs.go
@@ -1,0 +1,198 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package aws
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/ivs"
+	ivstypes "github.com/aws/aws-sdk-go-v2/service/ivs/types"
+	"github.com/chenrui333/terraformer/terraformutils"
+)
+
+const (
+	ivsChannelResourceType                = "aws_ivs_channel"
+	ivsRecordingConfigurationResourceType = "aws_ivs_recording_configuration"
+)
+
+var ivsAllowEmptyValues = []string{"tags."}
+
+type IvsGenerator struct {
+	AWSService
+}
+
+func (g *IvsGenerator) InitResources() error {
+	config, e := g.generateConfig()
+	if e != nil {
+		return e
+	}
+	svc := ivs.NewFromConfig(config)
+
+	if err := g.loadChannels(svc); err != nil {
+		return err
+	}
+	return g.loadRecordingConfigurations(svc)
+}
+
+func (g *IvsGenerator) loadChannels(svc *ivs.Client) error {
+	paginator := ivs.NewListChannelsPaginator(svc, &ivs.ListChannelsInput{})
+	for paginator.HasMorePages() {
+		page, err := paginator.NextPage(context.TODO())
+		if err != nil {
+			return err
+		}
+		for _, summary := range page.Channels {
+			channel, err := getIvsChannel(svc, StringValue(summary.Arn))
+			if ivsResourceNotFound(err) {
+				continue
+			}
+			if err != nil {
+				return err
+			}
+			if resource, ok := newIvsChannelResource(channel); ok {
+				g.Resources = append(g.Resources, resource)
+			}
+		}
+	}
+	return nil
+}
+
+func (g *IvsGenerator) loadRecordingConfigurations(svc *ivs.Client) error {
+	paginator := ivs.NewListRecordingConfigurationsPaginator(svc, &ivs.ListRecordingConfigurationsInput{})
+	for paginator.HasMorePages() {
+		page, err := paginator.NextPage(context.TODO())
+		if err != nil {
+			return err
+		}
+		for _, summary := range page.RecordingConfigurations {
+			recordingConfiguration, err := getIvsRecordingConfiguration(svc, StringValue(summary.Arn))
+			if ivsResourceNotFound(err) {
+				continue
+			}
+			if err != nil {
+				return err
+			}
+			if resource, ok := newIvsRecordingConfigurationResource(recordingConfiguration); ok {
+				g.Resources = append(g.Resources, resource)
+			}
+		}
+	}
+	return nil
+}
+
+func getIvsChannel(svc *ivs.Client, arn string) (*ivstypes.Channel, error) {
+	if arn == "" {
+		return nil, nil
+	}
+	output, err := svc.GetChannel(context.TODO(), &ivs.GetChannelInput{
+		Arn: aws.String(arn),
+	})
+	if err != nil {
+		return nil, err
+	}
+	if output == nil {
+		return nil, nil
+	}
+	return output.Channel, nil
+}
+
+func getIvsRecordingConfiguration(svc *ivs.Client, arn string) (*ivstypes.RecordingConfiguration, error) {
+	if arn == "" {
+		return nil, nil
+	}
+	output, err := svc.GetRecordingConfiguration(context.TODO(), &ivs.GetRecordingConfigurationInput{
+		Arn: aws.String(arn),
+	})
+	if err != nil {
+		return nil, err
+	}
+	if output == nil {
+		return nil, nil
+	}
+	return output.RecordingConfiguration, nil
+}
+
+func newIvsChannelResource(channel *ivstypes.Channel) (terraformutils.Resource, bool) {
+	if channel == nil {
+		return terraformutils.Resource{}, false
+	}
+	arn := StringValue(channel.Arn)
+	if arn == "" {
+		return terraformutils.Resource{}, false
+	}
+	return terraformutils.NewSimpleResource(
+		ivsARNImportID(arn),
+		ivsResourceName("channel", StringValue(channel.Name), arn),
+		ivsChannelResourceType,
+		"aws",
+		ivsAllowEmptyValues,
+	), true
+}
+
+func newIvsRecordingConfigurationResource(recordingConfiguration *ivstypes.RecordingConfiguration) (terraformutils.Resource, bool) {
+	if !ivsRecordingConfigurationImportable(recordingConfiguration) {
+		return terraformutils.Resource{}, false
+	}
+	arn := StringValue(recordingConfiguration.Arn)
+	return terraformutils.NewResource(
+		ivsARNImportID(arn),
+		ivsResourceName("recording-configuration", StringValue(recordingConfiguration.Name), arn),
+		ivsRecordingConfigurationResourceType,
+		"aws",
+		ivsRecordingConfigurationAttributes(recordingConfiguration),
+		ivsAllowEmptyValues,
+		map[string]interface{}{},
+	), true
+}
+
+func ivsRecordingConfigurationImportable(recordingConfiguration *ivstypes.RecordingConfiguration) bool {
+	if recordingConfiguration == nil || !ivsRecordingConfigurationStateImportable(recordingConfiguration.State) {
+		return false
+	}
+	return StringValue(recordingConfiguration.Arn) != "" && ivsRecordingConfigurationBucketName(recordingConfiguration) != ""
+}
+
+func ivsRecordingConfigurationAttributes(recordingConfiguration *ivstypes.RecordingConfiguration) map[string]string {
+	return map[string]string{
+		"destination_configuration.#":                  "1",
+		"destination_configuration.0.s3.#":             "1",
+		"destination_configuration.0.s3.0.bucket_name": ivsRecordingConfigurationBucketName(recordingConfiguration),
+	}
+}
+
+func ivsRecordingConfigurationBucketName(recordingConfiguration *ivstypes.RecordingConfiguration) string {
+	if recordingConfiguration == nil || recordingConfiguration.DestinationConfiguration == nil || recordingConfiguration.DestinationConfiguration.S3 == nil {
+		return ""
+	}
+	return StringValue(recordingConfiguration.DestinationConfiguration.S3.BucketName)
+}
+
+func ivsARNImportID(arn string) string {
+	return arn
+}
+
+func ivsRecordingConfigurationStateImportable(state ivstypes.RecordingConfigurationState) bool {
+	return state != ""
+}
+
+func ivsResourceName(parts ...string) string {
+	cleanParts := []string{}
+	for _, part := range parts {
+		if part != "" {
+			cleanParts = append(cleanParts, fmt.Sprintf("%d/%s", len(part), part))
+		}
+	}
+	if len(cleanParts) == 0 {
+		return "ivs-resource"
+	}
+	return strings.Join(cleanParts, "/")
+}
+
+func ivsResourceNotFound(err error) bool {
+	var notFound *ivstypes.ResourceNotFoundException
+	return errors.As(err, &notFound)
+}

--- a/providers/aws/ivs_test.go
+++ b/providers/aws/ivs_test.go
@@ -1,0 +1,162 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package aws
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	ivstypes "github.com/aws/aws-sdk-go-v2/service/ivs/types"
+	"github.com/chenrui333/terraformer/terraformutils"
+)
+
+const (
+	testIvsChannelARN                = "arn:aws:ivs:us-east-1:123456789012:channel/abc123"
+	testIvsRecordingConfigurationARN = "arn:aws:ivs:us-east-1:123456789012:recording-configuration/def456"
+)
+
+func TestNewIvsChannelResource(t *testing.T) {
+	resource, ok := newIvsChannelResource(&ivstypes.Channel{
+		Arn:  aws.String(testIvsChannelARN),
+		Name: aws.String("core-channel"),
+	})
+	assertIvsResource(t, resource, ok, testIvsChannelARN, ivsResourceName("channel", "core-channel", testIvsChannelARN), ivsChannelResourceType)
+
+	if _, ok := newIvsChannelResource(nil); ok {
+		t.Fatal("nil channel should be skipped")
+	}
+	if _, ok := newIvsChannelResource(&ivstypes.Channel{Name: aws.String("core-channel")}); ok {
+		t.Fatal("channel with empty ARN should be skipped")
+	}
+}
+
+func TestNewIvsRecordingConfigurationResource(t *testing.T) {
+	recordingConfiguration := validIvsRecordingConfiguration("core-recording")
+	resource, ok := newIvsRecordingConfigurationResource(recordingConfiguration)
+	assertIvsResource(t, resource, ok, testIvsRecordingConfigurationARN, ivsResourceName("recording-configuration", "core-recording", testIvsRecordingConfigurationARN), ivsRecordingConfigurationResourceType)
+	assertIvsAttribute(t, resource, "destination_configuration.#", "1")
+	assertIvsAttribute(t, resource, "destination_configuration.0.s3.#", "1")
+	assertIvsAttribute(t, resource, "destination_configuration.0.s3.0.bucket_name", "recording-bucket")
+}
+
+func TestNewIvsRecordingConfigurationResourceSkipsIncompleteConfigurations(t *testing.T) {
+	tests := []struct {
+		name   string
+		mutate func(*ivstypes.RecordingConfiguration)
+	}{
+		{name: "empty ARN", mutate: func(configuration *ivstypes.RecordingConfiguration) { configuration.Arn = nil }},
+		{name: "empty state", mutate: func(configuration *ivstypes.RecordingConfiguration) { configuration.State = "" }},
+		{name: "missing destination", mutate: func(configuration *ivstypes.RecordingConfiguration) { configuration.DestinationConfiguration = nil }},
+		{name: "missing S3 destination", mutate: func(configuration *ivstypes.RecordingConfiguration) { configuration.DestinationConfiguration.S3 = nil }},
+		{name: "empty bucket", mutate: func(configuration *ivstypes.RecordingConfiguration) {
+			configuration.DestinationConfiguration.S3.BucketName = nil
+		}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			configuration := validIvsRecordingConfiguration("core-recording")
+			tt.mutate(configuration)
+			if _, ok := newIvsRecordingConfigurationResource(configuration); ok {
+				t.Fatal("incomplete recording configuration should be skipped")
+			}
+		})
+	}
+
+	if _, ok := newIvsRecordingConfigurationResource(nil); ok {
+		t.Fatal("nil recording configuration should be skipped")
+	}
+}
+
+func TestIvsARNImportID(t *testing.T) {
+	if got := ivsARNImportID(testIvsChannelARN); got != testIvsChannelARN {
+		t.Fatalf("IVS ARN import ID = %q, want %q", got, testIvsChannelARN)
+	}
+}
+
+func TestIvsRecordingConfigurationStateImportable(t *testing.T) {
+	tests := []struct {
+		name  string
+		state ivstypes.RecordingConfigurationState
+		want  bool
+	}{
+		{name: "creating", state: ivstypes.RecordingConfigurationStateCreating, want: true},
+		{name: "create failed", state: ivstypes.RecordingConfigurationStateCreateFailed, want: true},
+		{name: "active", state: ivstypes.RecordingConfigurationStateActive, want: true},
+		{name: "empty", want: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := ivsRecordingConfigurationStateImportable(tt.state); got != tt.want {
+				t.Fatalf("ivsRecordingConfigurationStateImportable(%q) = %t, want %t", tt.state, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestIvsResourceNamesPreserveSegmentBoundaries(t *testing.T) {
+	left := terraformutils.TfSanitize(ivsResourceName("channel", "a/b_c", "d"))
+	right := terraformutils.TfSanitize(ivsResourceName("channel", "a", "b_c/d"))
+	if left == right {
+		t.Fatalf("IVS resource names collide: %q", left)
+	}
+}
+
+func TestIvsResourceNotFound(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{name: "nil", want: false},
+		{name: "resource not found", err: &ivstypes.ResourceNotFoundException{}, want: true},
+		{name: "wrapped resource not found", err: errors.Join(errors.New("lookup failed"), &ivstypes.ResourceNotFoundException{}), want: true},
+		{name: "generic", err: errors.New("boom"), want: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := ivsResourceNotFound(tt.err); got != tt.want {
+				t.Fatalf("ivsResourceNotFound(%v) = %t, want %t", tt.err, got, tt.want)
+			}
+		})
+	}
+}
+
+func validIvsRecordingConfiguration(name string) *ivstypes.RecordingConfiguration {
+	return &ivstypes.RecordingConfiguration{
+		Arn:   aws.String(testIvsRecordingConfigurationARN),
+		Name:  aws.String(name),
+		State: ivstypes.RecordingConfigurationStateActive,
+		DestinationConfiguration: &ivstypes.DestinationConfiguration{
+			S3: &ivstypes.S3DestinationConfiguration{
+				BucketName: aws.String("recording-bucket"),
+			},
+		},
+	}
+}
+
+func assertIvsResource(t *testing.T, resource terraformutils.Resource, ok bool, wantID, wantName, wantType string) {
+	t.Helper()
+	if !ok {
+		t.Fatal("resource was skipped")
+	}
+	if got := resource.InstanceState.ID; got != wantID {
+		t.Fatalf("resource ID = %q, want %q", got, wantID)
+	}
+	if got := resource.ResourceName; got != terraformutils.TfSanitize(wantName) {
+		t.Fatalf("resource name = %q, want %q", got, terraformutils.TfSanitize(wantName))
+	}
+	if got := resource.InstanceInfo.Type; got != wantType {
+		t.Fatalf("resource type = %q, want %q", got, wantType)
+	}
+}
+
+func assertIvsAttribute(t *testing.T, resource terraformutils.Resource, key, want string) {
+	t.Helper()
+	if got := resource.InstanceState.Attributes[key]; got != want {
+		t.Fatalf("resource attribute %q = %q, want %q", key, got, want)
+	}
+}

--- a/providers/aws/ivschat.go
+++ b/providers/aws/ivschat.go
@@ -1,0 +1,172 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package aws
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/ivschat"
+	ivschattypes "github.com/aws/aws-sdk-go-v2/service/ivschat/types"
+	"github.com/chenrui333/terraformer/terraformutils"
+)
+
+const (
+	ivsChatLoggingConfigurationResourceType = "aws_ivschat_logging_configuration"
+	ivsChatRoomResourceType                 = "aws_ivschat_room"
+)
+
+var ivsChatAllowEmptyValues = []string{"tags."}
+
+type IvsChatGenerator struct {
+	AWSService
+}
+
+func (g *IvsChatGenerator) InitResources() error {
+	config, e := g.generateConfig()
+	if e != nil {
+		return e
+	}
+	svc := ivschat.NewFromConfig(config)
+
+	if err := g.loadLoggingConfigurations(svc); err != nil {
+		return err
+	}
+	return g.loadRooms(svc)
+}
+
+func (g *IvsChatGenerator) loadLoggingConfigurations(svc *ivschat.Client) error {
+	paginator := ivschat.NewListLoggingConfigurationsPaginator(svc, &ivschat.ListLoggingConfigurationsInput{})
+	for paginator.HasMorePages() {
+		page, err := paginator.NextPage(context.TODO())
+		if err != nil {
+			return err
+		}
+		for _, summary := range page.LoggingConfigurations {
+			configuration, err := getIvsChatLoggingConfiguration(svc, StringValue(summary.Arn))
+			if ivsChatResourceNotFound(err) {
+				continue
+			}
+			if err != nil {
+				return err
+			}
+			if resource, ok := newIvsChatLoggingConfigurationResource(configuration); ok {
+				g.Resources = append(g.Resources, resource)
+			}
+		}
+	}
+	return nil
+}
+
+func (g *IvsChatGenerator) loadRooms(svc *ivschat.Client) error {
+	paginator := ivschat.NewListRoomsPaginator(svc, &ivschat.ListRoomsInput{})
+	for paginator.HasMorePages() {
+		page, err := paginator.NextPage(context.TODO())
+		if err != nil {
+			return err
+		}
+		for _, summary := range page.Rooms {
+			room, err := getIvsChatRoom(svc, StringValue(summary.Arn))
+			if ivsChatResourceNotFound(err) {
+				continue
+			}
+			if err != nil {
+				return err
+			}
+			if resource, ok := newIvsChatRoomResource(room); ok {
+				g.Resources = append(g.Resources, resource)
+			}
+		}
+	}
+	return nil
+}
+
+func getIvsChatLoggingConfiguration(svc *ivschat.Client, arn string) (*ivschat.GetLoggingConfigurationOutput, error) {
+	if arn == "" {
+		return nil, nil
+	}
+	return svc.GetLoggingConfiguration(context.TODO(), &ivschat.GetLoggingConfigurationInput{
+		Identifier: aws.String(arn),
+	})
+}
+
+func getIvsChatRoom(svc *ivschat.Client, arn string) (*ivschat.GetRoomOutput, error) {
+	if arn == "" {
+		return nil, nil
+	}
+	return svc.GetRoom(context.TODO(), &ivschat.GetRoomInput{
+		Identifier: aws.String(arn),
+	})
+}
+
+func newIvsChatLoggingConfigurationResource(configuration *ivschat.GetLoggingConfigurationOutput) (terraformutils.Resource, bool) {
+	if !ivsChatLoggingConfigurationImportable(configuration) {
+		return terraformutils.Resource{}, false
+	}
+	arn := StringValue(configuration.Arn)
+	return terraformutils.NewSimpleResource(
+		ivsChatARNImportID(arn),
+		ivsChatResourceName("logging-configuration", StringValue(configuration.Name), arn),
+		ivsChatLoggingConfigurationResourceType,
+		"aws",
+		ivsChatAllowEmptyValues,
+	), true
+}
+
+func newIvsChatRoomResource(room *ivschat.GetRoomOutput) (terraformutils.Resource, bool) {
+	if room == nil {
+		return terraformutils.Resource{}, false
+	}
+	arn := StringValue(room.Arn)
+	if arn == "" {
+		return terraformutils.Resource{}, false
+	}
+	return terraformutils.NewSimpleResource(
+		ivsChatARNImportID(arn),
+		ivsChatResourceName("room", StringValue(room.Name), arn),
+		ivsChatRoomResourceType,
+		"aws",
+		ivsChatAllowEmptyValues,
+	), true
+}
+
+func ivsChatLoggingConfigurationImportable(configuration *ivschat.GetLoggingConfigurationOutput) bool {
+	if configuration == nil || !ivsChatLoggingConfigurationStateImportable(configuration.State) {
+		return false
+	}
+	return StringValue(configuration.Arn) != ""
+}
+
+func ivsChatARNImportID(arn string) string {
+	return arn
+}
+
+func ivsChatLoggingConfigurationStateImportable(state ivschattypes.LoggingConfigurationState) bool {
+	switch state {
+	case "", ivschattypes.LoggingConfigurationStateDeleting:
+		return false
+	default:
+		return true
+	}
+}
+
+func ivsChatResourceName(parts ...string) string {
+	cleanParts := []string{}
+	for _, part := range parts {
+		if part != "" {
+			cleanParts = append(cleanParts, fmt.Sprintf("%d/%s", len(part), part))
+		}
+	}
+	if len(cleanParts) == 0 {
+		return "ivschat-resource"
+	}
+	return strings.Join(cleanParts, "/")
+}
+
+func ivsChatResourceNotFound(err error) bool {
+	var notFound *ivschattypes.ResourceNotFoundException
+	return errors.As(err, &notFound)
+}

--- a/providers/aws/ivschat_test.go
+++ b/providers/aws/ivschat_test.go
@@ -1,0 +1,150 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package aws
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/ivschat"
+	ivschattypes "github.com/aws/aws-sdk-go-v2/service/ivschat/types"
+	"github.com/chenrui333/terraformer/terraformutils"
+)
+
+const (
+	testIvsChatLoggingConfigurationARN = "arn:aws:ivschat:us-east-1:123456789012:logging-configuration/abc123"
+	testIvsChatRoomARN                 = "arn:aws:ivschat:us-east-1:123456789012:room/def456"
+)
+
+func TestNewIvsChatLoggingConfigurationResource(t *testing.T) {
+	configuration := validIvsChatLoggingConfiguration("chat-logs")
+	resource, ok := newIvsChatLoggingConfigurationResource(configuration)
+	assertIvsChatResource(t, resource, ok, testIvsChatLoggingConfigurationARN, ivsChatResourceName("logging-configuration", "chat-logs", testIvsChatLoggingConfigurationARN), ivsChatLoggingConfigurationResourceType)
+}
+
+func TestNewIvsChatLoggingConfigurationResourceSkipsIncompleteConfigurations(t *testing.T) {
+	tests := []struct {
+		name   string
+		mutate func(*ivschat.GetLoggingConfigurationOutput)
+	}{
+		{name: "empty ARN", mutate: func(configuration *ivschat.GetLoggingConfigurationOutput) { configuration.Arn = nil }},
+		{name: "empty state", mutate: func(configuration *ivschat.GetLoggingConfigurationOutput) { configuration.State = "" }},
+		{name: "deleting state", mutate: func(configuration *ivschat.GetLoggingConfigurationOutput) {
+			configuration.State = ivschattypes.LoggingConfigurationStateDeleting
+		}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			configuration := validIvsChatLoggingConfiguration("chat-logs")
+			tt.mutate(configuration)
+			if _, ok := newIvsChatLoggingConfigurationResource(configuration); ok {
+				t.Fatal("incomplete logging configuration should be skipped")
+			}
+		})
+	}
+
+	if _, ok := newIvsChatLoggingConfigurationResource(nil); ok {
+		t.Fatal("nil logging configuration should be skipped")
+	}
+}
+
+func TestNewIvsChatRoomResource(t *testing.T) {
+	resource, ok := newIvsChatRoomResource(&ivschat.GetRoomOutput{
+		Arn:  aws.String(testIvsChatRoomARN),
+		Name: aws.String("support-room"),
+	})
+	assertIvsChatResource(t, resource, ok, testIvsChatRoomARN, ivsChatResourceName("room", "support-room", testIvsChatRoomARN), ivsChatRoomResourceType)
+
+	if _, ok := newIvsChatRoomResource(nil); ok {
+		t.Fatal("nil room should be skipped")
+	}
+	if _, ok := newIvsChatRoomResource(&ivschat.GetRoomOutput{Name: aws.String("support-room")}); ok {
+		t.Fatal("room with empty ARN should be skipped")
+	}
+}
+
+func TestIvsChatARNImportID(t *testing.T) {
+	if got := ivsChatARNImportID(testIvsChatRoomARN); got != testIvsChatRoomARN {
+		t.Fatalf("IVS Chat ARN import ID = %q, want %q", got, testIvsChatRoomARN)
+	}
+}
+
+func TestIvsChatLoggingConfigurationStateImportable(t *testing.T) {
+	tests := []struct {
+		name  string
+		state ivschattypes.LoggingConfigurationState
+		want  bool
+	}{
+		{name: "creating", state: ivschattypes.LoggingConfigurationStateCreating, want: true},
+		{name: "create failed", state: ivschattypes.LoggingConfigurationStateCreateFailed, want: true},
+		{name: "delete failed", state: ivschattypes.LoggingConfigurationStateDeleteFailed, want: true},
+		{name: "updating", state: ivschattypes.LoggingConfigurationStateUpdating, want: true},
+		{name: "update failed", state: ivschattypes.LoggingConfigurationStateUpdateFailed, want: true},
+		{name: "active", state: ivschattypes.LoggingConfigurationStateActive, want: true},
+		{name: "empty", want: false},
+		{name: "deleting", state: ivschattypes.LoggingConfigurationStateDeleting, want: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := ivsChatLoggingConfigurationStateImportable(tt.state); got != tt.want {
+				t.Fatalf("ivsChatLoggingConfigurationStateImportable(%q) = %t, want %t", tt.state, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestIvsChatResourceNamesPreserveSegmentBoundaries(t *testing.T) {
+	left := terraformutils.TfSanitize(ivsChatResourceName("room", "a/b_c", "d"))
+	right := terraformutils.TfSanitize(ivsChatResourceName("room", "a", "b_c/d"))
+	if left == right {
+		t.Fatalf("IVS Chat resource names collide: %q", left)
+	}
+}
+
+func TestIvsChatResourceNotFound(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{name: "nil", want: false},
+		{name: "resource not found", err: &ivschattypes.ResourceNotFoundException{}, want: true},
+		{name: "wrapped resource not found", err: errors.Join(errors.New("lookup failed"), &ivschattypes.ResourceNotFoundException{}), want: true},
+		{name: "generic", err: errors.New("boom"), want: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := ivsChatResourceNotFound(tt.err); got != tt.want {
+				t.Fatalf("ivsChatResourceNotFound(%v) = %t, want %t", tt.err, got, tt.want)
+			}
+		})
+	}
+}
+
+func validIvsChatLoggingConfiguration(name string) *ivschat.GetLoggingConfigurationOutput {
+	return &ivschat.GetLoggingConfigurationOutput{
+		Arn:   aws.String(testIvsChatLoggingConfigurationARN),
+		Name:  aws.String(name),
+		State: ivschattypes.LoggingConfigurationStateActive,
+	}
+}
+
+func assertIvsChatResource(t *testing.T, resource terraformutils.Resource, ok bool, wantID, wantName, wantType string) {
+	t.Helper()
+	if !ok {
+		t.Fatal("resource was skipped")
+	}
+	if got := resource.InstanceState.ID; got != wantID {
+		t.Fatalf("resource ID = %q, want %q", got, wantID)
+	}
+	if got := resource.ResourceName; got != terraformutils.TfSanitize(wantName) {
+		t.Fatalf("resource name = %q, want %q", got, terraformutils.TfSanitize(wantName))
+	}
+	if got := resource.InstanceInfo.Type; got != wantType {
+		t.Fatalf("resource type = %q, want %q", got, wantType)
+	}
+}

--- a/providers/aws/media_store.go
+++ b/providers/aws/media_store.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"log"
 	"strings"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
@@ -43,11 +44,7 @@ func (g *MediaStoreGenerator) InitResources() error {
 				"aws_media_store_container",
 				"aws",
 				mediastoreAllowEmptyValues))
-			resource, ok, err := getMediaStoreContainerPolicyResource(svc, containerName)
-			if err != nil {
-				return err
-			}
-			if ok {
+			if resource, ok := getMediaStoreContainerPolicyResource(svc, containerName); ok {
 				resources = append(resources, resource)
 			}
 		}
@@ -65,24 +62,27 @@ func (g *MediaStoreGenerator) PostConvertHook() error {
 	return nil
 }
 
-func getMediaStoreContainerPolicyResource(svc *mediastore.Client, containerName string) (terraformutils.Resource, bool, error) {
+type mediaStoreContainerPolicyGetter interface {
+	GetContainerPolicy(context.Context, *mediastore.GetContainerPolicyInput, ...func(*mediastore.Options)) (*mediastore.GetContainerPolicyOutput, error)
+}
+
+func getMediaStoreContainerPolicyResource(svc mediaStoreContainerPolicyGetter, containerName string) (terraformutils.Resource, bool) {
 	if containerName == "" {
-		return terraformutils.Resource{}, false, nil
+		return terraformutils.Resource{}, false
 	}
 	output, err := svc.GetContainerPolicy(context.TODO(), &mediastore.GetContainerPolicyInput{
 		ContainerName: aws.String(containerName),
 	})
-	if mediaStoreContainerPolicyNotFound(err) {
-		return terraformutils.Resource{}, false, nil
-	}
 	if err != nil {
-		return terraformutils.Resource{}, false, err
+		if !mediaStoreContainerPolicyNotFound(err) {
+			log.Printf("skipping optional MediaStore container policy discovery for %s: %v", containerName, err)
+		}
+		return terraformutils.Resource{}, false
 	}
 	if output == nil {
-		return terraformutils.Resource{}, false, nil
+		return terraformutils.Resource{}, false
 	}
-	resource, ok := newMediaStoreContainerPolicyResource(containerName, StringValue(output.Policy))
-	return resource, ok, nil
+	return newMediaStoreContainerPolicyResource(containerName, StringValue(output.Policy))
 }
 
 func newMediaStoreContainerPolicyResource(containerName, policy string) (terraformutils.Resource, bool) {

--- a/providers/aws/media_store.go
+++ b/providers/aws/media_store.go
@@ -4,10 +4,17 @@ package aws
 
 import (
 	"context"
+	"errors"
+	"fmt"
+	"strings"
 
+	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/mediastore"
+	mediastoretypes "github.com/aws/aws-sdk-go-v2/service/mediastore/types"
 	"github.com/chenrui333/terraformer/terraformutils"
 )
+
+const mediaStoreContainerPolicyResourceType = "aws_media_store_container_policy"
 
 var mediastoreAllowEmptyValues = []string{"tags."}
 
@@ -36,8 +43,96 @@ func (g *MediaStoreGenerator) InitResources() error {
 				"aws_media_store_container",
 				"aws",
 				mediastoreAllowEmptyValues))
+			resource, ok, err := getMediaStoreContainerPolicyResource(svc, containerName)
+			if err != nil {
+				return err
+			}
+			if ok {
+				resources = append(resources, resource)
+			}
 		}
 	}
 	g.Resources = resources
 	return nil
+}
+
+func (g *MediaStoreGenerator) PostConvertHook() error {
+	for i := range g.Resources {
+		if g.Resources[i].InstanceInfo.Type == mediaStoreContainerPolicyResourceType {
+			wrapMediaStorePolicyHeredoc(g, &g.Resources[i])
+		}
+	}
+	return nil
+}
+
+func getMediaStoreContainerPolicyResource(svc *mediastore.Client, containerName string) (terraformutils.Resource, bool, error) {
+	if containerName == "" {
+		return terraformutils.Resource{}, false, nil
+	}
+	output, err := svc.GetContainerPolicy(context.TODO(), &mediastore.GetContainerPolicyInput{
+		ContainerName: aws.String(containerName),
+	})
+	if mediaStoreContainerPolicyNotFound(err) {
+		return terraformutils.Resource{}, false, nil
+	}
+	if err != nil {
+		return terraformutils.Resource{}, false, err
+	}
+	if output == nil {
+		return terraformutils.Resource{}, false, nil
+	}
+	resource, ok := newMediaStoreContainerPolicyResource(containerName, StringValue(output.Policy))
+	return resource, ok, nil
+}
+
+func newMediaStoreContainerPolicyResource(containerName, policy string) (terraformutils.Resource, bool) {
+	if containerName == "" || policy == "" {
+		return terraformutils.Resource{}, false
+	}
+	return terraformutils.NewResource(
+		mediaStoreContainerPolicyImportID(containerName),
+		mediaStoreResourceName("container-policy", containerName),
+		mediaStoreContainerPolicyResourceType,
+		"aws",
+		map[string]string{
+			"container_name": containerName,
+			"policy":         policy,
+		},
+		mediastoreAllowEmptyValues,
+		map[string]interface{}{},
+	), true
+}
+
+func mediaStoreContainerPolicyImportID(containerName string) string {
+	return containerName
+}
+
+func mediaStoreResourceName(parts ...string) string {
+	cleanParts := []string{}
+	for _, part := range parts {
+		if part != "" {
+			cleanParts = append(cleanParts, fmt.Sprintf("%d/%s", len(part), part))
+		}
+	}
+	if len(cleanParts) == 0 {
+		return "media-store-resource"
+	}
+	return strings.Join(cleanParts, "/")
+}
+
+func mediaStoreContainerPolicyNotFound(err error) bool {
+	var containerNotFound *mediastoretypes.ContainerNotFoundException
+	var policyNotFound *mediastoretypes.PolicyNotFoundException
+	return errors.As(err, &containerNotFound) || errors.As(err, &policyNotFound)
+}
+
+func wrapMediaStorePolicyHeredoc(g *MediaStoreGenerator, resource *terraformutils.Resource) {
+	if resource == nil || resource.Item == nil {
+		return
+	}
+	policy, ok := resource.Item["policy"].(string)
+	if !ok || policy == "" {
+		return
+	}
+	resource.Item["policy"] = fmt.Sprintf("<<POLICY\n%s\nPOLICY", g.escapeAwsInterpolation(policy))
 }

--- a/providers/aws/media_store_test.go
+++ b/providers/aws/media_store_test.go
@@ -3,9 +3,12 @@
 package aws
 
 import (
+	"context"
 	"errors"
 	"testing"
 
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/mediastore"
 	mediastoretypes "github.com/aws/aws-sdk-go-v2/service/mediastore/types"
 	"github.com/chenrui333/terraformer/terraformutils"
 )
@@ -28,6 +31,44 @@ func TestNewMediaStoreContainerPolicyResource(t *testing.T) {
 func TestMediaStoreContainerPolicyImportID(t *testing.T) {
 	if got := mediaStoreContainerPolicyImportID("media-container"); got != "media-container" {
 		t.Fatalf("container policy import ID = %q, want %q", got, "media-container")
+	}
+}
+
+func TestGetMediaStoreContainerPolicyResource(t *testing.T) {
+	policy := "{\"Version\":\"2012-10-17\"}"
+	resource, ok := getMediaStoreContainerPolicyResource(mediaStoreContainerPolicyGetterFunc(
+		func(_ context.Context, input *mediastore.GetContainerPolicyInput, _ ...func(*mediastore.Options)) (*mediastore.GetContainerPolicyOutput, error) {
+			if got := StringValue(input.ContainerName); got != "media-container" {
+				t.Fatalf("container name = %q, want %q", got, "media-container")
+			}
+			return &mediastore.GetContainerPolicyOutput{Policy: aws.String(policy)}, nil
+		},
+	), "media-container")
+	assertMediaStoreResource(t, resource, ok, "media-container", mediaStoreResourceName("container-policy", "media-container"), mediaStoreContainerPolicyResourceType)
+	assertMediaStoreAttribute(t, resource, "policy", policy)
+}
+
+func TestGetMediaStoreContainerPolicyResourceSkipsLookupErrors(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+	}{
+		{name: "access denied", err: errors.New("access denied")},
+		{name: "container not found", err: &mediastoretypes.ContainerNotFoundException{}},
+		{name: "policy not found", err: &mediastoretypes.PolicyNotFoundException{}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			resource, ok := getMediaStoreContainerPolicyResource(mediaStoreContainerPolicyGetterFunc(
+				func(context.Context, *mediastore.GetContainerPolicyInput, ...func(*mediastore.Options)) (*mediastore.GetContainerPolicyOutput, error) {
+					return nil, tt.err
+				},
+			), "media-container")
+			if ok {
+				t.Fatalf("policy lookup error returned resource %#v", resource)
+			}
+		})
 	}
 }
 
@@ -106,4 +147,10 @@ func assertMediaStoreAttribute(t *testing.T, resource terraformutils.Resource, k
 	if got := resource.InstanceState.Attributes[key]; got != want {
 		t.Fatalf("resource attribute %q = %q, want %q", key, got, want)
 	}
+}
+
+type mediaStoreContainerPolicyGetterFunc func(context.Context, *mediastore.GetContainerPolicyInput, ...func(*mediastore.Options)) (*mediastore.GetContainerPolicyOutput, error)
+
+func (f mediaStoreContainerPolicyGetterFunc) GetContainerPolicy(ctx context.Context, input *mediastore.GetContainerPolicyInput, optFns ...func(*mediastore.Options)) (*mediastore.GetContainerPolicyOutput, error) {
+	return f(ctx, input, optFns...)
 }

--- a/providers/aws/media_store_test.go
+++ b/providers/aws/media_store_test.go
@@ -1,0 +1,109 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package aws
+
+import (
+	"errors"
+	"testing"
+
+	mediastoretypes "github.com/aws/aws-sdk-go-v2/service/mediastore/types"
+	"github.com/chenrui333/terraformer/terraformutils"
+)
+
+func TestNewMediaStoreContainerPolicyResource(t *testing.T) {
+	policy := "{\"Version\":\"2012-10-17\"}"
+	resource, ok := newMediaStoreContainerPolicyResource("media-container", policy)
+	assertMediaStoreResource(t, resource, ok, "media-container", mediaStoreResourceName("container-policy", "media-container"), mediaStoreContainerPolicyResourceType)
+	assertMediaStoreAttribute(t, resource, "container_name", "media-container")
+	assertMediaStoreAttribute(t, resource, "policy", policy)
+
+	if _, ok := newMediaStoreContainerPolicyResource("", policy); ok {
+		t.Fatal("container policy with empty container name should be skipped")
+	}
+	if _, ok := newMediaStoreContainerPolicyResource("media-container", ""); ok {
+		t.Fatal("container policy with empty policy should be skipped")
+	}
+}
+
+func TestMediaStoreContainerPolicyImportID(t *testing.T) {
+	if got := mediaStoreContainerPolicyImportID("media-container"); got != "media-container" {
+		t.Fatalf("container policy import ID = %q, want %q", got, "media-container")
+	}
+}
+
+func TestMediaStoreResourceNamesPreserveSegmentBoundaries(t *testing.T) {
+	left := terraformutils.TfSanitize(mediaStoreResourceName("container-policy", "a/b_c"))
+	right := terraformutils.TfSanitize(mediaStoreResourceName("container", "policy/a_b_c"))
+	if left == right {
+		t.Fatalf("MediaStore resource names collide: %q", left)
+	}
+}
+
+func TestMediaStoreContainerPolicyNotFound(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{name: "nil", want: false},
+		{name: "container not found", err: &mediastoretypes.ContainerNotFoundException{}, want: true},
+		{name: "policy not found", err: &mediastoretypes.PolicyNotFoundException{}, want: true},
+		{name: "wrapped policy not found", err: errors.Join(errors.New("lookup failed"), &mediastoretypes.PolicyNotFoundException{}), want: true},
+		{name: "generic", err: errors.New("boom"), want: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := mediaStoreContainerPolicyNotFound(tt.err); got != tt.want {
+				t.Fatalf("mediaStoreContainerPolicyNotFound(%v) = %t, want %t", tt.err, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestMediaStorePostConvertHookWrapsContainerPolicy(t *testing.T) {
+	policy := "{\"Resource\":\"$" + "{aws:username}\"}"
+	resource, ok := newMediaStoreContainerPolicyResource("media-container", policy)
+	if !ok {
+		t.Fatal("container policy should be importable")
+	}
+	resource.Item = map[string]interface{}{
+		"policy": policy,
+	}
+	generator := MediaStoreGenerator{}
+	generator.Resources = []terraformutils.Resource{resource}
+	if err := generator.PostConvertHook(); err != nil {
+		t.Fatalf("PostConvertHook() error = %v", err)
+	}
+	got, ok := generator.Resources[0].Item["policy"].(string)
+	if !ok {
+		t.Fatalf("policy type = %T, want string", generator.Resources[0].Item["policy"])
+	}
+	want := "<<POLICY\n{\"Resource\":\"$" + "$" + "{aws:username}\"}\nPOLICY"
+	if got != want {
+		t.Fatalf("wrapped policy = %q, want %q", got, want)
+	}
+}
+
+func assertMediaStoreResource(t *testing.T, resource terraformutils.Resource, ok bool, wantID, wantName, wantType string) {
+	t.Helper()
+	if !ok {
+		t.Fatal("resource was skipped")
+	}
+	if got := resource.InstanceState.ID; got != wantID {
+		t.Fatalf("resource ID = %q, want %q", got, wantID)
+	}
+	if got := resource.ResourceName; got != terraformutils.TfSanitize(wantName) {
+		t.Fatalf("resource name = %q, want %q", got, terraformutils.TfSanitize(wantName))
+	}
+	if got := resource.InstanceInfo.Type; got != wantType {
+		t.Fatalf("resource type = %q, want %q", got, wantType)
+	}
+}
+
+func assertMediaStoreAttribute(t *testing.T, resource terraformutils.Resource, key, want string) {
+	t.Helper()
+	if got := resource.InstanceState.Attributes[key]; got != want {
+		t.Fatalf("resource attribute %q = %q, want %q", key, got, want)
+	}
+}

--- a/providers/aws/media_unsupported_test.go
+++ b/providers/aws/media_unsupported_test.go
@@ -1,0 +1,58 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package aws
+
+import (
+	"encoding/json"
+	"os"
+	"sort"
+	"testing"
+)
+
+func TestMediaUnsupportedResourceEntries(t *testing.T) {
+	data, err := os.ReadFile("unsupported_resources.json")
+	if err != nil {
+		t.Fatalf("read unsupported resources: %v", err)
+	}
+	var unsupported map[string]interface{}
+	if err := json.Unmarshal(data, &unsupported); err != nil {
+		t.Fatalf("decode unsupported resources: %v", err)
+	}
+
+	entries, ok := unsupported["resources"].([]interface{})
+	if !ok {
+		t.Fatal("unsupported resources file is missing resources list")
+	}
+
+	resources := make([]string, 0, len(entries))
+	foundPlaybackKeyPair := false
+	for _, rawEntry := range entries {
+		entry, ok := rawEntry.(map[string]interface{})
+		if !ok {
+			t.Fatalf("unsupported resource entry has unexpected type %T", rawEntry)
+		}
+		resource, _ := entry["resource"].(string)
+		resources = append(resources, resource)
+		if resource == "aws_ivs_playback_key_pair" {
+			foundPlaybackKeyPair = true
+			if serviceFamily, _ := entry["service_family"].(string); serviceFamily != "ivs" {
+				t.Fatalf("playback key pair service family = %q, want ivs", serviceFamily)
+			}
+			if status, _ := entry["status"].(string); status != "unsupported" {
+				t.Fatalf("playback key pair status = %q, want unsupported", status)
+			}
+			references, _ := entry["references"].([]interface{})
+			reason, _ := entry["reason"].(string)
+			evidence, _ := entry["evidence"].(string)
+			if reason == "" || evidence == "" || len(references) == 0 {
+				t.Fatal("playback key pair unsupported entry is missing reason, evidence, or references")
+			}
+		}
+	}
+	if !foundPlaybackKeyPair {
+		t.Fatal("aws_ivs_playback_key_pair unsupported entry was not found")
+	}
+	if !sort.StringsAreSorted(resources) {
+		t.Fatalf("unsupported resources are not sorted by resource: %v", resources)
+	}
+}

--- a/providers/aws/unsupported_resources.json
+++ b/providers/aws/unsupported_resources.json
@@ -23,6 +23,18 @@
         "https://github.com/chenrui333/terraformer/issues/338",
         "https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_event_connection"
       ]
+    },
+    {
+      "resource": "aws_ivs_playback_key_pair",
+      "service_family": "ivs",
+      "reason": "IVS playback key pairs require public_key, but IVS GetPlaybackKeyPair and ListPlaybackKeyPairs responses do not return the public key material needed to seed an imported resource.",
+      "evidence": "Terraform AWS provider marks public_key as required and ForceNew; its Read path only sets arn, name, and fingerprint, and provider tests mark public_key as importIgnore/plannable replace. AWS IVS PlaybackKeyPair responses expose ARN, name, fingerprint, and tags, not the public key.",
+      "status": "unsupported",
+      "references": [
+        "https://github.com/chenrui333/terraformer/issues/338",
+        "https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ivs_playback_key_pair",
+        "https://docs.aws.amazon.com/ivs/latest/LowLatencyAPIReference/API_GetPlaybackKeyPair.html"
+      ]
     }
   ]
 }


### PR DESCRIPTION
## Summary

- add IVS import discovery for `aws_ivs_channel` and `aws_ivs_recording_configuration`
- add IVS Chat import discovery for `aws_ivschat_room` and `aws_ivschat_logging_configuration`
- add MediaStore container policy discovery with policy heredoc escaping
- register `ivs` and `ivschat`, add the AWS SDK dependencies, and update `docs/aws.md`
- mark `aws_ivs_playback_key_pair` unsupported because IVS does not return required public key material

## References

- #338

## Validation

```bash
go test ./providers/aws -run 'Test.*Media|Test.*media|Test.*IVS|Test.*Ivs|Test.*ivs|Test.*Chat|Test.*chat'
go test ./providers/aws/... ./terraformutils/...
go test ./tools/aws-gap-inventory
go run ./tools/aws-gap-inventory \
  -docs docs/aws.md \
  -aws-dir providers/aws \
  -skip-list providers/aws/unsupported_resources.json \
  -format markdown
git diff --check
```

## Notes

Skipped/deferred resources:
- `aws_ivs_playback_key_pair`: unsupported because `public_key` is required by Terraform but not returned by IVS APIs
- MediaLive multiplex/programs: deferred because provider refresh relies on larger nested configuration and needs a dedicated pass
- `aws_media_convert_queue`: deferred because MediaConvert endpoint/discovery behavior needs a dedicated pass
- `aws_media_packagev2_channel_group`: deferred because MediaPackage v2 service/provider naming differs from the existing v1 generator

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds import discovery for AWS IVS, IVS Chat, and MediaStore container policies. Registers `ivs`/`ivschat`, updates docs, marks `aws_ivs_playback_key_pair` unsupported, and makes MediaStore policy lookup best‑effort. Addresses #338.

- **New Features**
  - Import discovery for `aws_ivs_channel`, `aws_ivs_recording_configuration`, `aws_ivschat_room`, and `aws_ivschat_logging_configuration`.
  - MediaStore container policy discovery with heredoc wrapping to escape interpolation; lookup is best‑effort (skip on not found or lookup errors).

- **Dependencies**
  - Add `github.com/aws/aws-sdk-go-v2/service/ivs` v1.50.1.
  - Add `github.com/aws/aws-sdk-go-v2/service/ivschat` v1.21.22.

<sup>Written for commit c9c93fadd581d87e21127e9ff3b98f8cf3fa98a6. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Import support for AWS IVS channels and recording configurations.
  * Import support for AWS IVS Chat logging configurations and rooms.
  * Import support for AWS MediaStore container policies.

* **Documentation**
  * Updated supported services to include IVS and IVS Chat.
  * Documented an unsupported IVS playback key pair resource.

* **Chores**
  * Added AWS SDK dependencies for IVS and IVS Chat.

* **Tests**
  * Added unit tests covering IVS, IVS Chat, and MediaStore policy behaviors.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/chenrui333/terraformer/pull/422)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->