### PR TITLE
aws(route53): add Route 53 and Resolver follow-up imports

### DIFF
--- a/docs/aws.md
+++ b/docs/aws.md
@@ -474,6 +474,20 @@ For AWS provider gap audits and unsupported-resource skip-list maintenance, see 
     * `aws_route53_zone`
     * `aws_route53_record`
     * `aws_route53_health_check`
+    * `aws_route53_query_log`
+    * `aws_route53_delegation_set`
+    * `aws_route53_key_signing_key`
+    * `aws_route53_hosted_zone_dnssec`
+*   `route53_resolver`
+    * `aws_route53_resolver_rule`
+    * `aws_route53_resolver_rule_association`
+    * `aws_route53_resolver_endpoint`
+    * `aws_route53_resolver_query_log_config`
+    * `aws_route53_resolver_query_log_config_association`
+    * `aws_route53_resolver_firewall_domain_list`
+    * `aws_route53_resolver_firewall_rule_group`
+    * `aws_route53_resolver_firewall_rule`
+    * `aws_route53_resolver_firewall_rule_group_association`
 *   `route_table`
     * `aws_route_table`
     * `aws_main_route_table_association`

--- a/go.mod
+++ b/go.mod
@@ -413,6 +413,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/mwaa v1.40.0
 	github.com/aws/aws-sdk-go-v2/service/pipes v1.23.22
 	github.com/aws/aws-sdk-go-v2/service/redshiftserverless v1.34.6
+	github.com/aws/aws-sdk-go-v2/service/route53resolver v1.43.0
 	github.com/aws/aws-sdk-go-v2/service/s3control v1.70.1
 	github.com/aws/aws-sdk-go-v2/service/s3tables v1.15.2
 	github.com/aws/aws-sdk-go-v2/service/scheduler v1.17.24

--- a/go.sum
+++ b/go.sum
@@ -353,6 +353,8 @@ github.com/aws/aws-sdk-go-v2/service/resourcegroups v1.33.26 h1:HmcCtAaTeZTskXrc
 github.com/aws/aws-sdk-go-v2/service/resourcegroups v1.33.26/go.mod h1:nYctzUkOuHA0n6thF68Td93Mm8NJzAhWuhKOIqk5vW8=
 github.com/aws/aws-sdk-go-v2/service/route53 v1.62.7 h1:twRRMmtSITnt/rrp+D7UDLzE5pKMZe759aalkUdN+OY=
 github.com/aws/aws-sdk-go-v2/service/route53 v1.62.7/go.mod h1:ztM1lr+sRoCAI8336ZUvlRPbToue0d3gE/wd6jomSJ8=
+github.com/aws/aws-sdk-go-v2/service/route53resolver v1.43.0 h1:+V3kVGgJclqO3Vt+KED8iIdefWIqg9n4/3wxb5H6TKw=
+github.com/aws/aws-sdk-go-v2/service/route53resolver v1.43.0/go.mod h1:OAvZZokn38D2+MY88EllrzDyl6MyEHTRAx0u5WvqBAI=
 github.com/aws/aws-sdk-go-v2/service/s3 v1.101.0 h1:etqBTKY581iwLL/H/S2sVgk3C9lAsTJFeXWFDsDcWOU=
 github.com/aws/aws-sdk-go-v2/service/s3 v1.101.0/go.mod h1:L2dcoOgS2VSgbPLvpak2NyUPsO1TBN7M45Z4H7DlRc4=
 github.com/aws/aws-sdk-go-v2/service/s3control v1.70.1 h1:jbMg6zIdFawDnLhbzaLGUxaMN2H42wP4hKsjG0OuLmA=

--- a/providers/aws/aws_provider.go
+++ b/providers/aws/aws_provider.go
@@ -338,6 +338,7 @@ func (p *AWSProvider) GetSupportedService() map[string]terraformutils.ServiceGen
 		"redshift":          &AwsFacade{service: &RedshiftGenerator{}},
 		"resourcegroups":    &AwsFacade{service: &ResourceGroupsGenerator{}},
 		"route53":           &AwsFacade{service: &Route53Generator{}},
+		"route53_resolver":  &AwsFacade{service: &Route53ResolverGenerator{}},
 		"route_table":       &AwsFacade{service: &RouteTableGenerator{}},
 		"s3":                &AwsFacade{service: &S3Generator{}},
 		"s3control":         &AwsFacade{service: &S3ControlGenerator{}},

