### PR TITLE
aws(media): add MediaPackage v2 and MediaLive imports

### DIFF
--- a/docs/aws.md
+++ b/docs/aws.md
@@ -397,6 +397,8 @@ For AWS provider gap audits and unsupported-resource skip-list maintenance, see 
     * `aws_cloudwatch_query_definition`
 *   `media_package`
     * `aws_media_package_channel`
+*   `media_packagev2`
+    * `aws_media_packagev2_channel_group`
 *   `media_store`
     * `aws_media_store_container`
     * `aws_media_store_container_policy`
@@ -404,6 +406,8 @@ For AWS provider gap audits and unsupported-resource skip-list maintenance, see 
     * `aws_medialive_channel`
     * `aws_medialive_input`
     * `aws_medialive_input_security_group`
+    * `aws_medialive_multiplex`
+    * `aws_medialive_multiplex_program`
 *   `mq`
     * `aws_mq_broker`
 *   `msk`

--- a/go.mod
+++ b/go.mod
@@ -410,6 +410,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/directconnect v1.38.17
 	github.com/aws/aws-sdk-go-v2/service/ivs v1.50.1
 	github.com/aws/aws-sdk-go-v2/service/ivschat v1.21.22
+	github.com/aws/aws-sdk-go-v2/service/mediapackagev2 v1.37.0
 	github.com/aws/aws-sdk-go-v2/service/mwaa v1.40.0
 	github.com/aws/aws-sdk-go-v2/service/pipes v1.23.22
 	github.com/aws/aws-sdk-go-v2/service/redshiftserverless v1.34.6

--- a/go.sum
+++ b/go.sum
@@ -329,6 +329,8 @@ github.com/aws/aws-sdk-go-v2/service/medialive v1.96.0 h1:2A2YYpr3IDLZ9y2WRg/oXS
 github.com/aws/aws-sdk-go-v2/service/medialive v1.96.0/go.mod h1:YtEXuL0GNGkAeeFSs2wT/KTnaqykXJ52d+4MefPwJKg=
 github.com/aws/aws-sdk-go-v2/service/mediapackage v1.39.23 h1:ztbUtcql2vd65yqnEz/k+bTX8PBP1J4to32/ck5hLAA=
 github.com/aws/aws-sdk-go-v2/service/mediapackage v1.39.23/go.mod h1:3+LhO1Y/ZUTvLmnBsWJyMs4qBBUQJ9dAe8/DqutP+48=
+github.com/aws/aws-sdk-go-v2/service/mediapackagev2 v1.37.0 h1:EhuYHjqXNpkpROCzG1ypSXS2oUhYoQRYl8239qtr45U=
+github.com/aws/aws-sdk-go-v2/service/mediapackagev2 v1.37.0/go.mod h1:lmYE+EShgxxI35+UwVCbE8Z3OsutViSOMNNx3Y3/Y3c=
 github.com/aws/aws-sdk-go-v2/service/mediastore v1.29.23 h1:yxt0mlXvIz6tBqE6tE+8nT4HInWgEjzwnHDI6TxKm7E=
 github.com/aws/aws-sdk-go-v2/service/mediastore v1.29.23/go.mod h1:8nxl+cuTs2USuUurU51GknJf37qAFtSRsrpSomYqqsA=
 github.com/aws/aws-sdk-go-v2/service/mq v1.34.22 h1:l7nzDTuFH15cvRIFo5cFokN5g+9sA/ZYUsiffFBTObk=

--- a/providers/aws/aws_provider.go
+++ b/providers/aws/aws_provider.go
@@ -323,6 +323,7 @@ func (p *AWSProvider) GetSupportedService() map[string]terraformutils.ServiceGen
 		"lambda":            &AwsFacade{service: &LambdaGenerator{}},
 		"logs":              &AwsFacade{service: &LogsGenerator{}},
 		"media_package":     &AwsFacade{service: &MediaPackageGenerator{}},
+		"media_packagev2":   &AwsFacade{service: &MediaPackageV2Generator{}},
 		"media_store":       &AwsFacade{service: &MediaStoreGenerator{}},
 		"medialive":         &AwsFacade{service: &MediaLiveGenerator{}},
 		"mq":                &AwsFacade{service: &MQGenerator{}},

