### PR TITLE
aws(app): add ECS App Runner and Batch follow-up imports

### DIFF
--- a/docs/aws.md
+++ b/docs/aws.md
@@ -98,6 +98,14 @@ For AWS provider gap audits and unsupported-resource skip-list maintenance, see 
     * `aws_appmesh_virtual_node`
     * `aws_appmesh_virtual_router`
     * `aws_appmesh_virtual_service`
+*   `apprunner`
+    * `aws_apprunner_auto_scaling_configuration_version`
+    * `aws_apprunner_connection`
+    * `aws_apprunner_custom_domain_association`
+    * `aws_apprunner_observability_configuration`
+    * `aws_apprunner_service`
+    * `aws_apprunner_vpc_connector`
+    * `aws_apprunner_vpc_ingress_connection`
 *   `appstream`
     * `aws_appstream_fleet`
     * `aws_appstream_fleet_stack_association`
@@ -138,6 +146,7 @@ For AWS provider gap audits and unsupported-resource skip-list maintenance, see 
     * `aws_batch_compute_environment`
     * `aws_batch_job_definition`
     * `aws_batch_job_queue`
+    * `aws_batch_scheduling_policy`
 *   `bedrock`
     * `aws_bedrock_guardrail`
     * `aws_bedrock_guardrail_version`

--- a/go.mod
+++ b/go.mod
@@ -403,6 +403,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/apigatewayv2 v1.34.3
 	github.com/aws/aws-sdk-go-v2/service/appconfig v1.43.15
 	github.com/aws/aws-sdk-go-v2/service/appmesh v1.35.14
+	github.com/aws/aws-sdk-go-v2/service/apprunner v1.39.16
 	github.com/aws/aws-sdk-go-v2/service/appstream v1.58.0
 	github.com/aws/aws-sdk-go-v2/service/backup v1.55.2
 	github.com/aws/aws-sdk-go-v2/service/bedrock v1.59.2

--- a/go.sum
+++ b/go.sum
@@ -211,6 +211,8 @@ github.com/aws/aws-sdk-go-v2/service/appconfig v1.43.15 h1:PwZaY+AGC6L7bGde+ESiR
 github.com/aws/aws-sdk-go-v2/service/appconfig v1.43.15/go.mod h1:rvo3cSBQ0Qgt6mF6ITZTZ0ssHQJ0kBcaUpIWCaldJVQ=
 github.com/aws/aws-sdk-go-v2/service/appmesh v1.35.14 h1:31mnzduRd3FyuGCwgdMfPAu6MG1XnQf4zJrPjpZvnbM=
 github.com/aws/aws-sdk-go-v2/service/appmesh v1.35.14/go.mod h1:u/RTn1872BcpTxDnsQXi0AO8nxMch/46nlr3/loCpu8=
+github.com/aws/aws-sdk-go-v2/service/apprunner v1.39.16 h1:fqfppotMvz3HCWi7vdL84uEk29lYeMqNwLH025r1k6A=
+github.com/aws/aws-sdk-go-v2/service/apprunner v1.39.16/go.mod h1:QA5CUOg5mkS73RhLYCDPeFuCFxoeW2TPA6XRo4JL2Ek=
 github.com/aws/aws-sdk-go-v2/service/appstream v1.58.0 h1:Z/lDyp10L7bUSQMFq3TS8wvZovf+Kb0zK7//Kp0MYMA=
 github.com/aws/aws-sdk-go-v2/service/appstream v1.58.0/go.mod h1:E5vrX7/8w/HM5rhk2LQyuzF+PKECUmE44tp6xvuNYTc=
 github.com/aws/aws-sdk-go-v2/service/appsync v1.53.7 h1:SjkXYNc15FoovS9k6ML7dO7pkXE3ns66RXwL+rfQVl8=

