### PR TITLE
aws(bedrockagent): add authoring resource imports

### DIFF
--- a/docs/aws.md
+++ b/docs/aws.md
@@ -140,10 +140,14 @@ For AWS provider gap audits and unsupported-resource skip-list maintenance, see 
     * `aws_bedrock_provisioned_model_throughput`
 *   `bedrockagent`
     * `aws_bedrockagent_agent`
+    * `aws_bedrockagent_agent_action_group`
     * `aws_bedrockagent_agent_alias`
+    * `aws_bedrockagent_agent_collaborator`
     * `aws_bedrockagent_agent_knowledge_base_association`
     * `aws_bedrockagent_data_source`
+    * `aws_bedrockagent_flow`
     * `aws_bedrockagent_knowledge_base`
+    * `aws_bedrockagent_prompt`
 *   `budgets`
     * `aws_budgets_budget`
 *   `cloud9`

--- a/providers/aws/bedrockagent.go
+++ b/providers/aws/bedrockagent.go
@@ -14,11 +14,15 @@ import (
 )
 
 const (
+	bedrockAgentAgentActionGroupResourceType              = "aws_bedrockagent_agent_action_group"
 	bedrockAgentAgentResourceType                         = "aws_bedrockagent_agent"
 	bedrockAgentAgentAliasResourceType                    = "aws_bedrockagent_agent_alias"
+	bedrockAgentAgentCollaboratorResourceType             = "aws_bedrockagent_agent_collaborator"
 	bedrockAgentAgentKnowledgeBaseAssociationResourceType = "aws_bedrockagent_agent_knowledge_base_association"
 	bedrockAgentDataSourceResourceType                    = "aws_bedrockagent_data_source"
+	bedrockAgentFlowResourceType                          = "aws_bedrockagent_flow"
 	bedrockAgentKnowledgeBaseResourceType                 = "aws_bedrockagent_knowledge_base"
+	bedrockAgentPromptResourceType                        = "aws_bedrockagent_prompt"
 	bedrockAgentDraftVersion                              = "DRAFT"
 	bedrockAgentImportIDSeparator                         = ","
 	bedrockAgentResourceNameFallback                      = "bedrockagent-resource"
@@ -27,11 +31,15 @@ const (
 var (
 	bedrockAgentAllowEmptyValues = []string{"tags."}
 	bedrockAgentResourceTypes    = []string{
+		bedrockAgentServiceName(bedrockAgentAgentActionGroupResourceType),
 		bedrockAgentServiceName(bedrockAgentAgentResourceType),
 		bedrockAgentServiceName(bedrockAgentAgentAliasResourceType),
+		bedrockAgentServiceName(bedrockAgentAgentCollaboratorResourceType),
 		bedrockAgentServiceName(bedrockAgentAgentKnowledgeBaseAssociationResourceType),
 		bedrockAgentServiceName(bedrockAgentDataSourceResourceType),
+		bedrockAgentServiceName(bedrockAgentFlowResourceType),
 		bedrockAgentServiceName(bedrockAgentKnowledgeBaseResourceType),
+		bedrockAgentServiceName(bedrockAgentPromptResourceType),
 	}
 )
 
@@ -71,9 +79,11 @@ func (g *BedrockAgentGenerator) InitResources() error {
 	svc := bedrockagent.NewFromConfig(config)
 
 	loadAgents := g.shouldLoadBedrockAgentResource(bedrockAgentServiceName(bedrockAgentAgentResourceType))
+	loadAgentActionGroups := g.shouldLoadBedrockAgentResource(bedrockAgentServiceName(bedrockAgentAgentActionGroupResourceType))
 	loadAgentAliases := g.shouldLoadBedrockAgentResource(bedrockAgentServiceName(bedrockAgentAgentAliasResourceType))
+	loadAgentCollaborators := g.shouldLoadBedrockAgentResource(bedrockAgentServiceName(bedrockAgentAgentCollaboratorResourceType))
 	loadAgentKnowledgeBaseAssociations := g.shouldLoadBedrockAgentResource(bedrockAgentServiceName(bedrockAgentAgentKnowledgeBaseAssociationResourceType))
-	if loadAgents || loadAgentAliases || loadAgentKnowledgeBaseAssociations {
+	if loadAgents || loadAgentActionGroups || loadAgentAliases || loadAgentCollaborators || loadAgentKnowledgeBaseAssociations {
 		agents, err := listBedrockAgentAgents(svc)
 		if err != nil {
 			return err
@@ -81,8 +91,18 @@ func (g *BedrockAgentGenerator) InitResources() error {
 		if loadAgents {
 			g.loadAgents(agents)
 		}
+		if loadAgentActionGroups {
+			if err := g.loadAgentActionGroups(svc, agents); err != nil {
+				return err
+			}
+		}
 		if loadAgentAliases {
 			if err := g.loadAgentAliases(svc, agents); err != nil {
+				return err
+			}
+		}
+		if loadAgentCollaborators {
+			if err := g.loadAgentCollaborators(svc, agents); err != nil {
 				return err
 			}
 		}
@@ -90,6 +110,26 @@ func (g *BedrockAgentGenerator) InitResources() error {
 			if err := g.loadAgentKnowledgeBaseAssociations(svc, agents); err != nil {
 				return err
 			}
+		}
+	}
+
+	if g.shouldLoadBedrockAgentResource(bedrockAgentServiceName(bedrockAgentFlowResourceType)) {
+		flows, err := listBedrockAgentFlows(svc)
+		if err != nil {
+			return err
+		}
+		if err := g.loadFlows(svc, flows); err != nil {
+			return err
+		}
+	}
+
+	if g.shouldLoadBedrockAgentResource(bedrockAgentServiceName(bedrockAgentPromptResourceType)) {
+		prompts, err := listBedrockAgentPrompts(svc)
+		if err != nil {
+			return err
+		}
+		if err := g.loadPrompts(svc, prompts); err != nil {
+			return err
 		}
 	}
 
@@ -179,12 +219,99 @@ func listBedrockAgentKnowledgeBases(svc *bedrockagent.Client) ([]bedrockagenttyp
 	return knowledgeBases, nil
 }
 
+func listBedrockAgentFlows(svc *bedrockagent.Client) ([]bedrockagenttypes.FlowSummary, error) {
+	p := bedrockagent.NewListFlowsPaginator(svc, &bedrockagent.ListFlowsInput{})
+	flows := []bedrockagenttypes.FlowSummary{}
+	for p.HasMorePages() {
+		page, err := p.NextPage(context.TODO())
+		if err != nil {
+			return nil, err
+		}
+		flows = append(flows, page.FlowSummaries...)
+	}
+	return flows, nil
+}
+
+func listBedrockAgentPrompts(svc *bedrockagent.Client) ([]bedrockagenttypes.PromptSummary, error) {
+	p := bedrockagent.NewListPromptsPaginator(svc, &bedrockagent.ListPromptsInput{})
+	prompts := []bedrockagenttypes.PromptSummary{}
+	for p.HasMorePages() {
+		page, err := p.NextPage(context.TODO())
+		if err != nil {
+			return nil, err
+		}
+		prompts = append(prompts, page.PromptSummaries...)
+	}
+	return prompts, nil
+}
+
 func (g *BedrockAgentGenerator) loadAgents(agents []bedrockagenttypes.AgentSummary) {
 	for _, agent := range agents {
 		if resource, ok := newBedrockAgentAgentResource(agent); ok {
 			g.Resources = append(g.Resources, resource)
 		}
 	}
+}
+
+func (g *BedrockAgentGenerator) loadAgentActionGroups(svc *bedrockagent.Client, agents []bedrockagenttypes.AgentSummary) error {
+	for _, agent := range agents {
+		agentID := StringValue(agent.AgentId)
+		if agentID == "" || !bedrockAgentAgentImportable(agent.AgentStatus) {
+			continue
+		}
+		actionGroups, err := listBedrockAgentActionGroups(svc, agentID, bedrockAgentDraftVersion)
+		if err != nil {
+			if bedrockAgentResourceNotFound(err) {
+				continue
+			}
+			return err
+		}
+		for _, actionGroup := range actionGroups {
+			actionGroupID := StringValue(actionGroup.ActionGroupId)
+			if actionGroupID == "" || !bedrockAgentActionGroupImportable(actionGroup.ActionGroupState) {
+				continue
+			}
+			agentActionGroup, err := getBedrockAgentActionGroup(svc, actionGroupID, agentID, bedrockAgentDraftVersion)
+			if err != nil {
+				if bedrockAgentResourceNotFound(err) {
+					continue
+				}
+				return err
+			}
+			if resource, ok := newBedrockAgentAgentActionGroupResource(agentActionGroup, agent.AgentStatus); ok {
+				g.Resources = append(g.Resources, resource)
+			}
+		}
+	}
+	return nil
+}
+
+func listBedrockAgentActionGroups(svc *bedrockagent.Client, agentID, agentVersion string) ([]bedrockagenttypes.ActionGroupSummary, error) {
+	p := bedrockagent.NewListAgentActionGroupsPaginator(svc, &bedrockagent.ListAgentActionGroupsInput{
+		AgentId:      &agentID,
+		AgentVersion: &agentVersion,
+	})
+	actionGroups := []bedrockagenttypes.ActionGroupSummary{}
+	for p.HasMorePages() {
+		page, err := p.NextPage(context.TODO())
+		if err != nil {
+			return nil, err
+		}
+		actionGroups = append(actionGroups, page.ActionGroupSummaries...)
+	}
+	return actionGroups, nil
+}
+
+func getBedrockAgentActionGroup(svc *bedrockagent.Client, actionGroupID, agentID, agentVersion string) (*bedrockagenttypes.AgentActionGroup, error) {
+	output, err := svc.GetAgentActionGroup(context.TODO(), &bedrockagent.GetAgentActionGroupInput{
+		ActionGroupId: &actionGroupID,
+		AgentId:       &agentID,
+		AgentVersion:  &agentVersion,
+	})
+	if err != nil {
+		return nil, err
+	}
+	return output.AgentActionGroup, nil
 }
 
 func (g *BedrockAgentGenerator) loadAgentAliases(svc *bedrockagent.Client, agents []bedrockagenttypes.AgentSummary) error {
@@ -212,6 +339,67 @@ func (g *BedrockAgentGenerator) loadAgentAliases(svc *bedrockagent.Client, agent
 		}
 	}
 	return nil
+}
+
+func (g *BedrockAgentGenerator) loadAgentCollaborators(svc *bedrockagent.Client, agents []bedrockagenttypes.AgentSummary) error {
+	for _, agent := range agents {
+		agentID := StringValue(agent.AgentId)
+		if agentID == "" || !bedrockAgentAgentImportable(agent.AgentStatus) {
+			continue
+		}
+		collaborators, err := listBedrockAgentCollaborators(svc, agentID, bedrockAgentDraftVersion)
+		if err != nil {
+			if bedrockAgentResourceNotFound(err) {
+				continue
+			}
+			return err
+		}
+		for _, collaborator := range collaborators {
+			collaboratorID := StringValue(collaborator.CollaboratorId)
+			if collaboratorID == "" {
+				continue
+			}
+			agentCollaborator, err := getBedrockAgentCollaborator(svc, agentID, bedrockAgentDraftVersion, collaboratorID)
+			if err != nil {
+				if bedrockAgentResourceNotFound(err) {
+					continue
+				}
+				return err
+			}
+			if resource, ok := newBedrockAgentAgentCollaboratorResource(agentCollaborator, agent.AgentStatus); ok {
+				g.Resources = append(g.Resources, resource)
+			}
+		}
+	}
+	return nil
+}
+
+func listBedrockAgentCollaborators(svc *bedrockagent.Client, agentID, agentVersion string) ([]bedrockagenttypes.AgentCollaboratorSummary, error) {
+	p := bedrockagent.NewListAgentCollaboratorsPaginator(svc, &bedrockagent.ListAgentCollaboratorsInput{
+		AgentId:      &agentID,
+		AgentVersion: &agentVersion,
+	})
+	collaborators := []bedrockagenttypes.AgentCollaboratorSummary{}
+	for p.HasMorePages() {
+		page, err := p.NextPage(context.TODO())
+		if err != nil {
+			return nil, err
+		}
+		collaborators = append(collaborators, page.AgentCollaboratorSummaries...)
+	}
+	return collaborators, nil
+}
+
+func getBedrockAgentCollaborator(svc *bedrockagent.Client, agentID, agentVersion, collaboratorID string) (*bedrockagenttypes.AgentCollaborator, error) {
+	output, err := svc.GetAgentCollaborator(context.TODO(), &bedrockagent.GetAgentCollaboratorInput{
+		AgentId:        &agentID,
+		AgentVersion:   &agentVersion,
+		CollaboratorId: &collaboratorID,
+	})
+	if err != nil {
+		return nil, err
+	}
+	return output.AgentCollaborator, nil
 }
 
 func (g *BedrockAgentGenerator) loadAgentKnowledgeBaseAssociations(svc *bedrockagent.Client, agents []bedrockagenttypes.AgentSummary) error {
@@ -364,6 +552,66 @@ func getBedrockAgentDataSource(svc *bedrockagent.Client, knowledgeBaseID, dataSo
 	return output.DataSource, nil
 }
 
+func (g *BedrockAgentGenerator) loadFlows(svc *bedrockagent.Client, flows []bedrockagenttypes.FlowSummary) error {
+	for _, flow := range flows {
+		flowID := StringValue(flow.Id)
+		if flowID == "" || !bedrockAgentFlowImportable(flow.Status) {
+			continue
+		}
+		flowOutput, err := getBedrockAgentFlow(svc, flowID)
+		if err != nil {
+			if bedrockAgentResourceNotFound(err) {
+				continue
+			}
+			return err
+		}
+		if resource, ok := newBedrockAgentFlowResource(flowOutput); ok {
+			g.Resources = append(g.Resources, resource)
+		}
+	}
+	return nil
+}
+
+func getBedrockAgentFlow(svc *bedrockagent.Client, flowID string) (*bedrockagent.GetFlowOutput, error) {
+	output, err := svc.GetFlow(context.TODO(), &bedrockagent.GetFlowInput{
+		FlowIdentifier: &flowID,
+	})
+	if err != nil {
+		return nil, err
+	}
+	return output, nil
+}
+
+func (g *BedrockAgentGenerator) loadPrompts(svc *bedrockagent.Client, prompts []bedrockagenttypes.PromptSummary) error {
+	for _, prompt := range prompts {
+		promptID := StringValue(prompt.Id)
+		if promptID == "" {
+			continue
+		}
+		promptOutput, err := getBedrockAgentPrompt(svc, promptID)
+		if err != nil {
+			if bedrockAgentResourceNotFound(err) {
+				continue
+			}
+			return err
+		}
+		if resource, ok := newBedrockAgentPromptResource(promptOutput); ok {
+			g.Resources = append(g.Resources, resource)
+		}
+	}
+	return nil
+}
+
+func getBedrockAgentPrompt(svc *bedrockagent.Client, promptID string) (*bedrockagent.GetPromptOutput, error) {
+	output, err := svc.GetPrompt(context.TODO(), &bedrockagent.GetPromptInput{
+		PromptIdentifier: &promptID,
+	})
+	if err != nil {
+		return nil, err
+	}
+	return output, nil
+}
+
 func newBedrockAgentAgentResource(agent bedrockagenttypes.AgentSummary) (terraformutils.Resource, bool) {
 	agentID := StringValue(agent.AgentId)
 	agentName := StringValue(agent.AgentName)
@@ -404,6 +652,84 @@ func newBedrockAgentAgentAliasResource(agentID string, alias bedrockagenttypes.A
 			"agent_alias_name": agentAliasName,
 			"agent_id":         agentID,
 		},
+		bedrockAgentAllowEmptyValues,
+		map[string]interface{}{},
+	), true
+}
+
+func newBedrockAgentAgentActionGroupResource(actionGroup *bedrockagenttypes.AgentActionGroup, agentStatus bedrockagenttypes.AgentStatus) (terraformutils.Resource, bool) {
+	if actionGroup == nil {
+		return terraformutils.Resource{}, false
+	}
+	actionGroupID := StringValue(actionGroup.ActionGroupId)
+	actionGroupName := StringValue(actionGroup.ActionGroupName)
+	agentID := StringValue(actionGroup.AgentId)
+	agentVersion := StringValue(actionGroup.AgentVersion)
+	if actionGroupID == "" ||
+		actionGroupName == "" ||
+		agentID == "" ||
+		agentVersion == "" ||
+		!bedrockAgentActionGroupImportable(actionGroup.ActionGroupState) {
+		return terraformutils.Resource{}, false
+	}
+	attributes := map[string]string{
+		"action_group_id":    actionGroupID,
+		"action_group_name":  actionGroupName,
+		"action_group_state": string(actionGroup.ActionGroupState),
+		"agent_id":           agentID,
+		"agent_version":      agentVersion,
+	}
+	bedrockAgentAddStringAttribute(attributes, "description", actionGroup.Description)
+	if actionGroup.ParentActionSignature != "" {
+		attributes["parent_action_group_signature"] = string(actionGroup.ParentActionSignature)
+	}
+	bedrockAgentAddPrepareAgentAttribute(attributes, agentStatus)
+	return terraformutils.NewResource(
+		bedrockAgentAgentActionGroupImportID(actionGroupID, agentID, agentVersion),
+		bedrockAgentResourceName("agent-action-group", agentID, agentVersion, actionGroupName, actionGroupID),
+		bedrockAgentAgentActionGroupResourceType,
+		"aws",
+		attributes,
+		bedrockAgentAllowEmptyValues,
+		map[string]interface{}{},
+	), true
+}
+
+func newBedrockAgentAgentCollaboratorResource(collaborator *bedrockagenttypes.AgentCollaborator, agentStatus bedrockagenttypes.AgentStatus) (terraformutils.Resource, bool) {
+	if collaborator == nil || collaborator.AgentDescriptor == nil {
+		return terraformutils.Resource{}, false
+	}
+	agentID := StringValue(collaborator.AgentId)
+	agentVersion := StringValue(collaborator.AgentVersion)
+	collaboratorID := StringValue(collaborator.CollaboratorId)
+	collaboratorName := StringValue(collaborator.CollaboratorName)
+	collaborationInstruction := StringValue(collaborator.CollaborationInstruction)
+	aliasARN := StringValue(collaborator.AgentDescriptor.AliasArn)
+	if agentID == "" ||
+		agentVersion == "" ||
+		collaboratorID == "" ||
+		collaboratorName == "" ||
+		collaborationInstruction == "" ||
+		aliasARN == "" ||
+		!bedrockAgentRelayConversationHistoryImportable(collaborator.RelayConversationHistory) {
+		return terraformutils.Resource{}, false
+	}
+	attributes := map[string]string{
+		"agent_descriptor.0.alias_arn": aliasARN,
+		"agent_id":                     agentID,
+		"agent_version":                agentVersion,
+		"collaboration_instruction":    collaborationInstruction,
+		"collaborator_id":              collaboratorID,
+		"collaborator_name":            collaboratorName,
+		"relay_conversation_history":   string(collaborator.RelayConversationHistory),
+	}
+	bedrockAgentAddPrepareAgentAttribute(attributes, agentStatus)
+	return terraformutils.NewResource(
+		bedrockAgentAgentCollaboratorImportID(agentID, agentVersion, collaboratorID),
+		bedrockAgentResourceName("agent-collaborator", agentID, agentVersion, collaboratorName, collaboratorID),
+		bedrockAgentAgentCollaboratorResourceType,
+		"aws",
+		attributes,
 		bedrockAgentAllowEmptyValues,
 		map[string]interface{}{},
 	), true
@@ -472,6 +798,39 @@ func newBedrockAgentKnowledgeBaseResource(knowledgeBase *bedrockagenttypes.Knowl
 	), true
 }
 
+func newBedrockAgentFlowResource(flow *bedrockagent.GetFlowOutput) (terraformutils.Resource, bool) {
+	if flow == nil {
+		return terraformutils.Resource{}, false
+	}
+	flowID := StringValue(flow.Id)
+	flowName := StringValue(flow.Name)
+	executionRoleARN := StringValue(flow.ExecutionRoleArn)
+	if flowID == "" ||
+		flowName == "" ||
+		executionRoleARN == "" ||
+		!bedrockAgentFlowImportable(flow.Status) {
+		return terraformutils.Resource{}, false
+	}
+	attributes := map[string]string{
+		"execution_role_arn": executionRoleARN,
+		"id":                 flowID,
+		"name":               flowName,
+		"status":             string(flow.Status),
+	}
+	bedrockAgentAddStringAttribute(attributes, "customer_encryption_key_arn", flow.CustomerEncryptionKeyArn)
+	bedrockAgentAddStringAttribute(attributes, "description", flow.Description)
+	bedrockAgentAddStringAttribute(attributes, "version", flow.Version)
+	return terraformutils.NewResource(
+		bedrockAgentFlowImportID(flowID),
+		bedrockAgentResourceName("flow", flowName, flowID),
+		bedrockAgentFlowResourceType,
+		"aws",
+		attributes,
+		bedrockAgentAllowEmptyValues,
+		map[string]interface{}{},
+	), true
+}
+
 func newBedrockAgentDataSourceResource(dataSource *bedrockagenttypes.DataSource) (terraformutils.Resource, bool) {
 	if dataSource == nil {
 		return terraformutils.Resource{}, false
@@ -501,8 +860,44 @@ func newBedrockAgentDataSourceResource(dataSource *bedrockagenttypes.DataSource)
 	), true
 }
 
+func newBedrockAgentPromptResource(prompt *bedrockagent.GetPromptOutput) (terraformutils.Resource, bool) {
+	if prompt == nil {
+		return terraformutils.Resource{}, false
+	}
+	promptID := StringValue(prompt.Id)
+	promptName := StringValue(prompt.Name)
+	if promptID == "" || promptName == "" {
+		return terraformutils.Resource{}, false
+	}
+	attributes := map[string]string{
+		"id":   promptID,
+		"name": promptName,
+	}
+	bedrockAgentAddStringAttribute(attributes, "customer_encryption_key_arn", prompt.CustomerEncryptionKeyArn)
+	bedrockAgentAddStringAttribute(attributes, "default_variant", prompt.DefaultVariant)
+	bedrockAgentAddStringAttribute(attributes, "description", prompt.Description)
+	bedrockAgentAddStringAttribute(attributes, "version", prompt.Version)
+	return terraformutils.NewResource(
+		bedrockAgentPromptImportID(promptID),
+		bedrockAgentResourceName("prompt", promptName, promptID),
+		bedrockAgentPromptResourceType,
+		"aws",
+		attributes,
+		bedrockAgentAllowEmptyValues,
+		map[string]interface{}{},
+	), true
+}
+
 func bedrockAgentAgentAliasImportID(agentAliasID, agentID string) string {
 	return agentAliasID + bedrockAgentImportIDSeparator + agentID
+}
+
+func bedrockAgentAgentActionGroupImportID(actionGroupID, agentID, agentVersion string) string {
+	return actionGroupID + bedrockAgentImportIDSeparator + agentID + bedrockAgentImportIDSeparator + agentVersion
+}
+
+func bedrockAgentAgentCollaboratorImportID(agentID, agentVersion, collaboratorID string) string {
+	return agentID + bedrockAgentImportIDSeparator + agentVersion + bedrockAgentImportIDSeparator + collaboratorID
 }
 
 func bedrockAgentAgentKnowledgeBaseAssociationImportID(agentID, agentVersion, knowledgeBaseID string) string {
@@ -511,6 +906,14 @@ func bedrockAgentAgentKnowledgeBaseAssociationImportID(agentID, agentVersion, kn
 
 func bedrockAgentDataSourceImportID(dataSourceID, knowledgeBaseID string) string {
 	return dataSourceID + bedrockAgentImportIDSeparator + knowledgeBaseID
+}
+
+func bedrockAgentFlowImportID(flowID string) string {
+	return flowID
+}
+
+func bedrockAgentPromptImportID(promptID string) string {
+	return promptID
 }
 
 func bedrockAgentResourceName(parts ...string) string {
@@ -534,6 +937,15 @@ func bedrockAgentAgentAliasImportable(status bedrockagenttypes.AgentAliasStatus)
 	return status == bedrockagenttypes.AgentAliasStatusPrepared || status == bedrockagenttypes.AgentAliasStatusDissociated
 }
 
+func bedrockAgentActionGroupImportable(state bedrockagenttypes.ActionGroupState) bool {
+	return state == bedrockagenttypes.ActionGroupStateEnabled || state == bedrockagenttypes.ActionGroupStateDisabled
+}
+
+func bedrockAgentRelayConversationHistoryImportable(history bedrockagenttypes.RelayConversationHistory) bool {
+	return history == bedrockagenttypes.RelayConversationHistoryToCollaborator ||
+		history == bedrockagenttypes.RelayConversationHistoryDisabled
+}
+
 func bedrockAgentAgentKnowledgeBaseAssociationImportable(agentVersion string, state bedrockagenttypes.KnowledgeBaseState) bool {
 	return agentVersion == bedrockAgentDraftVersion &&
 		(state == bedrockagenttypes.KnowledgeBaseStateEnabled || state == bedrockagenttypes.KnowledgeBaseStateDisabled)
@@ -545,6 +957,10 @@ func bedrockAgentKnowledgeBaseImportable(status bedrockagenttypes.KnowledgeBaseS
 
 func bedrockAgentDataSourceImportable(status bedrockagenttypes.DataSourceStatus) bool {
 	return status == bedrockagenttypes.DataSourceStatusAvailable
+}
+
+func bedrockAgentFlowImportable(status bedrockagenttypes.FlowStatus) bool {
+	return status == bedrockagenttypes.FlowStatusPrepared || status == bedrockagenttypes.FlowStatusNotPrepared
 }
 
 func bedrockAgentKnowledgeBaseConfigurationImportable(config *bedrockagenttypes.KnowledgeBaseConfiguration) bool {
@@ -614,6 +1030,18 @@ func bedrockAgentDataSourceConfigurationImportable(config *bedrockagenttypes.Dat
 		return true
 	default:
 		return false
+	}
+}
+
+func bedrockAgentAddStringAttribute(attributes map[string]string, name string, value *string) {
+	if StringValue(value) != "" {
+		attributes[name] = StringValue(value)
+	}
+}
+
+func bedrockAgentAddPrepareAgentAttribute(attributes map[string]string, agentStatus bedrockagenttypes.AgentStatus) {
+	if agentStatus == bedrockagenttypes.AgentStatusNotPrepared {
+		attributes["prepare_agent"] = "false"
 	}
 }
 

--- a/providers/aws/bedrockagent.go
+++ b/providers/aws/bedrockagent.go
@@ -721,7 +721,9 @@ func newBedrockAgentAgentCollaboratorResource(collaborator *bedrockagenttypes.Ag
 		"collaboration_instruction":    collaborationInstruction,
 		"collaborator_id":              collaboratorID,
 		"collaborator_name":            collaboratorName,
-		"relay_conversation_history":   string(collaborator.RelayConversationHistory),
+	}
+	if collaborator.RelayConversationHistory != "" {
+		attributes["relay_conversation_history"] = string(collaborator.RelayConversationHistory)
 	}
 	bedrockAgentAddPrepareAgentAttribute(attributes, agentStatus)
 	return terraformutils.NewResource(
@@ -942,7 +944,8 @@ func bedrockAgentActionGroupImportable(state bedrockagenttypes.ActionGroupState)
 }
 
 func bedrockAgentRelayConversationHistoryImportable(history bedrockagenttypes.RelayConversationHistory) bool {
-	return history == bedrockagenttypes.RelayConversationHistoryToCollaborator ||
+	return history == "" ||
+		history == bedrockagenttypes.RelayConversationHistoryToCollaborator ||
 		history == bedrockagenttypes.RelayConversationHistoryDisabled
 }
 

--- a/providers/aws/bedrockagent_test.go
+++ b/providers/aws/bedrockagent_test.go
@@ -7,15 +7,32 @@ import (
 	"testing"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/bedrockagent"
 	bedrockagenttypes "github.com/aws/aws-sdk-go-v2/service/bedrockagent/types"
 	"github.com/chenrui333/terraformer/terraformutils"
 )
+
+func TestBedrockAgentAgentActionGroupImportID(t *testing.T) {
+	got := bedrockAgentAgentActionGroupImportID("ACTGP12345", "GGRRAED6JP", bedrockAgentDraftVersion)
+	want := "ACTGP12345,GGRRAED6JP,DRAFT"
+	if got != want {
+		t.Fatalf("bedrockAgentAgentActionGroupImportID() = %q, want %q", got, want)
+	}
+}
 
 func TestBedrockAgentAgentAliasImportID(t *testing.T) {
 	got := bedrockAgentAgentAliasImportID("66IVY0GUTF", "GGRRAED6JP")
 	want := "66IVY0GUTF,GGRRAED6JP"
 	if got != want {
 		t.Fatalf("bedrockAgentAgentAliasImportID() = %q, want %q", got, want)
+	}
+}
+
+func TestBedrockAgentAgentCollaboratorImportID(t *testing.T) {
+	got := bedrockAgentAgentCollaboratorImportID("GGRRAED6JP", bedrockAgentDraftVersion, "COLLAB1234")
+	want := "GGRRAED6JP,DRAFT,COLLAB1234"
+	if got != want {
+		t.Fatalf("bedrockAgentAgentCollaboratorImportID() = %q, want %q", got, want)
 	}
 }
 
@@ -32,6 +49,22 @@ func TestBedrockAgentDataSourceImportID(t *testing.T) {
 	want := "GWCMFMQF6T,EMDPPAYPZI"
 	if got != want {
 		t.Fatalf("bedrockAgentDataSourceImportID() = %q, want %q", got, want)
+	}
+}
+
+func TestBedrockAgentFlowImportID(t *testing.T) {
+	got := bedrockAgentFlowImportID("FLOW123456")
+	want := "FLOW123456"
+	if got != want {
+		t.Fatalf("bedrockAgentFlowImportID() = %q, want %q", got, want)
+	}
+}
+
+func TestBedrockAgentPromptImportID(t *testing.T) {
+	got := bedrockAgentPromptImportID("PROMPT1234")
+	want := "PROMPT1234"
+	if got != want {
+		t.Fatalf("bedrockAgentPromptImportID() = %q, want %q", got, want)
 	}
 }
 
@@ -52,6 +85,16 @@ func TestBedrockAgentResourceNameUniqueness(t *testing.T) {
 	if aliasFirst == aliasSecond {
 		t.Fatalf("agent alias resource names should include parent agent identity: %q", aliasFirst)
 	}
+	actionGroupFirst := terraformutils.TfSanitize(bedrockAgentResourceName("agent-action-group", "agent-a", bedrockAgentDraftVersion, "lookup", "action-1"))
+	actionGroupSecond := terraformutils.TfSanitize(bedrockAgentResourceName("agent-action-group", "agent-b", bedrockAgentDraftVersion, "lookup", "action-1"))
+	if actionGroupFirst == actionGroupSecond {
+		t.Fatalf("action group resource names should include parent agent identity: %q", actionGroupFirst)
+	}
+	collaboratorFirst := terraformutils.TfSanitize(bedrockAgentResourceName("agent-collaborator", "agent-a", bedrockAgentDraftVersion, "helper", "collab-1"))
+	collaboratorSecond := terraformutils.TfSanitize(bedrockAgentResourceName("agent-collaborator", "agent-b", bedrockAgentDraftVersion, "helper", "collab-1"))
+	if collaboratorFirst == collaboratorSecond {
+		t.Fatalf("collaborator resource names should include parent agent identity: %q", collaboratorFirst)
+	}
 	dataSourceFirst := terraformutils.TfSanitize(bedrockAgentResourceName("data-source", "kb-a", "docs", "source-1"))
 	dataSourceSecond := terraformutils.TfSanitize(bedrockAgentResourceName("data-source", "kb-b", "docs", "source-1"))
 	if dataSourceFirst == dataSourceSecond {
@@ -61,6 +104,16 @@ func TestBedrockAgentResourceNameUniqueness(t *testing.T) {
 	associationSecond := terraformutils.TfSanitize(bedrockAgentResourceName("agent-knowledge-base-association", "agent-b", bedrockAgentDraftVersion, "kb-1"))
 	if associationFirst == associationSecond {
 		t.Fatalf("association resource names should include parent agent identity: %q", associationFirst)
+	}
+	flowFirst := terraformutils.TfSanitize(bedrockAgentResourceName("flow", "support", "flow-a"))
+	flowSecond := terraformutils.TfSanitize(bedrockAgentResourceName("flow", "support", "flow-b"))
+	if flowFirst == flowSecond {
+		t.Fatalf("flow resource names should include flow identity: %q", flowFirst)
+	}
+	promptFirst := terraformutils.TfSanitize(bedrockAgentResourceName("prompt", "support", "prompt-a"))
+	promptSecond := terraformutils.TfSanitize(bedrockAgentResourceName("prompt", "support", "prompt-b"))
+	if promptFirst == promptSecond {
+		t.Fatalf("prompt resource names should include prompt identity: %q", promptFirst)
 	}
 }
 
@@ -236,6 +289,133 @@ func TestNewBedrockAgentAgentAliasResource(t *testing.T) {
 	}
 }
 
+func TestNewBedrockAgentAgentActionGroupResource(t *testing.T) {
+	resource, ok := newBedrockAgentAgentActionGroupResource(bedrockAgentTestAgentActionGroup(), bedrockagenttypes.AgentStatusPrepared)
+	assertBedrockAgentResource(t, resource, ok, "ACTGP12345,GGRRAED6JP,DRAFT", bedrockAgentAgentActionGroupResourceType)
+	if got := resource.InstanceState.Attributes["action_group_id"]; got != "ACTGP12345" {
+		t.Fatalf("action_group_id attribute = %q, want ACTGP12345", got)
+	}
+	if got := resource.InstanceState.Attributes["action_group_name"]; got != "lookup-order" {
+		t.Fatalf("action_group_name attribute = %q, want lookup-order", got)
+	}
+	if got := resource.InstanceState.Attributes["action_group_state"]; got != "ENABLED" {
+		t.Fatalf("action_group_state attribute = %q, want ENABLED", got)
+	}
+	if got := resource.InstanceState.Attributes["agent_id"]; got != "GGRRAED6JP" {
+		t.Fatalf("agent_id attribute = %q, want GGRRAED6JP", got)
+	}
+	if got := resource.InstanceState.Attributes["agent_version"]; got != bedrockAgentDraftVersion {
+		t.Fatalf("agent_version attribute = %q, want %s", got, bedrockAgentDraftVersion)
+	}
+	if got := resource.InstanceState.Attributes["description"]; got != "order lookup" {
+		t.Fatalf("description attribute = %q, want order lookup", got)
+	}
+	if _, ok := resource.InstanceState.Attributes["prepare_agent"]; ok {
+		t.Fatal("prepared parent agent should not force prepare_agent")
+	}
+
+	unprepared, ok := newBedrockAgentAgentActionGroupResource(bedrockAgentTestAgentActionGroup(), bedrockagenttypes.AgentStatusNotPrepared)
+	assertBedrockAgentResource(t, unprepared, ok, "ACTGP12345,GGRRAED6JP,DRAFT", bedrockAgentAgentActionGroupResourceType)
+	if got := unprepared.InstanceState.Attributes["prepare_agent"]; got != "false" {
+		t.Fatalf("prepare_agent attribute = %q, want false", got)
+	}
+
+	parentSignature := bedrockAgentTestAgentActionGroup()
+	parentSignature.Description = nil
+	parentSignature.ParentActionSignature = bedrockagenttypes.ActionGroupSignatureAmazonUserinput
+	resource, ok = newBedrockAgentAgentActionGroupResource(parentSignature, bedrockagenttypes.AgentStatusPrepared)
+	assertBedrockAgentResource(t, resource, ok, "ACTGP12345,GGRRAED6JP,DRAFT", bedrockAgentAgentActionGroupResourceType)
+	if got := resource.InstanceState.Attributes["parent_action_group_signature"]; got != "AMAZON.UserInput" {
+		t.Fatalf("parent_action_group_signature attribute = %q, want AMAZON.UserInput", got)
+	}
+
+	if _, ok := newBedrockAgentAgentActionGroupResource(nil, bedrockagenttypes.AgentStatusPrepared); ok {
+		t.Fatal("nil action group should be skipped")
+	}
+	for name, mutate := range map[string]func(*bedrockagenttypes.AgentActionGroup){
+		"action group ID":   func(actionGroup *bedrockagenttypes.AgentActionGroup) { actionGroup.ActionGroupId = nil },
+		"action group name": func(actionGroup *bedrockagenttypes.AgentActionGroup) { actionGroup.ActionGroupName = nil },
+		"agent ID":          func(actionGroup *bedrockagenttypes.AgentActionGroup) { actionGroup.AgentId = nil },
+		"agent version":     func(actionGroup *bedrockagenttypes.AgentActionGroup) { actionGroup.AgentVersion = nil },
+	} {
+		t.Run("missing "+name, func(t *testing.T) {
+			actionGroup := bedrockAgentTestAgentActionGroup()
+			mutate(actionGroup)
+			if _, ok := newBedrockAgentAgentActionGroupResource(actionGroup, bedrockagenttypes.AgentStatusPrepared); ok {
+				t.Fatalf("action group without %s should be skipped", name)
+			}
+		})
+	}
+
+	unknownState := bedrockAgentTestAgentActionGroup()
+	unknownState.ActionGroupState = ""
+	if _, ok := newBedrockAgentAgentActionGroupResource(unknownState, bedrockagenttypes.AgentStatusPrepared); ok {
+		t.Fatal("action group with empty state should be skipped")
+	}
+}
+
+func TestNewBedrockAgentAgentCollaboratorResource(t *testing.T) {
+	resource, ok := newBedrockAgentAgentCollaboratorResource(bedrockAgentTestAgentCollaborator(), bedrockagenttypes.AgentStatusPrepared)
+	assertBedrockAgentResource(t, resource, ok, "GGRRAED6JP,DRAFT,COLLAB1234", bedrockAgentAgentCollaboratorResourceType)
+	if got := resource.InstanceState.Attributes["agent_descriptor.0.alias_arn"]; got != "arn:aws:bedrock:us-east-1:123456789012:agent-alias/OTHERAGENT/ALIAS12345" {
+		t.Fatalf("agent_descriptor.0.alias_arn attribute = %q, want collaborator alias ARN", got)
+	}
+	if got := resource.InstanceState.Attributes["agent_id"]; got != "GGRRAED6JP" {
+		t.Fatalf("agent_id attribute = %q, want GGRRAED6JP", got)
+	}
+	if got := resource.InstanceState.Attributes["agent_version"]; got != bedrockAgentDraftVersion {
+		t.Fatalf("agent_version attribute = %q, want %s", got, bedrockAgentDraftVersion)
+	}
+	if got := resource.InstanceState.Attributes["collaboration_instruction"]; got != "escalate billing questions" {
+		t.Fatalf("collaboration_instruction attribute = %q, want escalate billing questions", got)
+	}
+	if got := resource.InstanceState.Attributes["collaborator_id"]; got != "COLLAB1234" {
+		t.Fatalf("collaborator_id attribute = %q, want COLLAB1234", got)
+	}
+	if got := resource.InstanceState.Attributes["collaborator_name"]; got != "billing-helper" {
+		t.Fatalf("collaborator_name attribute = %q, want billing-helper", got)
+	}
+	if got := resource.InstanceState.Attributes["relay_conversation_history"]; got != "TO_COLLABORATOR" {
+		t.Fatalf("relay_conversation_history attribute = %q, want TO_COLLABORATOR", got)
+	}
+	if _, ok := resource.InstanceState.Attributes["prepare_agent"]; ok {
+		t.Fatal("prepared parent agent should not force prepare_agent")
+	}
+
+	unprepared, ok := newBedrockAgentAgentCollaboratorResource(bedrockAgentTestAgentCollaborator(), bedrockagenttypes.AgentStatusNotPrepared)
+	assertBedrockAgentResource(t, unprepared, ok, "GGRRAED6JP,DRAFT,COLLAB1234", bedrockAgentAgentCollaboratorResourceType)
+	if got := unprepared.InstanceState.Attributes["prepare_agent"]; got != "false" {
+		t.Fatalf("prepare_agent attribute = %q, want false", got)
+	}
+
+	if _, ok := newBedrockAgentAgentCollaboratorResource(nil, bedrockagenttypes.AgentStatusPrepared); ok {
+		t.Fatal("nil collaborator should be skipped")
+	}
+	for name, mutate := range map[string]func(*bedrockagenttypes.AgentCollaborator){
+		"agent descriptor":           func(collaborator *bedrockagenttypes.AgentCollaborator) { collaborator.AgentDescriptor = nil },
+		"agent descriptor alias ARN": func(collaborator *bedrockagenttypes.AgentCollaborator) { collaborator.AgentDescriptor.AliasArn = nil },
+		"agent ID":                   func(collaborator *bedrockagenttypes.AgentCollaborator) { collaborator.AgentId = nil },
+		"agent version":              func(collaborator *bedrockagenttypes.AgentCollaborator) { collaborator.AgentVersion = nil },
+		"collaborator ID":            func(collaborator *bedrockagenttypes.AgentCollaborator) { collaborator.CollaboratorId = nil },
+		"collaborator name":          func(collaborator *bedrockagenttypes.AgentCollaborator) { collaborator.CollaboratorName = nil },
+		"instruction":                func(collaborator *bedrockagenttypes.AgentCollaborator) { collaborator.CollaborationInstruction = nil },
+	} {
+		t.Run("missing "+name, func(t *testing.T) {
+			collaborator := bedrockAgentTestAgentCollaborator()
+			mutate(collaborator)
+			if _, ok := newBedrockAgentAgentCollaboratorResource(collaborator, bedrockagenttypes.AgentStatusPrepared); ok {
+				t.Fatalf("collaborator without %s should be skipped", name)
+			}
+		})
+	}
+
+	unknownHistory := bedrockAgentTestAgentCollaborator()
+	unknownHistory.RelayConversationHistory = ""
+	if _, ok := newBedrockAgentAgentCollaboratorResource(unknownHistory, bedrockagenttypes.AgentStatusPrepared); ok {
+		t.Fatal("collaborator with empty relay conversation history should be skipped")
+	}
+}
+
 func TestNewBedrockAgentAgentKnowledgeBaseAssociationResource(t *testing.T) {
 	resource, ok := newBedrockAgentAgentKnowledgeBaseAssociationResource(bedrockAgentTestAgentKnowledgeBaseAssociation())
 	assertBedrockAgentResource(t, resource, ok, "GGRRAED6JP,DRAFT,EMDPPAYPZI", bedrockAgentAgentKnowledgeBaseAssociationResourceType)
@@ -384,6 +564,101 @@ func TestNewBedrockAgentDataSourceResource(t *testing.T) {
 	}
 }
 
+func TestNewBedrockAgentFlowResource(t *testing.T) {
+	resource, ok := newBedrockAgentFlowResource(bedrockAgentTestFlow())
+	assertBedrockAgentResource(t, resource, ok, "FLOW123456", bedrockAgentFlowResourceType)
+	if got := resource.InstanceState.Attributes["id"]; got != "FLOW123456" {
+		t.Fatalf("id attribute = %q, want FLOW123456", got)
+	}
+	if got := resource.InstanceState.Attributes["name"]; got != "support-flow" {
+		t.Fatalf("name attribute = %q, want support-flow", got)
+	}
+	if got := resource.InstanceState.Attributes["execution_role_arn"]; got != "arn:aws:iam::123456789012:role/bedrock-flow" {
+		t.Fatalf("execution_role_arn attribute = %q, want arn:aws:iam::123456789012:role/bedrock-flow", got)
+	}
+	if got := resource.InstanceState.Attributes["status"]; got != "Prepared" {
+		t.Fatalf("status attribute = %q, want Prepared", got)
+	}
+	if got := resource.InstanceState.Attributes["description"]; got != "support workflow" {
+		t.Fatalf("description attribute = %q, want support workflow", got)
+	}
+	if got := resource.InstanceState.Attributes["version"]; got != "DRAFT" {
+		t.Fatalf("version attribute = %q, want DRAFT", got)
+	}
+
+	notPrepared := bedrockAgentTestFlow()
+	notPrepared.Status = bedrockagenttypes.FlowStatusNotPrepared
+	resource, ok = newBedrockAgentFlowResource(notPrepared)
+	assertBedrockAgentResource(t, resource, ok, "FLOW123456", bedrockAgentFlowResourceType)
+	if got := resource.InstanceState.Attributes["status"]; got != "NotPrepared" {
+		t.Fatalf("status attribute = %q, want NotPrepared", got)
+	}
+
+	if _, ok := newBedrockAgentFlowResource(nil); ok {
+		t.Fatal("nil flow should be skipped")
+	}
+	for name, mutate := range map[string]func(*bedrockagent.GetFlowOutput){
+		"ID":                 func(flow *bedrockagent.GetFlowOutput) { flow.Id = nil },
+		"name":               func(flow *bedrockagent.GetFlowOutput) { flow.Name = nil },
+		"execution role ARN": func(flow *bedrockagent.GetFlowOutput) { flow.ExecutionRoleArn = nil },
+	} {
+		t.Run("missing "+name, func(t *testing.T) {
+			flow := bedrockAgentTestFlow()
+			mutate(flow)
+			if _, ok := newBedrockAgentFlowResource(flow); ok {
+				t.Fatalf("flow without %s should be skipped", name)
+			}
+		})
+	}
+
+	preparing := bedrockAgentTestFlow()
+	preparing.Status = bedrockagenttypes.FlowStatusPreparing
+	if _, ok := newBedrockAgentFlowResource(preparing); ok {
+		t.Fatal("preparing flow should be skipped")
+	}
+	failed := bedrockAgentTestFlow()
+	failed.Status = bedrockagenttypes.FlowStatusFailed
+	if _, ok := newBedrockAgentFlowResource(failed); ok {
+		t.Fatal("failed flow should be skipped")
+	}
+}
+
+func TestNewBedrockAgentPromptResource(t *testing.T) {
+	resource, ok := newBedrockAgentPromptResource(bedrockAgentTestPrompt())
+	assertBedrockAgentResource(t, resource, ok, "PROMPT1234", bedrockAgentPromptResourceType)
+	if got := resource.InstanceState.Attributes["id"]; got != "PROMPT1234" {
+		t.Fatalf("id attribute = %q, want PROMPT1234", got)
+	}
+	if got := resource.InstanceState.Attributes["name"]; got != "support-prompt" {
+		t.Fatalf("name attribute = %q, want support-prompt", got)
+	}
+	if got := resource.InstanceState.Attributes["default_variant"]; got != "primary" {
+		t.Fatalf("default_variant attribute = %q, want primary", got)
+	}
+	if got := resource.InstanceState.Attributes["description"]; got != "support prompt" {
+		t.Fatalf("description attribute = %q, want support prompt", got)
+	}
+	if got := resource.InstanceState.Attributes["version"]; got != "DRAFT" {
+		t.Fatalf("version attribute = %q, want DRAFT", got)
+	}
+
+	if _, ok := newBedrockAgentPromptResource(nil); ok {
+		t.Fatal("nil prompt should be skipped")
+	}
+	for name, mutate := range map[string]func(*bedrockagent.GetPromptOutput){
+		"ID":   func(prompt *bedrockagent.GetPromptOutput) { prompt.Id = nil },
+		"name": func(prompt *bedrockagent.GetPromptOutput) { prompt.Name = nil },
+	} {
+		t.Run("missing "+name, func(t *testing.T) {
+			prompt := bedrockAgentTestPrompt()
+			mutate(prompt)
+			if _, ok := newBedrockAgentPromptResource(prompt); ok {
+				t.Fatalf("prompt without %s should be skipped", name)
+			}
+		})
+	}
+}
+
 func TestBedrockAgentImportableStatuses(t *testing.T) {
 	for _, status := range []bedrockagenttypes.AgentStatus{
 		bedrockagenttypes.AgentStatusPrepared,
@@ -425,6 +700,30 @@ func TestBedrockAgentImportableStatuses(t *testing.T) {
 		}
 	}
 
+	for _, state := range []bedrockagenttypes.ActionGroupState{
+		bedrockagenttypes.ActionGroupStateEnabled,
+		bedrockagenttypes.ActionGroupStateDisabled,
+	} {
+		if !bedrockAgentActionGroupImportable(state) {
+			t.Fatalf("%s action group should be importable", state)
+		}
+	}
+	if bedrockAgentActionGroupImportable("") {
+		t.Fatal("action group with empty state should not be importable")
+	}
+
+	for _, history := range []bedrockagenttypes.RelayConversationHistory{
+		bedrockagenttypes.RelayConversationHistoryToCollaborator,
+		bedrockagenttypes.RelayConversationHistoryDisabled,
+	} {
+		if !bedrockAgentRelayConversationHistoryImportable(history) {
+			t.Fatalf("%s collaborator relay history should be importable", history)
+		}
+	}
+	if bedrockAgentRelayConversationHistoryImportable("") {
+		t.Fatal("collaborator with empty relay history should not be importable")
+	}
+
 	for _, state := range []bedrockagenttypes.KnowledgeBaseState{
 		bedrockagenttypes.KnowledgeBaseStateEnabled,
 		bedrockagenttypes.KnowledgeBaseStateDisabled,
@@ -464,6 +763,23 @@ func TestBedrockAgentImportableStatuses(t *testing.T) {
 	} {
 		if bedrockAgentDataSourceImportable(status) {
 			t.Fatalf("%s data source should not be importable", status)
+		}
+	}
+
+	for _, status := range []bedrockagenttypes.FlowStatus{
+		bedrockagenttypes.FlowStatusPrepared,
+		bedrockagenttypes.FlowStatusNotPrepared,
+	} {
+		if !bedrockAgentFlowImportable(status) {
+			t.Fatalf("%s flow should be importable", status)
+		}
+	}
+	for _, status := range []bedrockagenttypes.FlowStatus{
+		bedrockagenttypes.FlowStatusPreparing,
+		bedrockagenttypes.FlowStatusFailed,
+	} {
+		if bedrockAgentFlowImportable(status) {
+			t.Fatalf("%s flow should not be importable", status)
 		}
 	}
 }
@@ -740,9 +1056,9 @@ func TestBedrockAgentResourceNotFound(t *testing.T) {
 }
 
 func TestBedrockAgentInitialCleanupHonorsTypedFilters(t *testing.T) {
-	agent, alias, association, dataSource, knowledgeBase := bedrockAgentTestResources(t)
+	agent, actionGroup, alias, collaborator, association, dataSource, flow, knowledgeBase, prompt := bedrockAgentTestResources(t)
 	g := BedrockAgentGenerator{}
-	g.Resources = []terraformutils.Resource{agent, alias, association, dataSource, knowledgeBase}
+	g.Resources = []terraformutils.Resource{agent, actionGroup, alias, collaborator, association, dataSource, flow, knowledgeBase, prompt}
 	g.Filter = []terraformutils.ResourceFilter{{
 		ServiceName:      "bedrockagent_agent_alias",
 		FieldPath:        "id",
@@ -760,9 +1076,9 @@ func TestBedrockAgentInitialCleanupHonorsTypedFilters(t *testing.T) {
 }
 
 func TestBedrockAgentInitialCleanupPreservesGlobalFilters(t *testing.T) {
-	agent, alias, association, dataSource, knowledgeBase := bedrockAgentTestResources(t)
+	agent, actionGroup, alias, collaborator, association, dataSource, flow, knowledgeBase, prompt := bedrockAgentTestResources(t)
 	g := BedrockAgentGenerator{}
-	g.Resources = []terraformutils.Resource{agent, alias, association, dataSource, knowledgeBase}
+	g.Resources = []terraformutils.Resource{agent, actionGroup, alias, collaborator, association, dataSource, flow, knowledgeBase, prompt}
 	g.Filter = []terraformutils.ResourceFilter{
 		{
 			ServiceName:      "bedrockagent_agent",
@@ -777,8 +1093,8 @@ func TestBedrockAgentInitialCleanupPreservesGlobalFilters(t *testing.T) {
 
 	g.InitialCleanup()
 
-	if len(g.Resources) != 5 {
-		t.Fatalf("InitialCleanup() resources len = %d, want 5", len(g.Resources))
+	if len(g.Resources) != 9 {
+		t.Fatalf("InitialCleanup() resources len = %d, want 9", len(g.Resources))
 	}
 }
 
@@ -798,7 +1114,7 @@ func assertBedrockAgentResource(t *testing.T, resource terraformutils.Resource, 
 	}
 }
 
-func bedrockAgentTestResources(t *testing.T) (terraformutils.Resource, terraformutils.Resource, terraformutils.Resource, terraformutils.Resource, terraformutils.Resource) {
+func bedrockAgentTestResources(t *testing.T) (terraformutils.Resource, terraformutils.Resource, terraformutils.Resource, terraformutils.Resource, terraformutils.Resource, terraformutils.Resource, terraformutils.Resource, terraformutils.Resource, terraformutils.Resource) {
 	t.Helper()
 	agent, ok := newBedrockAgentAgentResource(bedrockagenttypes.AgentSummary{
 		AgentId:     aws.String("GGRRAED6JP"),
@@ -808,6 +1124,10 @@ func bedrockAgentTestResources(t *testing.T) (terraformutils.Resource, terraform
 	if !ok {
 		t.Fatal("newBedrockAgentAgentResource() should create agent")
 	}
+	actionGroup, ok := newBedrockAgentAgentActionGroupResource(bedrockAgentTestAgentActionGroup(), bedrockagenttypes.AgentStatusPrepared)
+	if !ok {
+		t.Fatal("newBedrockAgentAgentActionGroupResource() should create action group")
+	}
 	alias, ok := newBedrockAgentAgentAliasResource("GGRRAED6JP", bedrockagenttypes.AgentAliasSummary{
 		AgentAliasId:     aws.String("66IVY0GUTF"),
 		AgentAliasName:   aws.String("prod"),
@@ -815,6 +1135,10 @@ func bedrockAgentTestResources(t *testing.T) (terraformutils.Resource, terraform
 	})
 	if !ok {
 		t.Fatal("newBedrockAgentAgentAliasResource() should create alias")
+	}
+	collaborator, ok := newBedrockAgentAgentCollaboratorResource(bedrockAgentTestAgentCollaborator(), bedrockagenttypes.AgentStatusPrepared)
+	if !ok {
+		t.Fatal("newBedrockAgentAgentCollaboratorResource() should create collaborator")
 	}
 	association, ok := newBedrockAgentAgentKnowledgeBaseAssociationResource(bedrockAgentTestAgentKnowledgeBaseAssociation())
 	if !ok {
@@ -824,11 +1148,44 @@ func bedrockAgentTestResources(t *testing.T) (terraformutils.Resource, terraform
 	if !ok {
 		t.Fatal("newBedrockAgentDataSourceResource() should create data source")
 	}
+	flow, ok := newBedrockAgentFlowResource(bedrockAgentTestFlow())
+	if !ok {
+		t.Fatal("newBedrockAgentFlowResource() should create flow")
+	}
 	knowledgeBase, ok := newBedrockAgentKnowledgeBaseResource(bedrockAgentTestKnowledgeBase())
 	if !ok {
 		t.Fatal("newBedrockAgentKnowledgeBaseResource() should create knowledge base")
 	}
-	return agent, alias, association, dataSource, knowledgeBase
+	prompt, ok := newBedrockAgentPromptResource(bedrockAgentTestPrompt())
+	if !ok {
+		t.Fatal("newBedrockAgentPromptResource() should create prompt")
+	}
+	return agent, actionGroup, alias, collaborator, association, dataSource, flow, knowledgeBase, prompt
+}
+
+func bedrockAgentTestAgentActionGroup() *bedrockagenttypes.AgentActionGroup {
+	return &bedrockagenttypes.AgentActionGroup{
+		ActionGroupId:    aws.String("ACTGP12345"),
+		ActionGroupName:  aws.String("lookup-order"),
+		ActionGroupState: bedrockagenttypes.ActionGroupStateEnabled,
+		AgentId:          aws.String("GGRRAED6JP"),
+		AgentVersion:     aws.String(bedrockAgentDraftVersion),
+		Description:      aws.String("order lookup"),
+	}
+}
+
+func bedrockAgentTestAgentCollaborator() *bedrockagenttypes.AgentCollaborator {
+	return &bedrockagenttypes.AgentCollaborator{
+		AgentDescriptor: &bedrockagenttypes.AgentDescriptor{
+			AliasArn: aws.String("arn:aws:bedrock:us-east-1:123456789012:agent-alias/OTHERAGENT/ALIAS12345"),
+		},
+		AgentId:                  aws.String("GGRRAED6JP"),
+		AgentVersion:             aws.String(bedrockAgentDraftVersion),
+		CollaborationInstruction: aws.String("escalate billing questions"),
+		CollaboratorId:           aws.String("COLLAB1234"),
+		CollaboratorName:         aws.String("billing-helper"),
+		RelayConversationHistory: bedrockagenttypes.RelayConversationHistoryToCollaborator,
+	}
 }
 
 func bedrockAgentTestAgentKnowledgeBaseAssociation() *bedrockagenttypes.AgentKnowledgeBase {
@@ -838,6 +1195,17 @@ func bedrockAgentTestAgentKnowledgeBaseAssociation() *bedrockagenttypes.AgentKno
 		Description:        aws.String("customer knowledge"),
 		KnowledgeBaseId:    aws.String("EMDPPAYPZI"),
 		KnowledgeBaseState: bedrockagenttypes.KnowledgeBaseStateEnabled,
+	}
+}
+
+func bedrockAgentTestFlow() *bedrockagent.GetFlowOutput {
+	return &bedrockagent.GetFlowOutput{
+		Description:      aws.String("support workflow"),
+		ExecutionRoleArn: aws.String("arn:aws:iam::123456789012:role/bedrock-flow"),
+		Id:               aws.String("FLOW123456"),
+		Name:             aws.String("support-flow"),
+		Status:           bedrockagenttypes.FlowStatusPrepared,
+		Version:          aws.String(bedrockAgentDraftVersion),
 	}
 }
 
@@ -855,6 +1223,16 @@ func bedrockAgentTestKnowledgeBase() *bedrockagenttypes.KnowledgeBase {
 			OpensearchServerlessConfiguration: &bedrockagenttypes.OpenSearchServerlessConfiguration{},
 		},
 		Status: bedrockagenttypes.KnowledgeBaseStatusActive,
+	}
+}
+
+func bedrockAgentTestPrompt() *bedrockagent.GetPromptOutput {
+	return &bedrockagent.GetPromptOutput{
+		DefaultVariant: aws.String("primary"),
+		Description:    aws.String("support prompt"),
+		Id:             aws.String("PROMPT1234"),
+		Name:           aws.String("support-prompt"),
+		Version:        aws.String(bedrockAgentDraftVersion),
 	}
 }
 

--- a/providers/aws/bedrockagent_test.go
+++ b/providers/aws/bedrockagent_test.go
@@ -411,8 +411,16 @@ func TestNewBedrockAgentAgentCollaboratorResource(t *testing.T) {
 
 	unknownHistory := bedrockAgentTestAgentCollaborator()
 	unknownHistory.RelayConversationHistory = ""
-	if _, ok := newBedrockAgentAgentCollaboratorResource(unknownHistory, bedrockagenttypes.AgentStatusPrepared); ok {
-		t.Fatal("collaborator with empty relay conversation history should be skipped")
+	resource, ok = newBedrockAgentAgentCollaboratorResource(unknownHistory, bedrockagenttypes.AgentStatusPrepared)
+	assertBedrockAgentResource(t, resource, ok, "GGRRAED6JP,DRAFT,COLLAB1234", bedrockAgentAgentCollaboratorResourceType)
+	if _, ok := resource.InstanceState.Attributes["relay_conversation_history"]; ok {
+		t.Fatal("collaborator with empty relay conversation history should omit relay_conversation_history attribute")
+	}
+
+	invalidHistory := bedrockAgentTestAgentCollaborator()
+	invalidHistory.RelayConversationHistory = bedrockagenttypes.RelayConversationHistory("UNKNOWN")
+	if _, ok := newBedrockAgentAgentCollaboratorResource(invalidHistory, bedrockagenttypes.AgentStatusPrepared); ok {
+		t.Fatal("collaborator with unknown relay conversation history should be skipped")
 	}
 }
 
@@ -720,8 +728,11 @@ func TestBedrockAgentImportableStatuses(t *testing.T) {
 			t.Fatalf("%s collaborator relay history should be importable", history)
 		}
 	}
-	if bedrockAgentRelayConversationHistoryImportable("") {
-		t.Fatal("collaborator with empty relay history should not be importable")
+	if !bedrockAgentRelayConversationHistoryImportable("") {
+		t.Fatal("collaborator with empty relay history should be importable")
+	}
+	if bedrockAgentRelayConversationHistoryImportable(bedrockagenttypes.RelayConversationHistory("UNKNOWN")) {
+		t.Fatal("collaborator with unknown relay history should not be importable")
 	}
 
 	for _, state := range []bedrockagenttypes.KnowledgeBaseState{


### PR DESCRIPTION
## Summary

- add Bedrock Agent authoring import discovery for `aws_bedrockagent_agent_action_group`, `aws_bedrockagent_agent_collaborator`, `aws_bedrockagent_flow`, and `aws_bedrockagent_prompt`
- seed import IDs as `action_group_id,agent_id,agent_version`, `agent_id,agent_version,collaborator_id`, `flow_id`, and `prompt_id`
- import DRAFT agent child resources only, preserve `prepare_agent=false` for NOT_PREPARED parent agents, and skip transient/failed flows
- update `docs/aws.md` for supported Bedrock Agent authoring resources
- add unit tests for Bedrock Agent authoring helper behavior

## References

- #338

## Validation

```bash
go test ./providers/aws -run 'Test.*BedrockAgent|Test.*Bedrockagent|Test.*bedrockagent'
go test ./providers/aws/... ./terraformutils/...
go run ./tools/aws-gap-inventory \
  -docs docs/aws.md \
  -aws-dir providers/aws \
  -skip-list providers/aws/unsupported_resources.json \
  -format markdown
git diff --check
```

## Notes

Skipped/deferred resources:
- `aws_bedrockagent_flow_alias`: not exposed by Terraform AWS provider v6.44.0 schema
- `aws_bedrockagent_flow_version`: not exposed by Terraform AWS provider v6.44.0 schema
- `aws_bedrockagent_prompt_version`: not exposed by Terraform AWS provider v6.44.0 schema
- `aws_bedrockagentcore_*`: deferred for Agent Core PR
- `aws_bedrock_custom_model`: deferred for customization-job-based discovery

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds import discovery for Bedrock Agent authoring resources so existing action groups, collaborators, flows, and prompts can be managed by Terraform. Also fixes collaborator imports when relay history is unset.

- **New Features**
  - Discover and import `aws_bedrockagent_agent_action_group`, `aws_bedrockagent_agent_collaborator`, `aws_bedrockagent_flow`, `aws_bedrockagent_prompt`.
  - Import IDs: action groups `action_group_id,agent_id,agent_version`; collaborators `agent_id,agent_version,collaborator_id`; flows `flow_id`; prompts `prompt_id`.
  - Agent child resources import only from `DRAFT`; set `prepare_agent=false` when parent agent is `NOT_PREPARED`.
  - Flows import only when `Prepared` or `NotPrepared`; skip transient or failed flows.
  - Updated `docs/aws.md` and added tests for behaviors and import guards.

- **Bug Fixes**
  - Allow `aws_bedrockagent_agent_collaborator` import when `relay_conversation_history` is unset; omit the attribute when empty.

<sup>Written for commit f778dea05ac83cdd998f500b0ddb864b1425c27f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Extended AWS Bedrock Agent support to include agent action groups, agent collaborators, agent flows, and agent prompts. These resources can now be discovered, imported, and managed through the provider.

* **Documentation**
  * Updated supported services list to reflect newly available resource types.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/chenrui333/terraformer/pull/427)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->