--- a/providers/aws/media_packagev2.go
+++ b/providers/aws/media_packagev2.go
@@ -11,6 +11,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/mediapackagev2"
 	mediapackagev2types "github.com/aws/aws-sdk-go-v2/service/mediapackagev2/types"
 	"github.com/chenrui333/terraformer/terraformutils"
+	"github.com/chenrui333/terraformer/terraformutils/tfcompat"
 )
 
 const mediaPackageV2ChannelGroupResourceType = "aws_media_packagev2_channel_group"
@@ -55,7 +56,7 @@ func newMediaPackageV2ChannelGroupResource(channelGroup mediapackagev2types.Chan
 	if channelGroupName == "" {
 		return terraformutils.Resource{}, false
 	}
-	return terraformutils.NewResource(
+	resource := terraformutils.NewResource(
 		mediaPackageV2ChannelGroupImportID(channelGroupName),
 		mediaPackageV2ResourceName("channel-group", channelGroupName),
 		mediaPackageV2ChannelGroupResourceType,
@@ -65,7 +66,12 @@ func newMediaPackageV2ChannelGroupResource(channelGroup mediapackagev2types.Chan
 		},
 		mediaPackageV2AllowEmptyValues,
 		map[string]interface{}{},
-	), true
+	)
+	if resource.InstanceState.Meta == nil {
+		resource.InstanceState.Meta = map[string]interface{}{}
+	}
+	resource.InstanceState.Meta[tfcompat.MetaKeyPreserveIDAfterRefresh] = true
+	return resource, true
 }
 
 func mediaPackageV2ChannelGroupImportID(channelGroupName string) string {

--- a/providers/aws/media_packagev2.go
+++ b/providers/aws/media_packagev2.go
@@ -1,0 +1,87 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package aws
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/aws/aws-sdk-go-v2/service/mediapackagev2"
+	mediapackagev2types "github.com/aws/aws-sdk-go-v2/service/mediapackagev2/types"
+	"github.com/chenrui333/terraformer/terraformutils"
+)
+
+const mediaPackageV2ChannelGroupResourceType = "aws_media_packagev2_channel_group"
+
+var mediaPackageV2AllowEmptyValues = []string{"tags."}
+
+type MediaPackageV2Generator struct {
+	AWSService
+}
+
+func (g *MediaPackageV2Generator) InitResources() error {
+	config, e := g.generateConfig()
+	if e != nil {
+		return e
+	}
+	svc := mediapackagev2.NewFromConfig(config)
+	return g.GetChannelGroups(svc)
+}
+
+func (g *MediaPackageV2Generator) GetChannelGroups(svc *mediapackagev2.Client) error {
+	p := mediapackagev2.NewListChannelGroupsPaginator(svc, &mediapackagev2.ListChannelGroupsInput{})
+	for p.HasMorePages() {
+		page, err := p.NextPage(context.TODO())
+		if mediaPackageV2ResourceNotFound(err) {
+			continue
+		}
+		if err != nil {
+			return err
+		}
+		for _, channelGroup := range page.Items {
+			if resource, ok := newMediaPackageV2ChannelGroupResource(channelGroup); ok {
+				g.Resources = append(g.Resources, resource)
+			}
+		}
+	}
+
+	return nil
+}
+
+func newMediaPackageV2ChannelGroupResource(channelGroup mediapackagev2types.ChannelGroupListConfiguration) (terraformutils.Resource, bool) {
+	channelGroupName := StringValue(channelGroup.ChannelGroupName)
+	if channelGroupName == "" {
+		return terraformutils.Resource{}, false
+	}
+	return terraformutils.NewSimpleResource(
+		mediaPackageV2ChannelGroupImportID(channelGroupName),
+		mediaPackageV2ResourceName("channel-group", channelGroupName),
+		mediaPackageV2ChannelGroupResourceType,
+		"aws",
+		mediaPackageV2AllowEmptyValues,
+	), true
+}
+
+func mediaPackageV2ChannelGroupImportID(channelGroupName string) string {
+	return channelGroupName
+}
+
+func mediaPackageV2ResourceName(parts ...string) string {
+	cleanParts := []string{}
+	for _, part := range parts {
+		if part != "" {
+			cleanParts = append(cleanParts, fmt.Sprintf("%d/%s", len(part), part))
+		}
+	}
+	if len(cleanParts) == 0 {
+		return "media-packagev2-resource"
+	}
+	return strings.Join(cleanParts, "/")
+}
+
+func mediaPackageV2ResourceNotFound(err error) bool {
+	var notFound *mediapackagev2types.ResourceNotFoundException
+	return errors.As(err, &notFound)
+}