--- a/providers/aws/app_runner.go
+++ b/providers/aws/app_runner.go
@@ -1,0 +1,458 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package aws
+
+import (
+	"context"
+	"errors"
+	"log"
+	"strconv"
+	"strings"
+
+	"github.com/aws/aws-sdk-go-v2/service/apprunner"
+	apprunnertypes "github.com/aws/aws-sdk-go-v2/service/apprunner/types"
+	"github.com/chenrui333/terraformer/terraformutils"
+)
+
+const (
+	appRunnerAutoScalingConfigurationVersionResourceType = "aws_apprunner_auto_scaling_configuration_version"
+	appRunnerConnectionResourceType                      = "aws_apprunner_connection"
+	appRunnerCustomDomainAssociationResourceType         = "aws_apprunner_custom_domain_association"
+	appRunnerObservabilityConfigurationResourceType      = "aws_apprunner_observability_configuration"
+	appRunnerServiceResourceType                         = "aws_apprunner_service"
+	appRunnerVpcConnectorResourceType                    = "aws_apprunner_vpc_connector"
+	appRunnerVpcIngressConnectionResourceType            = "aws_apprunner_vpc_ingress_connection"
+
+	appRunnerCustomDomainAssociationIDSeparator = ","
+)
+
+var appRunnerAllowEmptyValues = []string{"tags."}
+
+type AppRunnerGenerator struct {
+	AWSService
+}
+
+type appRunnerServiceReference struct {
+	arn  string
+	name string
+}
+
+type appRunnerOptionalResourceLoader struct {
+	name string
+	load func() error
+}
+
+func (g *AppRunnerGenerator) InitResources() error {
+	config, e := g.generateConfig()
+	if e != nil {
+		return e
+	}
+	svc := apprunner.NewFromConfig(config)
+
+	if err := g.loadAutoScalingConfigurations(svc); err != nil {
+		return err
+	}
+	if err := g.loadConnections(svc); err != nil {
+		return err
+	}
+	if err := g.loadObservabilityConfigurations(svc); err != nil {
+		return err
+	}
+	if err := g.loadVpcConnectors(svc); err != nil {
+		return err
+	}
+	services, err := g.loadServices(svc)
+	if err != nil {
+		return err
+	}
+	if err := g.loadVpcIngressConnections(svc); err != nil {
+		return err
+	}
+
+	g.getOptionalAppRunnerResources(
+		appRunnerOptionalResourceLoader{name: "custom domain associations", load: func() error {
+			return g.loadCustomDomainAssociations(svc, services)
+		}},
+	)
+
+	return nil
+}
+
+func (g *AppRunnerGenerator) loadAutoScalingConfigurations(svc *apprunner.Client) error {
+	p := apprunner.NewListAutoScalingConfigurationsPaginator(svc, &apprunner.ListAutoScalingConfigurationsInput{
+		LatestOnly: false,
+	})
+	for p.HasMorePages() {
+		page, err := p.NextPage(context.TODO())
+		if err != nil {
+			return err
+		}
+		for _, configuration := range page.AutoScalingConfigurationSummaryList {
+			if resource, ok := newAppRunnerAutoScalingConfigurationVersionResource(configuration); ok {
+				g.Resources = append(g.Resources, resource)
+			}
+		}
+	}
+	return nil
+}
+
+func (g *AppRunnerGenerator) loadConnections(svc *apprunner.Client) error {
+	p := apprunner.NewListConnectionsPaginator(svc, &apprunner.ListConnectionsInput{})
+	for p.HasMorePages() {
+		page, err := p.NextPage(context.TODO())
+		if err != nil {
+			return err
+		}
+		for _, connection := range page.ConnectionSummaryList {
+			if resource, ok := newAppRunnerConnectionResource(connection); ok {
+				g.Resources = append(g.Resources, resource)
+			}
+		}
+	}
+	return nil
+}
+
+func (g *AppRunnerGenerator) loadObservabilityConfigurations(svc *apprunner.Client) error {
+	p := apprunner.NewListObservabilityConfigurationsPaginator(svc, &apprunner.ListObservabilityConfigurationsInput{
+		LatestOnly: false,
+	})
+	for p.HasMorePages() {
+		page, err := p.NextPage(context.TODO())
+		if err != nil {
+			return err
+		}
+		for _, configuration := range page.ObservabilityConfigurationSummaryList {
+			if resource, ok := newAppRunnerObservabilityConfigurationResource(configuration); ok {
+				g.Resources = append(g.Resources, resource)
+			}
+		}
+	}
+	return nil
+}
+
+func (g *AppRunnerGenerator) loadVpcConnectors(svc *apprunner.Client) error {
+	p := apprunner.NewListVpcConnectorsPaginator(svc, &apprunner.ListVpcConnectorsInput{})
+	for p.HasMorePages() {
+		page, err := p.NextPage(context.TODO())
+		if err != nil {
+			return err
+		}
+		for _, connector := range page.VpcConnectors {
+			if resource, ok := newAppRunnerVpcConnectorResource(connector); ok {
+				g.Resources = append(g.Resources, resource)
+			}
+		}
+	}
+	return nil
+}
+
+func (g *AppRunnerGenerator) loadServices(svc *apprunner.Client) ([]appRunnerServiceReference, error) {
+	services := []appRunnerServiceReference{}
+	p := apprunner.NewListServicesPaginator(svc, &apprunner.ListServicesInput{})
+	for p.HasMorePages() {
+		page, err := p.NextPage(context.TODO())
+		if err != nil {
+			return nil, err
+		}
+		for _, service := range page.ServiceSummaryList {
+			resource, ok := newAppRunnerServiceResource(service)
+			if !ok {
+				continue
+			}
+			g.Resources = append(g.Resources, resource)
+			services = append(services, appRunnerServiceReference{
+				arn:  StringValue(service.ServiceArn),
+				name: StringValue(service.ServiceName),
+			})
+		}
+	}
+	return services, nil
+}
+
+func (g *AppRunnerGenerator) loadVpcIngressConnections(svc *apprunner.Client) error {
+	p := apprunner.NewListVpcIngressConnectionsPaginator(svc, &apprunner.ListVpcIngressConnectionsInput{})
+	for p.HasMorePages() {
+		page, err := p.NextPage(context.TODO())
+		if err != nil {
+			return err
+		}
+		for _, connection := range page.VpcIngressConnectionSummaryList {
+			arn := StringValue(connection.VpcIngressConnectionArn)
+			if arn == "" {
+				continue
+			}
+			output, err := svc.DescribeVpcIngressConnection(context.TODO(), &apprunner.DescribeVpcIngressConnectionInput{
+				VpcIngressConnectionArn: &arn,
+			})
+			if err != nil {
+				if appRunnerNotFound(err) {
+					continue
+				}
+				return err
+			}
+			if output == nil || output.VpcIngressConnection == nil {
+				continue
+			}
+			if resource, ok := newAppRunnerVpcIngressConnectionResource(*output.VpcIngressConnection); ok {
+				g.Resources = append(g.Resources, resource)
+			}
+		}
+	}
+	return nil
+}
+
+func (g *AppRunnerGenerator) loadCustomDomainAssociations(svc *apprunner.Client, services []appRunnerServiceReference) error {
+	for _, service := range services {
+		if service.arn == "" {
+			continue
+		}
+		p := apprunner.NewDescribeCustomDomainsPaginator(svc, &apprunner.DescribeCustomDomainsInput{
+			ServiceArn: &service.arn,
+		})
+		for p.HasMorePages() {
+			page, err := p.NextPage(context.TODO())
+			if err != nil {
+				if appRunnerNotFound(err) {
+					break
+				}
+				return err
+			}
+			for _, domain := range page.CustomDomains {
+				if resource, ok := newAppRunnerCustomDomainAssociationResource(service, domain); ok {
+					g.Resources = append(g.Resources, resource)
+				}
+			}
+		}
+	}
+	return nil
+}
+
+func (g *AppRunnerGenerator) getOptionalAppRunnerResources(loaders ...appRunnerOptionalResourceLoader) {
+	for _, loader := range loaders {
+		if err := loader.load(); err != nil {
+			log.Printf("skipping App Runner %s discovery: %v", loader.name, err)
+		}
+	}
+}
+
+func newAppRunnerAutoScalingConfigurationVersionResource(configuration apprunnertypes.AutoScalingConfigurationSummary) (terraformutils.Resource, bool) {
+	arn := StringValue(configuration.AutoScalingConfigurationArn)
+	name := StringValue(configuration.AutoScalingConfigurationName)
+	if arn == "" || name == "" || !appRunnerAutoScalingConfigurationImportable(configuration) {
+		return terraformutils.Resource{}, false
+	}
+	return terraformutils.NewResource(
+		appRunnerARNImportID(arn),
+		appRunnerResourceName("auto_scaling_configuration_version", name, strconv.Itoa(int(configuration.AutoScalingConfigurationRevision)), arnLastSegment(arn, "/")),
+		appRunnerAutoScalingConfigurationVersionResourceType,
+		"aws",
+		map[string]string{
+			"arn":                             arn,
+			"auto_scaling_configuration_name": name,
+		},
+		appRunnerAllowEmptyValues,
+		map[string]interface{}{},
+	), true
+}
+
+func newAppRunnerConnectionResource(connection apprunnertypes.ConnectionSummary) (terraformutils.Resource, bool) {
+	name := StringValue(connection.ConnectionName)
+	providerType := string(connection.ProviderType)
+	if name == "" || providerType == "" || !appRunnerConnectionImportable(connection) {
+		return terraformutils.Resource{}, false
+	}
+	attributes := map[string]string{
+		"connection_name": name,
+		"provider_type":   providerType,
+	}
+	if arn := StringValue(connection.ConnectionArn); arn != "" {
+		attributes["arn"] = arn
+	}
+	return terraformutils.NewResource(
+		appRunnerConnectionImportID(name),
+		appRunnerResourceName("connection", name),
+		appRunnerConnectionResourceType,
+		"aws",
+		attributes,
+		appRunnerAllowEmptyValues,
+		map[string]interface{}{},
+	), true
+}
+
+func newAppRunnerObservabilityConfigurationResource(configuration apprunnertypes.ObservabilityConfigurationSummary) (terraformutils.Resource, bool) {
+	arn := StringValue(configuration.ObservabilityConfigurationArn)
+	name := StringValue(configuration.ObservabilityConfigurationName)
+	if arn == "" || name == "" {
+		return terraformutils.Resource{}, false
+	}
+	return terraformutils.NewResource(
+		appRunnerARNImportID(arn),
+		appRunnerResourceName("observability_configuration", name, strconv.Itoa(int(configuration.ObservabilityConfigurationRevision)), arnLastSegment(arn, "/")),
+		appRunnerObservabilityConfigurationResourceType,
+		"aws",
+		map[string]string{
+			"arn":                              arn,
+			"observability_configuration_name": name,
+		},
+		appRunnerAllowEmptyValues,
+		map[string]interface{}{},
+	), true
+}
+
+func newAppRunnerVpcConnectorResource(connector apprunnertypes.VpcConnector) (terraformutils.Resource, bool) {
+	arn := StringValue(connector.VpcConnectorArn)
+	name := StringValue(connector.VpcConnectorName)
+	if arn == "" || name == "" || !appRunnerVpcConnectorImportable(connector) {
+		return terraformutils.Resource{}, false
+	}
+	return terraformutils.NewResource(
+		appRunnerARNImportID(arn),
+		appRunnerResourceName("vpc_connector", name, strconv.Itoa(int(connector.VpcConnectorRevision)), arnLastSegment(arn, "/")),
+		appRunnerVpcConnectorResourceType,
+		"aws",
+		map[string]string{
+			"arn":                arn,
+			"vpc_connector_name": name,
+		},
+		appRunnerAllowEmptyValues,
+		map[string]interface{}{},
+	), true
+}
+
+func newAppRunnerServiceResource(service apprunnertypes.ServiceSummary) (terraformutils.Resource, bool) {
+	arn := StringValue(service.ServiceArn)
+	name := StringValue(service.ServiceName)
+	if arn == "" || name == "" || !appRunnerServiceImportable(service) {
+		return terraformutils.Resource{}, false
+	}
+	return terraformutils.NewResource(
+		appRunnerARNImportID(arn),
+		appRunnerResourceName("service", name, arnLastSegment(arn, "/")),
+		appRunnerServiceResourceType,
+		"aws",
+		map[string]string{
+			"arn":          arn,
+			"service_name": name,
+		},
+		appRunnerAllowEmptyValues,
+		map[string]interface{}{},
+	), true
+}
+
+func newAppRunnerCustomDomainAssociationResource(service appRunnerServiceReference, domain apprunnertypes.CustomDomain) (terraformutils.Resource, bool) {
+	domainName := StringValue(domain.DomainName)
+	if service.arn == "" || domainName == "" || !appRunnerCustomDomainImportable(domain) {
+		return terraformutils.Resource{}, false
+	}
+	return terraformutils.NewResource(
+		appRunnerCustomDomainAssociationImportID(domainName, service.arn),
+		appRunnerResourceName("custom_domain_association", service.name, domainName),
+		appRunnerCustomDomainAssociationResourceType,
+		"aws",
+		map[string]string{
+			"domain_name": domainName,
+			"service_arn": service.arn,
+		},
+		appRunnerAllowEmptyValues,
+		map[string]interface{}{},
+	), true
+}
+
+func newAppRunnerVpcIngressConnectionResource(connection apprunnertypes.VpcIngressConnection) (terraformutils.Resource, bool) {
+	arn := StringValue(connection.VpcIngressConnectionArn)
+	if arn == "" || !appRunnerVpcIngressConnectionImportable(connection) {
+		return terraformutils.Resource{}, false
+	}
+	attributes := map[string]string{
+		"arn": arn,
+	}
+	if serviceARN := StringValue(connection.ServiceArn); serviceARN != "" {
+		attributes["service_arn"] = serviceARN
+	}
+	return terraformutils.NewResource(
+		appRunnerARNImportID(arn),
+		appRunnerARNResourceName("vpc_ingress_connection", arn),
+		appRunnerVpcIngressConnectionResourceType,
+		"aws",
+		attributes,
+		appRunnerAllowEmptyValues,
+		map[string]interface{}{},
+	), true
+}
+
+func appRunnerARNImportID(arn string) string {
+	return arn
+}
+
+func appRunnerConnectionImportID(name string) string {
+	return name
+}
+
+func appRunnerCustomDomainAssociationImportID(domainName, serviceARN string) string {
+	return strings.Join([]string{domainName, serviceARN}, appRunnerCustomDomainAssociationIDSeparator)
+}
+
+func appRunnerARNResourceName(prefix, arn string) string {
+	parts := []string{prefix}
+	for _, part := range strings.Split(arnLastSegment(arn, ":"), "/") {
+		if part != "" {
+			parts = append(parts, part)
+		}
+	}
+	return appRunnerResourceName(parts...)
+}
+
+func appRunnerResourceName(parts ...string) string {
+	var name strings.Builder
+	for _, part := range parts {
+		if part == "" {
+			continue
+		}
+		if name.Len() > 0 {
+			name.WriteString("_")
+		}
+		name.WriteString(strconv.Itoa(len(part)))
+		name.WriteString("_")
+		name.WriteString(part)
+	}
+	return name.String()
+}
+
+func appRunnerAutoScalingConfigurationImportable(configuration apprunnertypes.AutoScalingConfigurationSummary) bool {
+	return configuration.Status == "" || configuration.Status == apprunnertypes.AutoScalingConfigurationStatusActive
+}
+
+func appRunnerConnectionImportable(connection apprunnertypes.ConnectionSummary) bool {
+	return connection.Status != apprunnertypes.ConnectionStatusDeleted
+}
+
+func appRunnerVpcConnectorImportable(connector apprunnertypes.VpcConnector) bool {
+	return connector.Status == "" || connector.Status == apprunnertypes.VpcConnectorStatusActive
+}
+
+func appRunnerServiceImportable(service apprunnertypes.ServiceSummary) bool {
+	switch service.Status {
+	case "", apprunnertypes.ServiceStatusRunning, apprunnertypes.ServiceStatusPaused:
+		return true
+	default:
+		return false
+	}
+}
+
+func appRunnerCustomDomainImportable(domain apprunnertypes.CustomDomain) bool {
+	switch domain.Status {
+	case "", apprunnertypes.CustomDomainAssociationStatusActive, apprunnertypes.CustomDomainAssociationStatusPendingCertificateDnsValidation, apprunnertypes.CustomDomainAssociationStatusBindingCertificate:
+		return true
+	default:
+		return false
+	}
+}
+
+func appRunnerVpcIngressConnectionImportable(connection apprunnertypes.VpcIngressConnection) bool {
+	return connection.Status == "" || connection.Status == apprunnertypes.VpcIngressConnectionStatusAvailable
+}
+
+func appRunnerNotFound(err error) bool {
+	var notFound *apprunnertypes.ResourceNotFoundException
+	return errors.As(err, &notFound)
+}

