### PR TITLE
aws(redshiftserverless): add Redshift Serverless follow-up imports

### DIFF
--- a/docs/aws.md
+++ b/docs/aws.md
@@ -469,7 +469,12 @@ For AWS provider gap audits and unsupported-resource skip-list maintenance, see 
     * `aws_redshift_snapshot_schedule_association`
     * `aws_redshift_subnet_group`
 *   `redshiftserverless`
+    * `aws_redshiftserverless_custom_domain_association`
+    * `aws_redshiftserverless_endpoint_access`
     * `aws_redshiftserverless_namespace`
+    * `aws_redshiftserverless_resource_policy`
+    * `aws_redshiftserverless_snapshot`
+    * `aws_redshiftserverless_usage_limit`
     * `aws_redshiftserverless_workgroup`
 *   `resourcegroups`
     * `aws_resourcegroups_group`

--- a/providers/aws/redshiftserverless.go
+++ b/providers/aws/redshiftserverless.go
@@ -4,17 +4,26 @@ package aws
 
 import (
 	"context"
+	"errors"
+	"fmt"
+	"log"
 	"strconv"
 	"strings"
 
 	"github.com/aws/aws-sdk-go-v2/service/redshiftserverless"
 	redshiftserverlesstypes "github.com/aws/aws-sdk-go-v2/service/redshiftserverless/types"
+	"github.com/aws/smithy-go"
 	"github.com/chenrui333/terraformer/terraformutils"
 )
 
 const (
-	redshiftServerlessNamespaceResourceType = "aws_redshiftserverless_namespace"
-	redshiftServerlessWorkgroupResourceType = "aws_redshiftserverless_workgroup"
+	redshiftServerlessNamespaceResourceType               = "aws_redshiftserverless_namespace"
+	redshiftServerlessWorkgroupResourceType               = "aws_redshiftserverless_workgroup"
+	redshiftServerlessSnapshotResourceType                = "aws_redshiftserverless_snapshot"
+	redshiftServerlessUsageLimitResourceType              = "aws_redshiftserverless_usage_limit"
+	redshiftServerlessEndpointAccessResourceType          = "aws_redshiftserverless_endpoint_access"
+	redshiftServerlessCustomDomainAssociationResourceType = "aws_redshiftserverless_custom_domain_association"
+	redshiftServerlessResourcePolicyResourceType          = "aws_redshiftserverless_resource_policy"
 
 	redshiftServerlessResourceNameFallback = "redshiftserverless-resource"
 )
@@ -30,6 +39,38 @@ type RedshiftServerlessGenerator struct {
 	AWSService
 }
 
+type redshiftServerlessOptionalResourceLoader struct {
+	name string
+	load func() error
+}
+
+func (g *RedshiftServerlessGenerator) loadOptionalResources(loaders []redshiftServerlessOptionalResourceLoader) error {
+	for _, loader := range loaders {
+		if err := loader.load(); err != nil {
+			if redshiftServerlessOptionalResourceErrorSkippable(err) {
+				log.Printf("Skipping Redshift Serverless %s: %v", loader.name, err)
+				continue
+			}
+			log.Printf("Failed Redshift Serverless %s discovery: %v", loader.name, err)
+			return fmt.Errorf("loading Redshift Serverless %s: %w", loader.name, err)
+		}
+	}
+	return nil
+}
+
+func redshiftServerlessOptionalResourceErrorSkippable(err error) bool {
+	var notFound *redshiftserverlesstypes.ResourceNotFoundException
+	if errors.As(err, &notFound) {
+		return true
+	}
+	var accessDenied *redshiftserverlesstypes.AccessDeniedException
+	if errors.As(err, &accessDenied) {
+		return true
+	}
+	var apiErr smithy.APIError
+	return errors.As(err, &apiErr) && strings.Contains(strings.ToLower(apiErr.ErrorCode()), "accessdenied")
+}
+
 func (g *RedshiftServerlessGenerator) InitResources() error {
 	config, err := g.generateConfig()
 	if err != nil {
@@ -43,7 +84,25 @@ func (g *RedshiftServerlessGenerator) InitResources() error {
 	if err := g.loadWorkgroups(svc); err != nil {
 		return err
 	}
+	if err := g.loadOptionalResources([]redshiftServerlessOptionalResourceLoader{
+		{name: "usage limits", load: func() error { return g.loadUsageLimits(svc) }},
+		{name: "endpoint access", load: func() error { return g.loadEndpointAccess(svc) }},
+		{name: "custom domain associations", load: func() error { return g.loadCustomDomainAssociations(svc) }},
+		{name: "snapshots and resource policies", load: func() error { return g.loadSnapshots(svc) }},
+	}); err != nil {
+		return err
+	}
 
+	return nil
+}
+
+func (g *RedshiftServerlessGenerator) PostConvertHook() error {
+	for i := range g.Resources {
+		if g.Resources[i].InstanceInfo == nil || g.Resources[i].InstanceInfo.Type != redshiftServerlessResourcePolicyResourceType {
+			continue
+		}
+		wrapRedshiftServerlessPolicyHeredoc(g, &g.Resources[i])
+	}
 	return nil
 }
 
@@ -75,6 +134,94 @@ func (g *RedshiftServerlessGenerator) loadWorkgroups(svc *redshiftserverless.Cli
 				g.Resources = append(g.Resources, resource)
 			}
 		}
+	}
+	return nil
+}
+
+func (g *RedshiftServerlessGenerator) loadUsageLimits(svc *redshiftserverless.Client) error {
+	p := redshiftserverless.NewListUsageLimitsPaginator(svc, &redshiftserverless.ListUsageLimitsInput{})
+	for p.HasMorePages() {
+		page, err := p.NextPage(context.TODO())
+		if err != nil {
+			return err
+		}
+		for _, usageLimit := range page.UsageLimits {
+			if resource, ok := newRedshiftServerlessUsageLimitResource(usageLimit); ok {
+				g.Resources = append(g.Resources, resource)
+			}
+		}
+	}
+	return nil
+}
+
+func (g *RedshiftServerlessGenerator) loadEndpointAccess(svc *redshiftserverless.Client) error {
+	p := redshiftserverless.NewListEndpointAccessPaginator(svc, &redshiftserverless.ListEndpointAccessInput{})
+	for p.HasMorePages() {
+		page, err := p.NextPage(context.TODO())
+		if err != nil {
+			return err
+		}
+		for _, endpoint := range page.Endpoints {
+			if resource, ok := newRedshiftServerlessEndpointAccessResource(endpoint); ok {
+				g.Resources = append(g.Resources, resource)
+			}
+		}
+	}
+	return nil
+}
+
+func (g *RedshiftServerlessGenerator) loadCustomDomainAssociations(svc *redshiftserverless.Client) error {
+	p := redshiftserverless.NewListCustomDomainAssociationsPaginator(svc, &redshiftserverless.ListCustomDomainAssociationsInput{})
+	for p.HasMorePages() {
+		page, err := p.NextPage(context.TODO())
+		if err != nil {
+			return err
+		}
+		for _, association := range page.Associations {
+			if resource, ok := newRedshiftServerlessCustomDomainAssociationResource(association); ok {
+				g.Resources = append(g.Resources, resource)
+			}
+		}
+	}
+	return nil
+}
+
+func (g *RedshiftServerlessGenerator) loadSnapshots(svc *redshiftserverless.Client) error {
+	p := redshiftserverless.NewListSnapshotsPaginator(svc, &redshiftserverless.ListSnapshotsInput{})
+	for p.HasMorePages() {
+		page, err := p.NextPage(context.TODO())
+		if err != nil {
+			return err
+		}
+		for _, snapshot := range page.Snapshots {
+			if resource, ok := newRedshiftServerlessSnapshotResource(snapshot); ok {
+				g.Resources = append(g.Resources, resource)
+				if err := g.addRedshiftServerlessResourcePolicy(svc, snapshot); err != nil {
+					return err
+				}
+			}
+		}
+	}
+	return nil
+}
+
+func (g *RedshiftServerlessGenerator) addRedshiftServerlessResourcePolicy(svc *redshiftserverless.Client, snapshot redshiftserverlesstypes.Snapshot) error {
+	resourceArn := StringValue(snapshot.SnapshotArn)
+	if resourceArn == "" {
+		return nil
+	}
+	output, err := svc.GetResourcePolicy(context.TODO(), &redshiftserverless.GetResourcePolicyInput{ResourceArn: &resourceArn})
+	if err != nil {
+		if redshiftServerlessOptionalResourceErrorSkippable(err) {
+			return nil
+		}
+		return err
+	}
+	if output == nil || output.ResourcePolicy == nil {
+		return nil
+	}
+	if resource, ok := newRedshiftServerlessResourcePolicyResource(*output.ResourcePolicy); ok {
+		g.Resources = append(g.Resources, resource)
 	}
 	return nil
 }