--- a/providers/aws/media_packagev2.go
+++ b/providers/aws/media_packagev2.go
@@ -35,7 +35,7 @@ func (g *MediaPackageV2Generator) GetChannelGroups(svc *mediapackagev2.Client) e
 	for p.HasMorePages() {
 		page, err := p.NextPage(context.TODO())
 		if mediaPackageV2ResourceNotFound(err) {
-			continue
+			return nil
 		}
 		if err != nil {
 			return err

--- a/providers/aws/media_packagev2.go
+++ b/providers/aws/media_packagev2.go
@@ -55,12 +55,16 @@ func newMediaPackageV2ChannelGroupResource(channelGroup mediapackagev2types.Chan
 	if channelGroupName == "" {
 		return terraformutils.Resource{}, false
 	}
-	return terraformutils.NewSimpleResource(
+	return terraformutils.NewResource(
 		mediaPackageV2ChannelGroupImportID(channelGroupName),
 		mediaPackageV2ResourceName("channel-group", channelGroupName),
 		mediaPackageV2ChannelGroupResourceType,
 		"aws",
+		map[string]string{
+			"name": channelGroupName,
+		},
 		mediaPackageV2AllowEmptyValues,
+		map[string]interface{}{},
 	), true
 }
 

--- a/providers/aws/media_packagev2_test.go
+++ b/providers/aws/media_packagev2_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/aws"
 	mediapackagev2types "github.com/aws/aws-sdk-go-v2/service/mediapackagev2/types"
 	"github.com/chenrui333/terraformer/terraformutils"
+	"github.com/chenrui333/terraformer/terraformutils/tfcompat"
 )
 
 func TestNewMediaPackageV2ChannelGroupResource(t *testing.T) {
@@ -17,6 +18,7 @@ func TestNewMediaPackageV2ChannelGroupResource(t *testing.T) {
 	})
 	assertMediaPackageV2Resource(t, resource, ok, "core-group", mediaPackageV2ResourceName("channel-group", "core-group"), mediaPackageV2ChannelGroupResourceType)
 	assertMediaPackageV2Attribute(t, resource, "name", "core-group")
+	assertMediaPackageV2PreservesID(t, resource)
 
 	if _, ok := newMediaPackageV2ChannelGroupResource(mediapackagev2types.ChannelGroupListConfiguration{}); ok {
 		t.Fatal("channel group with empty name should be skipped")
@@ -80,5 +82,13 @@ func assertMediaPackageV2Attribute(t *testing.T, resource terraformutils.Resourc
 	t.Helper()
 	if got := resource.InstanceState.Attributes[key]; got != want {
 		t.Fatalf("resource attribute %q = %q, want %q", key, got, want)
+	}
+}
+
+func assertMediaPackageV2PreservesID(t *testing.T, resource terraformutils.Resource) {
+	t.Helper()
+	preserveID, ok := resource.InstanceState.Meta[tfcompat.MetaKeyPreserveIDAfterRefresh].(bool)
+	if !ok || !preserveID {
+		t.Fatalf("preserve ID metadata = %#v, want true", resource.InstanceState.Meta[tfcompat.MetaKeyPreserveIDAfterRefresh])
 	}
 }

--- a/providers/aws/media_packagev2_test.go
+++ b/providers/aws/media_packagev2_test.go
@@ -16,6 +16,7 @@ func TestNewMediaPackageV2ChannelGroupResource(t *testing.T) {
 		ChannelGroupName: aws.String("core-group"),
 	})
 	assertMediaPackageV2Resource(t, resource, ok, "core-group", mediaPackageV2ResourceName("channel-group", "core-group"), mediaPackageV2ChannelGroupResourceType)
+	assertMediaPackageV2Attribute(t, resource, "name", "core-group")
 
 	if _, ok := newMediaPackageV2ChannelGroupResource(mediapackagev2types.ChannelGroupListConfiguration{}); ok {
 		t.Fatal("channel group with empty name should be skipped")
@@ -72,5 +73,12 @@ func assertMediaPackageV2Resource(t *testing.T, resource terraformutils.Resource
 	}
 	if got := resource.InstanceInfo.Type; got != wantType {
 		t.Fatalf("resource type = %q, want %q", got, wantType)
+	}
+}
+
+func assertMediaPackageV2Attribute(t *testing.T, resource terraformutils.Resource, key, want string) {
+	t.Helper()
+	if got := resource.InstanceState.Attributes[key]; got != want {
+		t.Fatalf("resource attribute %q = %q, want %q", key, got, want)
 	}
 }

--- a/providers/aws/media_packagev2_test.go
+++ b/providers/aws/media_packagev2_test.go
@@ -1,0 +1,76 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package aws
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	mediapackagev2types "github.com/aws/aws-sdk-go-v2/service/mediapackagev2/types"
+	"github.com/chenrui333/terraformer/terraformutils"
+)
+
+func TestNewMediaPackageV2ChannelGroupResource(t *testing.T) {
+	resource, ok := newMediaPackageV2ChannelGroupResource(mediapackagev2types.ChannelGroupListConfiguration{
+		ChannelGroupName: aws.String("core-group"),
+	})
+	assertMediaPackageV2Resource(t, resource, ok, "core-group", mediaPackageV2ResourceName("channel-group", "core-group"), mediaPackageV2ChannelGroupResourceType)
+
+	if _, ok := newMediaPackageV2ChannelGroupResource(mediapackagev2types.ChannelGroupListConfiguration{}); ok {
+		t.Fatal("channel group with empty name should be skipped")
+	}
+}
+
+func TestMediaPackageV2ChannelGroupImportID(t *testing.T) {
+	got := mediaPackageV2ChannelGroupImportID("core-group")
+	want := "core-group"
+	if got != want {
+		t.Fatalf("channel group import ID = %q, want %q", got, want)
+	}
+}
+
+func TestMediaPackageV2ResourceNamesPreserveSegmentBoundaries(t *testing.T) {
+	left := terraformutils.TfSanitize(mediaPackageV2ResourceName("channel-group", "a/b_c"))
+	right := terraformutils.TfSanitize(mediaPackageV2ResourceName("channel", "group/a_b_c"))
+	if left == right {
+		t.Fatalf("MediaPackage v2 resource names collide: %q", left)
+	}
+}
+
+func TestMediaPackageV2ResourceNotFound(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{name: "nil", want: false},
+		{name: "resource not found", err: &mediapackagev2types.ResourceNotFoundException{}, want: true},
+		{name: "wrapped resource not found", err: errors.Join(errors.New("lookup failed"), &mediapackagev2types.ResourceNotFoundException{}), want: true},
+		{name: "generic", err: errors.New("boom"), want: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := mediaPackageV2ResourceNotFound(tt.err); got != tt.want {
+				t.Fatalf("mediaPackageV2ResourceNotFound(%v) = %t, want %t", tt.err, got, tt.want)
+			}
+		})
+	}
+}
+
+func assertMediaPackageV2Resource(t *testing.T, resource terraformutils.Resource, ok bool, wantID, wantName, wantType string) {
+	t.Helper()
+	if !ok {
+		t.Fatal("resource was skipped")
+	}
+	if got := resource.InstanceState.ID; got != wantID {
+		t.Fatalf("resource ID = %q, want %q", got, wantID)
+	}
+	if got := resource.ResourceName; got != terraformutils.TfSanitize(wantName) {
+		t.Fatalf("resource name = %q, want %q", got, terraformutils.TfSanitize(wantName))
+	}
+	if got := resource.InstanceInfo.Type; got != wantType {
+		t.Fatalf("resource type = %q, want %q", got, wantType)
+	}
+}