--- a/providers/aws/route53.go
+++ b/providers/aws/route53.go
@@ -383,7 +383,9 @@ func route53HostedZoneDNSSECImportable(output *route53.GetDNSSECOutput) bool {
 	if output == nil || output.Status == nil {
 		return false
 	}
-	return StringValue(output.Status.ServeSignature) == "SIGNING"
+	signingStatus := StringValue(output.Status.ServeSignature)
+	return signingStatus == "SIGNING" ||
+		(signingStatus == "NOT_SIGNING" && len(output.KeySigningKeys) > 0)
 }
 
 func route53KeySigningKeyImportable(keySigningKey route53types.KeySigningKey) bool {

--- a/providers/aws/route53.go
+++ b/providers/aws/route53.go
@@ -4,18 +4,34 @@ package aws
 
 import (
 	"context"
+	"errors"
 	"fmt"
+	"log"
+	"strconv"
 	"strings"
 
 	"github.com/chenrui333/terraformer/terraformutils"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/route53"
+	route53types "github.com/aws/aws-sdk-go-v2/service/route53/types"
+	"github.com/aws/smithy-go"
 )
 
 var route53AllowEmptyValues = []string{}
 
 var route53AdditionalFields = map[string]interface{}{}
+
+const (
+	route53ZoneResourceType             = "aws_route53_zone"
+	route53RecordResourceType           = "aws_route53_record"
+	route53HealthCheckResourceType      = "aws_route53_health_check"
+	route53QueryLogResourceType         = "aws_route53_query_log"
+	route53DelegationSetResourceType    = "aws_route53_delegation_set"
+	route53KeySigningKeyResourceType    = "aws_route53_key_signing_key"
+	route53HostedZoneDNSSECResourceType = "aws_route53_hosted_zone_dnssec"
+	route53IDSeparator                  = ","
+)
 
 type Route53Generator struct {
 	AWSService
@@ -34,7 +50,7 @@ func (g *Route53Generator) createZonesResources(svc *route53.Client) ([]terrafor
 			resources = append(resources, terraformutils.NewResource(
 				zoneID,
 				zoneID+"_"+strings.TrimSuffix(StringValue(zone.Name), "."),
-				"aws_route53_zone",
+				route53ZoneResourceType,
 				"aws",
 				map[string]string{
 					"name":          StringValue(zone.Name),
@@ -48,6 +64,12 @@ func (g *Route53Generator) createZonesResources(svc *route53.Client) ([]terrafor
 				return nil, err
 			}
 			resources = append(resources, records...)
+			dnssecResources, err := g.createDNSSECResources(svc, zoneID)
+			if err != nil {
+				log.Printf("skipping Route 53 DNSSEC discovery for hosted zone %s: %v", zoneID, err)
+			} else {
+				resources = append(resources, dnssecResources...)
+			}
 		}
 	}
 	return resources, nil
@@ -72,7 +94,7 @@ func (Route53Generator) createRecordsResources(svc *route53.Client, zoneID strin
 			resources = append(resources, terraformutils.NewResource(
 				fmt.Sprintf("%s_%s_%s_%s", zoneID, recordName, typeString, StringValue(record.SetIdentifier)),
 				fmt.Sprintf("%s_%s_%s_%s", zoneID, recordName, typeString, StringValue(record.SetIdentifier)),
-				"aws_route53_record",
+				route53RecordResourceType,
 				"aws",
 				map[string]string{
 					"name":           strings.TrimSuffix(recordName, "."),
@@ -111,10 +133,82 @@ func (Route53Generator) createHealthChecksResources(svc *route53.Client) ([]terr
 			resources = append(resources, terraformutils.NewSimpleResource(
 				StringValue(healthCheck.Id),
 				fmt.Sprintf("%s_%s", StringValue(healthCheck.Id), healthCheckStringType),
-				"aws_route53_health_check",
+				route53HealthCheckResourceType,
 				"aws",
 				route53AllowEmptyValues,
 			))
+		}
+	}
+	return resources, nil
+}
+
+func (Route53Generator) createQueryLogResources(svc *route53.Client) ([]terraformutils.Resource, error) {
+	var resources []terraformutils.Resource
+	p := route53.NewListQueryLoggingConfigsPaginator(svc, &route53.ListQueryLoggingConfigsInput{})
+	for p.HasMorePages() {
+		page, err := p.NextPage(context.TODO())
+		if route53ResourceNotFound(err) {
+			return resources, nil
+		}
+		if err != nil {
+			return nil, err
+		}
+		for _, queryLogConfig := range page.QueryLoggingConfigs {
+			if resource, ok := newRoute53QueryLogResource(queryLogConfig); ok {
+				resources = append(resources, resource)
+			}
+		}
+	}
+	return resources, nil
+}
+
+func (Route53Generator) createDelegationSetResources(svc *route53.Client) ([]terraformutils.Resource, error) {
+	var resources []terraformutils.Resource
+	input := &route53.ListReusableDelegationSetsInput{}
+	for {
+		page, err := svc.ListReusableDelegationSets(context.TODO(), input)
+		if route53ResourceNotFound(err) {
+			return resources, nil
+		}
+		if err != nil {
+			return nil, err
+		}
+		for _, delegationSet := range page.DelegationSets {
+			if resource, ok := newRoute53DelegationSetResource(delegationSet); ok {
+				resources = append(resources, resource)
+			}
+		}
+		if !page.IsTruncated {
+			break
+		}
+		input.Marker = page.NextMarker
+	}
+	return resources, nil
+}
+
+func (Route53Generator) createDNSSECResources(svc *route53.Client, zoneID string) ([]terraformutils.Resource, error) {
+	if zoneID == "" {
+		return nil, nil
+	}
+	output, err := svc.GetDNSSEC(context.TODO(), &route53.GetDNSSECInput{
+		HostedZoneId: aws.String(zoneID),
+	})
+	if route53ResourceNotFound(err) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+	if output == nil {
+		return nil, nil
+	}
+	var resources []terraformutils.Resource
+	if resource, ok := newRoute53HostedZoneDNSSECResource(zoneID, output); ok {
+		resources = append(resources, resource)
+	}
+	for _, keySigningKey := range output.KeySigningKeys {
+		if resource, ok := newRoute53KeySigningKeyResource(zoneID, keySigningKey); ok {
+			resources = append(resources, resource)
 		}
 	}
 	return resources, nil
@@ -139,6 +233,18 @@ func (g *Route53Generator) InitResources() error {
 		return err
 	}
 	g.Resources = append(g.Resources, healthCheckResources...)
+	queryLogResources, err := g.createQueryLogResources(svc)
+	if err != nil {
+		log.Printf("skipping Route 53 query log discovery: %v", err)
+	} else {
+		g.Resources = append(g.Resources, queryLogResources...)
+	}
+	delegationSetResources, err := g.createDelegationSetResources(svc)
+	if err != nil {
+		log.Printf("skipping Route 53 delegation set discovery: %v", err)
+	} else {
+		g.Resources = append(g.Resources, delegationSetResources...)
+	}
 
 	return nil
 }
@@ -146,11 +252,11 @@ func (g *Route53Generator) InitResources() error {
 func (g *Route53Generator) PostConvertHook() error {
 	for i, resource := range g.Resources {
 		resourceType := resource.InstanceInfo.Type
-		if resourceType == "aws_route53_zone" {
+		if resourceType == route53ZoneResourceType {
 			continue
 		}
 
-		if resourceType == "aws_route53_health_check" {
+		if resourceType == route53HealthCheckResourceType {
 			if _, childHealthChecksExist := resource.Item["child_healthchecks"]; !childHealthChecksExist {
 				if _, childHealthCheckThreshholdExist := resource.Item["child_health_threshold"]; childHealthCheckThreshholdExist {
 					delete(g.Resources[i].Item, "child_health_threshold")
@@ -160,14 +266,14 @@ func (g *Route53Generator) PostConvertHook() error {
 		}
 
 		item := resource.Item
-		zoneID := item["zone_id"].(string)
-		for _, resourceZone := range g.Resources {
-			if resourceZone.InstanceInfo.Type != "aws_route53_zone" {
-				continue
-			}
-			if zoneID == resourceZone.InstanceState.ID {
-				g.Resources[i].Item["zone_id"] = "${aws_route53_zone." + resourceZone.ResourceName + ".zone_id}"
-			}
+		if item == nil {
+			continue
+		}
+		switch resourceType {
+		case route53RecordResourceType, route53QueryLogResourceType:
+			g.replaceHostedZoneReference(i, "zone_id")
+		case route53KeySigningKeyResourceType, route53HostedZoneDNSSECResourceType:
+			g.replaceHostedZoneReference(i, "hosted_zone_id")
 		}
 		if _, aliasExist := resource.Item["alias"]; aliasExist {
 			if _, ttlExist := resource.Item["ttl"]; ttlExist {
@@ -178,8 +284,141 @@ func (g *Route53Generator) PostConvertHook() error {
 	return nil
 }
 
+func (g *Route53Generator) replaceHostedZoneReference(resourceIndex int, attributeName string) {
+	if resourceIndex < 0 || resourceIndex >= len(g.Resources) || g.Resources[resourceIndex].Item == nil {
+		return
+	}
+	zoneID, ok := g.Resources[resourceIndex].Item[attributeName].(string)
+	if !ok || zoneID == "" {
+		return
+	}
+	for _, resourceZone := range g.Resources {
+		if resourceZone.InstanceInfo == nil || resourceZone.InstanceInfo.Type != route53ZoneResourceType {
+			continue
+		}
+		if zoneID == resourceZone.InstanceState.ID {
+			g.Resources[resourceIndex].Item[attributeName] = "${aws_route53_zone." + resourceZone.ResourceName + ".zone_id}"
+			return
+		}
+	}
+}
+
+func newRoute53QueryLogResource(queryLogConfig route53types.QueryLoggingConfig) (terraformutils.Resource, bool) {
+	id := StringValue(queryLogConfig.Id)
+	zoneID := cleanZoneID(StringValue(queryLogConfig.HostedZoneId))
+	logGroupARN := StringValue(queryLogConfig.CloudWatchLogsLogGroupArn)
+	if id == "" || zoneID == "" || logGroupARN == "" {
+		return terraformutils.Resource{}, false
+	}
+	return terraformutils.NewResource(
+		id,
+		route53ResourceName("query_log", zoneID, id),
+		route53QueryLogResourceType,
+		"aws",
+		map[string]string{
+			"cloudwatch_log_group_arn": logGroupARN,
+			"zone_id":                  zoneID,
+		},
+		route53AllowEmptyValues,
+		route53AdditionalFields,
+	), true
+}
+
+func newRoute53DelegationSetResource(delegationSet route53types.DelegationSet) (terraformutils.Resource, bool) {
+	id := cleanDelegationSetID(StringValue(delegationSet.Id))
+	if id == "" {
+		return terraformutils.Resource{}, false
+	}
+	return terraformutils.NewResource(
+		id,
+		route53ResourceName("delegation_set", id),
+		route53DelegationSetResourceType,
+		"aws",
+		map[string]string{},
+		route53AllowEmptyValues,
+		route53AdditionalFields,
+	), true
+}
+
+func newRoute53HostedZoneDNSSECResource(zoneID string, output *route53.GetDNSSECOutput) (terraformutils.Resource, bool) {
+	if !route53HostedZoneDNSSECImportable(output) || zoneID == "" {
+		return terraformutils.Resource{}, false
+	}
+	return terraformutils.NewResource(
+		zoneID,
+		route53ResourceName("hosted_zone_dnssec", zoneID),
+		route53HostedZoneDNSSECResourceType,
+		"aws",
+		map[string]string{
+			"hosted_zone_id": zoneID,
+			"signing_status": StringValue(output.Status.ServeSignature),
+		},
+		route53AllowEmptyValues,
+		route53AdditionalFields,
+	), true
+}
+
+func newRoute53KeySigningKeyResource(zoneID string, keySigningKey route53types.KeySigningKey) (terraformutils.Resource, bool) {
+	if !route53KeySigningKeyImportable(keySigningKey) || zoneID == "" {
+		return terraformutils.Resource{}, false
+	}
+	name := StringValue(keySigningKey.Name)
+	return terraformutils.NewResource(
+		route53KeySigningKeyImportID(zoneID, name),
+		route53ResourceName("key_signing_key", zoneID, name),
+		route53KeySigningKeyResourceType,
+		"aws",
+		map[string]string{
+			"hosted_zone_id":             zoneID,
+			"key_management_service_arn": StringValue(keySigningKey.KmsArn),
+			"name":                       name,
+			"status":                     StringValue(keySigningKey.Status),
+		},
+		route53AllowEmptyValues,
+		route53AdditionalFields,
+	), true
+}
+
+func route53HostedZoneDNSSECImportable(output *route53.GetDNSSECOutput) bool {
+	if output == nil || output.Status == nil {
+		return false
+	}
+	return StringValue(output.Status.ServeSignature) == "SIGNING"
+}
+
+func route53KeySigningKeyImportable(keySigningKey route53types.KeySigningKey) bool {
+	status := StringValue(keySigningKey.Status)
+	return StringValue(keySigningKey.Name) != "" &&
+		StringValue(keySigningKey.KmsArn) != "" &&
+		(status == "ACTIVE" || status == "INACTIVE")
+}
+
+func route53KeySigningKeyImportID(zoneID, name string) string {
+	return strings.Join([]string{zoneID, name}, route53IDSeparator)
+}
+
+func route53ResourceName(parts ...string) string {
+	var name strings.Builder
+	for _, part := range parts {
+		if part == "" {
+			continue
+		}
+		if name.Len() > 0 {
+			name.WriteString("_")
+		}
+		name.WriteString(strconv.Itoa(len(part)))
+		name.WriteString("_")
+		name.WriteString(part)
+	}
+	return name.String()
+}
+
 func wildcardUnescape(s string) string {
 	return strings.Replace(s, "\\052", "*", 1)
+}
+
+func cleanDelegationSetID(id string) string {
+	return cleanPrefix(id, "/delegationset/")
 }
 
 // cleanZoneID is used to remove the leading /hostedzone/
@@ -190,4 +429,45 @@ func cleanZoneID(id string) string {
 // cleanPrefix removes a string prefix from an ID
 func cleanPrefix(id, prefix string) string {
 	return strings.TrimPrefix(id, prefix)
+}
+
+func route53ResourceNotFound(err error) bool {
+	if err == nil {
+		return false
+	}
+	var dnssecNotFound *route53types.DNSSECNotFound
+	if errors.As(err, &dnssecNotFound) {
+		return true
+	}
+	var noSuchDelegationSet *route53types.NoSuchDelegationSet
+	if errors.As(err, &noSuchDelegationSet) {
+		return true
+	}
+	var noSuchHostedZone *route53types.NoSuchHostedZone
+	if errors.As(err, &noSuchHostedZone) {
+		return true
+	}
+	var noSuchKeySigningKey *route53types.NoSuchKeySigningKey
+	if errors.As(err, &noSuchKeySigningKey) {
+		return true
+	}
+	var noSuchQueryLoggingConfig *route53types.NoSuchQueryLoggingConfig
+	if errors.As(err, &noSuchQueryLoggingConfig) {
+		return true
+	}
+	var apiErr smithy.APIError
+	if !errors.As(err, &apiErr) {
+		return false
+	}
+	switch apiErr.ErrorCode() {
+	case "DNSSECNotFound",
+		"HostedZoneNotFound",
+		"NoSuchDelegationSet",
+		"NoSuchHostedZone",
+		"NoSuchKeySigningKey",
+		"NoSuchQueryLoggingConfig":
+		return true
+	default:
+		return false
+	}
 }

--- a/providers/aws/route53_resolver.go
+++ b/providers/aws/route53_resolver.go
@@ -27,6 +27,8 @@ const (
 	route53ResolverFirewallRuleResourceType                 = "aws_route53_resolver_firewall_rule"
 	route53ResolverFirewallRuleGroupAssociationResourceType = "aws_route53_resolver_firewall_rule_group_association"
 	route53ResolverFirewallRuleIDSeparator                  = ":"
+	route53ResolverAutodefinedIDPart                        = "autodefined"
+	route53ResolverAWSOwnerID                               = "Route 53 Resolver"
 )
 
 var route53ResolverAllowEmptyValues = []string{"tags."}
@@ -103,7 +105,7 @@ func (g *Route53ResolverGenerator) loadResolverRules(svc *route53resolver.Client
 		}
 		for _, ruleSummary := range page.ResolverRules {
 			ruleID := StringValue(ruleSummary.Id)
-			if ruleID == "" {
+			if ruleID == "" || route53ResolverAutodefinedID(ruleID) {
 				continue
 			}
 			rule, err := getRoute53ResolverRule(svc, ruleID)
@@ -130,7 +132,9 @@ func (g *Route53ResolverGenerator) loadResolverRuleAssociations(svc *route53reso
 		}
 		for _, associationSummary := range page.ResolverRuleAssociations {
 			associationID := StringValue(associationSummary.Id)
-			if associationID == "" {
+			if associationID == "" ||
+				route53ResolverAutodefinedID(associationID) ||
+				route53ResolverAutodefinedID(StringValue(associationSummary.ResolverRuleId)) {
 				continue
 			}
 			association, err := getRoute53ResolverRuleAssociation(svc, associationID)
@@ -526,10 +530,11 @@ func route53ResolverEndpointHasImportableIP(ipAddresses []route53resolvertypes.I
 func route53ResolverRuleImportable(rule *route53resolvertypes.ResolverRule) bool {
 	return rule != nil &&
 		StringValue(rule.Id) != "" &&
-		StringValue(rule.DomainName) != "" &&
+		trimRoute53ResolverTrailingPeriod(StringValue(rule.DomainName)) != "" &&
 		rule.RuleType != "" &&
 		rule.Status == route53resolvertypes.ResolverRuleStatusComplete &&
-		rule.ShareStatus != route53resolvertypes.ShareStatusSharedWithMe
+		rule.ShareStatus != route53resolvertypes.ShareStatusSharedWithMe &&
+		!route53ResolverRuleSystemDefined(rule)
 }
 
 func route53ResolverRuleAssociationImportable(association *route53resolvertypes.ResolverRuleAssociation) bool {
@@ -537,7 +542,8 @@ func route53ResolverRuleAssociationImportable(association *route53resolvertypes.
 		StringValue(association.Id) != "" &&
 		StringValue(association.ResolverRuleId) != "" &&
 		StringValue(association.VPCId) != "" &&
-		association.Status == route53resolvertypes.ResolverRuleAssociationStatusComplete
+		association.Status == route53resolvertypes.ResolverRuleAssociationStatusComplete &&
+		!route53ResolverRuleAssociationSystemDefined(association)
 }
 
 func route53ResolverQueryLogConfigImportable(config *route53resolvertypes.ResolverQueryLogConfig) bool {
@@ -603,6 +609,22 @@ func route53ResolverFirewallRuleImportID(ruleGroupID, ruleIdentifier string) str
 	return strings.Join([]string{ruleGroupID, ruleIdentifier}, route53ResolverFirewallRuleIDSeparator)
 }
 
+func route53ResolverRuleSystemDefined(rule *route53resolvertypes.ResolverRule) bool {
+	return rule != nil &&
+		(route53ResolverAutodefinedID(StringValue(rule.Id)) ||
+			strings.EqualFold(StringValue(rule.OwnerId), route53ResolverAWSOwnerID))
+}
+
+func route53ResolverRuleAssociationSystemDefined(association *route53resolvertypes.ResolverRuleAssociation) bool {
+	return association != nil &&
+		(route53ResolverAutodefinedID(StringValue(association.Id)) ||
+			route53ResolverAutodefinedID(StringValue(association.ResolverRuleId)))
+}
+
+func route53ResolverAutodefinedID(id string) bool {
+	return strings.Contains(strings.ToLower(id), route53ResolverAutodefinedIDPart)
+}
+
 func route53ResolverResourceName(parts ...string) string {
 	var name strings.Builder
 	for _, part := range parts {
@@ -639,7 +661,11 @@ func putRoute53ResolverListAttributes(attributes map[string]string, key string, 
 }
 
 func trimRoute53ResolverTrailingPeriod(s string) string {
-	return strings.TrimSuffix(s, ".")
+	trimmed := strings.TrimSuffix(s, ".")
+	if trimmed == "" && s == "." {
+		return s
+	}
+	return trimmed
 }
 
 func getRoute53ResolverEndpoint(svc *route53resolver.Client, id string) (*route53resolvertypes.ResolverEndpoint, error) {

--- a/providers/aws/route53_resolver.go
+++ b/providers/aws/route53_resolver.go
@@ -1,0 +1,778 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package aws
+
+import (
+	"context"
+	"errors"
+	"log"
+	"strconv"
+	"strings"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/route53resolver"
+	route53resolvertypes "github.com/aws/aws-sdk-go-v2/service/route53resolver/types"
+	"github.com/aws/smithy-go"
+	"github.com/chenrui333/terraformer/terraformutils"
+)
+
+const (
+	route53ResolverRuleResourceType                         = "aws_route53_resolver_rule"
+	route53ResolverRuleAssociationResourceType              = "aws_route53_resolver_rule_association"
+	route53ResolverEndpointResourceType                     = "aws_route53_resolver_endpoint"
+	route53ResolverQueryLogConfigResourceType               = "aws_route53_resolver_query_log_config"
+	route53ResolverQueryLogConfigAssociationResourceType    = "aws_route53_resolver_query_log_config_association"
+	route53ResolverFirewallDomainListResourceType           = "aws_route53_resolver_firewall_domain_list"
+	route53ResolverFirewallRuleGroupResourceType            = "aws_route53_resolver_firewall_rule_group"
+	route53ResolverFirewallRuleResourceType                 = "aws_route53_resolver_firewall_rule"
+	route53ResolverFirewallRuleGroupAssociationResourceType = "aws_route53_resolver_firewall_rule_group_association"
+	route53ResolverFirewallRuleIDSeparator                  = ":"
+)
+
+var route53ResolverAllowEmptyValues = []string{"tags."}
+
+type Route53ResolverGenerator struct {
+	AWSService
+}
+
+func (g *Route53ResolverGenerator) InitResources() error {
+	config, err := g.generateConfig()
+	if err != nil {
+		return err
+	}
+	svc := route53resolver.NewFromConfig(config)
+
+	loaders := []func(*route53resolver.Client) error{
+		g.loadResolverEndpoints,
+		g.loadResolverRules,
+		g.loadResolverRuleAssociations,
+		g.loadResolverQueryLogConfigs,
+		g.loadResolverQueryLogConfigAssociations,
+		g.loadFirewallDomainLists,
+		g.loadFirewallRuleGroups,
+		g.loadFirewallRuleGroupAssociations,
+	}
+	for _, loader := range loaders {
+		if err := loader(svc); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (g *Route53ResolverGenerator) loadResolverEndpoints(svc *route53resolver.Client) error {
+	p := route53resolver.NewListResolverEndpointsPaginator(svc, &route53resolver.ListResolverEndpointsInput{})
+	for p.HasMorePages() {
+		page, err := p.NextPage(context.TODO())
+		if err != nil {
+			return err
+		}
+		for _, endpointSummary := range page.ResolverEndpoints {
+			endpointID := StringValue(endpointSummary.Id)
+			if endpointID == "" {
+				continue
+			}
+			endpoint, err := getRoute53ResolverEndpoint(svc, endpointID)
+			if route53ResolverResourceNotFound(err) {
+				continue
+			}
+			if err != nil {
+				return err
+			}
+			ipAddresses, err := listRoute53ResolverEndpointIPAddresses(svc, endpointID)
+			if route53ResolverResourceNotFound(err) {
+				continue
+			}
+			if err != nil {
+				return err
+			}
+			if resource, ok := newRoute53ResolverEndpointResource(endpoint, ipAddresses); ok {
+				g.Resources = append(g.Resources, resource)
+			}
+		}
+	}
+	return nil
+}
+
+func (g *Route53ResolverGenerator) loadResolverRules(svc *route53resolver.Client) error {
+	p := route53resolver.NewListResolverRulesPaginator(svc, &route53resolver.ListResolverRulesInput{})
+	for p.HasMorePages() {
+		page, err := p.NextPage(context.TODO())
+		if err != nil {
+			return err
+		}
+		for _, ruleSummary := range page.ResolverRules {
+			ruleID := StringValue(ruleSummary.Id)
+			if ruleID == "" {
+				continue
+			}
+			rule, err := getRoute53ResolverRule(svc, ruleID)
+			if route53ResolverResourceNotFound(err) {
+				continue
+			}
+			if err != nil {
+				return err
+			}
+			if resource, ok := newRoute53ResolverRuleResource(rule); ok {
+				g.Resources = append(g.Resources, resource)
+			}
+		}
+	}
+	return nil
+}
+
+func (g *Route53ResolverGenerator) loadResolverRuleAssociations(svc *route53resolver.Client) error {
+	p := route53resolver.NewListResolverRuleAssociationsPaginator(svc, &route53resolver.ListResolverRuleAssociationsInput{})
+	for p.HasMorePages() {
+		page, err := p.NextPage(context.TODO())
+		if err != nil {
+			return err
+		}
+		for _, associationSummary := range page.ResolverRuleAssociations {
+			associationID := StringValue(associationSummary.Id)
+			if associationID == "" {
+				continue
+			}
+			association, err := getRoute53ResolverRuleAssociation(svc, associationID)
+			if route53ResolverResourceNotFound(err) {
+				continue
+			}
+			if err != nil {
+				return err
+			}
+			if resource, ok := newRoute53ResolverRuleAssociationResource(association); ok {
+				g.Resources = append(g.Resources, resource)
+			}
+		}
+	}
+	return nil
+}
+
+func (g *Route53ResolverGenerator) loadResolverQueryLogConfigs(svc *route53resolver.Client) error {
+	p := route53resolver.NewListResolverQueryLogConfigsPaginator(svc, &route53resolver.ListResolverQueryLogConfigsInput{})
+	for p.HasMorePages() {
+		page, err := p.NextPage(context.TODO())
+		if err != nil {
+			return err
+		}
+		for _, configSummary := range page.ResolverQueryLogConfigs {
+			configID := StringValue(configSummary.Id)
+			if configID == "" {
+				continue
+			}
+			config, err := getRoute53ResolverQueryLogConfig(svc, configID)
+			if route53ResolverResourceNotFound(err) {
+				continue
+			}
+			if err != nil {
+				return err
+			}
+			if resource, ok := newRoute53ResolverQueryLogConfigResource(config); ok {
+				g.Resources = append(g.Resources, resource)
+			}
+		}
+	}
+	return nil
+}
+
+func (g *Route53ResolverGenerator) loadResolverQueryLogConfigAssociations(svc *route53resolver.Client) error {
+	p := route53resolver.NewListResolverQueryLogConfigAssociationsPaginator(svc, &route53resolver.ListResolverQueryLogConfigAssociationsInput{})
+	for p.HasMorePages() {
+		page, err := p.NextPage(context.TODO())
+		if err != nil {
+			return err
+		}
+		for _, associationSummary := range page.ResolverQueryLogConfigAssociations {
+			associationID := StringValue(associationSummary.Id)
+			if associationID == "" {
+				continue
+			}
+			association, err := getRoute53ResolverQueryLogConfigAssociation(svc, associationID)
+			if route53ResolverResourceNotFound(err) {
+				continue
+			}
+			if err != nil {
+				return err
+			}
+			if resource, ok := newRoute53ResolverQueryLogConfigAssociationResource(association); ok {
+				g.Resources = append(g.Resources, resource)
+			}
+		}
+	}
+	return nil
+}
+
+func (g *Route53ResolverGenerator) loadFirewallDomainLists(svc *route53resolver.Client) error {
+	p := route53resolver.NewListFirewallDomainListsPaginator(svc, &route53resolver.ListFirewallDomainListsInput{})
+	for p.HasMorePages() {
+		page, err := p.NextPage(context.TODO())
+		if err != nil {
+			return err
+		}
+		for _, domainListSummary := range page.FirewallDomainLists {
+			domainListID := StringValue(domainListSummary.Id)
+			if domainListID == "" || StringValue(domainListSummary.ManagedOwnerName) != "" {
+				continue
+			}
+			domainList, err := getRoute53ResolverFirewallDomainList(svc, domainListID)
+			if route53ResolverResourceNotFound(err) {
+				continue
+			}
+			if err != nil {
+				return err
+			}
+			domains, err := listRoute53ResolverFirewallDomains(svc, domainListID)
+			if route53ResolverResourceNotFound(err) {
+				continue
+			}
+			if err != nil {
+				return err
+			}
+			if resource, ok := newRoute53ResolverFirewallDomainListResource(domainList, domains); ok {
+				g.Resources = append(g.Resources, resource)
+			}
+		}
+	}
+	return nil
+}
+
+func (g *Route53ResolverGenerator) loadFirewallRuleGroups(svc *route53resolver.Client) error {
+	p := route53resolver.NewListFirewallRuleGroupsPaginator(svc, &route53resolver.ListFirewallRuleGroupsInput{})
+	for p.HasMorePages() {
+		page, err := p.NextPage(context.TODO())
+		if err != nil {
+			return err
+		}
+		for _, ruleGroupSummary := range page.FirewallRuleGroups {
+			ruleGroupID := StringValue(ruleGroupSummary.Id)
+			if ruleGroupID == "" || ruleGroupSummary.ShareStatus == route53resolvertypes.ShareStatusSharedWithMe {
+				continue
+			}
+			ruleGroup, err := getRoute53ResolverFirewallRuleGroup(svc, ruleGroupID)
+			if route53ResolverResourceNotFound(err) {
+				continue
+			}
+			if err != nil {
+				return err
+			}
+			if resource, ok := newRoute53ResolverFirewallRuleGroupResource(ruleGroup); ok {
+				g.Resources = append(g.Resources, resource)
+				if err := g.loadFirewallRules(svc, ruleGroupID); err != nil {
+					log.Printf("skipping Route 53 Resolver firewall rules for rule group %s: %v", ruleGroupID, err)
+				}
+			}
+		}
+	}
+	return nil
+}
+
+func (g *Route53ResolverGenerator) loadFirewallRules(svc *route53resolver.Client, ruleGroupID string) error {
+	if ruleGroupID == "" {
+		return nil
+	}
+	p := route53resolver.NewListFirewallRulesPaginator(svc, &route53resolver.ListFirewallRulesInput{
+		FirewallRuleGroupId: aws.String(ruleGroupID),
+	})
+	for p.HasMorePages() {
+		page, err := p.NextPage(context.TODO())
+		if err != nil {
+			return err
+		}
+		for _, firewallRule := range page.FirewallRules {
+			if resource, ok := newRoute53ResolverFirewallRuleResource(firewallRule); ok {
+				g.Resources = append(g.Resources, resource)
+			}
+		}
+	}
+	return nil
+}
+
+func (g *Route53ResolverGenerator) loadFirewallRuleGroupAssociations(svc *route53resolver.Client) error {
+	p := route53resolver.NewListFirewallRuleGroupAssociationsPaginator(svc, &route53resolver.ListFirewallRuleGroupAssociationsInput{})
+	for p.HasMorePages() {
+		page, err := p.NextPage(context.TODO())
+		if err != nil {
+			return err
+		}
+		for _, associationSummary := range page.FirewallRuleGroupAssociations {
+			associationID := StringValue(associationSummary.Id)
+			if associationID == "" || StringValue(associationSummary.ManagedOwnerName) != "" {
+				continue
+			}
+			association, err := getRoute53ResolverFirewallRuleGroupAssociation(svc, associationID)
+			if route53ResolverResourceNotFound(err) {
+				continue
+			}
+			if err != nil {
+				return err
+			}
+			if resource, ok := newRoute53ResolverFirewallRuleGroupAssociationResource(association); ok {
+				g.Resources = append(g.Resources, resource)
+			}
+		}
+	}
+	return nil
+}
+
+func newRoute53ResolverEndpointResource(endpoint *route53resolvertypes.ResolverEndpoint, ipAddresses []route53resolvertypes.IpAddressResponse) (terraformutils.Resource, bool) {
+	if !route53ResolverEndpointImportable(endpoint, ipAddresses) {
+		return terraformutils.Resource{}, false
+	}
+	endpointID := StringValue(endpoint.Id)
+	return terraformutils.NewResource(
+		endpointID,
+		route53ResolverResourceName("endpoint", StringValue(endpoint.Name), endpointID),
+		route53ResolverEndpointResourceType,
+		"aws",
+		map[string]string{
+			"direction": string(endpoint.Direction),
+			"name":      StringValue(endpoint.Name),
+		},
+		route53ResolverAllowEmptyValues,
+		map[string]interface{}{},
+	), true
+}
+
+func newRoute53ResolverRuleResource(rule *route53resolvertypes.ResolverRule) (terraformutils.Resource, bool) {
+	if !route53ResolverRuleImportable(rule) {
+		return terraformutils.Resource{}, false
+	}
+	ruleID := StringValue(rule.Id)
+	attributes := map[string]string{
+		"domain_name": trimRoute53ResolverTrailingPeriod(StringValue(rule.DomainName)),
+		"name":        StringValue(rule.Name),
+		"rule_type":   string(rule.RuleType),
+	}
+	putRoute53ResolverString(attributes, "resolver_endpoint_id", StringValue(rule.ResolverEndpointId))
+	return terraformutils.NewResource(
+		ruleID,
+		route53ResolverResourceName("rule", StringValue(rule.Name), StringValue(rule.DomainName), ruleID),
+		route53ResolverRuleResourceType,
+		"aws",
+		attributes,
+		route53ResolverAllowEmptyValues,
+		map[string]interface{}{},
+	), true
+}
+
+func newRoute53ResolverRuleAssociationResource(association *route53resolvertypes.ResolverRuleAssociation) (terraformutils.Resource, bool) {
+	if !route53ResolverRuleAssociationImportable(association) {
+		return terraformutils.Resource{}, false
+	}
+	associationID := StringValue(association.Id)
+	return terraformutils.NewResource(
+		associationID,
+		route53ResolverResourceName("rule_association", StringValue(association.ResolverRuleId), StringValue(association.VPCId), associationID),
+		route53ResolverRuleAssociationResourceType,
+		"aws",
+		map[string]string{
+			"name":             StringValue(association.Name),
+			"resolver_rule_id": StringValue(association.ResolverRuleId),
+			"vpc_id":           StringValue(association.VPCId),
+		},
+		route53ResolverAllowEmptyValues,
+		map[string]interface{}{},
+	), true
+}
+
+func newRoute53ResolverQueryLogConfigResource(config *route53resolvertypes.ResolverQueryLogConfig) (terraformutils.Resource, bool) {
+	if !route53ResolverQueryLogConfigImportable(config) {
+		return terraformutils.Resource{}, false
+	}
+	configID := StringValue(config.Id)
+	return terraformutils.NewResource(
+		configID,
+		route53ResolverResourceName("query_log_config", StringValue(config.Name), configID),
+		route53ResolverQueryLogConfigResourceType,
+		"aws",
+		map[string]string{
+			"destination_arn": StringValue(config.DestinationArn),
+			"name":            StringValue(config.Name),
+		},
+		route53ResolverAllowEmptyValues,
+		map[string]interface{}{},
+	), true
+}
+
+func newRoute53ResolverQueryLogConfigAssociationResource(association *route53resolvertypes.ResolverQueryLogConfigAssociation) (terraformutils.Resource, bool) {
+	if !route53ResolverQueryLogConfigAssociationImportable(association) {
+		return terraformutils.Resource{}, false
+	}
+	associationID := StringValue(association.Id)
+	return terraformutils.NewResource(
+		associationID,
+		route53ResolverResourceName("query_log_config_association", StringValue(association.ResolverQueryLogConfigId), StringValue(association.ResourceId), associationID),
+		route53ResolverQueryLogConfigAssociationResourceType,
+		"aws",
+		map[string]string{
+			"resolver_query_log_config_id": StringValue(association.ResolverQueryLogConfigId),
+			"resource_id":                  StringValue(association.ResourceId),
+		},
+		route53ResolverAllowEmptyValues,
+		map[string]interface{}{},
+	), true
+}
+
+func newRoute53ResolverFirewallDomainListResource(domainList *route53resolvertypes.FirewallDomainList, domains []string) (terraformutils.Resource, bool) {
+	if !route53ResolverFirewallDomainListImportable(domainList) {
+		return terraformutils.Resource{}, false
+	}
+	domainListID := StringValue(domainList.Id)
+	attributes := map[string]string{
+		"name": StringValue(domainList.Name),
+	}
+	putRoute53ResolverListAttributes(attributes, "domains", domains)
+	return terraformutils.NewResource(
+		domainListID,
+		route53ResolverResourceName("firewall_domain_list", StringValue(domainList.Name), domainListID),
+		route53ResolverFirewallDomainListResourceType,
+		"aws",
+		attributes,
+		route53ResolverAllowEmptyValues,
+		map[string]interface{}{},
+	), true
+}
+
+func newRoute53ResolverFirewallRuleGroupResource(ruleGroup *route53resolvertypes.FirewallRuleGroup) (terraformutils.Resource, bool) {
+	if !route53ResolverFirewallRuleGroupImportable(ruleGroup) {
+		return terraformutils.Resource{}, false
+	}
+	ruleGroupID := StringValue(ruleGroup.Id)
+	return terraformutils.NewResource(
+		ruleGroupID,
+		route53ResolverResourceName("firewall_rule_group", StringValue(ruleGroup.Name), ruleGroupID),
+		route53ResolverFirewallRuleGroupResourceType,
+		"aws",
+		map[string]string{
+			"name": StringValue(ruleGroup.Name),
+		},
+		route53ResolverAllowEmptyValues,
+		map[string]interface{}{},
+	), true
+}
+
+func newRoute53ResolverFirewallRuleResource(rule route53resolvertypes.FirewallRule) (terraformutils.Resource, bool) {
+	if !route53ResolverFirewallRuleImportable(rule) {
+		return terraformutils.Resource{}, false
+	}
+	ruleID := route53ResolverFirewallRuleImportID(StringValue(rule.FirewallRuleGroupId), route53ResolverFirewallRuleIdentifier(rule))
+	attributes := map[string]string{
+		"action":                 string(rule.Action),
+		"firewall_rule_group_id": StringValue(rule.FirewallRuleGroupId),
+		"name":                   StringValue(rule.Name),
+		"priority":               strconv.Itoa(int(aws.ToInt32(rule.Priority))),
+	}
+	putRoute53ResolverString(attributes, "block_override_dns_type", string(rule.BlockOverrideDnsType))
+	putRoute53ResolverString(attributes, "block_override_domain", StringValue(rule.BlockOverrideDomain))
+	putRoute53ResolverInt32(attributes, "block_override_ttl", rule.BlockOverrideTtl)
+	putRoute53ResolverString(attributes, "block_response", string(rule.BlockResponse))
+	putRoute53ResolverString(attributes, "confidence_threshold", string(rule.ConfidenceThreshold))
+	putRoute53ResolverString(attributes, "dns_threat_protection", string(rule.DnsThreatProtection))
+	putRoute53ResolverString(attributes, "firewall_domain_list_id", StringValue(rule.FirewallDomainListId))
+	putRoute53ResolverString(attributes, "firewall_domain_redirection_action", string(rule.FirewallDomainRedirectionAction))
+	putRoute53ResolverString(attributes, "firewall_threat_protection_id", StringValue(rule.FirewallThreatProtectionId))
+	putRoute53ResolverString(attributes, "q_type", StringValue(rule.Qtype))
+	return terraformutils.NewResource(
+		ruleID,
+		route53ResolverResourceName("firewall_rule", StringValue(rule.FirewallRuleGroupId), StringValue(rule.Name), route53ResolverFirewallRuleIdentifier(rule)),
+		route53ResolverFirewallRuleResourceType,
+		"aws",
+		attributes,
+		route53ResolverAllowEmptyValues,
+		map[string]interface{}{},
+	), true
+}
+
+func newRoute53ResolverFirewallRuleGroupAssociationResource(association *route53resolvertypes.FirewallRuleGroupAssociation) (terraformutils.Resource, bool) {
+	if !route53ResolverFirewallRuleGroupAssociationImportable(association) {
+		return terraformutils.Resource{}, false
+	}
+	associationID := StringValue(association.Id)
+	return terraformutils.NewResource(
+		associationID,
+		route53ResolverResourceName("firewall_rule_group_association", StringValue(association.FirewallRuleGroupId), StringValue(association.VpcId), associationID),
+		route53ResolverFirewallRuleGroupAssociationResourceType,
+		"aws",
+		map[string]string{
+			"firewall_rule_group_id": StringValue(association.FirewallRuleGroupId),
+			"mutation_protection":    string(association.MutationProtection),
+			"name":                   StringValue(association.Name),
+			"priority":               strconv.Itoa(int(aws.ToInt32(association.Priority))),
+			"vpc_id":                 StringValue(association.VpcId),
+		},
+		route53ResolverAllowEmptyValues,
+		map[string]interface{}{},
+	), true
+}
+
+func route53ResolverEndpointImportable(endpoint *route53resolvertypes.ResolverEndpoint, ipAddresses []route53resolvertypes.IpAddressResponse) bool {
+	return endpoint != nil &&
+		StringValue(endpoint.Id) != "" &&
+		endpoint.Direction != "" &&
+		endpoint.Status == route53resolvertypes.ResolverEndpointStatusOperational &&
+		len(endpoint.SecurityGroupIds) > 0 &&
+		route53ResolverEndpointHasImportableIP(ipAddresses)
+}
+
+func route53ResolverEndpointHasImportableIP(ipAddresses []route53resolvertypes.IpAddressResponse) bool {
+	for _, ipAddress := range ipAddresses {
+		if StringValue(ipAddress.SubnetId) != "" && ipAddress.Status != route53resolvertypes.IpAddressStatusDeleting {
+			return true
+		}
+	}
+	return false
+}
+
+func route53ResolverRuleImportable(rule *route53resolvertypes.ResolverRule) bool {
+	return rule != nil &&
+		StringValue(rule.Id) != "" &&
+		StringValue(rule.DomainName) != "" &&
+		rule.RuleType != "" &&
+		rule.Status == route53resolvertypes.ResolverRuleStatusComplete &&
+		rule.ShareStatus != route53resolvertypes.ShareStatusSharedWithMe
+}
+
+func route53ResolverRuleAssociationImportable(association *route53resolvertypes.ResolverRuleAssociation) bool {
+	return association != nil &&
+		StringValue(association.Id) != "" &&
+		StringValue(association.ResolverRuleId) != "" &&
+		StringValue(association.VPCId) != "" &&
+		association.Status == route53resolvertypes.ResolverRuleAssociationStatusComplete
+}
+
+func route53ResolverQueryLogConfigImportable(config *route53resolvertypes.ResolverQueryLogConfig) bool {
+	return config != nil &&
+		StringValue(config.Id) != "" &&
+		StringValue(config.DestinationArn) != "" &&
+		StringValue(config.Name) != "" &&
+		config.Status == route53resolvertypes.ResolverQueryLogConfigStatusCreated &&
+		config.ShareStatus != route53resolvertypes.ShareStatusSharedWithMe
+}
+
+func route53ResolverQueryLogConfigAssociationImportable(association *route53resolvertypes.ResolverQueryLogConfigAssociation) bool {
+	return association != nil &&
+		StringValue(association.Id) != "" &&
+		StringValue(association.ResolverQueryLogConfigId) != "" &&
+		StringValue(association.ResourceId) != "" &&
+		association.Status == route53resolvertypes.ResolverQueryLogConfigAssociationStatusActive
+}
+
+func route53ResolverFirewallDomainListImportable(domainList *route53resolvertypes.FirewallDomainList) bool {
+	return domainList != nil &&
+		StringValue(domainList.Id) != "" &&
+		StringValue(domainList.ManagedOwnerName) == "" &&
+		StringValue(domainList.Name) != "" &&
+		domainList.Status == route53resolvertypes.FirewallDomainListStatusComplete
+}
+
+func route53ResolverFirewallRuleGroupImportable(ruleGroup *route53resolvertypes.FirewallRuleGroup) bool {
+	return ruleGroup != nil &&
+		StringValue(ruleGroup.Id) != "" &&
+		StringValue(ruleGroup.Name) != "" &&
+		ruleGroup.Status == route53resolvertypes.FirewallRuleGroupStatusComplete &&
+		ruleGroup.ShareStatus != route53resolvertypes.ShareStatusSharedWithMe
+}
+
+func route53ResolverFirewallRuleImportable(rule route53resolvertypes.FirewallRule) bool {
+	return StringValue(rule.FirewallRuleGroupId) != "" &&
+		StringValue(rule.Name) != "" &&
+		rule.Action != "" &&
+		rule.Priority != nil &&
+		route53ResolverFirewallRuleIdentifier(rule) != ""
+}
+
+func route53ResolverFirewallRuleGroupAssociationImportable(association *route53resolvertypes.FirewallRuleGroupAssociation) bool {
+	return association != nil &&
+		StringValue(association.Id) != "" &&
+		StringValue(association.FirewallRuleGroupId) != "" &&
+		StringValue(association.ManagedOwnerName) == "" &&
+		StringValue(association.Name) != "" &&
+		association.Priority != nil &&
+		StringValue(association.VpcId) != "" &&
+		association.Status == route53resolvertypes.FirewallRuleGroupAssociationStatusComplete
+}
+
+func route53ResolverFirewallRuleIdentifier(rule route53resolvertypes.FirewallRule) string {
+	if id := StringValue(rule.FirewallDomainListId); id != "" {
+		return id
+	}
+	return StringValue(rule.FirewallThreatProtectionId)
+}
+
+func route53ResolverFirewallRuleImportID(ruleGroupID, ruleIdentifier string) string {
+	return strings.Join([]string{ruleGroupID, ruleIdentifier}, route53ResolverFirewallRuleIDSeparator)
+}
+
+func route53ResolverResourceName(parts ...string) string {
+	var name strings.Builder
+	for _, part := range parts {
+		if part == "" {
+			continue
+		}
+		if name.Len() > 0 {
+			name.WriteString("_")
+		}
+		name.WriteString(strconv.Itoa(len(part)))
+		name.WriteString("_")
+		name.WriteString(part)
+	}
+	return name.String()
+}
+
+func putRoute53ResolverString(attributes map[string]string, key, value string) {
+	if value != "" {
+		attributes[key] = value
+	}
+}
+
+func putRoute53ResolverInt32(attributes map[string]string, key string, value *int32) {
+	if value != nil {
+		attributes[key] = strconv.Itoa(int(aws.ToInt32(value)))
+	}
+}
+
+func putRoute53ResolverListAttributes(attributes map[string]string, key string, values []string) {
+	attributes[key+".#"] = strconv.Itoa(len(values))
+	for i, value := range values {
+		attributes[key+"."+strconv.Itoa(i)] = value
+	}
+}
+
+func trimRoute53ResolverTrailingPeriod(s string) string {
+	return strings.TrimSuffix(s, ".")
+}
+
+func getRoute53ResolverEndpoint(svc *route53resolver.Client, id string) (*route53resolvertypes.ResolverEndpoint, error) {
+	output, err := svc.GetResolverEndpoint(context.TODO(), &route53resolver.GetResolverEndpointInput{
+		ResolverEndpointId: aws.String(id),
+	})
+	if err != nil || output == nil {
+		return nil, err
+	}
+	return output.ResolverEndpoint, nil
+}
+
+func getRoute53ResolverRule(svc *route53resolver.Client, id string) (*route53resolvertypes.ResolverRule, error) {
+	output, err := svc.GetResolverRule(context.TODO(), &route53resolver.GetResolverRuleInput{
+		ResolverRuleId: aws.String(id),
+	})
+	if err != nil || output == nil {
+		return nil, err
+	}
+	return output.ResolverRule, nil
+}
+
+func getRoute53ResolverRuleAssociation(svc *route53resolver.Client, id string) (*route53resolvertypes.ResolverRuleAssociation, error) {
+	output, err := svc.GetResolverRuleAssociation(context.TODO(), &route53resolver.GetResolverRuleAssociationInput{
+		ResolverRuleAssociationId: aws.String(id),
+	})
+	if err != nil || output == nil {
+		return nil, err
+	}
+	return output.ResolverRuleAssociation, nil
+}
+
+func getRoute53ResolverQueryLogConfig(svc *route53resolver.Client, id string) (*route53resolvertypes.ResolverQueryLogConfig, error) {
+	output, err := svc.GetResolverQueryLogConfig(context.TODO(), &route53resolver.GetResolverQueryLogConfigInput{
+		ResolverQueryLogConfigId: aws.String(id),
+	})
+	if err != nil || output == nil {
+		return nil, err
+	}
+	return output.ResolverQueryLogConfig, nil
+}
+
+func getRoute53ResolverQueryLogConfigAssociation(svc *route53resolver.Client, id string) (*route53resolvertypes.ResolverQueryLogConfigAssociation, error) {
+	output, err := svc.GetResolverQueryLogConfigAssociation(context.TODO(), &route53resolver.GetResolverQueryLogConfigAssociationInput{
+		ResolverQueryLogConfigAssociationId: aws.String(id),
+	})
+	if err != nil || output == nil {
+		return nil, err
+	}
+	return output.ResolverQueryLogConfigAssociation, nil
+}
+
+func getRoute53ResolverFirewallDomainList(svc *route53resolver.Client, id string) (*route53resolvertypes.FirewallDomainList, error) {
+	output, err := svc.GetFirewallDomainList(context.TODO(), &route53resolver.GetFirewallDomainListInput{
+		FirewallDomainListId: aws.String(id),
+	})
+	if err != nil || output == nil {
+		return nil, err
+	}
+	return output.FirewallDomainList, nil
+}
+
+func getRoute53ResolverFirewallRuleGroup(svc *route53resolver.Client, id string) (*route53resolvertypes.FirewallRuleGroup, error) {
+	output, err := svc.GetFirewallRuleGroup(context.TODO(), &route53resolver.GetFirewallRuleGroupInput{
+		FirewallRuleGroupId: aws.String(id),
+	})
+	if err != nil || output == nil {
+		return nil, err
+	}
+	return output.FirewallRuleGroup, nil
+}
+
+func getRoute53ResolverFirewallRuleGroupAssociation(svc *route53resolver.Client, id string) (*route53resolvertypes.FirewallRuleGroupAssociation, error) {
+	output, err := svc.GetFirewallRuleGroupAssociation(context.TODO(), &route53resolver.GetFirewallRuleGroupAssociationInput{
+		FirewallRuleGroupAssociationId: aws.String(id),
+	})
+	if err != nil || output == nil {
+		return nil, err
+	}
+	return output.FirewallRuleGroupAssociation, nil
+}
+
+func listRoute53ResolverEndpointIPAddresses(svc *route53resolver.Client, endpointID string) ([]route53resolvertypes.IpAddressResponse, error) {
+	p := route53resolver.NewListResolverEndpointIpAddressesPaginator(svc, &route53resolver.ListResolverEndpointIpAddressesInput{
+		ResolverEndpointId: aws.String(endpointID),
+	})
+	var ipAddresses []route53resolvertypes.IpAddressResponse
+	for p.HasMorePages() {
+		page, err := p.NextPage(context.TODO())
+		if err != nil {
+			return nil, err
+		}
+		ipAddresses = append(ipAddresses, page.IpAddresses...)
+	}
+	return ipAddresses, nil
+}
+
+func listRoute53ResolverFirewallDomains(svc *route53resolver.Client, domainListID string) ([]string, error) {
+	p := route53resolver.NewListFirewallDomainsPaginator(svc, &route53resolver.ListFirewallDomainsInput{
+		FirewallDomainListId: aws.String(domainListID),
+	})
+	var domains []string
+	for p.HasMorePages() {
+		page, err := p.NextPage(context.TODO())
+		if err != nil {
+			return nil, err
+		}
+		domains = append(domains, page.Domains...)
+	}
+	return domains, nil
+}
+
+func route53ResolverResourceNotFound(err error) bool {
+	if err == nil {
+		return false
+	}
+	var resourceNotFound *route53resolvertypes.ResourceNotFoundException
+	if errors.As(err, &resourceNotFound) {
+		return true
+	}
+	var unknownResource *route53resolvertypes.UnknownResourceException
+	if errors.As(err, &unknownResource) {
+		return true
+	}
+	var apiErr smithy.APIError
+	if !errors.As(err, &apiErr) {
+		return false
+	}
+	switch apiErr.ErrorCode() {
+	case "ResourceNotFoundException",
+		"UnknownResourceException":
+		return true
+	default:
+		return false
+	}
+}

--- a/providers/aws/route53_resolver_test.go
+++ b/providers/aws/route53_resolver_test.go
@@ -72,6 +72,12 @@ func TestNewRoute53ResolverRuleResource(t *testing.T) {
 	if _, ok := newRoute53ResolverRuleResource(&route53resolvertypes.ResolverRule{DomainName: aws.String("example.com."), Id: aws.String(testRoute53ResolverRuleID), RuleType: route53resolvertypes.RuleTypeOptionForward, ShareStatus: route53resolvertypes.ShareStatusSharedWithMe, Status: route53resolvertypes.ResolverRuleStatusComplete}); ok {
 		t.Fatal("shared-with-me resolver rule should be skipped")
 	}
+	if _, ok := newRoute53ResolverRuleResource(&route53resolvertypes.ResolverRule{DomainName: aws.String("."), Id: aws.String("rslvr-autodefined-rr-internet-resolver"), OwnerId: aws.String("Route 53 Resolver"), RuleType: route53resolvertypes.RuleTypeOptionRecursive, ShareStatus: route53resolvertypes.ShareStatusNotShared, Status: route53resolvertypes.ResolverRuleStatusComplete}); ok {
+		t.Fatal("AWS-owned autodefined resolver rule should be skipped")
+	}
+	if _, ok := newRoute53ResolverRuleResource(&route53resolvertypes.ResolverRule{DomainName: aws.String("example.org."), Id: aws.String(testRoute53ResolverRuleID), OwnerId: aws.String("Route 53 Resolver"), RuleType: route53resolvertypes.RuleTypeOptionForward, ShareStatus: route53resolvertypes.ShareStatusNotShared, Status: route53resolvertypes.ResolverRuleStatusComplete}); ok {
+		t.Fatal("AWS-owned resolver rule should be skipped")
+	}
 }
 
 func TestNewRoute53ResolverRuleAssociationResource(t *testing.T) {
@@ -92,6 +98,12 @@ func TestNewRoute53ResolverRuleAssociationResource(t *testing.T) {
 
 	if _, ok := newRoute53ResolverRuleAssociationResource(&route53resolvertypes.ResolverRuleAssociation{Id: aws.String(testRoute53ResolverRuleAssociationID), ResolverRuleId: aws.String(testRoute53ResolverRuleID), Status: route53resolvertypes.ResolverRuleAssociationStatusFailed, VPCId: aws.String(testRoute53ResolverVPCID)}); ok {
 		t.Fatal("failed resolver rule association should be skipped")
+	}
+	if _, ok := newRoute53ResolverRuleAssociationResource(&route53resolvertypes.ResolverRuleAssociation{Id: aws.String("rslvr-autodefined-rrassoc-vpc-1234567890abcdef0"), ResolverRuleId: aws.String(testRoute53ResolverRuleID), Status: route53resolvertypes.ResolverRuleAssociationStatusComplete, VPCId: aws.String(testRoute53ResolverVPCID)}); ok {
+		t.Fatal("autodefined resolver rule association should be skipped")
+	}
+	if _, ok := newRoute53ResolverRuleAssociationResource(&route53resolvertypes.ResolverRuleAssociation{Id: aws.String(testRoute53ResolverRuleAssociationID), ResolverRuleId: aws.String("rslvr-autodefined-rr-internet-resolver"), Status: route53resolvertypes.ResolverRuleAssociationStatusComplete, VPCId: aws.String(testRoute53ResolverVPCID)}); ok {
+		t.Fatal("association for an autodefined resolver rule should be skipped")
 	}
 }
 

--- a/providers/aws/route53_resolver_test.go
+++ b/providers/aws/route53_resolver_test.go
@@ -1,0 +1,253 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package aws
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	route53resolvertypes "github.com/aws/aws-sdk-go-v2/service/route53resolver/types"
+	"github.com/aws/smithy-go"
+	"github.com/chenrui333/terraformer/terraformutils"
+)
+
+const (
+	testRoute53ResolverEndpointID          = "rslvr-in-1234567890abcdef0"
+	testRoute53ResolverRuleID              = "rslvr-rr-1234567890abcdef0"
+	testRoute53ResolverRuleAssociationID   = "rslvr-rrassoc-1234567890abcdef0"
+	testRoute53ResolverQueryLogConfigID    = "rqlc-1234567890abcdef0"
+	testRoute53ResolverQueryLogAssocID     = "rqlca-1234567890abcdef0"
+	testRoute53ResolverFirewallDomainID    = "rslvr-fdl-1234567890abcdef0"
+	testRoute53ResolverFirewallRuleGroupID = "rslvr-frg-1234567890abcdef0"
+	testRoute53ResolverFirewallAssocID     = "rslvr-frgassoc-1234567890abcdef0"
+	testRoute53ResolverVPCID               = "vpc-1234567890abcdef0"
+)
+
+func TestRoute53ResolverResourceIDs(t *testing.T) {
+	if got, want := route53ResolverFirewallRuleImportID(testRoute53ResolverFirewallRuleGroupID, testRoute53ResolverFirewallDomainID), testRoute53ResolverFirewallRuleGroupID+":"+testRoute53ResolverFirewallDomainID; got != want {
+		t.Fatalf("firewall rule import ID = %q, want %q", got, want)
+	}
+}
+
+func TestNewRoute53ResolverEndpointResource(t *testing.T) {
+	resource, ok := newRoute53ResolverEndpointResource(&route53resolvertypes.ResolverEndpoint{
+		Direction:        route53resolvertypes.ResolverEndpointDirectionInbound,
+		Id:               aws.String(testRoute53ResolverEndpointID),
+		Name:             aws.String("inbound"),
+		SecurityGroupIds: []string{"sg-1234567890abcdef0"},
+		Status:           route53resolvertypes.ResolverEndpointStatusOperational,
+	}, []route53resolvertypes.IpAddressResponse{{Status: route53resolvertypes.IpAddressStatusAttached, SubnetId: aws.String("subnet-1234567890abcdef0")}})
+	assertRoute53ResolverResourceAttributes(t, resource, ok, route53ResolverEndpointResourceType, testRoute53ResolverEndpointID,
+		[]string{"endpoint", "inbound", testRoute53ResolverEndpointID},
+		map[string]string{"direction": "INBOUND", "name": "inbound"})
+
+	if _, ok := newRoute53ResolverEndpointResource(&route53resolvertypes.ResolverEndpoint{Direction: route53resolvertypes.ResolverEndpointDirectionInbound, Id: aws.String(testRoute53ResolverEndpointID), SecurityGroupIds: []string{"sg-1"}, Status: route53resolvertypes.ResolverEndpointStatusDeleting}, []route53resolvertypes.IpAddressResponse{{SubnetId: aws.String("subnet-1")}}); ok {
+		t.Fatal("deleting endpoint should be skipped")
+	}
+	if _, ok := newRoute53ResolverEndpointResource(&route53resolvertypes.ResolverEndpoint{Direction: route53resolvertypes.ResolverEndpointDirectionInbound, Id: aws.String(testRoute53ResolverEndpointID), SecurityGroupIds: []string{"sg-1"}, Status: route53resolvertypes.ResolverEndpointStatusOperational}, nil); ok {
+		t.Fatal("endpoint without IP addresses should be skipped")
+	}
+}
+
+func TestNewRoute53ResolverRuleResource(t *testing.T) {
+	resource, ok := newRoute53ResolverRuleResource(&route53resolvertypes.ResolverRule{
+		DomainName:         aws.String("example.com."),
+		Id:                 aws.String(testRoute53ResolverRuleID),
+		Name:               aws.String("example-forward"),
+		ResolverEndpointId: aws.String(testRoute53ResolverEndpointID),
+		RuleType:           route53resolvertypes.RuleTypeOptionForward,
+		ShareStatus:        route53resolvertypes.ShareStatusNotShared,
+		Status:             route53resolvertypes.ResolverRuleStatusComplete,
+	})
+	assertRoute53ResolverResourceAttributes(t, resource, ok, route53ResolverRuleResourceType, testRoute53ResolverRuleID,
+		[]string{"rule", "example-forward", "example.com.", testRoute53ResolverRuleID},
+		map[string]string{
+			"domain_name":          "example.com",
+			"name":                 "example-forward",
+			"resolver_endpoint_id": testRoute53ResolverEndpointID,
+			"rule_type":            "FORWARD",
+		})
+
+	if _, ok := newRoute53ResolverRuleResource(&route53resolvertypes.ResolverRule{DomainName: aws.String("example.com."), Id: aws.String(testRoute53ResolverRuleID), RuleType: route53resolvertypes.RuleTypeOptionForward, ShareStatus: route53resolvertypes.ShareStatusSharedWithMe, Status: route53resolvertypes.ResolverRuleStatusComplete}); ok {
+		t.Fatal("shared-with-me resolver rule should be skipped")
+	}
+}
+
+func TestNewRoute53ResolverRuleAssociationResource(t *testing.T) {
+	resource, ok := newRoute53ResolverRuleAssociationResource(&route53resolvertypes.ResolverRuleAssociation{
+		Id:             aws.String(testRoute53ResolverRuleAssociationID),
+		Name:           aws.String("example-association"),
+		ResolverRuleId: aws.String(testRoute53ResolverRuleID),
+		Status:         route53resolvertypes.ResolverRuleAssociationStatusComplete,
+		VPCId:          aws.String(testRoute53ResolverVPCID),
+	})
+	assertRoute53ResolverResourceAttributes(t, resource, ok, route53ResolverRuleAssociationResourceType, testRoute53ResolverRuleAssociationID,
+		[]string{"rule_association", testRoute53ResolverRuleID, testRoute53ResolverVPCID, testRoute53ResolverRuleAssociationID},
+		map[string]string{
+			"name":             "example-association",
+			"resolver_rule_id": testRoute53ResolverRuleID,
+			"vpc_id":           testRoute53ResolverVPCID,
+		})
+
+	if _, ok := newRoute53ResolverRuleAssociationResource(&route53resolvertypes.ResolverRuleAssociation{Id: aws.String(testRoute53ResolverRuleAssociationID), ResolverRuleId: aws.String(testRoute53ResolverRuleID), Status: route53resolvertypes.ResolverRuleAssociationStatusFailed, VPCId: aws.String(testRoute53ResolverVPCID)}); ok {
+		t.Fatal("failed resolver rule association should be skipped")
+	}
+}
+
+func TestNewRoute53ResolverQueryLogResources(t *testing.T) {
+	config, ok := newRoute53ResolverQueryLogConfigResource(&route53resolvertypes.ResolverQueryLogConfig{
+		DestinationArn: aws.String("arn:aws:logs:us-east-1:123456789012:log-group:/resolver"),
+		Id:             aws.String(testRoute53ResolverQueryLogConfigID),
+		Name:           aws.String("resolver-queries"),
+		ShareStatus:    route53resolvertypes.ShareStatusNotShared,
+		Status:         route53resolvertypes.ResolverQueryLogConfigStatusCreated,
+	})
+	assertRoute53ResolverResourceAttributes(t, config, ok, route53ResolverQueryLogConfigResourceType, testRoute53ResolverQueryLogConfigID,
+		[]string{"query_log_config", "resolver-queries", testRoute53ResolverQueryLogConfigID},
+		map[string]string{"destination_arn": "arn:aws:logs:us-east-1:123456789012:log-group:/resolver", "name": "resolver-queries"})
+
+	association, ok := newRoute53ResolverQueryLogConfigAssociationResource(&route53resolvertypes.ResolverQueryLogConfigAssociation{
+		Id:                       aws.String(testRoute53ResolverQueryLogAssocID),
+		ResolverQueryLogConfigId: aws.String(testRoute53ResolverQueryLogConfigID),
+		ResourceId:               aws.String(testRoute53ResolverVPCID),
+		Status:                   route53resolvertypes.ResolverQueryLogConfigAssociationStatusActive,
+	})
+	assertRoute53ResolverResourceAttributes(t, association, ok, route53ResolverQueryLogConfigAssociationResourceType, testRoute53ResolverQueryLogAssocID,
+		[]string{"query_log_config_association", testRoute53ResolverQueryLogConfigID, testRoute53ResolverVPCID, testRoute53ResolverQueryLogAssocID},
+		map[string]string{"resolver_query_log_config_id": testRoute53ResolverQueryLogConfigID, "resource_id": testRoute53ResolverVPCID})
+
+	if _, ok := newRoute53ResolverQueryLogConfigResource(&route53resolvertypes.ResolverQueryLogConfig{DestinationArn: aws.String("arn"), Id: aws.String(testRoute53ResolverQueryLogConfigID), Name: aws.String("shared"), ShareStatus: route53resolvertypes.ShareStatusSharedWithMe, Status: route53resolvertypes.ResolverQueryLogConfigStatusCreated}); ok {
+		t.Fatal("shared-with-me query log config should be skipped")
+	}
+	if _, ok := newRoute53ResolverQueryLogConfigAssociationResource(&route53resolvertypes.ResolverQueryLogConfigAssociation{Id: aws.String(testRoute53ResolverQueryLogAssocID), ResolverQueryLogConfigId: aws.String(testRoute53ResolverQueryLogConfigID), ResourceId: aws.String(testRoute53ResolverVPCID), Status: route53resolvertypes.ResolverQueryLogConfigAssociationStatusFailed}); ok {
+		t.Fatal("failed query log association should be skipped")
+	}
+}
+
+func TestNewRoute53ResolverFirewallResources(t *testing.T) {
+	domainList, ok := newRoute53ResolverFirewallDomainListResource(&route53resolvertypes.FirewallDomainList{
+		Id:     aws.String(testRoute53ResolverFirewallDomainID),
+		Name:   aws.String("blocked-domains"),
+		Status: route53resolvertypes.FirewallDomainListStatusComplete,
+	}, []string{"example.com", "example.org"})
+	assertRoute53ResolverResourceAttributes(t, domainList, ok, route53ResolverFirewallDomainListResourceType, testRoute53ResolverFirewallDomainID,
+		[]string{"firewall_domain_list", "blocked-domains", testRoute53ResolverFirewallDomainID},
+		map[string]string{"name": "blocked-domains", "domains.#": "2", "domains.0": "example.com", "domains.1": "example.org"})
+
+	ruleGroup, ok := newRoute53ResolverFirewallRuleGroupResource(&route53resolvertypes.FirewallRuleGroup{
+		Id:          aws.String(testRoute53ResolverFirewallRuleGroupID),
+		Name:        aws.String("core-firewall"),
+		ShareStatus: route53resolvertypes.ShareStatusNotShared,
+		Status:      route53resolvertypes.FirewallRuleGroupStatusComplete,
+	})
+	assertRoute53ResolverResourceAttributes(t, ruleGroup, ok, route53ResolverFirewallRuleGroupResourceType, testRoute53ResolverFirewallRuleGroupID,
+		[]string{"firewall_rule_group", "core-firewall", testRoute53ResolverFirewallRuleGroupID},
+		map[string]string{"name": "core-firewall"})
+
+	priority := int32(100)
+	rule, ok := newRoute53ResolverFirewallRuleResource(route53resolvertypes.FirewallRule{
+		Action:               route53resolvertypes.ActionBlock,
+		BlockResponse:        route53resolvertypes.BlockResponseNodata,
+		FirewallDomainListId: aws.String(testRoute53ResolverFirewallDomainID),
+		FirewallRuleGroupId:  aws.String(testRoute53ResolverFirewallRuleGroupID),
+		Name:                 aws.String("block-example"),
+		Priority:             aws.Int32(priority),
+	})
+	assertRoute53ResolverResourceAttributes(t, rule, ok, route53ResolverFirewallRuleResourceType, testRoute53ResolverFirewallRuleGroupID+":"+testRoute53ResolverFirewallDomainID,
+		[]string{"firewall_rule", testRoute53ResolverFirewallRuleGroupID, "block-example", testRoute53ResolverFirewallDomainID},
+		map[string]string{
+			"action":                  "BLOCK",
+			"block_response":          "NODATA",
+			"firewall_domain_list_id": testRoute53ResolverFirewallDomainID,
+			"firewall_rule_group_id":  testRoute53ResolverFirewallRuleGroupID,
+			"name":                    "block-example",
+			"priority":                "100",
+		})
+
+	association, ok := newRoute53ResolverFirewallRuleGroupAssociationResource(&route53resolvertypes.FirewallRuleGroupAssociation{
+		FirewallRuleGroupId: aws.String(testRoute53ResolverFirewallRuleGroupID),
+		Id:                  aws.String(testRoute53ResolverFirewallAssocID),
+		MutationProtection:  route53resolvertypes.MutationProtectionStatusEnabled,
+		Name:                aws.String("core-vpc"),
+		Priority:            aws.Int32(priority),
+		Status:              route53resolvertypes.FirewallRuleGroupAssociationStatusComplete,
+		VpcId:               aws.String(testRoute53ResolverVPCID),
+	})
+	assertRoute53ResolverResourceAttributes(t, association, ok, route53ResolverFirewallRuleGroupAssociationResourceType, testRoute53ResolverFirewallAssocID,
+		[]string{"firewall_rule_group_association", testRoute53ResolverFirewallRuleGroupID, testRoute53ResolverVPCID, testRoute53ResolverFirewallAssocID},
+		map[string]string{
+			"firewall_rule_group_id": testRoute53ResolverFirewallRuleGroupID,
+			"mutation_protection":    "ENABLED",
+			"name":                   "core-vpc",
+			"priority":               "100",
+			"vpc_id":                 testRoute53ResolverVPCID,
+		})
+
+	if _, ok := newRoute53ResolverFirewallDomainListResource(&route53resolvertypes.FirewallDomainList{Id: aws.String(testRoute53ResolverFirewallDomainID), ManagedOwnerName: aws.String("Route 53 Resolver DNS Firewall"), Name: aws.String("aws-managed"), Status: route53resolvertypes.FirewallDomainListStatusComplete}, nil); ok {
+		t.Fatal("AWS-managed firewall domain list should be skipped")
+	}
+	if _, ok := newRoute53ResolverFirewallRuleGroupResource(&route53resolvertypes.FirewallRuleGroup{Id: aws.String(testRoute53ResolverFirewallRuleGroupID), Name: aws.String("shared"), ShareStatus: route53resolvertypes.ShareStatusSharedWithMe, Status: route53resolvertypes.FirewallRuleGroupStatusComplete}); ok {
+		t.Fatal("shared-with-me firewall rule group should be skipped")
+	}
+	if _, ok := newRoute53ResolverFirewallRuleResource(route53resolvertypes.FirewallRule{Action: route53resolvertypes.ActionBlock, FirewallRuleGroupId: aws.String(testRoute53ResolverFirewallRuleGroupID), Name: aws.String("missing-priority")}); ok {
+		t.Fatal("firewall rule without priority should be skipped")
+	}
+	if _, ok := newRoute53ResolverFirewallRuleGroupAssociationResource(&route53resolvertypes.FirewallRuleGroupAssociation{FirewallRuleGroupId: aws.String(testRoute53ResolverFirewallRuleGroupID), Id: aws.String(testRoute53ResolverFirewallAssocID), ManagedOwnerName: aws.String("Firewall Manager"), Name: aws.String("managed"), Priority: aws.Int32(priority), Status: route53resolvertypes.FirewallRuleGroupAssociationStatusComplete, VpcId: aws.String(testRoute53ResolverVPCID)}); ok {
+		t.Fatal("managed firewall rule group association should be skipped")
+	}
+}
+
+func TestRoute53ResolverResourceNameAvoidsSanitizedCollisions(t *testing.T) {
+	left := terraformutils.TfSanitize(route53ResolverResourceName("rule", "a_b", "c"))
+	right := terraformutils.TfSanitize(route53ResolverResourceName("rule", "a", "b_c"))
+	if left == right {
+		t.Fatalf("resource names collide: %q", left)
+	}
+}
+
+func TestRoute53ResolverResourceNotFound(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{name: "nil", want: false},
+		{name: "typed resource not found", err: &route53resolvertypes.ResourceNotFoundException{}, want: true},
+		{name: "typed unknown resource", err: &route53resolvertypes.UnknownResourceException{}, want: true},
+		{name: "generic resource not found", err: &smithy.GenericAPIError{Code: "ResourceNotFoundException"}, want: true},
+		{name: "wrapped resource not found", err: errors.Join(errors.New("lookup failed"), &route53resolvertypes.ResourceNotFoundException{}), want: true},
+		{name: "access denied", err: &smithy.GenericAPIError{Code: "AccessDeniedException"}, want: false},
+		{name: "generic", err: errors.New("boom"), want: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := route53ResolverResourceNotFound(tt.err); got != tt.want {
+				t.Fatalf("not found = %t, want %t", got, tt.want)
+			}
+		})
+	}
+}
+
+func assertRoute53ResolverResourceAttributes(t *testing.T, resource terraformutils.Resource, ok bool, resourceType, resourceID string, nameParts []string, attributes map[string]string) {
+	t.Helper()
+	if !ok {
+		t.Fatal("resource was skipped")
+	}
+	if resource.InstanceInfo.Type != resourceType {
+		t.Fatalf("resource type = %q, want %q", resource.InstanceInfo.Type, resourceType)
+	}
+	if resource.InstanceState.ID != resourceID {
+		t.Fatalf("resource ID = %q, want %q", resource.InstanceState.ID, resourceID)
+	}
+	for key, want := range attributes {
+		if got := resource.InstanceState.Attributes[key]; got != want {
+			t.Fatalf("%s = %q, want %q", key, got, want)
+		}
+	}
+	wantName := terraformutils.TfSanitize(route53ResolverResourceName(nameParts...))
+	if resource.ResourceName != wantName {
+		t.Fatalf("resource name = %q, want %q", resource.ResourceName, wantName)
+	}
+}

--- a/providers/aws/route53_test.go
+++ b/providers/aws/route53_test.go
@@ -132,8 +132,19 @@ func TestNewRoute53HostedZoneDNSSECResource(t *testing.T) {
 			"signing_status": "SIGNING",
 		})
 
+	disabledResource, ok := newRoute53HostedZoneDNSSECResource(testRoute53ZoneID, &route53.GetDNSSECOutput{
+		KeySigningKeys: []route53types.KeySigningKey{{Name: aws.String("core-key")}},
+		Status:         &route53types.DNSSECStatus{ServeSignature: aws.String("NOT_SIGNING")},
+	})
+	assertRoute53ResourceAttributes(t, disabledResource, ok, route53HostedZoneDNSSECResourceType, testRoute53ZoneID,
+		[]string{"hosted_zone_dnssec", testRoute53ZoneID},
+		map[string]string{
+			"hosted_zone_id": testRoute53ZoneID,
+			"signing_status": "NOT_SIGNING",
+		})
+
 	if _, ok := newRoute53HostedZoneDNSSECResource(testRoute53ZoneID, &route53.GetDNSSECOutput{Status: &route53types.DNSSECStatus{ServeSignature: aws.String("NOT_SIGNING")}}); ok {
-		t.Fatal("DNSSEC resource should skip non-signing hosted zones")
+		t.Fatal("DNSSEC resource should skip non-signing hosted zones without key-signing keys")
 	}
 	if _, ok := newRoute53HostedZoneDNSSECResource("", &route53.GetDNSSECOutput{Status: &route53types.DNSSECStatus{ServeSignature: aws.String("SIGNING")}}); ok {
 		t.Fatal("DNSSEC resource with empty zone ID should be skipped")

--- a/providers/aws/route53_test.go
+++ b/providers/aws/route53_test.go
@@ -2,7 +2,23 @@
 
 package aws
 
-import "testing"
+import (
+	"errors"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/route53"
+	route53types "github.com/aws/aws-sdk-go-v2/service/route53/types"
+	"github.com/aws/smithy-go"
+	"github.com/chenrui333/terraformer/terraformutils"
+)
+
+const (
+	testRoute53ZoneID      = "Z1234567890"
+	testRoute53QueryLogID  = "qlc-1234567890"
+	testRoute53KMSKeyARN   = "arn:aws:kms:us-east-1:123456789012:key/12345678-1234-1234-1234-123456789012"
+	testRoute53LogGroupARN = "arn:aws:logs:us-east-1:123456789012:log-group:/aws/route53/example"
+)
 
 func TestWildcardUnescape(t *testing.T) {
 	tests := []struct {
@@ -64,5 +80,173 @@ func TestCleanPrefix(t *testing.T) {
 				t.Errorf("cleanPrefix(%q, %q) = %q, want %q", tc.id, tc.prefix, got, tc.want)
 			}
 		})
+	}
+}
+
+func TestRoute53ResourceIDs(t *testing.T) {
+	if got, want := route53KeySigningKeyImportID(testRoute53ZoneID, "core-key"), testRoute53ZoneID+",core-key"; got != want {
+		t.Fatalf("key signing key import ID = %q, want %q", got, want)
+	}
+	if got, want := cleanDelegationSetID("/delegationset/N1234567890"), "N1234567890"; got != want {
+		t.Fatalf("delegation set ID = %q, want %q", got, want)
+	}
+}
+
+func TestNewRoute53QueryLogResource(t *testing.T) {
+	resource, ok := newRoute53QueryLogResource(route53types.QueryLoggingConfig{
+		CloudWatchLogsLogGroupArn: aws.String(testRoute53LogGroupARN),
+		HostedZoneId:              aws.String("/hostedzone/" + testRoute53ZoneID),
+		Id:                        aws.String(testRoute53QueryLogID),
+	})
+	assertRoute53ResourceAttributes(t, resource, ok, route53QueryLogResourceType, testRoute53QueryLogID,
+		[]string{"query_log", testRoute53ZoneID, testRoute53QueryLogID},
+		map[string]string{
+			"cloudwatch_log_group_arn": testRoute53LogGroupARN,
+			"zone_id":                  testRoute53ZoneID,
+		})
+
+	if _, ok := newRoute53QueryLogResource(route53types.QueryLoggingConfig{HostedZoneId: aws.String(testRoute53ZoneID), Id: aws.String(testRoute53QueryLogID)}); ok {
+		t.Fatal("query log with empty CloudWatch log group ARN should be skipped")
+	}
+}
+
+func TestNewRoute53DelegationSetResource(t *testing.T) {
+	resource, ok := newRoute53DelegationSetResource(route53types.DelegationSet{Id: aws.String("/delegationset/N1234567890")})
+	assertRoute53ResourceAttributes(t, resource, ok, route53DelegationSetResourceType, "N1234567890",
+		[]string{"delegation_set", "N1234567890"},
+		map[string]string{})
+
+	if _, ok := newRoute53DelegationSetResource(route53types.DelegationSet{}); ok {
+		t.Fatal("delegation set with empty ID should be skipped")
+	}
+}
+
+func TestNewRoute53HostedZoneDNSSECResource(t *testing.T) {
+	resource, ok := newRoute53HostedZoneDNSSECResource(testRoute53ZoneID, &route53.GetDNSSECOutput{
+		Status: &route53types.DNSSECStatus{ServeSignature: aws.String("SIGNING")},
+	})
+	assertRoute53ResourceAttributes(t, resource, ok, route53HostedZoneDNSSECResourceType, testRoute53ZoneID,
+		[]string{"hosted_zone_dnssec", testRoute53ZoneID},
+		map[string]string{
+			"hosted_zone_id": testRoute53ZoneID,
+			"signing_status": "SIGNING",
+		})
+
+	if _, ok := newRoute53HostedZoneDNSSECResource(testRoute53ZoneID, &route53.GetDNSSECOutput{Status: &route53types.DNSSECStatus{ServeSignature: aws.String("NOT_SIGNING")}}); ok {
+		t.Fatal("DNSSEC resource should skip non-signing hosted zones")
+	}
+	if _, ok := newRoute53HostedZoneDNSSECResource("", &route53.GetDNSSECOutput{Status: &route53types.DNSSECStatus{ServeSignature: aws.String("SIGNING")}}); ok {
+		t.Fatal("DNSSEC resource with empty zone ID should be skipped")
+	}
+}
+
+func TestNewRoute53KeySigningKeyResource(t *testing.T) {
+	resource, ok := newRoute53KeySigningKeyResource(testRoute53ZoneID, route53types.KeySigningKey{
+		KmsArn: aws.String(testRoute53KMSKeyARN),
+		Name:   aws.String("core-key"),
+		Status: aws.String("ACTIVE"),
+	})
+	assertRoute53ResourceAttributes(t, resource, ok, route53KeySigningKeyResourceType, testRoute53ZoneID+",core-key",
+		[]string{"key_signing_key", testRoute53ZoneID, "core-key"},
+		map[string]string{
+			"hosted_zone_id":             testRoute53ZoneID,
+			"key_management_service_arn": testRoute53KMSKeyARN,
+			"name":                       "core-key",
+			"status":                     "ACTIVE",
+		})
+
+	if _, ok := newRoute53KeySigningKeyResource(testRoute53ZoneID, route53types.KeySigningKey{KmsArn: aws.String(testRoute53KMSKeyARN), Name: aws.String("core-key"), Status: aws.String("ACTION_NEEDED")}); ok {
+		t.Fatal("key signing key with unsupported status should be skipped")
+	}
+	if _, ok := newRoute53KeySigningKeyResource(testRoute53ZoneID, route53types.KeySigningKey{Name: aws.String("core-key"), Status: aws.String("ACTIVE")}); ok {
+		t.Fatal("key signing key with empty KMS ARN should be skipped")
+	}
+}
+
+func TestRoute53PostConvertHookReplacesHostedZoneReferences(t *testing.T) {
+	zone := terraformutils.NewResource(
+		testRoute53ZoneID,
+		"example_com",
+		route53ZoneResourceType,
+		"aws",
+		map[string]string{"name": "example.com."},
+		route53AllowEmptyValues,
+		route53AdditionalFields,
+	)
+	queryLog, _ := newRoute53QueryLogResource(route53types.QueryLoggingConfig{
+		CloudWatchLogsLogGroupArn: aws.String(testRoute53LogGroupARN),
+		HostedZoneId:              aws.String(testRoute53ZoneID),
+		Id:                        aws.String(testRoute53QueryLogID),
+	})
+	queryLog.Item = map[string]interface{}{"zone_id": testRoute53ZoneID}
+	dnssec, _ := newRoute53HostedZoneDNSSECResource(testRoute53ZoneID, &route53.GetDNSSECOutput{
+		Status: &route53types.DNSSECStatus{ServeSignature: aws.String("SIGNING")},
+	})
+	dnssec.Item = map[string]interface{}{"hosted_zone_id": testRoute53ZoneID}
+
+	generator := Route53Generator{AWSService: AWSService{Service: terraformutils.Service{Resources: []terraformutils.Resource{zone, queryLog, dnssec}}}}
+	if err := generator.PostConvertHook(); err != nil {
+		t.Fatalf("PostConvertHook() error = %v", err)
+	}
+	want := "${aws_route53_zone." + zone.ResourceName + ".zone_id}"
+	if got := generator.Resources[1].Item["zone_id"]; got != want {
+		t.Fatalf("query log zone_id = %q, want %q", got, want)
+	}
+	if got := generator.Resources[2].Item["hosted_zone_id"]; got != want {
+		t.Fatalf("DNSSEC hosted_zone_id = %q, want %q", got, want)
+	}
+}
+
+func TestRoute53ResourceNameAvoidsSanitizedCollisions(t *testing.T) {
+	left := terraformutils.TfSanitize(route53ResourceName("query_log", "a_b", "c"))
+	right := terraformutils.TfSanitize(route53ResourceName("query_log", "a", "b_c"))
+	if left == right {
+		t.Fatalf("resource names collide: %q", left)
+	}
+}
+
+func TestRoute53ResourceNotFound(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{name: "nil", want: false},
+		{name: "typed DNSSEC not found", err: &route53types.DNSSECNotFound{}, want: true},
+		{name: "typed hosted zone not found", err: &route53types.NoSuchHostedZone{}, want: true},
+		{name: "generic query log not found", err: &smithy.GenericAPIError{Code: "NoSuchQueryLoggingConfig"}, want: true},
+		{name: "wrapped delegation set not found", err: errors.Join(errors.New("lookup failed"), &route53types.NoSuchDelegationSet{}), want: true},
+		{name: "access denied", err: &smithy.GenericAPIError{Code: "AccessDenied"}, want: false},
+		{name: "generic", err: errors.New("boom"), want: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := route53ResourceNotFound(tt.err); got != tt.want {
+				t.Fatalf("not found = %t, want %t", got, tt.want)
+			}
+		})
+	}
+}
+
+func assertRoute53ResourceAttributes(t *testing.T, resource terraformutils.Resource, ok bool, resourceType, resourceID string, nameParts []string, attributes map[string]string) {
+	t.Helper()
+	if !ok {
+		t.Fatal("resource was skipped")
+	}
+	if resource.InstanceInfo.Type != resourceType {
+		t.Fatalf("resource type = %q, want %q", resource.InstanceInfo.Type, resourceType)
+	}
+	if resource.InstanceState.ID != resourceID {
+		t.Fatalf("resource ID = %q, want %q", resource.InstanceState.ID, resourceID)
+	}
+	for key, want := range attributes {
+		if got := resource.InstanceState.Attributes[key]; got != want {
+			t.Fatalf("%s = %q, want %q", key, got, want)
+		}
+	}
+	wantName := terraformutils.TfSanitize(route53ResourceName(nameParts...))
+	if resource.ResourceName != wantName {
+		t.Fatalf("resource name = %q, want %q", resource.ResourceName, wantName)
 	}
 }


### PR DESCRIPTION
## Summary

- add Route 53 import discovery for query logs, reusable delegation sets, hosted zone DNSSEC, and key signing keys
- register route53_resolver and add discovery for resolver rules, endpoints, query logs, and firewall resources
- seed import IDs as provider-compatible hosted zone IDs, query log IDs, delegation set IDs, hosted_zone_id,name key IDs, resolver IDs, and firewall_rule_group_id:rule_identifier firewall rule IDs
- update docs/aws.md for the newly supported Route 53 and Route 53 Resolver resources
- add unit tests for Route 53 and Resolver helper behavior

## References

- #338

## Validation

    go test ./providers/aws -run 'Test.*Route53|Test.*route53|Test.*Resolver|Test.*resolver|Test.*Profiles|Test.*profiles'
    go test ./providers/aws/... ./terraformutils/...
    go run ./tools/aws-gap-inventory \
      -docs docs/aws.md \
      -aws-dir providers/aws \
      -skip-list providers/aws/unsupported_resources.json \
      -format markdown
    git diff --check

## Notes

Skipped/deferred resources:
- aws_route53_record: existing importer left in place; no broad record behavior expansion in this PR
- aws_route53_traffic_policy / aws_route53_traffic_policy_instance: deferred due XML/document and version handling complexity
- aws_route53_vpc_association_authorization: deferred as an authorization/handshake artifact
- aws_route53_zone_association: deferred because standalone private-zone associations can conflict with hosted zone VPC ownership
- aws_route53_cidr_collection / aws_route53_cidr_location: deferred for a focused Route 53 CIDR PR
- aws_route53_resolver_dnssec_config, aws_route53_resolver_config, aws_route53_resolver_outpost_resolver, aws_route53_resolver_delegation_rule: deferred pending focused provider/API verification
- aws_route53profiles_*: deferred for a separate Profiles SDK/provider PR

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds import discovery for more Route 53 resources and introduces Route 53 Resolver imports to expand coverage and improve import compatibility. Registers `route53_resolver`, links hosted zone refs to `aws_route53_zone`, seeds provider-compatible import IDs, and treats “not found” errors as non-fatal.

- **New Features**
  - Route 53: import discovery for query logs, reusable delegation sets, hosted zone DNSSEC, and key signing keys; child resources now reference `aws_route53_zone`.
  - Route 53 Resolver: register `route53_resolver` and add import discovery for rules (+ associations), endpoints, query log configs (+ associations), and DNS Firewall (domain lists, rule groups, rules, associations). Skips shared/managed or non-ready resources.

- **Bug Fixes**
  - Import DNSSEC when configured but disabled (`NOT_SIGNING` with existing key signing keys).
  - Skip AWS-owned/autodefined Resolver rules and their associations.

<sup>Written for commit e8fc4960e193af6091de91b72d64a7f92c00b65e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added AWS Route 53 Resolver support (endpoints, rules, associations, query log configs, firewall domain lists/rule-groups/rules).
  * Expanded Route 53 discovery to include DNSSEC, query logging, delegation sets, and key signing keys.

* **Documentation**
  * Updated supported services list for Route 53 and Route 53 Resolver.

* **Tests**
  * Added comprehensive tests covering new Route 53 and Route 53 Resolver resources and discovery behaviors.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/chenrui333/terraformer/pull/424)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->