--- a/providers/aws/app_runner.go
+++ b/providers/aws/app_runner.go
@@ -122,7 +122,23 @@ func (g *AppRunnerGenerator) loadObservabilityConfigurations(svc *apprunner.Clie
 			return err
 		}
 		for _, configuration := range page.ObservabilityConfigurationSummaryList {
-			if resource, ok := newAppRunnerObservabilityConfigurationResource(configuration); ok {
+			arn := StringValue(configuration.ObservabilityConfigurationArn)
+			if arn == "" {
+				continue
+			}
+			output, err := svc.DescribeObservabilityConfiguration(context.TODO(), &apprunner.DescribeObservabilityConfigurationInput{
+				ObservabilityConfigurationArn: &arn,
+			})
+			if err != nil {
+				if appRunnerNotFound(err) {
+					continue
+				}
+				return err
+			}
+			if output == nil || output.ObservabilityConfiguration == nil {
+				continue
+			}
+			if resource, ok := newAppRunnerObservabilityConfigurationResource(*output.ObservabilityConfiguration); ok {
 				g.Resources = append(g.Resources, resource)
 			}
 		}
@@ -279,10 +295,10 @@ func newAppRunnerConnectionResource(connection apprunnertypes.ConnectionSummary)
 	), true
 }
 
-func newAppRunnerObservabilityConfigurationResource(configuration apprunnertypes.ObservabilityConfigurationSummary) (terraformutils.Resource, bool) {
+func newAppRunnerObservabilityConfigurationResource(configuration apprunnertypes.ObservabilityConfiguration) (terraformutils.Resource, bool) {
 	arn := StringValue(configuration.ObservabilityConfigurationArn)
 	name := StringValue(configuration.ObservabilityConfigurationName)
-	if arn == "" || name == "" {
+	if arn == "" || name == "" || !appRunnerObservabilityConfigurationImportable(configuration) {
 		return terraformutils.Resource{}, false
 	}
 	return terraformutils.NewResource(
@@ -424,6 +440,10 @@ func appRunnerAutoScalingConfigurationImportable(configuration apprunnertypes.Au
 
 func appRunnerConnectionImportable(connection apprunnertypes.ConnectionSummary) bool {
 	return connection.Status != apprunnertypes.ConnectionStatusDeleted
+}
+
+func appRunnerObservabilityConfigurationImportable(configuration apprunnertypes.ObservabilityConfiguration) bool {
+	return configuration.Status == "" || configuration.Status == apprunnertypes.ObservabilityConfigurationStatusActive
 }
 
 func appRunnerVpcConnectorImportable(connector apprunnertypes.VpcConnector) bool {

--- a/providers/aws/app_runner_test.go
+++ b/providers/aws/app_runner_test.go
@@ -112,17 +112,25 @@ func TestNewAppRunnerConnectionResource(t *testing.T) {
 
 func TestNewAppRunnerObservabilityConfigurationResource(t *testing.T) {
 	arn := "arn:aws:apprunner:us-east-1:123456789012:observabilityconfiguration/core/1/d75bc7ea55b71e724fe5c23452fe22a1"
-	resource, ok := newAppRunnerObservabilityConfigurationResource(apprunnertypes.ObservabilityConfigurationSummary{
+	resource, ok := newAppRunnerObservabilityConfigurationResource(apprunnertypes.ObservabilityConfiguration{
 		ObservabilityConfigurationArn:      aws.String(arn),
 		ObservabilityConfigurationName:     aws.String("core"),
 		ObservabilityConfigurationRevision: 1,
+		Status:                             apprunnertypes.ObservabilityConfigurationStatusActive,
 	})
 	assertAppRunnerResource(t, resource, ok, arn, appRunnerResourceName("observability_configuration", "core", "1", "d75bc7ea55b71e724fe5c23452fe22a1"), appRunnerObservabilityConfigurationResourceType, map[string]string{
 		"arn":                              arn,
 		"observability_configuration_name": "core",
 	})
 
-	if _, ok := newAppRunnerObservabilityConfigurationResource(apprunnertypes.ObservabilityConfigurationSummary{
+	if _, ok := newAppRunnerObservabilityConfigurationResource(apprunnertypes.ObservabilityConfiguration{
+		ObservabilityConfigurationArn:  aws.String(arn),
+		ObservabilityConfigurationName: aws.String("core"),
+		Status:                         apprunnertypes.ObservabilityConfigurationStatusInactive,
+	}); ok {
+		t.Fatal("inactive observability configuration should be skipped")
+	}
+	if _, ok := newAppRunnerObservabilityConfigurationResource(apprunnertypes.ObservabilityConfiguration{
 		ObservabilityConfigurationName: aws.String("core"),
 	}); ok {
 		t.Fatal("observability configuration with empty ARN should be skipped")

--- a/providers/aws/app_runner_test.go
+++ b/providers/aws/app_runner_test.go
@@ -1,0 +1,276 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package aws
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	apprunnertypes "github.com/aws/aws-sdk-go-v2/service/apprunner/types"
+	"github.com/chenrui333/terraformer/terraformutils"
+)
+
+func TestAppRunnerImportIDs(t *testing.T) {
+	serviceARN := "arn:aws:apprunner:us-east-1:123456789012:service/example/8fe1e10304f84fd2b0df550fe98a71fa"
+	tests := []struct {
+		name string
+		got  string
+		want string
+	}{
+		{name: "arn", got: appRunnerARNImportID(serviceARN), want: serviceARN},
+		{name: "connection", got: appRunnerConnectionImportID("github"), want: "github"},
+		{name: "custom domain", got: appRunnerCustomDomainAssociationImportID("example.com", serviceARN), want: "example.com," + serviceARN},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.got != tt.want {
+				t.Fatalf("import ID = %q, want %q", tt.got, tt.want)
+			}
+		})
+	}
+}
+
+func TestAppRunnerResourceNameAvoidsSanitizedCollisions(t *testing.T) {
+	tests := []struct {
+		name   string
+		first  []string
+		second []string
+	}{
+		{name: "separator boundary", first: []string{"custom_domain_association", "a_b", "c"}, second: []string{"custom_domain_association", "a", "b_c"}},
+		{name: "slash encoding", first: []string{"vpc_connector", "a/b"}, second: []string{"vpc_connector", "a-002F-b"}},
+		{name: "at sign encoding", first: []string{"connection", "a@example.com"}, second: []string{"connection", "a-0040-example.com"}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			first := terraformutils.TfSanitize(appRunnerResourceName(tt.first...))
+			second := terraformutils.TfSanitize(appRunnerResourceName(tt.second...))
+			if first == second {
+				t.Fatalf("appRunnerResourceName() generated duplicate sanitized names %q", first)
+			}
+		})
+	}
+}
+
+func TestNewAppRunnerAutoScalingConfigurationVersionResource(t *testing.T) {
+	arn := "arn:aws:apprunner:us-east-1:123456789012:autoscalingconfiguration/core/2/a1b2c3d4567890ab"
+	resource, ok := newAppRunnerAutoScalingConfigurationVersionResource(apprunnertypes.AutoScalingConfigurationSummary{
+		AutoScalingConfigurationArn:      aws.String(arn),
+		AutoScalingConfigurationName:     aws.String("core"),
+		AutoScalingConfigurationRevision: 2,
+		Status:                           apprunnertypes.AutoScalingConfigurationStatusActive,
+	})
+	assertAppRunnerResource(t, resource, ok, arn, appRunnerResourceName("auto_scaling_configuration_version", "core", "2", "a1b2c3d4567890ab"), appRunnerAutoScalingConfigurationVersionResourceType, map[string]string{
+		"arn":                             arn,
+		"auto_scaling_configuration_name": "core",
+	})
+
+	if _, ok := newAppRunnerAutoScalingConfigurationVersionResource(apprunnertypes.AutoScalingConfigurationSummary{
+		AutoScalingConfigurationArn:  aws.String(arn),
+		AutoScalingConfigurationName: aws.String("core"),
+		Status:                       apprunnertypes.AutoScalingConfigurationStatusInactive,
+	}); ok {
+		t.Fatal("inactive auto scaling configuration should be skipped")
+	}
+	if _, ok := newAppRunnerAutoScalingConfigurationVersionResource(apprunnertypes.AutoScalingConfigurationSummary{
+		AutoScalingConfigurationName: aws.String("core"),
+	}); ok {
+		t.Fatal("auto scaling configuration with empty ARN should be skipped")
+	}
+}
+
+func TestNewAppRunnerConnectionResource(t *testing.T) {
+	resource, ok := newAppRunnerConnectionResource(apprunnertypes.ConnectionSummary{
+		ConnectionArn:  aws.String("arn:aws:apprunner:us-east-1:123456789012:connection/github/a1b2c3d4567890ab"),
+		ConnectionName: aws.String("github"),
+		ProviderType:   apprunnertypes.ProviderTypeGithub,
+		Status:         apprunnertypes.ConnectionStatusAvailable,
+	})
+	assertAppRunnerResource(t, resource, ok, "github", appRunnerResourceName("connection", "github"), appRunnerConnectionResourceType, map[string]string{
+		"connection_name": "github",
+		"provider_type":   "GITHUB",
+	})
+
+	if _, ok := newAppRunnerConnectionResource(apprunnertypes.ConnectionSummary{
+		ConnectionName: aws.String("github"),
+		Status:         apprunnertypes.ConnectionStatusDeleted,
+	}); ok {
+		t.Fatal("deleted connection should be skipped")
+	}
+	if _, ok := newAppRunnerConnectionResource(apprunnertypes.ConnectionSummary{
+		ConnectionName: aws.String("github"),
+		Status:         apprunnertypes.ConnectionStatusAvailable,
+	}); ok {
+		t.Fatal("connection with empty provider type should be skipped")
+	}
+	if _, ok := newAppRunnerConnectionResource(apprunnertypes.ConnectionSummary{}); ok {
+		t.Fatal("connection with empty name should be skipped")
+	}
+}
+
+func TestNewAppRunnerObservabilityConfigurationResource(t *testing.T) {
+	arn := "arn:aws:apprunner:us-east-1:123456789012:observabilityconfiguration/core/1/d75bc7ea55b71e724fe5c23452fe22a1"
+	resource, ok := newAppRunnerObservabilityConfigurationResource(apprunnertypes.ObservabilityConfigurationSummary{
+		ObservabilityConfigurationArn:      aws.String(arn),
+		ObservabilityConfigurationName:     aws.String("core"),
+		ObservabilityConfigurationRevision: 1,
+	})
+	assertAppRunnerResource(t, resource, ok, arn, appRunnerResourceName("observability_configuration", "core", "1", "d75bc7ea55b71e724fe5c23452fe22a1"), appRunnerObservabilityConfigurationResourceType, map[string]string{
+		"arn":                              arn,
+		"observability_configuration_name": "core",
+	})
+
+	if _, ok := newAppRunnerObservabilityConfigurationResource(apprunnertypes.ObservabilityConfigurationSummary{
+		ObservabilityConfigurationName: aws.String("core"),
+	}); ok {
+		t.Fatal("observability configuration with empty ARN should be skipped")
+	}
+}
+
+func TestNewAppRunnerVpcConnectorResource(t *testing.T) {
+	arn := "arn:aws:apprunner:us-east-1:123456789012:vpcconnector/private/1/0a03292a89764e5882c41d8f991c82fe"
+	resource, ok := newAppRunnerVpcConnectorResource(apprunnertypes.VpcConnector{
+		VpcConnectorArn:      aws.String(arn),
+		VpcConnectorName:     aws.String("private"),
+		VpcConnectorRevision: 1,
+		Status:               apprunnertypes.VpcConnectorStatusActive,
+	})
+	assertAppRunnerResource(t, resource, ok, arn, appRunnerResourceName("vpc_connector", "private", "1", "0a03292a89764e5882c41d8f991c82fe"), appRunnerVpcConnectorResourceType, map[string]string{
+		"arn":                arn,
+		"vpc_connector_name": "private",
+	})
+
+	if _, ok := newAppRunnerVpcConnectorResource(apprunnertypes.VpcConnector{
+		VpcConnectorArn:  aws.String(arn),
+		VpcConnectorName: aws.String("private"),
+		Status:           apprunnertypes.VpcConnectorStatusInactive,
+	}); ok {
+		t.Fatal("inactive VPC connector should be skipped")
+	}
+	if _, ok := newAppRunnerVpcConnectorResource(apprunnertypes.VpcConnector{}); ok {
+		t.Fatal("VPC connector with empty identifiers should be skipped")
+	}
+}
+
+func TestNewAppRunnerServiceResource(t *testing.T) {
+	arn := "arn:aws:apprunner:us-east-1:123456789012:service/core/8fe1e10304f84fd2b0df550fe98a71fa"
+	for _, status := range []apprunnertypes.ServiceStatus{"", apprunnertypes.ServiceStatusRunning, apprunnertypes.ServiceStatusPaused} {
+		resource, ok := newAppRunnerServiceResource(apprunnertypes.ServiceSummary{
+			ServiceArn:  aws.String(arn),
+			ServiceName: aws.String("core"),
+			Status:      status,
+		})
+		assertAppRunnerResource(t, resource, ok, arn, appRunnerResourceName("service", "core", "8fe1e10304f84fd2b0df550fe98a71fa"), appRunnerServiceResourceType, map[string]string{
+			"arn":          arn,
+			"service_name": "core",
+		})
+	}
+
+	for _, status := range []apprunnertypes.ServiceStatus{apprunnertypes.ServiceStatusCreateFailed, apprunnertypes.ServiceStatusDeleted, apprunnertypes.ServiceStatusDeleteFailed, apprunnertypes.ServiceStatusOperationInProgress} {
+		if _, ok := newAppRunnerServiceResource(apprunnertypes.ServiceSummary{
+			ServiceArn:  aws.String(arn),
+			ServiceName: aws.String("core"),
+			Status:      status,
+		}); ok {
+			t.Fatalf("service with status %q should be skipped", status)
+		}
+	}
+	if _, ok := newAppRunnerServiceResource(apprunnertypes.ServiceSummary{}); ok {
+		t.Fatal("service with empty identifiers should be skipped")
+	}
+}
+
+func TestNewAppRunnerCustomDomainAssociationResource(t *testing.T) {
+	service := appRunnerServiceReference{
+		arn:  "arn:aws:apprunner:us-east-1:123456789012:service/core/8fe1e10304f84fd2b0df550fe98a71fa",
+		name: "core",
+	}
+	for _, status := range []apprunnertypes.CustomDomainAssociationStatus{
+		"",
+		apprunnertypes.CustomDomainAssociationStatusActive,
+		apprunnertypes.CustomDomainAssociationStatusPendingCertificateDnsValidation,
+		apprunnertypes.CustomDomainAssociationStatusBindingCertificate,
+	} {
+		resource, ok := newAppRunnerCustomDomainAssociationResource(service, apprunnertypes.CustomDomain{
+			DomainName: aws.String("example.com"),
+			Status:     status,
+		})
+		assertAppRunnerResource(t, resource, ok, appRunnerCustomDomainAssociationImportID("example.com", service.arn), appRunnerResourceName("custom_domain_association", "core", "example.com"), appRunnerCustomDomainAssociationResourceType, map[string]string{
+			"domain_name": "example.com",
+			"service_arn": service.arn,
+		})
+	}
+
+	if _, ok := newAppRunnerCustomDomainAssociationResource(service, apprunnertypes.CustomDomain{
+		DomainName: aws.String("example.com"),
+		Status:     apprunnertypes.CustomDomainAssociationStatusDeleting,
+	}); ok {
+		t.Fatal("deleting custom domain association should be skipped")
+	}
+	if _, ok := newAppRunnerCustomDomainAssociationResource(appRunnerServiceReference{}, apprunnertypes.CustomDomain{
+		DomainName: aws.String("example.com"),
+	}); ok {
+		t.Fatal("custom domain association with empty service ARN should be skipped")
+	}
+}
+
+func TestNewAppRunnerVpcIngressConnectionResource(t *testing.T) {
+	arn := "arn:aws:apprunner:us-east-1:123456789012:vpcingressconnection/private/a1b2c3d4567890ab"
+	serviceARN := "arn:aws:apprunner:us-east-1:123456789012:service/core/8fe1e10304f84fd2b0df550fe98a71fa"
+	resource, ok := newAppRunnerVpcIngressConnectionResource(apprunnertypes.VpcIngressConnection{
+		ServiceArn:               aws.String(serviceARN),
+		Status:                   apprunnertypes.VpcIngressConnectionStatusAvailable,
+		VpcIngressConnectionArn:  aws.String(arn),
+		VpcIngressConnectionName: aws.String("private"),
+		IngressVpcConfiguration:  &apprunnertypes.IngressVpcConfiguration{VpcId: aws.String("vpc-123"), VpcEndpointId: aws.String("vpce-123")},
+	})
+	assertAppRunnerResource(t, resource, ok, arn, appRunnerARNResourceName("vpc_ingress_connection", arn), appRunnerVpcIngressConnectionResourceType, map[string]string{
+		"arn":         arn,
+		"service_arn": serviceARN,
+	})
+
+	if _, ok := newAppRunnerVpcIngressConnectionResource(apprunnertypes.VpcIngressConnection{
+		Status:                  apprunnertypes.VpcIngressConnectionStatusDeleted,
+		VpcIngressConnectionArn: aws.String(arn),
+	}); ok {
+		t.Fatal("deleted VPC ingress connection should be skipped")
+	}
+	if _, ok := newAppRunnerVpcIngressConnectionResource(apprunnertypes.VpcIngressConnection{}); ok {
+		t.Fatal("VPC ingress connection with empty ARN should be skipped")
+	}
+}
+
+func TestAppRunnerNotFound(t *testing.T) {
+	if !appRunnerNotFound(&apprunnertypes.ResourceNotFoundException{}) {
+		t.Fatal("appRunnerNotFound() = false for ResourceNotFoundException, want true")
+	}
+	if appRunnerNotFound(errors.New("boom")) {
+		t.Fatal("appRunnerNotFound() = true for generic error, want false")
+	}
+	if appRunnerNotFound(nil) {
+		t.Fatal("appRunnerNotFound() = true for nil error, want false")
+	}
+}
+
+func assertAppRunnerResource(t *testing.T, resource terraformutils.Resource, ok bool, resourceID, resourceName, resourceType string, attributes map[string]string) {
+	t.Helper()
+	if !ok {
+		t.Fatal("resource should be importable")
+	}
+	if resource.InstanceState.ID != resourceID {
+		t.Fatalf("resource ID = %q, want %q", resource.InstanceState.ID, resourceID)
+	}
+	if resource.ResourceName != terraformutils.TfSanitize(resourceName) {
+		t.Fatalf("resource name = %q, want %q", resource.ResourceName, terraformutils.TfSanitize(resourceName))
+	}
+	if resource.InstanceInfo.Type != resourceType {
+		t.Fatalf("resource type = %q, want %q", resource.InstanceInfo.Type, resourceType)
+	}
+	for name, want := range attributes {
+		if got := resource.InstanceState.Attributes[name]; got != want {
+			t.Fatalf("%s = %q, want %q", name, got, want)
+		}
+	}
+}

--- a/providers/aws/aws_provider.go
+++ b/providers/aws/aws_provider.go
@@ -269,6 +269,7 @@ func (p *AWSProvider) GetSupportedService() map[string]terraformutils.ServiceGen
 		"api_gatewayv2":     &AwsFacade{service: &APIGatewayV2Generator{}},
 		"appconfig":         &AwsFacade{service: &AppConfigGenerator{}},
 		"appmesh":           &AwsFacade{service: &AppMeshGenerator{}},
+		"apprunner":         &AwsFacade{service: &AppRunnerGenerator{}},
 		"appstream":         &AwsFacade{service: &AppStreamGenerator{}},
 		"appsync":           &AwsFacade{service: &AppSyncGenerator{}},
 		"auto_scaling":      &AwsFacade{service: &AutoScalingGenerator{}},

--- a/providers/aws/batch.go
+++ b/providers/aws/batch.go
@@ -3,16 +3,20 @@ package aws
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	"github.com/chenrui333/terraformer/terraformutils"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/batch"
+	batchtypes "github.com/aws/aws-sdk-go-v2/service/batch/types"
 )
 
 var BatchAllowEmptyValues = []string{"tags."}
 
 var BatchAdditionalFields = map[string]interface{}{}
+
+const batchSchedulingPolicyResourceType = "aws_batch_scheduling_policy"
 
 type BatchGenerator struct {
 	AWSService
@@ -32,6 +36,9 @@ func (g *BatchGenerator) InitResources() error {
 		return err
 	}
 	if err := g.loadJobQueues(batchClient); err != nil {
+		return err
+	}
+	if err := g.loadSchedulingPolicies(batchClient); err != nil {
 		return err
 	}
 
@@ -61,6 +68,50 @@ func (g *BatchGenerator) loadComputeEnvironments(batchClient *batch.Client) erro
 		}
 	}
 	return nil
+}
+
+func (g *BatchGenerator) loadSchedulingPolicies(batchClient *batch.Client) error {
+	p := batch.NewListSchedulingPoliciesPaginator(batchClient, &batch.ListSchedulingPoliciesInput{})
+	for p.HasMorePages() {
+		page, err := p.NextPage(context.TODO())
+		if err != nil {
+			return err
+		}
+		for _, schedulingPolicy := range page.SchedulingPolicies {
+			if resource, ok := newBatchSchedulingPolicyResource(schedulingPolicy); ok {
+				g.Resources = append(g.Resources, resource)
+			}
+		}
+	}
+	return nil
+}
+
+func newBatchSchedulingPolicyResource(schedulingPolicy batchtypes.SchedulingPolicyListingDetail) (terraformutils.Resource, bool) {
+	arn := StringValue(schedulingPolicy.Arn)
+	name := arnLastSegment(arn, "/")
+	if arn == "" || name == "" {
+		return terraformutils.Resource{}, false
+	}
+	return terraformutils.NewResource(
+		batchSchedulingPolicyImportID(arn),
+		batchResourceName("scheduling_policy", name),
+		batchSchedulingPolicyResourceType,
+		"aws",
+		map[string]string{
+			"arn":  arn,
+			"name": name,
+		},
+		BatchAllowEmptyValues,
+		BatchAdditionalFields,
+	), true
+}
+
+func batchSchedulingPolicyImportID(arn string) string {
+	return arn
+}
+
+func batchResourceName(parts ...string) string {
+	return strings.Join(parts, "_")
 }
 
 func (g *BatchGenerator) loadJobDefinitions(batchClient *batch.Client) error {

--- a/providers/aws/batch_test.go
+++ b/providers/aws/batch_test.go
@@ -1,0 +1,52 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package aws
+
+import (
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	batchtypes "github.com/aws/aws-sdk-go-v2/service/batch/types"
+	"github.com/chenrui333/terraformer/terraformutils"
+)
+
+func TestBatchSchedulingPolicyImportID(t *testing.T) {
+	arn := "arn:aws:batch:us-east-1:123456789012:scheduling-policy/core"
+	if got := batchSchedulingPolicyImportID(arn); got != arn {
+		t.Fatalf("batchSchedulingPolicyImportID() = %q, want %q", got, arn)
+	}
+}
+
+func TestNewBatchSchedulingPolicyResource(t *testing.T) {
+	arn := "arn:aws:batch:us-east-1:123456789012:scheduling-policy/core"
+	resource, ok := newBatchSchedulingPolicyResource(batchtypes.SchedulingPolicyListingDetail{
+		Arn: aws.String(arn),
+	})
+	if !ok {
+		t.Fatal("scheduling policy should be importable")
+	}
+	if resource.InstanceState.ID != arn {
+		t.Fatalf("resource ID = %q, want %q", resource.InstanceState.ID, arn)
+	}
+	if got, want := resource.ResourceName, terraformutils.TfSanitize(batchResourceName("scheduling_policy", "core")); got != want {
+		t.Fatalf("resource name = %q, want %q", got, want)
+	}
+	if resource.InstanceInfo.Type != batchSchedulingPolicyResourceType {
+		t.Fatalf("resource type = %q, want %q", resource.InstanceInfo.Type, batchSchedulingPolicyResourceType)
+	}
+	if got := resource.InstanceState.Attributes["name"]; got != "core" {
+		t.Fatalf("name = %q, want core", got)
+	}
+	if got := resource.InstanceState.Attributes["arn"]; got != arn {
+		t.Fatalf("arn = %q, want %q", got, arn)
+	}
+
+	if _, ok := newBatchSchedulingPolicyResource(batchtypes.SchedulingPolicyListingDetail{}); ok {
+		t.Fatal("scheduling policy with empty ARN should be skipped")
+	}
+	if _, ok := newBatchSchedulingPolicyResource(batchtypes.SchedulingPolicyListingDetail{
+		Arn: aws.String("arn:aws:batch:us-east-1:123456789012:scheduling-policy/"),
+	}); ok {
+		t.Fatal("scheduling policy with empty name should be skipped")
+	}
+}

--- a/providers/aws/unsupported_resources.json
+++ b/providers/aws/unsupported_resources.json
@@ -25,6 +25,18 @@
       ]
     },
     {
+      "resource": "aws_ecs_account_setting_default",
+      "service_family": "ecs",
+      "reason": "ECS account setting defaults are not safely discoverable without importing inherited or AWS-managed defaults as explicitly managed Terraform resources.",
+      "evidence": "Terraform AWS provider imports by setting name, but its Read path calls ListAccountSettings with EffectiveSettings=true. The ECS API response does not distinguish a user-configured account default from an inherited effective/default value during broad discovery.",
+      "status": "unsupported",
+      "references": [
+        "https://github.com/chenrui333/terraformer/issues/338",
+        "https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ecs_account_setting_default",
+        "https://docs.aws.amazon.com/AmazonECS/latest/APIReference/API_ListAccountSettings.html"
+      ]
+    },
+    {
       "resource": "aws_ivs_playback_key_pair",
       "service_family": "ivs",
       "reason": "IVS playback key pairs require public_key, but IVS GetPlaybackKeyPair and ListPlaybackKeyPairs responses do not return the public key material needed to seed an imported resource.",


### PR DESCRIPTION
## Summary

- add App Runner import discovery for services, connections, custom domain associations, auto scaling configuration versions, observability configurations, VPC connectors, and VPC ingress connections
- add Batch scheduling policy import discovery
- register the apprunner AWS service and add the App Runner SDK dependency
- seed import IDs as ARN, connection name, domain_name,service_arn, and scheduling policy ARN
- update docs/aws.md and add focused helper tests
- mark aws_ecs_account_setting_default unsupported for broad discovery because ECS only exposes effective settings

## References

- #338

## Validation

~~~bash
go test ./providers/aws -run 'Test.*AppRunner|Test.*Apprunner|Test.*appRunner|Test.*apprunner|Test.*Batch|Test.*batch|Test.*ECS|Test.*Ecs|Test.*ecs'
go test ./providers/aws/... ./terraformutils/...
go run ./tools/aws-gap-inventory \
  -docs docs/aws.md \
  -aws-dir providers/aws \
  -skip-list providers/aws/unsupported_resources.json \
  -format markdown
git diff --check
~~~

## Notes

Skipped/deferred resources:
- aws_ecs_account_setting_default: unsupported for broad discovery because the provider reads effective account settings and the ECS API does not distinguish explicitly configured defaults from inherited/default values.
- aws_batch_consumable_resource / aws_batch_service_environment: current Terraform AWS provider source/docs checked during investigation did not expose importable resources for these names.
- Existing ECS resources were already covered on main, including capacity providers, cluster capacity providers, services, task definitions, and task sets.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds import discovery for AWS App Runner resources and Batch scheduling policies to expand AWS coverage and improve inventory. Also registers `apprunner`, updates docs and tests, and improves observability handling.

- **New Features**
  - Import discovery for App Runner: services, connections, custom domain associations, auto scaling configuration versions, observability configurations, VPC connectors, and VPC ingress connections.
  - Import discovery for Batch scheduling policies.
  - Register `apprunner`; seed import IDs (ARNs, connection name, custom domain as domain_name+service_arn, scheduling policy ARN); update docs/tests; mark `aws_ecs_account_setting_default` unsupported for broad discovery.

- **Bug Fixes**
  - Skip inactive App Runner observability configurations during discovery.

<sup>Written for commit 78881c3162ea03d7a0bd4e5523def05e8dfb6986. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added AWS App Runner resource discovery (services, VPC connectors, connections, observability configurations, custom domain associations, VPC ingress connections, and auto-scaling configurations).
  * Added AWS Batch Scheduling Policies resource discovery.

* **Documentation**
  * Updated supported services inventory to include App Runner and Batch Scheduling Policy resources.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/chenrui333/terraformer/pull/428)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->