--- a/providers/aws/medialive.go
+++ b/providers/aws/medialive.go
@@ -48,10 +48,12 @@ func (g *MediaLiveGenerator) InitResources() error {
 		return err
 	}
 
+	// Keep multiplex discovery optional so follow-up coverage does not block existing MediaLive imports.
 	if err := g.GetMultiplexes(svc); err != nil {
-		if !mediaLiveResourceNotFound(err) {
-			log.Printf("skipping optional MediaLive multiplex discovery: %v", err)
+		if mediaLiveResourceNotFound(err) {
+			return nil
 		}
+		log.Printf("skipping optional MediaLive multiplex discovery: %v", err)
 	}
 
 	return nil
@@ -131,9 +133,9 @@ func (g *MediaLiveGenerator) GetMultiplexes(svc *medialive.Client) error {
 			multiplexID := StringValue(multiplex.Id)
 			if resource, ok := newMediaLiveMultiplexResource(multiplex); ok {
 				g.Resources = append(g.Resources, resource)
-			}
-			if err := g.GetMultiplexPrograms(svc, multiplexID); err != nil {
-				return err
+				if err := g.GetMultiplexPrograms(svc, multiplexID); err != nil {
+					return err
+				}
 			}
 		}
 	}

--- a/providers/aws/medialive.go
+++ b/providers/aws/medialive.go
@@ -4,9 +4,22 @@ package aws
 
 import (
 	"context"
+	"errors"
+	"fmt"
+	"log"
+	"strings"
 
 	"github.com/aws/aws-sdk-go-v2/service/medialive"
+	medialivetypes "github.com/aws/aws-sdk-go-v2/service/medialive/types"
 	"github.com/chenrui333/terraformer/terraformutils"
+)
+
+const (
+	mediaLiveChannelResourceType            = "aws_medialive_channel"
+	mediaLiveInputResourceType              = "aws_medialive_input"
+	mediaLiveInputSecurityGroupResourceType = "aws_medialive_input_security_group"
+	mediaLiveMultiplexResourceType          = "aws_medialive_multiplex"
+	mediaLiveMultiplexProgramResourceType   = "aws_medialive_multiplex_program"
 )
 
 var medialiveAllowEmptyValues = []string{"tags."}