@@ -117,12 +264,158 @@ func newRedshiftServerlessWorkgroupResource(workgroup redshiftserverlesstypes.Wo
 	), true
 }
 
+func newRedshiftServerlessSnapshotResource(snapshot redshiftserverlesstypes.Snapshot) (terraformutils.Resource, bool) {
+	importID := redshiftServerlessSnapshotImportID(snapshot)
+	if importID == "" || !redshiftServerlessSnapshotImportable(snapshot) {
+		return terraformutils.Resource{}, false
+	}
+	attributes := map[string]string{
+		"namespace_name": StringValue(snapshot.NamespaceName),
+		"snapshot_name":  importID,
+	}
+	if snapshot.SnapshotRetentionPeriod != nil {
+		attributes["retention_period"] = strconv.Itoa(int(*snapshot.SnapshotRetentionPeriod))
+	}
+	return terraformutils.NewResource(
+		importID,
+		redshiftServerlessResourceName("snapshot", StringValue(snapshot.NamespaceName), importID),
+		redshiftServerlessSnapshotResourceType,
+		"aws",
+		attributes,
+		redshiftServerlessAllowEmptyValues,
+		map[string]interface{}{},
+	), true
+}
+
+func newRedshiftServerlessUsageLimitResource(usageLimit redshiftserverlesstypes.UsageLimit) (terraformutils.Resource, bool) {
+	importID := redshiftServerlessUsageLimitImportID(usageLimit)
+	if importID == "" || !redshiftServerlessUsageLimitImportable(usageLimit) {
+		return terraformutils.Resource{}, false
+	}
+	attributes := map[string]string{
+		"amount":       strconv.FormatInt(*usageLimit.Amount, 10),
+		"resource_arn": StringValue(usageLimit.ResourceArn),
+		"usage_type":   string(usageLimit.UsageType),
+	}
+	if usageLimit.BreachAction != "" {
+		attributes["breach_action"] = string(usageLimit.BreachAction)
+	}
+	if usageLimit.Period != "" {
+		attributes["period"] = string(usageLimit.Period)
+	}
+	return terraformutils.NewResource(
+		importID,
+		redshiftServerlessResourceName("usage-limit", StringValue(usageLimit.ResourceArn), importID),
+		redshiftServerlessUsageLimitResourceType,
+		"aws",
+		attributes,
+		redshiftServerlessAllowEmptyValues,
+		map[string]interface{}{},
+	), true
+}
+
+func newRedshiftServerlessEndpointAccessResource(endpoint redshiftserverlesstypes.EndpointAccess) (terraformutils.Resource, bool) {
+	importID := redshiftServerlessEndpointAccessImportID(endpoint)
+	if importID == "" || !redshiftServerlessEndpointAccessImportable(endpoint) {
+		return terraformutils.Resource{}, false
+	}
+	attributes := map[string]string{
+		"endpoint_name":  importID,
+		"workgroup_name": StringValue(endpoint.WorkgroupName),
+	}
+	for key, value := range redshiftServerlessStringSliceAttributes("subnet_ids", endpoint.SubnetIds) {
+		attributes[key] = value
+	}
+	securityGroupIDs := redshiftServerlessEndpointAccessSecurityGroupIDs(endpoint.VpcSecurityGroups)
+	if len(securityGroupIDs) > 0 {
+		for key, value := range redshiftServerlessStringSliceAttributes("vpc_security_group_ids", securityGroupIDs) {
+			attributes[key] = value
+		}
+	}
+	return terraformutils.NewResource(
+		importID,
+		redshiftServerlessResourceName("endpoint-access", StringValue(endpoint.WorkgroupName), importID),
+		redshiftServerlessEndpointAccessResourceType,
+		"aws",
+		attributes,
+		redshiftServerlessAllowEmptyValues,
+		map[string]interface{}{},
+	), true
+}
+
+func newRedshiftServerlessCustomDomainAssociationResource(association redshiftserverlesstypes.Association) (terraformutils.Resource, bool) {
+	importID := redshiftServerlessCustomDomainAssociationImportID(association)
+	if importID == "" || !redshiftServerlessCustomDomainAssociationImportable(association) {
+		return terraformutils.Resource{}, false
+	}
+	attributes := map[string]string{
+		"custom_domain_certificate_arn": StringValue(association.CustomDomainCertificateArn),
+		"custom_domain_name":            StringValue(association.CustomDomainName),
+		"workgroup_name":                StringValue(association.WorkgroupName),
+	}
+	return terraformutils.NewResource(
+		importID,
+		redshiftServerlessResourceName("custom-domain-association", StringValue(association.WorkgroupName), StringValue(association.CustomDomainName)),
+		redshiftServerlessCustomDomainAssociationResourceType,
+		"aws",
+		attributes,
+		redshiftServerlessAllowEmptyValues,
+		map[string]interface{}{},
+	), true
+}
+
+func newRedshiftServerlessResourcePolicyResource(resourcePolicy redshiftserverlesstypes.ResourcePolicy) (terraformutils.Resource, bool) {
+	importID := redshiftServerlessResourcePolicyImportID(resourcePolicy)
+	if importID == "" || !redshiftServerlessResourcePolicyImportable(resourcePolicy) {
+		return terraformutils.Resource{}, false
+	}
+	return terraformutils.NewResource(
+		importID,
+		redshiftServerlessResourceName("resource-policy", importID),
+		redshiftServerlessResourcePolicyResourceType,
+		"aws",
+		map[string]string{
+			"policy":       StringValue(resourcePolicy.Policy),
+			"resource_arn": importID,
+		},
+		redshiftServerlessAllowEmptyValues,
+		map[string]interface{}{},
+	), true
+}
+
 func redshiftServerlessNamespaceImportID(namespace redshiftserverlesstypes.Namespace) string {
 	return StringValue(namespace.NamespaceName)
 }
 
 func redshiftServerlessWorkgroupImportID(workgroup redshiftserverlesstypes.Workgroup) string {
 	return StringValue(workgroup.WorkgroupName)
+}
+
+func redshiftServerlessSnapshotImportID(snapshot redshiftserverlesstypes.Snapshot) string {
+	return StringValue(snapshot.SnapshotName)
+}
+
+func redshiftServerlessUsageLimitImportID(usageLimit redshiftserverlesstypes.UsageLimit) string {
+	return StringValue(usageLimit.UsageLimitId)
+}
+
+func redshiftServerlessEndpointAccessImportID(endpoint redshiftserverlesstypes.EndpointAccess) string {
+	return StringValue(endpoint.EndpointName)
+}
+
+func redshiftServerlessCustomDomainAssociationImportID(association redshiftserverlesstypes.Association) string {
+	return redshiftServerlessCustomDomainAssociationImportIDFromParts(StringValue(association.WorkgroupName), StringValue(association.CustomDomainName))
+}
+
+func redshiftServerlessCustomDomainAssociationImportIDFromParts(workgroupName, customDomainName string) string {
+	if workgroupName == "" || customDomainName == "" {
+		return ""
+	}
+	return workgroupName + "," + customDomainName
+}
+
+func redshiftServerlessResourcePolicyImportID(resourcePolicy redshiftserverlesstypes.ResourcePolicy) string {
+	return StringValue(resourcePolicy.ResourceArn)
 }
 
 func redshiftServerlessResourceName(parts ...string) string {
@@ -149,12 +442,57 @@ func redshiftServerlessWorkgroupImportable(workgroup redshiftserverlesstypes.Wor
 		redshiftServerlessWorkgroupStatusImportable(workgroup.Status)
 }
 
+func redshiftServerlessSnapshotImportable(snapshot redshiftserverlesstypes.Snapshot) bool {
+	return redshiftServerlessSnapshotImportID(snapshot) != "" &&
+		StringValue(snapshot.NamespaceName) != "" &&
+		redshiftServerlessSnapshotStatusImportable(snapshot.Status)
+}
+
+func redshiftServerlessUsageLimitImportable(usageLimit redshiftserverlesstypes.UsageLimit) bool {
+	return redshiftServerlessUsageLimitImportID(usageLimit) != "" &&
+		StringValue(usageLimit.ResourceArn) != "" &&
+		usageLimit.Amount != nil &&
+		*usageLimit.Amount > 0 &&
+		usageLimit.UsageType != ""
+}
+
+func redshiftServerlessEndpointAccessImportable(endpoint redshiftserverlesstypes.EndpointAccess) bool {
+	return redshiftServerlessEndpointAccessImportID(endpoint) != "" &&
+		StringValue(endpoint.WorkgroupName) != "" &&
+		len(endpoint.SubnetIds) > 0 &&
+		redshiftServerlessEndpointAccessStatusImportable(StringValue(endpoint.EndpointStatus))
+}
+
+func redshiftServerlessCustomDomainAssociationImportable(association redshiftserverlesstypes.Association) bool {
+	return redshiftServerlessCustomDomainAssociationImportID(association) != "" &&
+		StringValue(association.CustomDomainCertificateArn) != "" &&
+		association.CustomDomainCertificateExpiryTime != nil
+}
+
+func redshiftServerlessResourcePolicyImportable(resourcePolicy redshiftserverlesstypes.ResourcePolicy) bool {
+	return redshiftServerlessResourcePolicyImportID(resourcePolicy) != "" &&
+		StringValue(resourcePolicy.Policy) != ""
+}
+
 func redshiftServerlessNamespaceStatusImportable(status redshiftserverlesstypes.NamespaceStatus) bool {
 	return status != "" && status != redshiftserverlesstypes.NamespaceStatusDeleting
 }
 
 func redshiftServerlessWorkgroupStatusImportable(status redshiftserverlesstypes.WorkgroupStatus) bool {
 	return status != "" && status != redshiftserverlesstypes.WorkgroupStatusDeleting
+}
+
+func redshiftServerlessSnapshotStatusImportable(status redshiftserverlesstypes.SnapshotStatus) bool {
+	return status == redshiftserverlesstypes.SnapshotStatusAvailable
+}
+
+func redshiftServerlessEndpointAccessStatusImportable(status string) bool {
+	switch strings.ToLower(strings.TrimSpace(status)) {
+	case "", "creating", "deleting", "failed":
+		return false
+	default:
+		return true
+	}
 }
 
 func redshiftServerlessWorkgroupAttributes(workgroup redshiftserverlesstypes.Workgroup) map[string]string {
@@ -194,6 +532,16 @@ func redshiftServerlessWorkgroupAttributes(workgroup redshiftserverlesstypes.Wor
 	return attributes
 }
 
+func redshiftServerlessEndpointAccessSecurityGroupIDs(groups []redshiftserverlesstypes.VpcSecurityGroupMembership) []string {
+	var ids []string
+	for _, group := range groups {
+		if id := StringValue(group.VpcSecurityGroupId); id != "" {
+			ids = append(ids, id)
+		}
+	}
+	return ids
+}
+
 func redshiftServerlessPricePerformanceTargetAttributes(prefix string, target *redshiftserverlesstypes.PerformanceTarget) map[string]string {
 	attributes := map[string]string{
 		prefix + ".#":         "1",
@@ -203,6 +551,17 @@ func redshiftServerlessPricePerformanceTargetAttributes(prefix string, target *r
 		attributes[prefix+".0.level"] = strconv.Itoa(int(*target.Level))
 	}
 	return attributes
+}
+
+func wrapRedshiftServerlessPolicyHeredoc(g *RedshiftServerlessGenerator, resource *terraformutils.Resource) {
+	if resource.Item == nil {
+		return
+	}
+	policy, ok := resource.Item["policy"].(string)
+	if !ok || policy == "" {
+		return
+	}
+	resource.Item["policy"] = fmt.Sprintf("<<POLICY\n%s\nPOLICY", g.escapeAwsInterpolation(policy))
 }
 
 func redshiftServerlessStringSliceAttributes(prefix string, values []string) map[string]string {

--- a/providers/aws/redshiftserverless_test.go
+++ b/providers/aws/redshiftserverless_test.go
@@ -3,9 +3,12 @@
 package aws
 
 import (
+	"errors"
 	"testing"
+	"time"
 
 	redshiftserverlesstypes "github.com/aws/aws-sdk-go-v2/service/redshiftserverless/types"
+	"github.com/aws/smithy-go"
 	"github.com/chenrui333/terraformer/terraformutils"
 )
 
@@ -46,6 +49,37 @@ func TestRedshiftServerlessImportIDs(t *testing.T) {
 	workgroup := redshiftserverlesstypes.Workgroup{WorkgroupName: redshiftServerlessString("reporting")}
 	if got := redshiftServerlessWorkgroupImportID(workgroup); got != "reporting" {
 		t.Fatalf("workgroup import ID = %q, want reporting", got)
+	}
+
+	snapshot := redshiftserverlesstypes.Snapshot{SnapshotName: redshiftServerlessString("daily")}
+	if got := redshiftServerlessSnapshotImportID(snapshot); got != "daily" {
+		t.Fatalf("snapshot import ID = %q, want daily", got)
+	}
+
+	usageLimit := redshiftserverlesstypes.UsageLimit{UsageLimitId: redshiftServerlessString("usage-limit-id")}
+	if got := redshiftServerlessUsageLimitImportID(usageLimit); got != "usage-limit-id" {
+		t.Fatalf("usage limit import ID = %q, want usage-limit-id", got)
+	}
+
+	endpoint := redshiftserverlesstypes.EndpointAccess{EndpointName: redshiftServerlessString("analytics-endpoint")}
+	if got := redshiftServerlessEndpointAccessImportID(endpoint); got != "analytics-endpoint" {
+		t.Fatalf("endpoint access import ID = %q, want analytics-endpoint", got)
+	}
+
+	association := redshiftserverlesstypes.Association{
+		CustomDomainName: redshiftServerlessString("analytics.example.com"),
+		WorkgroupName:    redshiftServerlessString("reporting"),
+	}
+	if got := redshiftServerlessCustomDomainAssociationImportID(association); got != "reporting,analytics.example.com" {
+		t.Fatalf("custom domain association import ID = %q, want reporting,analytics.example.com", got)
+	}
+	if got := redshiftServerlessCustomDomainAssociationImportIDFromParts("", "analytics.example.com"); got != "" {
+		t.Fatalf("custom domain association empty import ID = %q, want empty", got)
+	}
+
+	resourcePolicy := redshiftserverlesstypes.ResourcePolicy{ResourceArn: redshiftServerlessString("arn:aws:redshift-serverless:us-east-1:123456789012:snapshot/analytics/daily")}
+	if got := redshiftServerlessResourcePolicyImportID(resourcePolicy); got != "arn:aws:redshift-serverless:us-east-1:123456789012:snapshot/analytics/daily" {
+		t.Fatalf("resource policy import ID = %q, want snapshot ARN", got)
 	}
 }
 
@@ -173,6 +207,340 @@ func TestNewRedshiftServerlessWorkgroupResourceSkipsUnsafeWorkgroups(t *testing.
 	}
 }
 
+func TestNewRedshiftServerlessSnapshotResource(t *testing.T) {
+	resource, ok := newRedshiftServerlessSnapshotResource(redshiftserverlesstypes.Snapshot{
+		NamespaceName:           redshiftServerlessString("analytics"),
+		SnapshotName:            redshiftServerlessString("daily"),
+		SnapshotRetentionPeriod: redshiftServerlessInt32(7),
+		Status:                  redshiftserverlesstypes.SnapshotStatusAvailable,
+	})
+	assertRedshiftServerlessResource(
+		t,
+		resource,
+		ok,
+		"daily",
+		redshiftServerlessResourceName("snapshot", "analytics", "daily"),
+		redshiftServerlessSnapshotResourceType,
+	)
+	assertRedshiftServerlessAttribute(t, resource, "namespace_name", "analytics")
+	assertRedshiftServerlessAttribute(t, resource, "snapshot_name", "daily")
+	assertRedshiftServerlessAttribute(t, resource, "retention_period", "7")
+
+	if _, ok := newRedshiftServerlessSnapshotResource(redshiftserverlesstypes.Snapshot{
+		NamespaceName: redshiftServerlessString("analytics"),
+		Status:        redshiftserverlesstypes.SnapshotStatusAvailable,
+	}); ok {
+		t.Fatal("snapshot with empty name should be skipped")
+	}
+	if _, ok := newRedshiftServerlessSnapshotResource(redshiftserverlesstypes.Snapshot{
+		SnapshotName: redshiftServerlessString("daily"),
+		Status:       redshiftserverlesstypes.SnapshotStatusAvailable,
+	}); ok {
+		t.Fatal("snapshot with empty namespace should be skipped")
+	}
+	if _, ok := newRedshiftServerlessSnapshotResource(redshiftserverlesstypes.Snapshot{
+		NamespaceName: redshiftServerlessString("analytics"),
+		SnapshotName:  redshiftServerlessString("daily"),
+		Status:        redshiftserverlesstypes.SnapshotStatusCreating,
+	}); ok {
+		t.Fatal("creating snapshot should be skipped")
+	}
+}
+
+func TestNewRedshiftServerlessUsageLimitResource(t *testing.T) {
+	resource, ok := newRedshiftServerlessUsageLimitResource(redshiftserverlesstypes.UsageLimit{
+		Amount:       redshiftServerlessInt64(60),
+		BreachAction: redshiftserverlesstypes.UsageLimitBreachActionEmitMetric,
+		Period:       redshiftserverlesstypes.UsageLimitPeriodDaily,
+		ResourceArn:  redshiftServerlessString("arn:aws:redshift-serverless:us-east-1:123456789012:workgroup/reporting"),
+		UsageLimitId: redshiftServerlessString("limit-123"),
+		UsageType:    redshiftserverlesstypes.UsageLimitUsageTypeServerlessCompute,
+	})
+	assertRedshiftServerlessResource(
+		t,
+		resource,
+		ok,
+		"limit-123",
+		redshiftServerlessResourceName("usage-limit", "arn:aws:redshift-serverless:us-east-1:123456789012:workgroup/reporting", "limit-123"),
+		redshiftServerlessUsageLimitResourceType,
+	)
+	expected := map[string]string{
+		"amount":        "60",
+		"breach_action": "emit-metric",
+		"period":        "daily",
+		"resource_arn":  "arn:aws:redshift-serverless:us-east-1:123456789012:workgroup/reporting",
+		"usage_type":    "serverless-compute",
+	}
+	for key, want := range expected {
+		assertRedshiftServerlessAttribute(t, resource, key, want)
+	}
+
+	validUsageLimit := func() redshiftserverlesstypes.UsageLimit {
+		return redshiftserverlesstypes.UsageLimit{
+			Amount:       redshiftServerlessInt64(60),
+			ResourceArn:  redshiftServerlessString("arn:aws:redshift-serverless:us-east-1:123456789012:workgroup/reporting"),
+			UsageLimitId: redshiftServerlessString("limit-123"),
+			UsageType:    redshiftserverlesstypes.UsageLimitUsageTypeServerlessCompute,
+		}
+	}
+	tests := []struct {
+		name   string
+		mutate func(*redshiftserverlesstypes.UsageLimit)
+	}{
+		{name: "empty usage limit ID", mutate: func(usageLimit *redshiftserverlesstypes.UsageLimit) { usageLimit.UsageLimitId = nil }},
+		{name: "empty resource ARN", mutate: func(usageLimit *redshiftserverlesstypes.UsageLimit) { usageLimit.ResourceArn = nil }},
+		{name: "empty amount", mutate: func(usageLimit *redshiftserverlesstypes.UsageLimit) { usageLimit.Amount = nil }},
+		{name: "zero amount", mutate: func(usageLimit *redshiftserverlesstypes.UsageLimit) { usageLimit.Amount = redshiftServerlessInt64(0) }},
+		{name: "empty usage type", mutate: func(usageLimit *redshiftserverlesstypes.UsageLimit) { usageLimit.UsageType = "" }},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			usageLimit := validUsageLimit()
+			tt.mutate(&usageLimit)
+			if _, ok := newRedshiftServerlessUsageLimitResource(usageLimit); ok {
+				t.Fatal("usage limit should be skipped")
+			}
+		})
+	}
+}
+
+func TestNewRedshiftServerlessEndpointAccessResource(t *testing.T) {
+	resource, ok := newRedshiftServerlessEndpointAccessResource(redshiftserverlesstypes.EndpointAccess{
+		EndpointName:   redshiftServerlessString("analytics-endpoint"),
+		EndpointStatus: redshiftServerlessString("ACTIVE"),
+		SubnetIds:      []string{"subnet-1", "subnet-2"},
+		VpcSecurityGroups: []redshiftserverlesstypes.VpcSecurityGroupMembership{
+			{VpcSecurityGroupId: redshiftServerlessString("sg-1")},
+			{VpcSecurityGroupId: redshiftServerlessString("sg-2")},
+			{},
+		},
+		WorkgroupName: redshiftServerlessString("reporting"),
+	})
+	assertRedshiftServerlessResource(
+		t,
+		resource,
+		ok,
+		"analytics-endpoint",
+		redshiftServerlessResourceName("endpoint-access", "reporting", "analytics-endpoint"),
+		redshiftServerlessEndpointAccessResourceType,
+	)
+	expected := map[string]string{
+		"endpoint_name":            "analytics-endpoint",
+		"subnet_ids.#":             "2",
+		"subnet_ids.1":             "subnet-2",
+		"vpc_security_group_ids.#": "2",
+		"vpc_security_group_ids.1": "sg-2",
+		"workgroup_name":           "reporting",
+	}
+	for key, want := range expected {
+		assertRedshiftServerlessAttribute(t, resource, key, want)
+	}
+
+	validEndpoint := func() redshiftserverlesstypes.EndpointAccess {
+		return redshiftserverlesstypes.EndpointAccess{
+			EndpointName:   redshiftServerlessString("analytics-endpoint"),
+			EndpointStatus: redshiftServerlessString("ACTIVE"),
+			SubnetIds:      []string{"subnet-1"},
+			WorkgroupName:  redshiftServerlessString("reporting"),
+		}
+	}
+	tests := []struct {
+		name   string
+		mutate func(*redshiftserverlesstypes.EndpointAccess)
+	}{
+		{name: "empty endpoint name", mutate: func(endpoint *redshiftserverlesstypes.EndpointAccess) { endpoint.EndpointName = nil }},
+		{name: "empty workgroup name", mutate: func(endpoint *redshiftserverlesstypes.EndpointAccess) { endpoint.WorkgroupName = nil }},
+		{name: "empty subnet IDs", mutate: func(endpoint *redshiftserverlesstypes.EndpointAccess) { endpoint.SubnetIds = nil }},
+		{name: "creating status", mutate: func(endpoint *redshiftserverlesstypes.EndpointAccess) {
+			endpoint.EndpointStatus = redshiftServerlessString("CREATING")
+		}},
+		{name: "deleting status", mutate: func(endpoint *redshiftserverlesstypes.EndpointAccess) {
+			endpoint.EndpointStatus = redshiftServerlessString("DELETING")
+		}},
+		{name: "failed status", mutate: func(endpoint *redshiftserverlesstypes.EndpointAccess) {
+			endpoint.EndpointStatus = redshiftServerlessString("FAILED")
+		}},
+		{name: "empty status", mutate: func(endpoint *redshiftserverlesstypes.EndpointAccess) { endpoint.EndpointStatus = nil }},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			endpoint := validEndpoint()
+			tt.mutate(&endpoint)
+			if _, ok := newRedshiftServerlessEndpointAccessResource(endpoint); ok {
+				t.Fatal("endpoint access should be skipped")
+			}
+		})
+	}
+}
+
+func TestNewRedshiftServerlessCustomDomainAssociationResource(t *testing.T) {
+	expiry := time.Unix(1700000000, 0)
+	resource, ok := newRedshiftServerlessCustomDomainAssociationResource(redshiftserverlesstypes.Association{
+		CustomDomainCertificateArn:        redshiftServerlessString("arn:aws:acm:us-east-1:123456789012:certificate/cert-1"),
+		CustomDomainCertificateExpiryTime: &expiry,
+		CustomDomainName:                  redshiftServerlessString("analytics.example.com"),
+		WorkgroupName:                     redshiftServerlessString("reporting"),
+	})
+	assertRedshiftServerlessResource(
+		t,
+		resource,
+		ok,
+		"reporting,analytics.example.com",
+		redshiftServerlessResourceName("custom-domain-association", "reporting", "analytics.example.com"),
+		redshiftServerlessCustomDomainAssociationResourceType,
+	)
+	assertRedshiftServerlessAttribute(t, resource, "custom_domain_certificate_arn", "arn:aws:acm:us-east-1:123456789012:certificate/cert-1")
+	assertRedshiftServerlessAttribute(t, resource, "custom_domain_name", "analytics.example.com")
+	assertRedshiftServerlessAttribute(t, resource, "workgroup_name", "reporting")
+
+	validAssociation := func() redshiftserverlesstypes.Association {
+		return redshiftserverlesstypes.Association{
+			CustomDomainCertificateArn:        redshiftServerlessString("arn:aws:acm:us-east-1:123456789012:certificate/cert-1"),
+			CustomDomainCertificateExpiryTime: &expiry,
+			CustomDomainName:                  redshiftServerlessString("analytics.example.com"),
+			WorkgroupName:                     redshiftServerlessString("reporting"),
+		}
+	}
+	tests := []struct {
+		name   string
+		mutate func(*redshiftserverlesstypes.Association)
+	}{
+		{name: "empty workgroup", mutate: func(association *redshiftserverlesstypes.Association) { association.WorkgroupName = nil }},
+		{name: "empty custom domain", mutate: func(association *redshiftserverlesstypes.Association) { association.CustomDomainName = nil }},
+		{name: "empty certificate ARN", mutate: func(association *redshiftserverlesstypes.Association) { association.CustomDomainCertificateArn = nil }},
+		{name: "empty certificate expiry", mutate: func(association *redshiftserverlesstypes.Association) {
+			association.CustomDomainCertificateExpiryTime = nil
+		}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			association := validAssociation()
+			tt.mutate(&association)
+			if _, ok := newRedshiftServerlessCustomDomainAssociationResource(association); ok {
+				t.Fatal("custom domain association should be skipped")
+			}
+		})
+	}
+}
+
+func TestNewRedshiftServerlessResourcePolicyResource(t *testing.T) {
+	policy := `{"Version":"2012-10-17","Statement":[]}`
+	resource, ok := newRedshiftServerlessResourcePolicyResource(redshiftserverlesstypes.ResourcePolicy{
+		Policy:      redshiftServerlessString(policy),
+		ResourceArn: redshiftServerlessString("arn:aws:redshift-serverless:us-east-1:123456789012:snapshot/analytics/daily"),
+	})
+	assertRedshiftServerlessResource(
+		t,
+		resource,
+		ok,
+		"arn:aws:redshift-serverless:us-east-1:123456789012:snapshot/analytics/daily",
+		redshiftServerlessResourceName("resource-policy", "arn:aws:redshift-serverless:us-east-1:123456789012:snapshot/analytics/daily"),
+		redshiftServerlessResourcePolicyResourceType,
+	)
+	assertRedshiftServerlessAttribute(t, resource, "policy", policy)
+	assertRedshiftServerlessAttribute(t, resource, "resource_arn", "arn:aws:redshift-serverless:us-east-1:123456789012:snapshot/analytics/daily")
+
+	if _, ok := newRedshiftServerlessResourcePolicyResource(redshiftserverlesstypes.ResourcePolicy{
+		Policy: redshiftServerlessString(policy),
+	}); ok {
+		t.Fatal("resource policy with empty ARN should be skipped")
+	}
+	if _, ok := newRedshiftServerlessResourcePolicyResource(redshiftserverlesstypes.ResourcePolicy{
+		ResourceArn: redshiftServerlessString("arn:aws:redshift-serverless:us-east-1:123456789012:snapshot/analytics/daily"),
+	}); ok {
+		t.Fatal("resource policy with empty policy should be skipped")
+	}
+}
+
+func TestRedshiftServerlessPostConvertHookWrapsResourcePolicy(t *testing.T) {
+	policy := "{\"Resource\":\"" + "$" + "{aws:username}\"}"
+	resource, ok := newRedshiftServerlessResourcePolicyResource(redshiftserverlesstypes.ResourcePolicy{
+		Policy:      redshiftServerlessString(policy),
+		ResourceArn: redshiftServerlessString("arn:aws:redshift-serverless:us-east-1:123456789012:snapshot/analytics/daily"),
+	})
+	if !ok {
+		t.Fatal("resource policy was skipped")
+	}
+	resource.Item = map[string]interface{}{"policy": policy}
+	g := &RedshiftServerlessGenerator{}
+	g.Resources = []terraformutils.Resource{resource}
+	if err := g.PostConvertHook(); err != nil {
+		t.Fatalf("PostConvertHook() error = %v", err)
+	}
+	want := "<<POLICY\n{\"Resource\":\"$" + "$" + "{aws:username}\"}\nPOLICY"
+	if got := g.Resources[0].Item["policy"]; got != want {
+		t.Fatalf("wrapped policy = %q, want %q", got, want)
+	}
+}
+
+func TestRedshiftServerlessOptionalResourceLoaderErrors(t *testing.T) {
+	g := &RedshiftServerlessGenerator{}
+	called := false
+	if err := g.loadOptionalResources([]redshiftServerlessOptionalResourceLoader{
+		{name: "missing", load: func() error { return &redshiftserverlesstypes.ResourceNotFoundException{} }},
+		{name: "next", load: func() error {
+			called = true
+			return nil
+		}},
+	}); err != nil {
+		t.Fatalf("loadOptionalResources() error = %v, want nil", err)
+	}
+	if !called {
+		t.Fatal("loadOptionalResources() should continue after not found")
+	}
+
+	called = false
+	if err := g.loadOptionalResources([]redshiftServerlessOptionalResourceLoader{
+		{name: "denied", load: func() error { return &redshiftserverlesstypes.AccessDeniedException{} }},
+		{name: "next", load: func() error {
+			called = true
+			return nil
+		}},
+	}); err != nil {
+		t.Fatalf("loadOptionalResources() error = %v, want nil", err)
+	}
+	if !called {
+		t.Fatal("loadOptionalResources() should continue after access denied")
+	}
+
+	boom := errors.New("boom")
+	called = false
+	err := g.loadOptionalResources([]redshiftServerlessOptionalResourceLoader{
+		{name: "boom", load: func() error { return boom }},
+		{name: "next", load: func() error {
+			called = true
+			return nil
+		}},
+	})
+	if !errors.Is(err, boom) {
+		t.Fatalf("loadOptionalResources() error = %v, want %v", err, boom)
+	}
+	if called {
+		t.Fatal("loadOptionalResources() should stop after unexpected error")
+	}
+}
+
+func TestRedshiftServerlessOptionalResourceErrorSkippable(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{name: "typed resource not found", err: &redshiftserverlesstypes.ResourceNotFoundException{}, want: true},
+		{name: "typed access denied", err: &redshiftserverlesstypes.AccessDeniedException{}, want: true},
+		{name: "generic access denied", err: &smithy.GenericAPIError{Code: "AccessDeniedException"}, want: true},
+		{name: "unexpected generic error", err: &smithy.GenericAPIError{Code: "ThrottlingException"}, want: false},
+		{name: "nil error", err: nil, want: false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := redshiftServerlessOptionalResourceErrorSkippable(tt.err); got != tt.want {
+				t.Fatalf("redshiftServerlessOptionalResourceErrorSkippable() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
 func TestRedshiftServerlessStatusImportability(t *testing.T) {
 	if !redshiftServerlessNamespaceImportable(redshiftserverlesstypes.Namespace{
 		NamespaceName: redshiftServerlessString("analytics"),
@@ -220,6 +588,44 @@ func TestRedshiftServerlessStatusImportability(t *testing.T) {
 			t.Fatalf("workgroup status %q should not be importable", status)
 		}
 	}
+
+	if !redshiftServerlessSnapshotImportable(redshiftserverlesstypes.Snapshot{
+		NamespaceName: redshiftServerlessString("analytics"),
+		SnapshotName:  redshiftServerlessString("daily"),
+		Status:        redshiftserverlesstypes.SnapshotStatusAvailable,
+	}) {
+		t.Fatal("available snapshot should be importable")
+	}
+	for _, status := range []redshiftserverlesstypes.SnapshotStatus{"", redshiftserverlesstypes.SnapshotStatusCreating, redshiftserverlesstypes.SnapshotStatusCopying, redshiftserverlesstypes.SnapshotStatusDeleted, redshiftserverlesstypes.SnapshotStatusCancelled, redshiftserverlesstypes.SnapshotStatusFailed} {
+		if redshiftServerlessSnapshotImportable(redshiftserverlesstypes.Snapshot{
+			NamespaceName: redshiftServerlessString("analytics"),
+			SnapshotName:  redshiftServerlessString("daily"),
+			Status:        status,
+		}) {
+			t.Fatalf("snapshot status %q should not be importable", status)
+		}
+	}
+
+	for _, status := range []string{"ACTIVE", "MODIFYING"} {
+		if !redshiftServerlessEndpointAccessImportable(redshiftserverlesstypes.EndpointAccess{
+			EndpointName:   redshiftServerlessString("analytics-endpoint"),
+			EndpointStatus: redshiftServerlessString(status),
+			SubnetIds:      []string{"subnet-1"},
+			WorkgroupName:  redshiftServerlessString("reporting"),
+		}) {
+			t.Fatalf("endpoint access status %q should be importable", status)
+		}
+	}
+	for _, status := range []string{"", "CREATING", "DELETING", "FAILED"} {
+		if redshiftServerlessEndpointAccessImportable(redshiftserverlesstypes.EndpointAccess{
+			EndpointName:   redshiftServerlessString("analytics-endpoint"),
+			EndpointStatus: redshiftServerlessString(status),
+			SubnetIds:      []string{"subnet-1"},
+			WorkgroupName:  redshiftServerlessString("reporting"),
+		}) {
+			t.Fatalf("endpoint access status %q should not be importable", status)
+		}
+	}
 }
 
 func assertRedshiftServerlessResource(t *testing.T, resource terraformutils.Resource, ok bool, wantID, wantName, wantType string) {
@@ -260,5 +666,9 @@ func redshiftServerlessString(value string) *string {
 }
 
 func redshiftServerlessInt32(value int32) *int32 {
+	return &value
+}
+
+func redshiftServerlessInt64(value int64) *int64 {
 	return &value
 }


### PR DESCRIPTION
## Summary

- add Redshift Serverless import discovery for usage limits, endpoint access, custom domain associations, snapshots, and snapshot resource policies
- seed import IDs as provider-verified names, IDs, ARNs, or workgroup/domain composites
- keep follow-up loaders optional so AccessDenied/ResourceNotFound does not regress namespace/workgroup imports
- update docs/aws.md for supported Redshift Serverless resources
- add unit tests for Redshift Serverless helper behavior, status guards, optional loader errors, and policy heredoc wrapping

## References

- #338

## Validation

```bash
go test ./providers/aws -run 'Test.*RedshiftServerless|Test.*Redshiftserverless|Test.*redshiftserverless'
go test ./providers/aws/... ./terraformutils/...
go run ./tools/aws-gap-inventory \
  -docs docs/aws.md \
  -aws-dir providers/aws \
  -skip-list providers/aws/unsupported_resources.json \
  -format markdown
git diff --check
```

## Notes

Skipped/deferred resources:
- aws_redshiftserverless_scheduled_action: not present in the current Terraform AWS provider resource docs/source inspected for this PR

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds follow-up import support for Redshift Serverless resources: `aws_redshiftserverless_usage_limit`, `aws_redshiftserverless_endpoint_access`, `aws_redshiftserverless_custom_domain_association`, `aws_redshiftserverless_snapshot`, and `aws_redshiftserverless_resource_policy`. Loaders are optional so AccessDenied/ResourceNotFound won’t block namespace/workgroup imports.

- **New Features**
  - Discovers and seeds import IDs using provider-verified names/IDs/ARNs; custom domains use a workgroup,domain composite.
  - Adds status guards (snapshots only when available; endpoint access not in creating/deleting/failed).
  - Fetches snapshot resource policies and wraps the `policy` field in a heredoc during post-convert to avoid interpolation issues.
  - Updates `docs/aws.md` for supported resources and adds unit tests for helpers, guards, optional loader behavior, and policy wrapping.

<sup>Written for commit 1c16effece66e0f649bc8d6e6bba0c6790e47235. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added support for discovering and importing additional Redshift Serverless resource types: snapshots, usage limits, endpoint access, custom domain associations, and resource policies.
  * Automatic formatting support for resource policy configurations.

* **Documentation**
  * Extended Redshift Serverless documentation to include all newly supported resource types.

* **Tests**
  * Comprehensive test coverage added for new Redshift Serverless functionality, including edge cases and error handling.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/chenrui333/terraformer/pull/425)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->