### PR TITLE
aws(bedrockagent): add knowledge base imports

### DIFF
--- a/docs/aws.md
+++ b/docs/aws.md
@@ -141,6 +141,9 @@ For AWS provider gap audits and unsupported-resource skip-list maintenance, see 
 *   `bedrockagent`
     * `aws_bedrockagent_agent`
     * `aws_bedrockagent_agent_alias`
+    * `aws_bedrockagent_agent_knowledge_base_association`
+    * `aws_bedrockagent_data_source`
+    * `aws_bedrockagent_knowledge_base`
 *   `budgets`
     * `aws_budgets_budget`
 *   `cloud9`

--- a/providers/aws/bedrockagent.go
+++ b/providers/aws/bedrockagent.go
@@ -14,10 +14,14 @@ import (
 )
 
 const (
-	bedrockAgentAgentResourceType      = "aws_bedrockagent_agent"
-	bedrockAgentAgentAliasResourceType = "aws_bedrockagent_agent_alias"
-	bedrockAgentImportIDSeparator      = ","
-	bedrockAgentResourceNameFallback   = "bedrockagent-resource"
+	bedrockAgentAgentResourceType                         = "aws_bedrockagent_agent"
+	bedrockAgentAgentAliasResourceType                    = "aws_bedrockagent_agent_alias"
+	bedrockAgentAgentKnowledgeBaseAssociationResourceType = "aws_bedrockagent_agent_knowledge_base_association"
+	bedrockAgentDataSourceResourceType                    = "aws_bedrockagent_data_source"
+	bedrockAgentKnowledgeBaseResourceType                 = "aws_bedrockagent_knowledge_base"
+	bedrockAgentDraftVersion                              = "DRAFT"
+	bedrockAgentImportIDSeparator                         = ","
+	bedrockAgentResourceNameFallback                      = "bedrockagent-resource"
 )
 
 var (
@@ -25,6 +29,9 @@ var (
 	bedrockAgentResourceTypes    = []string{
 		bedrockAgentServiceName(bedrockAgentAgentResourceType),
 		bedrockAgentServiceName(bedrockAgentAgentAliasResourceType),
+		bedrockAgentServiceName(bedrockAgentAgentKnowledgeBaseAssociationResourceType),
+		bedrockAgentServiceName(bedrockAgentDataSourceResourceType),
+		bedrockAgentServiceName(bedrockAgentKnowledgeBaseResourceType),
 	}
 )
 
@@ -65,7 +72,8 @@ func (g *BedrockAgentGenerator) InitResources() error {
 
 	loadAgents := g.shouldLoadBedrockAgentResource(bedrockAgentServiceName(bedrockAgentAgentResourceType))
 	loadAgentAliases := g.shouldLoadBedrockAgentResource(bedrockAgentServiceName(bedrockAgentAgentAliasResourceType))
-	if loadAgents || loadAgentAliases {
+	loadAgentKnowledgeBaseAssociations := g.shouldLoadBedrockAgentResource(bedrockAgentServiceName(bedrockAgentAgentKnowledgeBaseAssociationResourceType))
+	if loadAgents || loadAgentAliases || loadAgentKnowledgeBaseAssociations {
 		agents, err := listBedrockAgentAgents(svc)
 		if err != nil {
 			return err
@@ -75,6 +83,30 @@ func (g *BedrockAgentGenerator) InitResources() error {
 		}
 		if loadAgentAliases {
 			if err := g.loadAgentAliases(svc, agents); err != nil {
+				return err
+			}
+		}
+		if loadAgentKnowledgeBaseAssociations {
+			if err := g.loadAgentKnowledgeBaseAssociations(svc, agents); err != nil {
+				return err
+			}
+		}
+	}
+
+	loadKnowledgeBases := g.shouldLoadBedrockAgentResource(bedrockAgentServiceName(bedrockAgentKnowledgeBaseResourceType))
+	loadDataSources := g.shouldLoadBedrockAgentResource(bedrockAgentServiceName(bedrockAgentDataSourceResourceType))
+	if loadKnowledgeBases || loadDataSources {
+		knowledgeBases, err := listBedrockAgentKnowledgeBases(svc)
+		if err != nil {
+			return err
+		}
+		if loadKnowledgeBases {
+			if err := g.loadKnowledgeBases(svc, knowledgeBases); err != nil {
+				return err
+			}
+		}
+		if loadDataSources {
+			if err := g.loadDataSources(svc, knowledgeBases); err != nil {
 				return err
 			}
 		}
@@ -134,6 +166,19 @@ func listBedrockAgentAgents(svc *bedrockagent.Client) ([]bedrockagenttypes.Agent
 	return agents, nil
 }
 
+func listBedrockAgentKnowledgeBases(svc *bedrockagent.Client) ([]bedrockagenttypes.KnowledgeBaseSummary, error) {
+	p := bedrockagent.NewListKnowledgeBasesPaginator(svc, &bedrockagent.ListKnowledgeBasesInput{})
+	knowledgeBases := []bedrockagenttypes.KnowledgeBaseSummary{}
+	for p.HasMorePages() {
+		page, err := p.NextPage(context.TODO())
+		if err != nil {
+			return nil, err
+		}
+		knowledgeBases = append(knowledgeBases, page.KnowledgeBaseSummaries...)
+	}
+	return knowledgeBases, nil
+}
+
 func (g *BedrockAgentGenerator) loadAgents(agents []bedrockagenttypes.AgentSummary) {
 	for _, agent := range agents {
 		if resource, ok := newBedrockAgentAgentResource(agent); ok {
@@ -167,6 +212,156 @@ func (g *BedrockAgentGenerator) loadAgentAliases(svc *bedrockagent.Client, agent
 		}
 	}
 	return nil
+}
+
+func (g *BedrockAgentGenerator) loadAgentKnowledgeBaseAssociations(svc *bedrockagent.Client, agents []bedrockagenttypes.AgentSummary) error {
+	for _, agent := range agents {
+		agentID := StringValue(agent.AgentId)
+		if agentID == "" || !bedrockAgentAgentImportable(agent.AgentStatus) {
+			continue
+		}
+		associations, err := listBedrockAgentKnowledgeBaseAssociations(svc, agentID, bedrockAgentDraftVersion)
+		if err != nil {
+			if bedrockAgentResourceNotFound(err) {
+				continue
+			}
+			return err
+		}
+		for _, association := range associations {
+			knowledgeBaseID := StringValue(association.KnowledgeBaseId)
+			if knowledgeBaseID == "" {
+				continue
+			}
+			agentKnowledgeBase, err := getBedrockAgentKnowledgeBaseAssociation(svc, agentID, bedrockAgentDraftVersion, knowledgeBaseID)
+			if err != nil {
+				if bedrockAgentResourceNotFound(err) {
+					continue
+				}
+				return err
+			}
+			if resource, ok := newBedrockAgentAgentKnowledgeBaseAssociationResource(agentKnowledgeBase); ok {
+				g.Resources = append(g.Resources, resource)
+			}
+		}
+	}
+	return nil
+}
+
+func listBedrockAgentKnowledgeBaseAssociations(svc *bedrockagent.Client, agentID, agentVersion string) ([]bedrockagenttypes.AgentKnowledgeBaseSummary, error) {
+	p := bedrockagent.NewListAgentKnowledgeBasesPaginator(svc, &bedrockagent.ListAgentKnowledgeBasesInput{
+		AgentId:      &agentID,
+		AgentVersion: &agentVersion,
+	})
+	associations := []bedrockagenttypes.AgentKnowledgeBaseSummary{}
+	for p.HasMorePages() {
+		page, err := p.NextPage(context.TODO())
+		if err != nil {
+			return nil, err
+		}
+		associations = append(associations, page.AgentKnowledgeBaseSummaries...)
+	}
+	return associations, nil
+}
+
+func getBedrockAgentKnowledgeBaseAssociation(svc *bedrockagent.Client, agentID, agentVersion, knowledgeBaseID string) (*bedrockagenttypes.AgentKnowledgeBase, error) {
+	output, err := svc.GetAgentKnowledgeBase(context.TODO(), &bedrockagent.GetAgentKnowledgeBaseInput{
+		AgentId:         &agentID,
+		AgentVersion:    &agentVersion,
+		KnowledgeBaseId: &knowledgeBaseID,
+	})
+	if err != nil {
+		return nil, err
+	}
+	return output.AgentKnowledgeBase, nil
+}
+
+func (g *BedrockAgentGenerator) loadKnowledgeBases(svc *bedrockagent.Client, knowledgeBases []bedrockagenttypes.KnowledgeBaseSummary) error {
+	for _, summary := range knowledgeBases {
+		knowledgeBaseID := StringValue(summary.KnowledgeBaseId)
+		if knowledgeBaseID == "" || !bedrockAgentKnowledgeBaseImportable(summary.Status) {
+			continue
+		}
+		knowledgeBase, err := getBedrockAgentKnowledgeBase(svc, knowledgeBaseID)
+		if err != nil {
+			if bedrockAgentResourceNotFound(err) {
+				continue
+			}
+			return err
+		}
+		if resource, ok := newBedrockAgentKnowledgeBaseResource(knowledgeBase); ok {
+			g.Resources = append(g.Resources, resource)
+		}
+	}
+	return nil
+}
+
+func getBedrockAgentKnowledgeBase(svc *bedrockagent.Client, knowledgeBaseID string) (*bedrockagenttypes.KnowledgeBase, error) {
+	output, err := svc.GetKnowledgeBase(context.TODO(), &bedrockagent.GetKnowledgeBaseInput{
+		KnowledgeBaseId: &knowledgeBaseID,
+	})
+	if err != nil {
+		return nil, err
+	}
+	return output.KnowledgeBase, nil
+}
+
+func (g *BedrockAgentGenerator) loadDataSources(svc *bedrockagent.Client, knowledgeBases []bedrockagenttypes.KnowledgeBaseSummary) error {
+	for _, knowledgeBase := range knowledgeBases {
+		knowledgeBaseID := StringValue(knowledgeBase.KnowledgeBaseId)
+		if knowledgeBaseID == "" || !bedrockAgentKnowledgeBaseImportable(knowledgeBase.Status) {
+			continue
+		}
+		dataSources, err := listBedrockAgentDataSources(svc, knowledgeBaseID)
+		if err != nil {
+			if bedrockAgentResourceNotFound(err) {
+				continue
+			}
+			return err
+		}
+		for _, summary := range dataSources {
+			dataSourceID := StringValue(summary.DataSourceId)
+			if dataSourceID == "" || !bedrockAgentDataSourceImportable(summary.Status) {
+				continue
+			}
+			dataSource, err := getBedrockAgentDataSource(svc, knowledgeBaseID, dataSourceID)
+			if err != nil {
+				if bedrockAgentResourceNotFound(err) {
+					continue
+				}
+				return err
+			}
+			if resource, ok := newBedrockAgentDataSourceResource(dataSource); ok {
+				g.Resources = append(g.Resources, resource)
+			}
+		}
+	}
+	return nil
+}
+
+func listBedrockAgentDataSources(svc *bedrockagent.Client, knowledgeBaseID string) ([]bedrockagenttypes.DataSourceSummary, error) {
+	p := bedrockagent.NewListDataSourcesPaginator(svc, &bedrockagent.ListDataSourcesInput{
+		KnowledgeBaseId: &knowledgeBaseID,
+	})
+	dataSources := []bedrockagenttypes.DataSourceSummary{}
+	for p.HasMorePages() {
+		page, err := p.NextPage(context.TODO())
+		if err != nil {
+			return nil, err
+		}
+		dataSources = append(dataSources, page.DataSourceSummaries...)
+	}
+	return dataSources, nil
+}
+
+func getBedrockAgentDataSource(svc *bedrockagent.Client, knowledgeBaseID, dataSourceID string) (*bedrockagenttypes.DataSource, error) {
+	output, err := svc.GetDataSource(context.TODO(), &bedrockagent.GetDataSourceInput{
+		DataSourceId:    &dataSourceID,
+		KnowledgeBaseId: &knowledgeBaseID,
+	})
+	if err != nil {
+		return nil, err
+	}
+	return output.DataSource, nil
 }
 
 func newBedrockAgentAgentResource(agent bedrockagenttypes.AgentSummary) (terraformutils.Resource, bool) {
@@ -214,8 +409,108 @@ func newBedrockAgentAgentAliasResource(agentID string, alias bedrockagenttypes.A
 	), true
 }
 
+func newBedrockAgentAgentKnowledgeBaseAssociationResource(association *bedrockagenttypes.AgentKnowledgeBase) (terraformutils.Resource, bool) {
+	if association == nil {
+		return terraformutils.Resource{}, false
+	}
+	agentID := StringValue(association.AgentId)
+	agentVersion := StringValue(association.AgentVersion)
+	knowledgeBaseID := StringValue(association.KnowledgeBaseId)
+	description := StringValue(association.Description)
+	knowledgeBaseState := string(association.KnowledgeBaseState)
+	if agentID == "" ||
+		agentVersion == "" ||
+		knowledgeBaseID == "" ||
+		description == "" ||
+		!bedrockAgentAgentKnowledgeBaseAssociationImportable(agentVersion, association.KnowledgeBaseState) {
+		return terraformutils.Resource{}, false
+	}
+	return terraformutils.NewResource(
+		bedrockAgentAgentKnowledgeBaseAssociationImportID(agentID, agentVersion, knowledgeBaseID),
+		bedrockAgentResourceName("agent-knowledge-base-association", agentID, agentVersion, knowledgeBaseID),
+		bedrockAgentAgentKnowledgeBaseAssociationResourceType,
+		"aws",
+		map[string]string{
+			"agent_id":             agentID,
+			"agent_version":        agentVersion,
+			"description":          description,
+			"knowledge_base_id":    knowledgeBaseID,
+			"knowledge_base_state": knowledgeBaseState,
+		},
+		bedrockAgentAllowEmptyValues,
+		map[string]interface{}{},
+	), true
+}
+
+func newBedrockAgentKnowledgeBaseResource(knowledgeBase *bedrockagenttypes.KnowledgeBase) (terraformutils.Resource, bool) {
+	if knowledgeBase == nil {
+		return terraformutils.Resource{}, false
+	}
+	knowledgeBaseID := StringValue(knowledgeBase.KnowledgeBaseId)
+	knowledgeBaseName := StringValue(knowledgeBase.Name)
+	roleARN := StringValue(knowledgeBase.RoleArn)
+	if knowledgeBaseID == "" ||
+		knowledgeBaseName == "" ||
+		roleARN == "" ||
+		!bedrockAgentKnowledgeBaseConfigurationImportable(knowledgeBase.KnowledgeBaseConfiguration) ||
+		!bedrockAgentKnowledgeBaseStorageConfigurationImportable(knowledgeBase.KnowledgeBaseConfiguration, knowledgeBase.StorageConfiguration) ||
+		!bedrockAgentKnowledgeBaseImportable(knowledgeBase.Status) {
+		return terraformutils.Resource{}, false
+	}
+	return terraformutils.NewResource(
+		knowledgeBaseID,
+		bedrockAgentResourceName("knowledge-base", knowledgeBaseName, knowledgeBaseID),
+		bedrockAgentKnowledgeBaseResourceType,
+		"aws",
+		map[string]string{
+			"id":       knowledgeBaseID,
+			"name":     knowledgeBaseName,
+			"role_arn": roleARN,
+		},
+		bedrockAgentAllowEmptyValues,
+		map[string]interface{}{},
+	), true
+}
+
+func newBedrockAgentDataSourceResource(dataSource *bedrockagenttypes.DataSource) (terraformutils.Resource, bool) {
+	if dataSource == nil {
+		return terraformutils.Resource{}, false
+	}
+	dataSourceID := StringValue(dataSource.DataSourceId)
+	knowledgeBaseID := StringValue(dataSource.KnowledgeBaseId)
+	dataSourceName := StringValue(dataSource.Name)
+	if dataSourceID == "" ||
+		knowledgeBaseID == "" ||
+		dataSourceName == "" ||
+		!bedrockAgentDataSourceConfigurationImportable(dataSource.DataSourceConfiguration) ||
+		!bedrockAgentDataSourceImportable(dataSource.Status) {
+		return terraformutils.Resource{}, false
+	}
+	return terraformutils.NewResource(
+		bedrockAgentDataSourceImportID(dataSourceID, knowledgeBaseID),
+		bedrockAgentResourceName("data-source", knowledgeBaseID, dataSourceName, dataSourceID),
+		bedrockAgentDataSourceResourceType,
+		"aws",
+		map[string]string{
+			"data_source_id":    dataSourceID,
+			"knowledge_base_id": knowledgeBaseID,
+			"name":              dataSourceName,
+		},
+		bedrockAgentAllowEmptyValues,
+		map[string]interface{}{},
+	), true
+}
+
 func bedrockAgentAgentAliasImportID(agentAliasID, agentID string) string {
 	return agentAliasID + bedrockAgentImportIDSeparator + agentID
+}
+
+func bedrockAgentAgentKnowledgeBaseAssociationImportID(agentID, agentVersion, knowledgeBaseID string) string {
+	return agentID + bedrockAgentImportIDSeparator + agentVersion + bedrockAgentImportIDSeparator + knowledgeBaseID
+}
+
+func bedrockAgentDataSourceImportID(dataSourceID, knowledgeBaseID string) string {
+	return dataSourceID + bedrockAgentImportIDSeparator + knowledgeBaseID
 }
 
 func bedrockAgentResourceName(parts ...string) string {
@@ -237,6 +532,89 @@ func bedrockAgentAgentImportable(status bedrockagenttypes.AgentStatus) bool {
 
 func bedrockAgentAgentAliasImportable(status bedrockagenttypes.AgentAliasStatus) bool {
 	return status == bedrockagenttypes.AgentAliasStatusPrepared || status == bedrockagenttypes.AgentAliasStatusDissociated
+}
+
+func bedrockAgentAgentKnowledgeBaseAssociationImportable(agentVersion string, state bedrockagenttypes.KnowledgeBaseState) bool {
+	return agentVersion == bedrockAgentDraftVersion &&
+		(state == bedrockagenttypes.KnowledgeBaseStateEnabled || state == bedrockagenttypes.KnowledgeBaseStateDisabled)
+}
+
+func bedrockAgentKnowledgeBaseImportable(status bedrockagenttypes.KnowledgeBaseStatus) bool {
+	return status == bedrockagenttypes.KnowledgeBaseStatusActive
+}
+
+func bedrockAgentDataSourceImportable(status bedrockagenttypes.DataSourceStatus) bool {
+	return status == bedrockagenttypes.DataSourceStatusAvailable
+}
+
+func bedrockAgentKnowledgeBaseConfigurationImportable(config *bedrockagenttypes.KnowledgeBaseConfiguration) bool {
+	if config == nil {
+		return false
+	}
+	switch config.Type {
+	case bedrockagenttypes.KnowledgeBaseTypeVector:
+		return config.VectorKnowledgeBaseConfiguration != nil
+	case bedrockagenttypes.KnowledgeBaseTypeKendra:
+		return config.KendraKnowledgeBaseConfiguration != nil
+	case bedrockagenttypes.KnowledgeBaseTypeSql:
+		return config.SqlKnowledgeBaseConfiguration != nil
+	default:
+		return false
+	}
+}
+
+func bedrockAgentKnowledgeBaseStorageConfigurationImportable(config *bedrockagenttypes.KnowledgeBaseConfiguration, storage *bedrockagenttypes.StorageConfiguration) bool {
+	if config == nil {
+		return false
+	}
+	if config.Type != bedrockagenttypes.KnowledgeBaseTypeVector {
+		return true
+	}
+	if storage == nil {
+		return false
+	}
+	switch storage.Type {
+	case bedrockagenttypes.KnowledgeBaseStorageTypeOpensearchServerless:
+		return storage.OpensearchServerlessConfiguration != nil
+	case bedrockagenttypes.KnowledgeBaseStorageTypePinecone:
+		return storage.PineconeConfiguration != nil
+	case bedrockagenttypes.KnowledgeBaseStorageTypeRedisEnterpriseCloud:
+		return storage.RedisEnterpriseCloudConfiguration != nil
+	case bedrockagenttypes.KnowledgeBaseStorageTypeRds:
+		return storage.RdsConfiguration != nil
+	case bedrockagenttypes.KnowledgeBaseStorageTypeMongoDbAtlas:
+		return storage.MongoDbAtlasConfiguration != nil
+	case bedrockagenttypes.KnowledgeBaseStorageTypeNeptuneAnalytics:
+		return storage.NeptuneAnalyticsConfiguration != nil
+	case bedrockagenttypes.KnowledgeBaseStorageTypeOpensearchManagedCluster:
+		return storage.OpensearchManagedClusterConfiguration != nil
+	case bedrockagenttypes.KnowledgeBaseStorageTypeS3Vectors:
+		return storage.S3VectorsConfiguration != nil
+	default:
+		return false
+	}
+}
+
+func bedrockAgentDataSourceConfigurationImportable(config *bedrockagenttypes.DataSourceConfiguration) bool {
+	if config == nil {
+		return false
+	}
+	switch config.Type {
+	case bedrockagenttypes.DataSourceTypeS3:
+		return config.S3Configuration != nil
+	case bedrockagenttypes.DataSourceTypeWeb:
+		return config.WebConfiguration != nil
+	case bedrockagenttypes.DataSourceTypeConfluence:
+		return config.ConfluenceConfiguration != nil
+	case bedrockagenttypes.DataSourceTypeSalesforce:
+		return config.SalesforceConfiguration != nil
+	case bedrockagenttypes.DataSourceTypeSharepoint:
+		return config.SharePointConfiguration != nil
+	case bedrockagenttypes.DataSourceTypeCustom, bedrockagenttypes.DataSourceTypeRedshiftMetadata:
+		return true
+	default:
+		return false
+	}
 }
 
 func bedrockAgentResourceNotFound(err error) bool {

--- a/providers/aws/bedrockagent_test.go
+++ b/providers/aws/bedrockagent_test.go
@@ -19,6 +19,22 @@ func TestBedrockAgentAgentAliasImportID(t *testing.T) {
 	}
 }
 
+func TestBedrockAgentAgentKnowledgeBaseAssociationImportID(t *testing.T) {
+	got := bedrockAgentAgentKnowledgeBaseAssociationImportID("GGRRAED6JP", bedrockAgentDraftVersion, "EMDPPAYPZI")
+	want := "GGRRAED6JP,DRAFT,EMDPPAYPZI"
+	if got != want {
+		t.Fatalf("bedrockAgentAgentKnowledgeBaseAssociationImportID() = %q, want %q", got, want)
+	}
+}
+
+func TestBedrockAgentDataSourceImportID(t *testing.T) {
+	got := bedrockAgentDataSourceImportID("GWCMFMQF6T", "EMDPPAYPZI")
+	want := "GWCMFMQF6T,EMDPPAYPZI"
+	if got != want {
+		t.Fatalf("bedrockAgentDataSourceImportID() = %q, want %q", got, want)
+	}
+}
+
 func TestBedrockAgentResourceNameFallback(t *testing.T) {
 	if got := bedrockAgentResourceName("", ""); got != bedrockAgentResourceNameFallback {
 		t.Fatalf("bedrockAgentResourceName() = %q, want %q", got, bedrockAgentResourceNameFallback)
@@ -36,37 +52,41 @@ func TestBedrockAgentResourceNameUniqueness(t *testing.T) {
 	if aliasFirst == aliasSecond {
 		t.Fatalf("agent alias resource names should include parent agent identity: %q", aliasFirst)
 	}
+	dataSourceFirst := terraformutils.TfSanitize(bedrockAgentResourceName("data-source", "kb-a", "docs", "source-1"))
+	dataSourceSecond := terraformutils.TfSanitize(bedrockAgentResourceName("data-source", "kb-b", "docs", "source-1"))
+	if dataSourceFirst == dataSourceSecond {
+		t.Fatalf("data source resource names should include parent knowledge base identity: %q", dataSourceFirst)
+	}
+	associationFirst := terraformutils.TfSanitize(bedrockAgentResourceName("agent-knowledge-base-association", "agent-a", bedrockAgentDraftVersion, "kb-1"))
+	associationSecond := terraformutils.TfSanitize(bedrockAgentResourceName("agent-knowledge-base-association", "agent-b", bedrockAgentDraftVersion, "kb-1"))
+	if associationFirst == associationSecond {
+		t.Fatalf("association resource names should include parent agent identity: %q", associationFirst)
+	}
 }
 
 func TestBedrockAgentShouldLoadResourceHonorsTypedFilters(t *testing.T) {
 	g := BedrockAgentGenerator{}
-	if !g.shouldLoadBedrockAgentResource("bedrockagent_agent") ||
-		!g.shouldLoadBedrockAgentResource("bedrockagent_agent_alias") {
-		t.Fatal("without typed filters, all Bedrock Agent resource families should be loaded")
+	for _, serviceName := range bedrockAgentResourceTypes {
+		if !g.shouldLoadBedrockAgentResource(serviceName) {
+			t.Fatalf("without typed filters, %s should be loaded", serviceName)
+		}
 	}
 
-	g.Filter = []terraformutils.ResourceFilter{{
-		ServiceName:      "bedrockagent_agent",
-		FieldPath:        "id",
-		AcceptableValues: []string{"GGRRAED6JP"},
-	}}
-	if !g.shouldLoadBedrockAgentResource("bedrockagent_agent") {
-		t.Fatal("typed agent filter should load agents")
-	}
-	if g.shouldLoadBedrockAgentResource("bedrockagent_agent_alias") {
-		t.Fatal("typed agent filter should not load agent aliases")
-	}
-
-	g.Filter = []terraformutils.ResourceFilter{{
-		ServiceName:      "bedrockagent_agent_alias",
-		FieldPath:        "id",
-		AcceptableValues: []string{"66IVY0GUTF,GGRRAED6JP"},
-	}}
-	if !g.shouldLoadBedrockAgentResource("bedrockagent_agent_alias") {
-		t.Fatal("typed agent alias filter should load agent aliases")
-	}
-	if g.shouldLoadBedrockAgentResource("bedrockagent_agent") {
-		t.Fatal("typed agent alias filter should not emit agent resources")
+	for _, typedServiceName := range bedrockAgentResourceTypes {
+		t.Run(typedServiceName, func(t *testing.T) {
+			g.Filter = []terraformutils.ResourceFilter{{
+				ServiceName:      typedServiceName,
+				FieldPath:        "id",
+				AcceptableValues: []string{"example-id"},
+			}}
+			for _, serviceName := range bedrockAgentResourceTypes {
+				got := g.shouldLoadBedrockAgentResource(serviceName)
+				want := serviceName == typedServiceName
+				if got != want {
+					t.Fatalf("shouldLoadBedrockAgentResource(%q) = %t, want %t for typed filter %q", serviceName, got, want, typedServiceName)
+				}
+			}
+		})
 	}
 }
 
@@ -107,8 +127,10 @@ func TestBedrockAgentShouldLoadResourceAllowsUntypedFilters(t *testing.T) {
 					},
 				},
 			}
-			if !g.shouldLoadBedrockAgentResource("bedrockagent_agent_alias") {
-				t.Fatal("untyped filter should keep agent alias discovery available")
+			for _, serviceName := range bedrockAgentResourceTypes {
+				if !g.shouldLoadBedrockAgentResource(serviceName) {
+					t.Fatalf("untyped filter should keep %s discovery available", serviceName)
+				}
 			}
 		})
 	}
@@ -214,6 +236,154 @@ func TestNewBedrockAgentAgentAliasResource(t *testing.T) {
 	}
 }
 
+func TestNewBedrockAgentAgentKnowledgeBaseAssociationResource(t *testing.T) {
+	resource, ok := newBedrockAgentAgentKnowledgeBaseAssociationResource(bedrockAgentTestAgentKnowledgeBaseAssociation())
+	assertBedrockAgentResource(t, resource, ok, "GGRRAED6JP,DRAFT,EMDPPAYPZI", bedrockAgentAgentKnowledgeBaseAssociationResourceType)
+	if got := resource.InstanceState.Attributes["agent_id"]; got != "GGRRAED6JP" {
+		t.Fatalf("agent_id attribute = %q, want GGRRAED6JP", got)
+	}
+	if got := resource.InstanceState.Attributes["agent_version"]; got != bedrockAgentDraftVersion {
+		t.Fatalf("agent_version attribute = %q, want %s", got, bedrockAgentDraftVersion)
+	}
+	if got := resource.InstanceState.Attributes["knowledge_base_id"]; got != "EMDPPAYPZI" {
+		t.Fatalf("knowledge_base_id attribute = %q, want EMDPPAYPZI", got)
+	}
+	if got := resource.InstanceState.Attributes["description"]; got != "customer knowledge" {
+		t.Fatalf("description attribute = %q, want customer knowledge", got)
+	}
+	if got := resource.InstanceState.Attributes["knowledge_base_state"]; got != "ENABLED" {
+		t.Fatalf("knowledge_base_state attribute = %q, want ENABLED", got)
+	}
+
+	disabled := bedrockAgentTestAgentKnowledgeBaseAssociation()
+	disabled.KnowledgeBaseState = bedrockagenttypes.KnowledgeBaseStateDisabled
+	resource, ok = newBedrockAgentAgentKnowledgeBaseAssociationResource(disabled)
+	assertBedrockAgentResource(t, resource, ok, "GGRRAED6JP,DRAFT,EMDPPAYPZI", bedrockAgentAgentKnowledgeBaseAssociationResourceType)
+	if got := resource.InstanceState.Attributes["knowledge_base_state"]; got != "DISABLED" {
+		t.Fatalf("knowledge_base_state attribute = %q, want DISABLED", got)
+	}
+
+	if _, ok := newBedrockAgentAgentKnowledgeBaseAssociationResource(nil); ok {
+		t.Fatal("nil association should be skipped")
+	}
+	for name, mutate := range map[string]func(*bedrockagenttypes.AgentKnowledgeBase){
+		"agent ID":          func(association *bedrockagenttypes.AgentKnowledgeBase) { association.AgentId = nil },
+		"agent version":     func(association *bedrockagenttypes.AgentKnowledgeBase) { association.AgentVersion = nil },
+		"knowledge base ID": func(association *bedrockagenttypes.AgentKnowledgeBase) { association.KnowledgeBaseId = nil },
+		"description":       func(association *bedrockagenttypes.AgentKnowledgeBase) { association.Description = nil },
+	} {
+		t.Run("missing "+name, func(t *testing.T) {
+			association := bedrockAgentTestAgentKnowledgeBaseAssociation()
+			mutate(association)
+			if _, ok := newBedrockAgentAgentKnowledgeBaseAssociationResource(association); ok {
+				t.Fatalf("association without %s should be skipped", name)
+			}
+		})
+	}
+
+	versioned := bedrockAgentTestAgentKnowledgeBaseAssociation()
+	versioned.AgentVersion = aws.String("1")
+	if _, ok := newBedrockAgentAgentKnowledgeBaseAssociationResource(versioned); ok {
+		t.Fatal("non-DRAFT association should be skipped")
+	}
+	unknownState := bedrockAgentTestAgentKnowledgeBaseAssociation()
+	unknownState.KnowledgeBaseState = ""
+	if _, ok := newBedrockAgentAgentKnowledgeBaseAssociationResource(unknownState); ok {
+		t.Fatal("association with empty state should be skipped")
+	}
+}
+
+func TestNewBedrockAgentKnowledgeBaseResource(t *testing.T) {
+	resource, ok := newBedrockAgentKnowledgeBaseResource(bedrockAgentTestKnowledgeBase())
+	assertBedrockAgentResource(t, resource, ok, "EMDPPAYPZI", bedrockAgentKnowledgeBaseResourceType)
+	if got := resource.InstanceState.Attributes["id"]; got != "EMDPPAYPZI" {
+		t.Fatalf("id attribute = %q, want EMDPPAYPZI", got)
+	}
+	if got := resource.InstanceState.Attributes["name"]; got != "customer-kb" {
+		t.Fatalf("name attribute = %q, want customer-kb", got)
+	}
+	if got := resource.InstanceState.Attributes["role_arn"]; got != "arn:aws:iam::123456789012:role/bedrock-kb" {
+		t.Fatalf("role_arn attribute = %q, want arn:aws:iam::123456789012:role/bedrock-kb", got)
+	}
+
+	if _, ok := newBedrockAgentKnowledgeBaseResource(nil); ok {
+		t.Fatal("nil knowledge base should be skipped")
+	}
+	for name, mutate := range map[string]func(*bedrockagenttypes.KnowledgeBase){
+		"ID":     func(knowledgeBase *bedrockagenttypes.KnowledgeBase) { knowledgeBase.KnowledgeBaseId = nil },
+		"name":   func(knowledgeBase *bedrockagenttypes.KnowledgeBase) { knowledgeBase.Name = nil },
+		"role":   func(knowledgeBase *bedrockagenttypes.KnowledgeBase) { knowledgeBase.RoleArn = nil },
+		"config": func(knowledgeBase *bedrockagenttypes.KnowledgeBase) { knowledgeBase.KnowledgeBaseConfiguration = nil },
+	} {
+		t.Run("missing "+name, func(t *testing.T) {
+			knowledgeBase := bedrockAgentTestKnowledgeBase()
+			mutate(knowledgeBase)
+			if _, ok := newBedrockAgentKnowledgeBaseResource(knowledgeBase); ok {
+				t.Fatalf("knowledge base without %s should be skipped", name)
+			}
+		})
+	}
+
+	creating := bedrockAgentTestKnowledgeBase()
+	creating.Status = bedrockagenttypes.KnowledgeBaseStatusCreating
+	if _, ok := newBedrockAgentKnowledgeBaseResource(creating); ok {
+		t.Fatal("creating knowledge base should be skipped")
+	}
+	vectorMissingConfig := bedrockAgentTestKnowledgeBase()
+	vectorMissingConfig.KnowledgeBaseConfiguration.VectorKnowledgeBaseConfiguration = nil
+	if _, ok := newBedrockAgentKnowledgeBaseResource(vectorMissingConfig); ok {
+		t.Fatal("vector knowledge base without vector configuration should be skipped")
+	}
+	vectorMissingStorage := bedrockAgentTestKnowledgeBase()
+	vectorMissingStorage.StorageConfiguration = nil
+	if _, ok := newBedrockAgentKnowledgeBaseResource(vectorMissingStorage); ok {
+		t.Fatal("vector knowledge base without storage configuration should be skipped")
+	}
+}
+
+func TestNewBedrockAgentDataSourceResource(t *testing.T) {
+	resource, ok := newBedrockAgentDataSourceResource(bedrockAgentTestDataSource())
+	assertBedrockAgentResource(t, resource, ok, "GWCMFMQF6T,EMDPPAYPZI", bedrockAgentDataSourceResourceType)
+	if got := resource.InstanceState.Attributes["data_source_id"]; got != "GWCMFMQF6T" {
+		t.Fatalf("data_source_id attribute = %q, want GWCMFMQF6T", got)
+	}
+	if got := resource.InstanceState.Attributes["knowledge_base_id"]; got != "EMDPPAYPZI" {
+		t.Fatalf("knowledge_base_id attribute = %q, want EMDPPAYPZI", got)
+	}
+	if got := resource.InstanceState.Attributes["name"]; got != "support-docs" {
+		t.Fatalf("name attribute = %q, want support-docs", got)
+	}
+
+	if _, ok := newBedrockAgentDataSourceResource(nil); ok {
+		t.Fatal("nil data source should be skipped")
+	}
+	for name, mutate := range map[string]func(*bedrockagenttypes.DataSource){
+		"ID":                func(dataSource *bedrockagenttypes.DataSource) { dataSource.DataSourceId = nil },
+		"knowledge base ID": func(dataSource *bedrockagenttypes.DataSource) { dataSource.KnowledgeBaseId = nil },
+		"name":              func(dataSource *bedrockagenttypes.DataSource) { dataSource.Name = nil },
+		"config":            func(dataSource *bedrockagenttypes.DataSource) { dataSource.DataSourceConfiguration = nil },
+	} {
+		t.Run("missing "+name, func(t *testing.T) {
+			dataSource := bedrockAgentTestDataSource()
+			mutate(dataSource)
+			if _, ok := newBedrockAgentDataSourceResource(dataSource); ok {
+				t.Fatalf("data source without %s should be skipped", name)
+			}
+		})
+	}
+
+	deleting := bedrockAgentTestDataSource()
+	deleting.Status = bedrockagenttypes.DataSourceStatusDeleting
+	if _, ok := newBedrockAgentDataSourceResource(deleting); ok {
+		t.Fatal("deleting data source should be skipped")
+	}
+	s3MissingConfig := bedrockAgentTestDataSource()
+	s3MissingConfig.DataSourceConfiguration.S3Configuration = nil
+	if _, ok := newBedrockAgentDataSourceResource(s3MissingConfig); ok {
+		t.Fatal("S3 data source without S3 configuration should be skipped")
+	}
+}
+
 func TestBedrockAgentImportableStatuses(t *testing.T) {
 	for _, status := range []bedrockagenttypes.AgentStatus{
 		bedrockagenttypes.AgentStatusPrepared,
@@ -254,6 +424,307 @@ func TestBedrockAgentImportableStatuses(t *testing.T) {
 			t.Fatalf("%s agent alias should not be importable", status)
 		}
 	}
+
+	for _, state := range []bedrockagenttypes.KnowledgeBaseState{
+		bedrockagenttypes.KnowledgeBaseStateEnabled,
+		bedrockagenttypes.KnowledgeBaseStateDisabled,
+	} {
+		if !bedrockAgentAgentKnowledgeBaseAssociationImportable(bedrockAgentDraftVersion, state) {
+			t.Fatalf("%s association should be importable for DRAFT agents", state)
+		}
+	}
+	if bedrockAgentAgentKnowledgeBaseAssociationImportable("1", bedrockagenttypes.KnowledgeBaseStateEnabled) {
+		t.Fatal("non-DRAFT association should not be importable")
+	}
+	if bedrockAgentAgentKnowledgeBaseAssociationImportable(bedrockAgentDraftVersion, "") {
+		t.Fatal("association with empty state should not be importable")
+	}
+
+	if !bedrockAgentKnowledgeBaseImportable(bedrockagenttypes.KnowledgeBaseStatusActive) {
+		t.Fatal("ACTIVE knowledge base should be importable")
+	}
+	for _, status := range []bedrockagenttypes.KnowledgeBaseStatus{
+		bedrockagenttypes.KnowledgeBaseStatusCreating,
+		bedrockagenttypes.KnowledgeBaseStatusUpdating,
+		bedrockagenttypes.KnowledgeBaseStatusDeleting,
+		bedrockagenttypes.KnowledgeBaseStatusFailed,
+		bedrockagenttypes.KnowledgeBaseStatusDeleteUnsuccessful,
+	} {
+		if bedrockAgentKnowledgeBaseImportable(status) {
+			t.Fatalf("%s knowledge base should not be importable", status)
+		}
+	}
+
+	if !bedrockAgentDataSourceImportable(bedrockagenttypes.DataSourceStatusAvailable) {
+		t.Fatal("AVAILABLE data source should be importable")
+	}
+	for _, status := range []bedrockagenttypes.DataSourceStatus{
+		bedrockagenttypes.DataSourceStatusDeleting,
+		bedrockagenttypes.DataSourceStatusDeleteUnsuccessful,
+	} {
+		if bedrockAgentDataSourceImportable(status) {
+			t.Fatalf("%s data source should not be importable", status)
+		}
+	}
+}
+
+func TestBedrockAgentKnowledgeBaseConfigurationImportable(t *testing.T) {
+	tests := []struct {
+		name   string
+		config *bedrockagenttypes.KnowledgeBaseConfiguration
+		want   bool
+	}{
+		{name: "nil", want: false},
+		{
+			name: "vector",
+			config: &bedrockagenttypes.KnowledgeBaseConfiguration{
+				Type:                             bedrockagenttypes.KnowledgeBaseTypeVector,
+				VectorKnowledgeBaseConfiguration: &bedrockagenttypes.VectorKnowledgeBaseConfiguration{},
+			},
+			want: true,
+		},
+		{
+			name: "vector missing config",
+			config: &bedrockagenttypes.KnowledgeBaseConfiguration{
+				Type: bedrockagenttypes.KnowledgeBaseTypeVector,
+			},
+			want: false,
+		},
+		{
+			name: "kendra",
+			config: &bedrockagenttypes.KnowledgeBaseConfiguration{
+				Type:                             bedrockagenttypes.KnowledgeBaseTypeKendra,
+				KendraKnowledgeBaseConfiguration: &bedrockagenttypes.KendraKnowledgeBaseConfiguration{},
+			},
+			want: true,
+		},
+		{
+			name: "sql",
+			config: &bedrockagenttypes.KnowledgeBaseConfiguration{
+				Type:                          bedrockagenttypes.KnowledgeBaseTypeSql,
+				SqlKnowledgeBaseConfiguration: &bedrockagenttypes.SqlKnowledgeBaseConfiguration{},
+			},
+			want: true,
+		},
+		{
+			name: "unknown",
+			config: &bedrockagenttypes.KnowledgeBaseConfiguration{
+				Type: "UNKNOWN",
+			},
+			want: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := bedrockAgentKnowledgeBaseConfigurationImportable(tt.config); got != tt.want {
+				t.Fatalf("bedrockAgentKnowledgeBaseConfigurationImportable() = %t, want %t", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestBedrockAgentKnowledgeBaseStorageConfigurationImportable(t *testing.T) {
+	vectorConfig := &bedrockagenttypes.KnowledgeBaseConfiguration{
+		Type:                             bedrockagenttypes.KnowledgeBaseTypeVector,
+		VectorKnowledgeBaseConfiguration: &bedrockagenttypes.VectorKnowledgeBaseConfiguration{},
+	}
+	kendraConfig := &bedrockagenttypes.KnowledgeBaseConfiguration{
+		Type:                             bedrockagenttypes.KnowledgeBaseTypeKendra,
+		KendraKnowledgeBaseConfiguration: &bedrockagenttypes.KendraKnowledgeBaseConfiguration{},
+	}
+	tests := []struct {
+		name    string
+		config  *bedrockagenttypes.KnowledgeBaseConfiguration
+		storage *bedrockagenttypes.StorageConfiguration
+		want    bool
+	}{
+		{name: "nil config", want: false},
+		{name: "Kendra no vector storage", config: kendraConfig, want: true},
+		{name: "vector missing storage", config: vectorConfig, want: false},
+		{
+			name:   "OpenSearch Serverless",
+			config: vectorConfig,
+			storage: &bedrockagenttypes.StorageConfiguration{
+				Type:                              bedrockagenttypes.KnowledgeBaseStorageTypeOpensearchServerless,
+				OpensearchServerlessConfiguration: &bedrockagenttypes.OpenSearchServerlessConfiguration{},
+			},
+			want: true,
+		},
+		{
+			name:   "OpenSearch Serverless missing config",
+			config: vectorConfig,
+			storage: &bedrockagenttypes.StorageConfiguration{
+				Type: bedrockagenttypes.KnowledgeBaseStorageTypeOpensearchServerless,
+			},
+			want: false,
+		},
+		{
+			name:   "Pinecone",
+			config: vectorConfig,
+			storage: &bedrockagenttypes.StorageConfiguration{
+				Type:                  bedrockagenttypes.KnowledgeBaseStorageTypePinecone,
+				PineconeConfiguration: &bedrockagenttypes.PineconeConfiguration{},
+			},
+			want: true,
+		},
+		{
+			name:   "Redis Enterprise Cloud",
+			config: vectorConfig,
+			storage: &bedrockagenttypes.StorageConfiguration{
+				Type:                              bedrockagenttypes.KnowledgeBaseStorageTypeRedisEnterpriseCloud,
+				RedisEnterpriseCloudConfiguration: &bedrockagenttypes.RedisEnterpriseCloudConfiguration{},
+			},
+			want: true,
+		},
+		{
+			name:   "RDS",
+			config: vectorConfig,
+			storage: &bedrockagenttypes.StorageConfiguration{
+				Type:             bedrockagenttypes.KnowledgeBaseStorageTypeRds,
+				RdsConfiguration: &bedrockagenttypes.RdsConfiguration{},
+			},
+			want: true,
+		},
+		{
+			name:   "MongoDB Atlas",
+			config: vectorConfig,
+			storage: &bedrockagenttypes.StorageConfiguration{
+				Type:                      bedrockagenttypes.KnowledgeBaseStorageTypeMongoDbAtlas,
+				MongoDbAtlasConfiguration: &bedrockagenttypes.MongoDbAtlasConfiguration{},
+			},
+			want: true,
+		},
+		{
+			name:   "Neptune Analytics",
+			config: vectorConfig,
+			storage: &bedrockagenttypes.StorageConfiguration{
+				Type:                          bedrockagenttypes.KnowledgeBaseStorageTypeNeptuneAnalytics,
+				NeptuneAnalyticsConfiguration: &bedrockagenttypes.NeptuneAnalyticsConfiguration{},
+			},
+			want: true,
+		},
+		{
+			name:   "OpenSearch Managed Cluster",
+			config: vectorConfig,
+			storage: &bedrockagenttypes.StorageConfiguration{
+				Type:                                  bedrockagenttypes.KnowledgeBaseStorageTypeOpensearchManagedCluster,
+				OpensearchManagedClusterConfiguration: &bedrockagenttypes.OpenSearchManagedClusterConfiguration{},
+			},
+			want: true,
+		},
+		{
+			name:   "S3 Vectors",
+			config: vectorConfig,
+			storage: &bedrockagenttypes.StorageConfiguration{
+				Type:                   bedrockagenttypes.KnowledgeBaseStorageTypeS3Vectors,
+				S3VectorsConfiguration: &bedrockagenttypes.S3VectorsConfiguration{},
+			},
+			want: true,
+		},
+		{
+			name:   "unknown",
+			config: vectorConfig,
+			storage: &bedrockagenttypes.StorageConfiguration{
+				Type: "UNKNOWN",
+			},
+			want: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := bedrockAgentKnowledgeBaseStorageConfigurationImportable(tt.config, tt.storage); got != tt.want {
+				t.Fatalf("bedrockAgentKnowledgeBaseStorageConfigurationImportable() = %t, want %t", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestBedrockAgentDataSourceConfigurationImportable(t *testing.T) {
+	tests := []struct {
+		name   string
+		config *bedrockagenttypes.DataSourceConfiguration
+		want   bool
+	}{
+		{name: "nil", want: false},
+		{
+			name: "S3",
+			config: &bedrockagenttypes.DataSourceConfiguration{
+				Type:            bedrockagenttypes.DataSourceTypeS3,
+				S3Configuration: &bedrockagenttypes.S3DataSourceConfiguration{},
+			},
+			want: true,
+		},
+		{
+			name: "S3 missing config",
+			config: &bedrockagenttypes.DataSourceConfiguration{
+				Type: bedrockagenttypes.DataSourceTypeS3,
+			},
+			want: false,
+		},
+		{
+			name: "web",
+			config: &bedrockagenttypes.DataSourceConfiguration{
+				Type:             bedrockagenttypes.DataSourceTypeWeb,
+				WebConfiguration: &bedrockagenttypes.WebDataSourceConfiguration{},
+			},
+			want: true,
+		},
+		{
+			name: "Confluence",
+			config: &bedrockagenttypes.DataSourceConfiguration{
+				Type:                    bedrockagenttypes.DataSourceTypeConfluence,
+				ConfluenceConfiguration: &bedrockagenttypes.ConfluenceDataSourceConfiguration{},
+			},
+			want: true,
+		},
+		{
+			name: "Salesforce",
+			config: &bedrockagenttypes.DataSourceConfiguration{
+				Type:                    bedrockagenttypes.DataSourceTypeSalesforce,
+				SalesforceConfiguration: &bedrockagenttypes.SalesforceDataSourceConfiguration{},
+			},
+			want: true,
+		},
+		{
+			name: "SharePoint",
+			config: &bedrockagenttypes.DataSourceConfiguration{
+				Type:                    bedrockagenttypes.DataSourceTypeSharepoint,
+				SharePointConfiguration: &bedrockagenttypes.SharePointDataSourceConfiguration{},
+			},
+			want: true,
+		},
+		{
+			name: "custom",
+			config: &bedrockagenttypes.DataSourceConfiguration{
+				Type: bedrockagenttypes.DataSourceTypeCustom,
+			},
+			want: true,
+		},
+		{
+			name: "redshift metadata",
+			config: &bedrockagenttypes.DataSourceConfiguration{
+				Type: bedrockagenttypes.DataSourceTypeRedshiftMetadata,
+			},
+			want: true,
+		},
+		{
+			name: "unknown",
+			config: &bedrockagenttypes.DataSourceConfiguration{
+				Type: "UNKNOWN",
+			},
+			want: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := bedrockAgentDataSourceConfigurationImportable(tt.config); got != tt.want {
+				t.Fatalf("bedrockAgentDataSourceConfigurationImportable() = %t, want %t", got, tt.want)
+			}
+		})
+	}
 }
 
 func TestBedrockAgentResourceNotFound(t *testing.T) {
@@ -269,9 +740,9 @@ func TestBedrockAgentResourceNotFound(t *testing.T) {
 }
 
 func TestBedrockAgentInitialCleanupHonorsTypedFilters(t *testing.T) {
-	agent, alias := bedrockAgentTestResources(t)
+	agent, alias, association, dataSource, knowledgeBase := bedrockAgentTestResources(t)
 	g := BedrockAgentGenerator{}
-	g.Resources = []terraformutils.Resource{agent, alias}
+	g.Resources = []terraformutils.Resource{agent, alias, association, dataSource, knowledgeBase}
 	g.Filter = []terraformutils.ResourceFilter{{
 		ServiceName:      "bedrockagent_agent_alias",
 		FieldPath:        "id",
@@ -289,9 +760,9 @@ func TestBedrockAgentInitialCleanupHonorsTypedFilters(t *testing.T) {
 }
 
 func TestBedrockAgentInitialCleanupPreservesGlobalFilters(t *testing.T) {
-	agent, alias := bedrockAgentTestResources(t)
+	agent, alias, association, dataSource, knowledgeBase := bedrockAgentTestResources(t)
 	g := BedrockAgentGenerator{}
-	g.Resources = []terraformutils.Resource{agent, alias}
+	g.Resources = []terraformutils.Resource{agent, alias, association, dataSource, knowledgeBase}
 	g.Filter = []terraformutils.ResourceFilter{
 		{
 			ServiceName:      "bedrockagent_agent",
@@ -306,8 +777,8 @@ func TestBedrockAgentInitialCleanupPreservesGlobalFilters(t *testing.T) {
 
 	g.InitialCleanup()
 
-	if len(g.Resources) != 2 {
-		t.Fatalf("InitialCleanup() resources len = %d, want 2", len(g.Resources))
+	if len(g.Resources) != 5 {
+		t.Fatalf("InitialCleanup() resources len = %d, want 5", len(g.Resources))
 	}
 }
 
@@ -327,7 +798,7 @@ func assertBedrockAgentResource(t *testing.T, resource terraformutils.Resource, 
 	}
 }
 
-func bedrockAgentTestResources(t *testing.T) (terraformutils.Resource, terraformutils.Resource) {
+func bedrockAgentTestResources(t *testing.T) (terraformutils.Resource, terraformutils.Resource, terraformutils.Resource, terraformutils.Resource, terraformutils.Resource) {
 	t.Helper()
 	agent, ok := newBedrockAgentAgentResource(bedrockagenttypes.AgentSummary{
 		AgentId:     aws.String("GGRRAED6JP"),
@@ -345,5 +816,57 @@ func bedrockAgentTestResources(t *testing.T) (terraformutils.Resource, terraform
 	if !ok {
 		t.Fatal("newBedrockAgentAgentAliasResource() should create alias")
 	}
-	return agent, alias
+	association, ok := newBedrockAgentAgentKnowledgeBaseAssociationResource(bedrockAgentTestAgentKnowledgeBaseAssociation())
+	if !ok {
+		t.Fatal("newBedrockAgentAgentKnowledgeBaseAssociationResource() should create association")
+	}
+	dataSource, ok := newBedrockAgentDataSourceResource(bedrockAgentTestDataSource())
+	if !ok {
+		t.Fatal("newBedrockAgentDataSourceResource() should create data source")
+	}
+	knowledgeBase, ok := newBedrockAgentKnowledgeBaseResource(bedrockAgentTestKnowledgeBase())
+	if !ok {
+		t.Fatal("newBedrockAgentKnowledgeBaseResource() should create knowledge base")
+	}
+	return agent, alias, association, dataSource, knowledgeBase
+}
+
+func bedrockAgentTestAgentKnowledgeBaseAssociation() *bedrockagenttypes.AgentKnowledgeBase {
+	return &bedrockagenttypes.AgentKnowledgeBase{
+		AgentId:            aws.String("GGRRAED6JP"),
+		AgentVersion:       aws.String(bedrockAgentDraftVersion),
+		Description:        aws.String("customer knowledge"),
+		KnowledgeBaseId:    aws.String("EMDPPAYPZI"),
+		KnowledgeBaseState: bedrockagenttypes.KnowledgeBaseStateEnabled,
+	}
+}
+
+func bedrockAgentTestKnowledgeBase() *bedrockagenttypes.KnowledgeBase {
+	return &bedrockagenttypes.KnowledgeBase{
+		KnowledgeBaseConfiguration: &bedrockagenttypes.KnowledgeBaseConfiguration{
+			Type:                             bedrockagenttypes.KnowledgeBaseTypeVector,
+			VectorKnowledgeBaseConfiguration: &bedrockagenttypes.VectorKnowledgeBaseConfiguration{},
+		},
+		KnowledgeBaseId: aws.String("EMDPPAYPZI"),
+		Name:            aws.String("customer-kb"),
+		RoleArn:         aws.String("arn:aws:iam::123456789012:role/bedrock-kb"),
+		StorageConfiguration: &bedrockagenttypes.StorageConfiguration{
+			Type:                              bedrockagenttypes.KnowledgeBaseStorageTypeOpensearchServerless,
+			OpensearchServerlessConfiguration: &bedrockagenttypes.OpenSearchServerlessConfiguration{},
+		},
+		Status: bedrockagenttypes.KnowledgeBaseStatusActive,
+	}
+}
+
+func bedrockAgentTestDataSource() *bedrockagenttypes.DataSource {
+	return &bedrockagenttypes.DataSource{
+		DataSourceConfiguration: &bedrockagenttypes.DataSourceConfiguration{
+			Type:            bedrockagenttypes.DataSourceTypeS3,
+			S3Configuration: &bedrockagenttypes.S3DataSourceConfiguration{},
+		},
+		DataSourceId:    aws.String("GWCMFMQF6T"),
+		KnowledgeBaseId: aws.String("EMDPPAYPZI"),
+		Name:            aws.String("support-docs"),
+		Status:          bedrockagenttypes.DataSourceStatusAvailable,
+	}
 }


### PR DESCRIPTION
## Summary

- add Bedrock Agent knowledge-base import discovery for `aws_bedrockagent_knowledge_base`, `aws_bedrockagent_data_source`, and `aws_bedrockagent_agent_knowledge_base_association`
- seed import IDs as `knowledge_base_id`, `data_source_id,knowledge_base_id`, and `agent_id,agent_version,knowledge_base_id`
- skip non-stable knowledge bases and data sources, and only import DRAFT agent knowledge-base associations with enabled/disabled states
- update `docs/aws.md` for supported Bedrock Agent knowledge-base resources
- add unit tests for import IDs, resource construction, typed filters, status/config predicates, and parent/child attributes

## References

- #338

## Validation

```bash
go test ./providers/aws -run 'Test.*BedrockAgent|Test.*Bedrockagent|Test.*bedrockagent'
go test ./providers/aws/... ./terraformutils/...
go run ./tools/aws-gap-inventory \
  -docs docs/aws.md \
  -aws-dir providers/aws \
  -skip-list providers/aws/unsupported_resources.json \
  -format markdown
git diff --check
```

## Notes

Skipped/deferred resources:
- `aws_bedrockagent_agent_action_group`: deferred for child-resource PR
- `aws_bedrockagent_agent_collaborator`: deferred for child-resource PR
- `aws_bedrockagent_flow*`: deferred for flow PR
- `aws_bedrockagent_prompt*`: deferred for prompt PR
- `aws_bedrockagentcore_*`: deferred for Agent Core PR
- `aws_bedrock_custom_model`: deferred for customization-job-based discovery


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds import discovery for `aws_bedrockagent_knowledge_base`, `aws_bedrockagent_data_source`, and `aws_bedrockagent_agent_knowledge_base_association` to expand Bedrock Agent coverage while importing only stable resources.

- **New Features**
  - Discover and import: `aws_bedrockagent_knowledge_base`, `aws_bedrockagent_data_source`, `aws_bedrockagent_agent_knowledge_base_association`.
  - Import IDs: `knowledge_base_id`; `data_source_id,knowledge_base_id`; `agent_id,agent_version,knowledge_base_id`.
  - Import rules: only ACTIVE knowledge bases, AVAILABLE data sources; only DRAFT agent–KB associations in ENABLED/DISABLED states.
  - Updated `docs/aws.md` to list supported resources.
  - Added unit tests for IDs, resource construction, typed filters, status/config predicates, and parent/child attributes.

<sup>Written for commit 00be322eae881a86d474f0682c88dbb8302c787d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added comprehensive support for discovering and importing AWS Bedrock Agent knowledge base associations, knowledge bases, and data sources with the AWS provider.

* **Documentation**
  * Updated AWS supported services documentation to include newly supported Bedrock Agent resource types and import inventory entries.

* **Tests**
  * Enhanced test coverage for Bedrock Agent resource discovery and import functionality across all resource types.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/chenrui333/terraformer/pull/423)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->