@@ -35,6 +48,12 @@ func (g *MediaLiveGenerator) InitResources() error {
 		return err
 	}
 
+	if err := g.GetMultiplexes(svc); err != nil {
+		if !mediaLiveResourceNotFound(err) {
+			log.Printf("skipping optional MediaLive multiplex discovery: %v", err)
+		}
+	}
+
 	return nil
 }
 
@@ -50,7 +69,7 @@ func (g *MediaLiveGenerator) GetChannels(svc *medialive.Client) error {
 			g.Resources = append(g.Resources, terraformutils.NewSimpleResource(
 				channelID,
 				channelID,
-				"aws_medialive_channel",
+				mediaLiveChannelResourceType,
 				"aws",
 				medialiveAllowEmptyValues))
 		}
@@ -71,7 +90,7 @@ func (g *MediaLiveGenerator) GetInputs(svc *medialive.Client) error {
 			g.Resources = append(g.Resources, terraformutils.NewSimpleResource(
 				inputID,
 				inputID,
-				"aws_medialive_input",
+				mediaLiveInputResourceType,
 				"aws",
 				medialiveAllowEmptyValues))
 		}
@@ -92,11 +111,121 @@ func (g *MediaLiveGenerator) GetInputSecurityGroups(svc *medialive.Client) error
 			g.Resources = append(g.Resources, terraformutils.NewSimpleResource(
 				inputSecurityGroupID,
 				inputSecurityGroupID,
-				"aws_medialive_input_security_group",
+				mediaLiveInputSecurityGroupResourceType,
 				"aws",
 				medialiveAllowEmptyValues))
 		}
 	}
 
 	return nil
+}
+
+func (g *MediaLiveGenerator) GetMultiplexes(svc *medialive.Client) error {
+	p := medialive.NewListMultiplexesPaginator(svc, &medialive.ListMultiplexesInput{})
+	for p.HasMorePages() {
+		page, err := p.NextPage(context.TODO())
+		if err != nil {
+			return err
+		}
+		for _, multiplex := range page.Multiplexes {
+			multiplexID := StringValue(multiplex.Id)
+			if resource, ok := newMediaLiveMultiplexResource(multiplex); ok {
+				g.Resources = append(g.Resources, resource)
+			}
+			if err := g.GetMultiplexPrograms(svc, multiplexID); err != nil {
+				return err
+			}
+		}
+	}
+
+	return nil
+}
+
+func (g *MediaLiveGenerator) GetMultiplexPrograms(svc *medialive.Client, multiplexID string) error {
+	if multiplexID == "" {
+		return nil
+	}
+	p := medialive.NewListMultiplexProgramsPaginator(svc, &medialive.ListMultiplexProgramsInput{
+		MultiplexId: &multiplexID,
+	})
+	for p.HasMorePages() {
+		page, err := p.NextPage(context.TODO())
+		if mediaLiveResourceNotFound(err) {
+			return nil
+		}
+		if err != nil {
+			log.Printf("skipping optional MediaLive multiplex program discovery for %s: %v", multiplexID, err)
+			return nil
+		}
+		for _, program := range page.MultiplexPrograms {
+			if resource, ok := newMediaLiveMultiplexProgramResource(multiplexID, program); ok {
+				g.Resources = append(g.Resources, resource)
+			}
+		}
+	}
+
+	return nil
+}
+
+func newMediaLiveMultiplexResource(multiplex medialivetypes.MultiplexSummary) (terraformutils.Resource, bool) {
+	multiplexID := StringValue(multiplex.Id)
+	if multiplexID == "" || !mediaLiveMultiplexStateImportable(multiplex.State) {
+		return terraformutils.Resource{}, false
+	}
+	return terraformutils.NewSimpleResource(
+		mediaLiveMultiplexImportID(multiplexID),
+		mediaLiveResourceName("multiplex", StringValue(multiplex.Name), multiplexID),
+		mediaLiveMultiplexResourceType,
+		"aws",
+		medialiveAllowEmptyValues,
+	), true
+}
+
+func newMediaLiveMultiplexProgramResource(multiplexID string, program medialivetypes.MultiplexProgramSummary) (terraformutils.Resource, bool) {
+	programName := StringValue(program.ProgramName)
+	if multiplexID == "" || programName == "" {
+		return terraformutils.Resource{}, false
+	}
+	return terraformutils.NewResource(
+		mediaLiveMultiplexProgramImportID(programName, multiplexID),
+		mediaLiveResourceName("multiplex-program", multiplexID, programName),
+		mediaLiveMultiplexProgramResourceType,
+		"aws",
+		map[string]string{
+			"multiplex_id": multiplexID,
+			"program_name": programName,
+		},
+		medialiveAllowEmptyValues,
+		map[string]interface{}{},
+	), true
+}
+
+func mediaLiveMultiplexImportID(multiplexID string) string {
+	return multiplexID
+}
+
+func mediaLiveMultiplexProgramImportID(programName, multiplexID string) string {
+	return fmt.Sprintf("%s/%s", programName, multiplexID)
+}
+
+func mediaLiveMultiplexStateImportable(state medialivetypes.MultiplexState) bool {
+	return state != medialivetypes.MultiplexStateDeleting && state != medialivetypes.MultiplexStateDeleted
+}
+
+func mediaLiveResourceName(parts ...string) string {
+	cleanParts := []string{}
+	for _, part := range parts {
+		if part != "" {
+			cleanParts = append(cleanParts, fmt.Sprintf("%d/%s", len(part), part))
+		}
+	}
+	if len(cleanParts) == 0 {
+		return "medialive-resource"
+	}
+	return strings.Join(cleanParts, "/")
+}
+
+func mediaLiveResourceNotFound(err error) bool {
+	var notFound *medialivetypes.NotFoundException
+	return errors.As(err, &notFound)
 }

--- a/providers/aws/medialive_test.go
+++ b/providers/aws/medialive_test.go
@@ -1,0 +1,163 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package aws
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	medialivetypes "github.com/aws/aws-sdk-go-v2/service/medialive/types"
+	"github.com/chenrui333/terraformer/terraformutils"
+)
+
+func TestNewMediaLiveMultiplexResource(t *testing.T) {
+	for _, state := range []medialivetypes.MultiplexState{
+		"",
+		medialivetypes.MultiplexStateCreating,
+		medialivetypes.MultiplexStateCreateFailed,
+		medialivetypes.MultiplexStateIdle,
+		medialivetypes.MultiplexStateStarting,
+		medialivetypes.MultiplexStateRunning,
+		medialivetypes.MultiplexStateRecovering,
+		medialivetypes.MultiplexStateStopping,
+	} {
+		resource, ok := newMediaLiveMultiplexResource(medialivetypes.MultiplexSummary{
+			Id:    aws.String("multiplex-123"),
+			Name:  aws.String("core-multiplex"),
+			State: state,
+		})
+		assertMediaLiveResource(t, resource, ok, "multiplex-123", mediaLiveResourceName("multiplex", "core-multiplex", "multiplex-123"), mediaLiveMultiplexResourceType)
+	}
+
+	if _, ok := newMediaLiveMultiplexResource(medialivetypes.MultiplexSummary{
+		Name:  aws.String("core-multiplex"),
+		State: medialivetypes.MultiplexStateIdle,
+	}); ok {
+		t.Fatal("multiplex with empty ID should be skipped")
+	}
+
+	for _, state := range []medialivetypes.MultiplexState{
+		medialivetypes.MultiplexStateDeleting,
+		medialivetypes.MultiplexStateDeleted,
+	} {
+		if _, ok := newMediaLiveMultiplexResource(medialivetypes.MultiplexSummary{
+			Id:    aws.String("multiplex-123"),
+			Name:  aws.String("core-multiplex"),
+			State: state,
+		}); ok {
+			t.Fatalf("multiplex in %q state should be skipped", state)
+		}
+	}
+}
+
+func TestNewMediaLiveMultiplexProgramResource(t *testing.T) {
+	resource, ok := newMediaLiveMultiplexProgramResource("multiplex-123", medialivetypes.MultiplexProgramSummary{
+		ProgramName: aws.String("core-program"),
+	})
+	assertMediaLiveResource(t, resource, ok, "core-program/multiplex-123", mediaLiveResourceName("multiplex-program", "multiplex-123", "core-program"), mediaLiveMultiplexProgramResourceType)
+	assertMediaLiveAttribute(t, resource, "multiplex_id", "multiplex-123")
+	assertMediaLiveAttribute(t, resource, "program_name", "core-program")
+
+	if _, ok := newMediaLiveMultiplexProgramResource("", medialivetypes.MultiplexProgramSummary{ProgramName: aws.String("core-program")}); ok {
+		t.Fatal("multiplex program with empty multiplex ID should be skipped")
+	}
+	if _, ok := newMediaLiveMultiplexProgramResource("multiplex-123", medialivetypes.MultiplexProgramSummary{}); ok {
+		t.Fatal("multiplex program with empty program name should be skipped")
+	}
+}
+
+func TestMediaLiveMultiplexImportID(t *testing.T) {
+	got := mediaLiveMultiplexImportID("multiplex-123")
+	want := "multiplex-123"
+	if got != want {
+		t.Fatalf("multiplex import ID = %q, want %q", got, want)
+	}
+}
+
+func TestMediaLiveMultiplexProgramImportID(t *testing.T) {
+	got := mediaLiveMultiplexProgramImportID("core-program", "multiplex-123")
+	want := "core-program/multiplex-123"
+	if got != want {
+		t.Fatalf("multiplex program import ID = %q, want %q", got, want)
+	}
+}
+
+func TestMediaLiveMultiplexStateImportable(t *testing.T) {
+	tests := []struct {
+		name  string
+		state medialivetypes.MultiplexState
+		want  bool
+	}{
+		{name: "empty", want: true},
+		{name: "creating", state: medialivetypes.MultiplexStateCreating, want: true},
+		{name: "create failed", state: medialivetypes.MultiplexStateCreateFailed, want: true},
+		{name: "idle", state: medialivetypes.MultiplexStateIdle, want: true},
+		{name: "starting", state: medialivetypes.MultiplexStateStarting, want: true},
+		{name: "running", state: medialivetypes.MultiplexStateRunning, want: true},
+		{name: "recovering", state: medialivetypes.MultiplexStateRecovering, want: true},
+		{name: "stopping", state: medialivetypes.MultiplexStateStopping, want: true},
+		{name: "deleting", state: medialivetypes.MultiplexStateDeleting, want: false},
+		{name: "deleted", state: medialivetypes.MultiplexStateDeleted, want: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := mediaLiveMultiplexStateImportable(tt.state); got != tt.want {
+				t.Fatalf("mediaLiveMultiplexStateImportable(%q) = %t, want %t", tt.state, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestMediaLiveResourceNamesPreserveSegmentBoundaries(t *testing.T) {
+	left := terraformutils.TfSanitize(mediaLiveResourceName("multiplex-program", "a/b_c", "d"))
+	right := terraformutils.TfSanitize(mediaLiveResourceName("multiplex", "program/a", "b_c/d"))
+	if left == right {
+		t.Fatalf("MediaLive resource names collide: %q", left)
+	}
+}
+
+func TestMediaLiveResourceNotFound(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{name: "nil", want: false},
+		{name: "not found", err: &medialivetypes.NotFoundException{}, want: true},
+		{name: "wrapped not found", err: errors.Join(errors.New("lookup failed"), &medialivetypes.NotFoundException{}), want: true},
+		{name: "generic", err: errors.New("boom"), want: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := mediaLiveResourceNotFound(tt.err); got != tt.want {
+				t.Fatalf("mediaLiveResourceNotFound(%v) = %t, want %t", tt.err, got, tt.want)
+			}
+		})
+	}
+}
+
+func assertMediaLiveResource(t *testing.T, resource terraformutils.Resource, ok bool, wantID, wantName, wantType string) {
+	t.Helper()
+	if !ok {
+		t.Fatal("resource was skipped")
+	}
+	if got := resource.InstanceState.ID; got != wantID {
+		t.Fatalf("resource ID = %q, want %q", got, wantID)
+	}
+	if got := resource.ResourceName; got != terraformutils.TfSanitize(wantName) {
+		t.Fatalf("resource name = %q, want %q", got, terraformutils.TfSanitize(wantName))
+	}
+	if got := resource.InstanceInfo.Type; got != wantType {
+		t.Fatalf("resource type = %q, want %q", got, wantType)
+	}
+}
+
+func assertMediaLiveAttribute(t *testing.T, resource terraformutils.Resource, key, want string) {
+	t.Helper()
+	if got := resource.InstanceState.Attributes[key]; got != want {
+		t.Fatalf("resource attribute %q = %q, want %q", key, got, want)
+	}
+}


### PR DESCRIPTION
## Summary

- add MediaPackage v2 channel group import discovery
- add MediaLive multiplex and multiplex program import discovery
- register the `media_packagev2` AWS service and add the MediaPackage v2 SDK dependency
- seed import IDs as channel group name, multiplex ID, and `program_name/multiplex_id`
- update docs/aws.md for supported MediaPackage v2 and MediaLive resources
- add unit tests for MediaPackage v2 and MediaLive helper behavior

## References

- #338

## Validation

```bash
go test ./providers/aws -run 'Test.*Media|Test.*media|Test.*Live|Test.*live|Test.*Package|Test.*package'
go test ./providers/aws/... ./terraformutils/...
go run ./tools/aws-gap-inventory \
  -docs docs/aws.md \
  -aws-dir providers/aws \
  -skip-list providers/aws/unsupported_resources.json \
  -format markdown
git diff --check
```

## Notes

Skipped/deferred resources:
- MediaPackage v2 channel/origin endpoint: not present in the Terraform AWS provider v6.44.0 schema used for this pass.
- MediaLive channel/input/input security group: already supported by the existing MediaLive generator; this PR leaves that support in place.
- MediaConvert queue: deferred for a separate service-family PR.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds import discovery for AWS MediaPackage v2 channel groups and MediaLive multiplexes/programs. Registers `media_packagev2`, updates docs/tests, adds `github.com/aws/aws-sdk-go-v2/service/mediapackagev2`, seeds channel group names, and preserves their IDs after refresh.

- **New Features**
  - MediaPackage v2: discover channel groups; create `aws_media_packagev2_channel_group` (import ID = channel group name).
  - MediaLive: discover multiplexes and programs; create `aws_medialive_multiplex` (import ID = multiplex ID) and `aws_medialive_multiplex_program` (import ID = `program_name/multiplex_id`); skip deleting/deleted multiplexes.

- **Bug Fixes**
  - Make MediaLive multiplex/program discovery optional and non-blocking; handle not-found and other API errors without failing the run.
  - Preserve MediaPackage v2 channel group IDs across refresh for stable imports.

<sup>Written for commit 5bb7f9b1d9191dbf035e3d351e8f756aaede684a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added AWS MediaPackage v2 channel group discovery and resource support
  * Extended AWS MediaLive to discover and import multiplexes and multiplex programs

* **Documentation**
  * Updated supported services list to include AWS MediaPackage v2 and new MediaLive resources

* **Tests**
  * Added tests for MediaPackage v2 and MediaLive multiplex/program discovery, import IDs, naming, and error handling

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/chenrui333/terraformer/pull/426)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->