### PR TITLE
aws(guardduty): add GuardDuty follow-up imports

### DIFF
--- a/docs/aws.md
+++ b/docs/aws.md
@@ -357,6 +357,11 @@ For AWS provider gap audits and unsupported-resource skip-list maintenance, see 
     * `aws_guardduty_detector`
     * `aws_guardduty_filter`
     * `aws_guardduty_ipset`
+    * `aws_guardduty_malware_protection_plan`
+    * `aws_guardduty_member`
+    * `aws_guardduty_organization_admin_account`
+    * `aws_guardduty_organization_configuration`
+    * `aws_guardduty_publishing_destination`
     * `aws_guardduty_threatintelset`
 *   `iam`
     * `aws_iam_access_key`

--- a/providers/aws/guardduty.go
+++ b/providers/aws/guardduty.go
@@ -328,7 +328,7 @@ func (g *GuardDutyGenerator) loadPublishingDestinations(svc *guardduty.Client, d
 				DestinationId: aws.String(destinationID),
 				DetectorId:    aws.String(detectorID),
 			})
-			if guardDutyResourceNotFound(err) {
+			if guardDutyPublishingDestinationNotFound(err) {
 				continue
 			}
 			if err != nil {
@@ -1069,6 +1069,17 @@ func guardDutyResourceNotFound(err error) bool {
 	return strings.Contains(message, "no such resource found") ||
 		strings.Contains(message, "input detectorid is not owned by the current account") ||
 		strings.Contains(message, "input detectorid is not owned by current account")
+}
+
+func guardDutyPublishingDestinationNotFound(err error) bool {
+	if guardDutyResourceNotFound(err) {
+		return true
+	}
+	var badRequest *guarddutytypes.BadRequestException
+	if !errors.As(err, &badRequest) {
+		return false
+	}
+	return strings.Contains(strings.ToLower(badRequest.ErrorMessage()), "one or more input parameters have invalid values")
 }
 
 func guardDutyOrganizationResourceUnavailable(err error) bool {

--- a/providers/aws/guardduty.go
+++ b/providers/aws/guardduty.go
@@ -1084,6 +1084,9 @@ func guardDutyOrganizationResourceUnavailable(err error) bool {
 		return false
 	}
 	message := strings.ToLower(badRequest.ErrorMessage())
+	if strings.Contains(message, "delegated administrator") && strings.Contains(message, "not been enabled") {
+		return true
+	}
 	return strings.Contains(message, "organization") &&
 		(strings.Contains(message, "administrator") ||
 			strings.Contains(message, "delegated") ||

--- a/providers/aws/guardduty.go
+++ b/providers/aws/guardduty.go
@@ -313,7 +313,7 @@ func (g *GuardDutyGenerator) loadPublishingDestinations(svc *guardduty.Client, d
 		}
 		for _, destinationSummary := range page.Destinations {
 			destinationID := StringValue(destinationSummary.DestinationId)
-			if destinationID == "" || !guardDutyPublishingDestinationStatusImportable(destinationSummary.Status) {
+			if destinationID == "" {
 				continue
 			}
 			destination, err := svc.DescribePublishingDestination(context.TODO(), &guardduty.DescribePublishingDestinationInput{
@@ -605,7 +605,7 @@ func newGuardDutyOrganizationConfigurationResource(detectorID string, configurat
 }
 
 func newGuardDutyPublishingDestinationResource(detectorID, destinationID string, destination *guardduty.DescribePublishingDestinationOutput) (terraformutils.Resource, bool) {
-	if detectorID == "" || destinationID == "" || destination == nil || !guardDutyPublishingDestinationStatusImportable(destination.Status) {
+	if detectorID == "" || destinationID == "" || destination == nil {
 		return terraformutils.Resource{}, false
 	}
 	properties := destination.DestinationProperties
@@ -971,10 +971,6 @@ func guardDutyMemberInviteEnabled(status string) bool {
 
 func guardDutyOrganizationAdminAccountImportable(adminAccount guarddutytypes.AdminAccount) bool {
 	return StringValue(adminAccount.AdminAccountId) != "" && adminAccount.AdminStatus == guarddutytypes.AdminStatusEnabled
-}
-
-func guardDutyPublishingDestinationStatusImportable(status guarddutytypes.PublishingStatus) bool {
-	return status == guarddutytypes.PublishingStatusPublishing
 }
 
 func guardDutyResourceNotFound(err error) bool {

--- a/providers/aws/guardduty.go
+++ b/providers/aws/guardduty.go
@@ -20,16 +20,27 @@ import (
 )
 
 const (
-	guardDutyDetectorResourceType       = "aws_guardduty_detector"
-	guardDutyFilterResourceType         = "aws_guardduty_filter"
-	guardDutyIPSetResourceType          = "aws_guardduty_ipset"
-	guardDutyThreatIntelSetResourceType = "aws_guardduty_threatintelset"
+	guardDutyDetectorResourceType                  = "aws_guardduty_detector"
+	guardDutyFilterResourceType                    = "aws_guardduty_filter"
+	guardDutyIPSetResourceType                     = "aws_guardduty_ipset"
+	guardDutyMalwareProtectionPlanResourceType     = "aws_guardduty_malware_protection_plan"
+	guardDutyMemberResourceType                    = "aws_guardduty_member"
+	guardDutyOrganizationAdminAccountResourceType  = "aws_guardduty_organization_admin_account"
+	guardDutyOrganizationConfigurationResourceType = "aws_guardduty_organization_configuration"
+	guardDutyPublishingDestinationResourceType     = "aws_guardduty_publishing_destination"
+	guardDutyThreatIntelSetResourceType            = "aws_guardduty_threatintelset"
 
 	guardDutyResourceIDSeparator   = ":"
 	guardDutyResourceNameSeparator = ":"
 	guardDutyUpdatedAtField        = "updatedAt"
 
 	guardDutyFilterUpdatedAtCriteriaAdditionalField = "__guardduty_filter_updated_at_criteria"
+
+	guardDutyMemberRelationshipStatusCreated                     = "Created"
+	guardDutyMemberRelationshipStatusDisabled                    = "Disabled"
+	guardDutyMemberRelationshipStatusEnabled                     = "Enabled"
+	guardDutyMemberRelationshipStatusEmailVerificationInProgress = "EmailVerificationInProgress"
+	guardDutyMemberRelationshipStatusInvited                     = "Invited"
 )
 
 var guardDutyAllowEmptyValues = []string{"tags."}
@@ -46,6 +57,14 @@ func (g *GuardDutyGenerator) InitResources() error {
 		return e
 	}
 	svc := guardduty.NewFromConfig(config)
+	if err := g.loadOrganizationAdminAccounts(svc); err != nil {
+		if !guardDutyOrganizationResourceUnavailable(err) {
+			return err
+		}
+	}
+	if err := g.loadMalwareProtectionPlans(svc); err != nil {
+		return err
+	}
 	detectors, e := listGuardDutyDetectors(svc)
 	if e != nil {
 		return e
@@ -102,7 +121,39 @@ func (g *GuardDutyGenerator) loadDetectorChildren(svc *guardduty.Client, detecto
 	if err := g.loadIPSets(svc, detectorID); err != nil {
 		return err
 	}
-	return g.loadThreatIntelSets(svc, detectorID)
+	if err := g.loadThreatIntelSets(svc, detectorID); err != nil {
+		return err
+	}
+	if err := g.loadMembers(svc, detectorID); err != nil {
+		return err
+	}
+	if err := g.loadOrganizationConfiguration(svc, detectorID); err != nil {
+		if guardDutyResourceNotFound(err) {
+			return err
+		}
+		if !guardDutyOrganizationResourceUnavailable(err) {
+			return err
+		}
+	}
+	return g.loadPublishingDestinations(svc, detectorID)
+}
+
+func (g *GuardDutyGenerator) loadOrganizationAdminAccounts(svc *guardduty.Client) error {
+	paginator := guardduty.NewListOrganizationAdminAccountsPaginator(svc, &guardduty.ListOrganizationAdminAccountsInput{})
+	for paginator.HasMorePages() {
+		page, err := paginator.NextPage(context.TODO())
+		if err != nil {
+			return err
+		}
+		for _, adminAccount := range page.AdminAccounts {
+			resource, ok := newGuardDutyOrganizationAdminAccountResource(adminAccount)
+			if !ok {
+				continue
+			}
+			g.Resources = append(g.Resources, resource)
+		}
+	}
+	return nil
 }
 
 func (g *GuardDutyGenerator) loadFilters(svc *guardduty.Client, detectorID string) error {
@@ -204,6 +255,114 @@ func (g *GuardDutyGenerator) loadThreatIntelSets(svc *guardduty.Client, detector
 	return nil
 }
 
+func (g *GuardDutyGenerator) loadMembers(svc *guardduty.Client, detectorID string) error {
+	paginator := guardduty.NewListMembersPaginator(svc, &guardduty.ListMembersInput{
+		DetectorId:     aws.String(detectorID),
+		OnlyAssociated: aws.String("false"),
+	})
+	for paginator.HasMorePages() {
+		page, err := paginator.NextPage(context.TODO())
+		if err != nil {
+			return err
+		}
+		for _, memberSummary := range page.Members {
+			accountID := StringValue(memberSummary.AccountId)
+			if accountID == "" {
+				continue
+			}
+			member, err := getGuardDutyMember(svc, detectorID, accountID)
+			if guardDutyResourceNotFound(err) {
+				continue
+			}
+			if err != nil {
+				return err
+			}
+			resource, ok := newGuardDutyMemberResource(detectorID, accountID, member)
+			if !ok {
+				continue
+			}
+			g.Resources = append(g.Resources, resource)
+		}
+	}
+	return nil
+}
+
+func (g *GuardDutyGenerator) loadOrganizationConfiguration(svc *guardduty.Client, detectorID string) error {
+	configuration, err := svc.DescribeOrganizationConfiguration(context.TODO(), &guardduty.DescribeOrganizationConfigurationInput{
+		DetectorId: aws.String(detectorID),
+	})
+	if err != nil {
+		return err
+	}
+	resource, ok := newGuardDutyOrganizationConfigurationResource(detectorID, configuration)
+	if !ok {
+		return nil
+	}
+	g.Resources = append(g.Resources, resource)
+	return nil
+}
+
+func (g *GuardDutyGenerator) loadPublishingDestinations(svc *guardduty.Client, detectorID string) error {
+	paginator := guardduty.NewListPublishingDestinationsPaginator(svc, &guardduty.ListPublishingDestinationsInput{
+		DetectorId: aws.String(detectorID),
+	})
+	for paginator.HasMorePages() {
+		page, err := paginator.NextPage(context.TODO())
+		if err != nil {
+			return err
+		}
+		for _, destinationSummary := range page.Destinations {
+			destinationID := StringValue(destinationSummary.DestinationId)
+			if destinationID == "" || !guardDutyPublishingDestinationStatusImportable(destinationSummary.Status) {
+				continue
+			}
+			destination, err := svc.DescribePublishingDestination(context.TODO(), &guardduty.DescribePublishingDestinationInput{
+				DestinationId: aws.String(destinationID),
+				DetectorId:    aws.String(detectorID),
+			})
+			if guardDutyResourceNotFound(err) {
+				continue
+			}
+			if err != nil {
+				return err
+			}
+			resource, ok := newGuardDutyPublishingDestinationResource(detectorID, destinationID, destination)
+			if !ok {
+				continue
+			}
+			g.Resources = append(g.Resources, resource)
+		}
+	}
+	return nil
+}
+
+func (g *GuardDutyGenerator) loadMalwareProtectionPlans(svc *guardduty.Client) error {
+	planIDs, err := listGuardDutyMalwareProtectionPlans(svc)
+	if err != nil {
+		return err
+	}
+	for _, planID := range planIDs {
+		if planID == "" {
+			continue
+		}
+		plan, err := svc.GetMalwareProtectionPlan(context.TODO(), &guardduty.GetMalwareProtectionPlanInput{
+			MalwareProtectionPlanId: aws.String(planID),
+		})
+		if guardDutyResourceNotFound(err) {
+			continue
+		}
+		if err != nil {
+			return err
+		}
+		resource, ok := newGuardDutyMalwareProtectionPlanResource(planID, plan)
+		if !ok {
+			continue
+		}
+		g.Resources = append(g.Resources, resource)
+	}
+	return nil
+}
+
 func listGuardDutyDetectors(svc *guardduty.Client) ([]string, error) {
 	var detectors []string
 	paginator := guardduty.NewListDetectorsPaginator(svc, &guardduty.ListDetectorsInput{})
@@ -215,6 +374,39 @@ func listGuardDutyDetectors(svc *guardduty.Client) ([]string, error) {
 		detectors = append(detectors, page.DetectorIds...)
 	}
 	return detectors, nil
+}
+
+func listGuardDutyMalwareProtectionPlans(svc *guardduty.Client) ([]string, error) {
+	var planIDs []string
+	input := &guardduty.ListMalwareProtectionPlansInput{}
+	for {
+		page, err := svc.ListMalwareProtectionPlans(context.TODO(), input)
+		if err != nil {
+			return nil, err
+		}
+		for _, plan := range page.MalwareProtectionPlans {
+			planIDs = append(planIDs, StringValue(plan.MalwareProtectionPlanId))
+		}
+		if page.NextToken == nil {
+			break
+		}
+		input.NextToken = page.NextToken
+	}
+	return planIDs, nil
+}
+
+func getGuardDutyMember(svc *guardduty.Client, detectorID, accountID string) (*guarddutytypes.Member, error) {
+	output, err := svc.GetMembers(context.TODO(), &guardduty.GetMembersInput{
+		AccountIds: []string{accountID},
+		DetectorId: aws.String(detectorID),
+	})
+	if err != nil {
+		return nil, err
+	}
+	if output == nil || len(output.Members) == 0 {
+		return nil, nil
+	}
+	return &output.Members[0], nil
 }
 
 func newGuardDutyDetectorResource(detectorID string, detector *guardduty.GetDetectorOutput) (terraformutils.Resource, bool) {
@@ -306,6 +498,142 @@ func newGuardDutyIPSetResource(detectorID, ipSetID string, ipSet *guardduty.GetI
 	), true
 }
 
+func newGuardDutyMalwareProtectionPlanResource(planID string, plan *guardduty.GetMalwareProtectionPlanOutput) (terraformutils.Resource, bool) {
+	if planID == "" || plan == nil || !guardDutyMalwareProtectionPlanStatusImportable(plan.Status) {
+		return terraformutils.Resource{}, false
+	}
+	role := StringValue(plan.Role)
+	bucket := guardDutyMalwareProtectionPlanBucket(plan)
+	if bucket == nil {
+		return terraformutils.Resource{}, false
+	}
+	bucketName := StringValue(bucket.BucketName)
+	if role == "" || bucketName == "" {
+		return terraformutils.Resource{}, false
+	}
+
+	attributes := map[string]string{
+		"protected_resource.#":                         "1",
+		"protected_resource.0.s3_bucket.#":             "1",
+		"protected_resource.0.s3_bucket.0.bucket_name": bucketName,
+		"role": role,
+	}
+	if arn := StringValue(plan.Arn); arn != "" {
+		attributes["arn"] = arn
+	}
+	if plan.CreatedAt != nil {
+		attributes["created_at"] = plan.CreatedAt.UTC().Format(time.RFC3339)
+	}
+	if plan.Status != "" {
+		attributes["status"] = string(plan.Status)
+	}
+	guardDutyListAttributes(attributes, "protected_resource.0.s3_bucket.0.object_prefixes", bucket.ObjectPrefixes)
+	addGuardDutyMalwareProtectionPlanActions(attributes, plan.Actions)
+
+	return terraformutils.NewResource(
+		guardDutyMalwareProtectionPlanResourceID(planID),
+		guardDutyResourceName("malware_protection_plan", bucketName, planID),
+		guardDutyMalwareProtectionPlanResourceType,
+		"aws",
+		attributes,
+		guardDutyAllowEmptyValues,
+		map[string]interface{}{},
+	), true
+}
+
+func newGuardDutyMemberResource(detectorID, accountID string, member *guarddutytypes.Member) (terraformutils.Resource, bool) {
+	if detectorID == "" || accountID == "" || member == nil || !guardDutyMemberImportable(member) {
+		return terraformutils.Resource{}, false
+	}
+	if StringValue(member.AccountId) != accountID {
+		return terraformutils.Resource{}, false
+	}
+	status := StringValue(member.RelationshipStatus)
+	attributes := map[string]string{
+		"account_id":  accountID,
+		"detector_id": detectorID,
+		"email":       StringValue(member.Email),
+		"invite":      strconv.FormatBool(guardDutyMemberInviteEnabled(status)),
+	}
+
+	return terraformutils.NewResource(
+		guardDutyMemberResourceID(detectorID, accountID),
+		guardDutyResourceName("member", detectorID, accountID),
+		guardDutyMemberResourceType,
+		"aws",
+		attributes,
+		guardDutyAllowEmptyValues,
+		map[string]interface{}{},
+	), true
+}
+
+func newGuardDutyOrganizationAdminAccountResource(adminAccount guarddutytypes.AdminAccount) (terraformutils.Resource, bool) {
+	accountID := StringValue(adminAccount.AdminAccountId)
+	if accountID == "" || !guardDutyOrganizationAdminAccountImportable(adminAccount) {
+		return terraformutils.Resource{}, false
+	}
+
+	return terraformutils.NewResource(
+		guardDutyOrganizationAdminAccountResourceID(accountID),
+		guardDutyResourceName("organization_admin_account", accountID),
+		guardDutyOrganizationAdminAccountResourceType,
+		"aws",
+		map[string]string{"admin_account_id": accountID},
+		guardDutyAllowEmptyValues,
+		map[string]interface{}{},
+	), true
+}
+
+func newGuardDutyOrganizationConfigurationResource(detectorID string, configuration *guardduty.DescribeOrganizationConfigurationOutput) (terraformutils.Resource, bool) {
+	if detectorID == "" || configuration == nil || configuration.AutoEnableOrganizationMembers == "" {
+		return terraformutils.Resource{}, false
+	}
+	attributes := map[string]string{
+		"auto_enable_organization_members": string(configuration.AutoEnableOrganizationMembers),
+		"detector_id":                      detectorID,
+	}
+
+	return terraformutils.NewResource(
+		guardDutyOrganizationConfigurationResourceID(detectorID),
+		guardDutyResourceName("organization_configuration", detectorID),
+		guardDutyOrganizationConfigurationResourceType,
+		"aws",
+		attributes,
+		guardDutyAllowEmptyValues,
+		map[string]interface{}{},
+	), true
+}
+
+func newGuardDutyPublishingDestinationResource(detectorID, destinationID string, destination *guardduty.DescribePublishingDestinationOutput) (terraformutils.Resource, bool) {
+	if detectorID == "" || destinationID == "" || destination == nil || !guardDutyPublishingDestinationStatusImportable(destination.Status) {
+		return terraformutils.Resource{}, false
+	}
+	properties := destination.DestinationProperties
+	if properties == nil || StringValue(properties.DestinationArn) == "" || StringValue(properties.KmsKeyArn) == "" || destination.DestinationType == "" {
+		return terraformutils.Resource{}, false
+	}
+	attributes := map[string]string{
+		"destination_arn":  StringValue(properties.DestinationArn),
+		"destination_type": string(destination.DestinationType),
+		"detector_id":      detectorID,
+		"kms_key_arn":      StringValue(properties.KmsKeyArn),
+	}
+	if id := StringValue(destination.DestinationId); id != "" {
+		destinationID = id
+		attributes["destination_id"] = id
+	}
+
+	return terraformutils.NewResource(
+		guardDutyPublishingDestinationResourceID(detectorID, destinationID),
+		guardDutyResourceName("publishing_destination", detectorID, destinationID),
+		guardDutyPublishingDestinationResourceType,
+		"aws",
+		attributes,
+		guardDutyAllowEmptyValues,
+		map[string]interface{}{},
+	), true
+}
+
 func newGuardDutyThreatIntelSetResource(detectorID, threatIntelSetID string, threatIntelSet *guardduty.GetThreatIntelSetOutput) (terraformutils.Resource, bool) {
 	if detectorID == "" || threatIntelSetID == "" || threatIntelSet == nil || threatIntelSet.Status == guarddutytypes.ThreatIntelSetStatusDeleted {
 		return terraformutils.Resource{}, false
@@ -331,6 +659,15 @@ func newGuardDutyThreatIntelSetResource(detectorID, threatIntelSetID string, thr
 		guardDutyAllowEmptyValues,
 		map[string]interface{}{},
 	), true
+}
+
+func addGuardDutyMalwareProtectionPlanActions(attributes map[string]string, actions *guarddutytypes.MalwareProtectionPlanActions) {
+	if actions == nil || actions.Tagging == nil || actions.Tagging.Status == "" {
+		return
+	}
+	attributes["actions.#"] = "1"
+	attributes["actions.0.tagging.#"] = "1"
+	attributes["actions.0.tagging.0.status"] = string(actions.Tagging.Status)
 }
 
 func addGuardDutyDataSources(attributes map[string]string, dataSources *guarddutytypes.DataSourceConfigurationsResult) {
@@ -563,13 +900,90 @@ func guardDutyChildResourceID(detectorID, resourceID string) string {
 	return strings.Join([]string{detectorID, resourceID}, guardDutyResourceIDSeparator)
 }
 
+func guardDutyMalwareProtectionPlanResourceID(planID string) string {
+	return planID
+}
+
+func guardDutyMemberResourceID(detectorID, accountID string) string {
+	return guardDutyChildResourceID(detectorID, accountID)
+}
+
+func guardDutyOrganizationAdminAccountResourceID(accountID string) string {
+	return accountID
+}
+
+func guardDutyOrganizationConfigurationResourceID(detectorID string) string {
+	return detectorID
+}
+
+func guardDutyPublishingDestinationResourceID(detectorID, destinationID string) string {
+	return guardDutyChildResourceID(detectorID, destinationID)
+}
+
 func guardDutyResourceName(parts ...string) string {
 	return strings.Join(parts, guardDutyResourceNameSeparator)
+}
+
+func guardDutyMalwareProtectionPlanBucket(plan *guardduty.GetMalwareProtectionPlanOutput) *guarddutytypes.CreateS3BucketResource {
+	if plan == nil || plan.ProtectedResource == nil {
+		return nil
+	}
+	return plan.ProtectedResource.S3Bucket
+}
+
+func guardDutyMalwareProtectionPlanStatusImportable(status guarddutytypes.MalwareProtectionPlanStatus) bool {
+	return status == guarddutytypes.MalwareProtectionPlanStatusActive ||
+		status == guarddutytypes.MalwareProtectionPlanStatusWarning ||
+		status == guarddutytypes.MalwareProtectionPlanStatusError
+}
+
+func guardDutyMemberImportable(member *guarddutytypes.Member) bool {
+	if member == nil || StringValue(member.AccountId) == "" || StringValue(member.Email) == "" {
+		return false
+	}
+	return guardDutyMemberRelationshipImportable(StringValue(member.RelationshipStatus))
+}
+
+func guardDutyMemberRelationshipImportable(status string) bool {
+	switch status {
+	case guardDutyMemberRelationshipStatusCreated,
+		guardDutyMemberRelationshipStatusDisabled,
+		guardDutyMemberRelationshipStatusEnabled,
+		guardDutyMemberRelationshipStatusEmailVerificationInProgress,
+		guardDutyMemberRelationshipStatusInvited:
+		return true
+	default:
+		return false
+	}
+}
+
+func guardDutyMemberInviteEnabled(status string) bool {
+	switch status {
+	case guardDutyMemberRelationshipStatusDisabled,
+		guardDutyMemberRelationshipStatusEnabled,
+		guardDutyMemberRelationshipStatusEmailVerificationInProgress,
+		guardDutyMemberRelationshipStatusInvited:
+		return true
+	default:
+		return false
+	}
+}
+
+func guardDutyOrganizationAdminAccountImportable(adminAccount guarddutytypes.AdminAccount) bool {
+	return StringValue(adminAccount.AdminAccountId) != "" && adminAccount.AdminStatus == guarddutytypes.AdminStatusEnabled
+}
+
+func guardDutyPublishingDestinationStatusImportable(status guarddutytypes.PublishingStatus) bool {
+	return status == guarddutytypes.PublishingStatusPublishing
 }
 
 func guardDutyResourceNotFound(err error) bool {
 	if err == nil {
 		return false
+	}
+	var notFound *guarddutytypes.ResourceNotFoundException
+	if errors.As(err, &notFound) {
+		return true
 	}
 	var badRequest *guarddutytypes.BadRequestException
 	if !errors.As(err, &badRequest) {
@@ -579,4 +993,20 @@ func guardDutyResourceNotFound(err error) bool {
 	return strings.Contains(message, "no such resource found") ||
 		strings.Contains(message, "input detectorid is not owned by the current account") ||
 		strings.Contains(message, "input detectorid is not owned by current account")
+}
+
+func guardDutyOrganizationResourceUnavailable(err error) bool {
+	if err == nil {
+		return false
+	}
+	var badRequest *guarddutytypes.BadRequestException
+	if !errors.As(err, &badRequest) {
+		return false
+	}
+	message := strings.ToLower(badRequest.ErrorMessage())
+	return strings.Contains(message, "organization") &&
+		(strings.Contains(message, "administrator") ||
+			strings.Contains(message, "delegated") ||
+			strings.Contains(message, "master") ||
+			strings.Contains(message, "member"))
 }

--- a/providers/aws/guardduty.go
+++ b/providers/aws/guardduty.go
@@ -63,7 +63,9 @@ func (g *GuardDutyGenerator) InitResources() error {
 		}
 	}
 	if err := g.loadMalwareProtectionPlans(svc); err != nil {
-		return err
+		if !guardDutyMalwareProtectionPlansUnavailable(err) {
+			return err
+		}
 	}
 	detectors, e := listGuardDutyDetectors(svc)
 	if e != nil {
@@ -142,6 +144,9 @@ func (g *GuardDutyGenerator) loadOrganizationAdminAccounts(svc *guardduty.Client
 	paginator := guardduty.NewListOrganizationAdminAccountsPaginator(svc, &guardduty.ListOrganizationAdminAccountsInput{})
 	for paginator.HasMorePages() {
 		page, err := paginator.NextPage(context.TODO())
+		if guardDutyOrganizationResourceUnavailable(err) {
+			return nil
+		}
 		if err != nil {
 			return err
 		}
@@ -195,6 +200,9 @@ func (g *GuardDutyGenerator) loadIPSets(svc *guardduty.Client, detectorID string
 	})
 	for paginator.HasMorePages() {
 		page, err := paginator.NextPage(context.TODO())
+		if guardDutyMemberListingUnavailable(err) {
+			return nil
+		}
 		if err != nil {
 			return err
 		}
@@ -349,6 +357,9 @@ func (g *GuardDutyGenerator) loadMalwareProtectionPlans(svc *guardduty.Client) e
 			MalwareProtectionPlanId: aws.String(planID),
 		})
 		if guardDutyResourceNotFound(err) {
+			continue
+		}
+		if guardDutyMalwareProtectionPlansUnavailable(err) {
 			continue
 		}
 		if err != nil {
@@ -592,6 +603,7 @@ func newGuardDutyOrganizationConfigurationResource(detectorID string, configurat
 		"auto_enable_organization_members": string(configuration.AutoEnableOrganizationMembers),
 		"detector_id":                      detectorID,
 	}
+	addGuardDutyOrganizationDataSources(attributes, configuration.DataSources) //nolint:staticcheck // DataSources backs Terraform's deprecated datasources block.
 
 	return terraformutils.NewResource(
 		guardDutyOrganizationConfigurationResourceID(detectorID),
@@ -689,6 +701,28 @@ func addGuardDutyDataSources(attributes map[string]string, dataSources *guarddut
 		attributes["datasources.0.malware_protection.0.scan_ec2_instance_with_findings.#"] = "1"
 		attributes["datasources.0.malware_protection.0.scan_ec2_instance_with_findings.0.ebs_volumes.#"] = "1"
 		attributes["datasources.0.malware_protection.0.scan_ec2_instance_with_findings.0.ebs_volumes.0.enable"] = strconv.FormatBool(dataSources.MalwareProtection.ScanEc2InstanceWithFindings.EbsVolumes.Status == guarddutytypes.DataSourceStatusEnabled)
+	}
+}
+
+func addGuardDutyOrganizationDataSources(attributes map[string]string, dataSources *guarddutytypes.OrganizationDataSourceConfigurationsResult) {
+	if dataSources == nil {
+		return
+	}
+	attributes["datasources.#"] = "1"
+	if dataSources.S3Logs != nil && dataSources.S3Logs.AutoEnable != nil {
+		attributes["datasources.0.s3_logs.#"] = "1"
+		attributes["datasources.0.s3_logs.0.auto_enable"] = strconv.FormatBool(aws.ToBool(dataSources.S3Logs.AutoEnable))
+	}
+	if dataSources.Kubernetes != nil && dataSources.Kubernetes.AuditLogs != nil && dataSources.Kubernetes.AuditLogs.AutoEnable != nil {
+		attributes["datasources.0.kubernetes.#"] = "1"
+		attributes["datasources.0.kubernetes.0.audit_logs.#"] = "1"
+		attributes["datasources.0.kubernetes.0.audit_logs.0.enable"] = strconv.FormatBool(aws.ToBool(dataSources.Kubernetes.AuditLogs.AutoEnable))
+	}
+	if dataSources.MalwareProtection != nil && dataSources.MalwareProtection.ScanEc2InstanceWithFindings != nil && dataSources.MalwareProtection.ScanEc2InstanceWithFindings.EbsVolumes != nil && dataSources.MalwareProtection.ScanEc2InstanceWithFindings.EbsVolumes.AutoEnable != nil {
+		attributes["datasources.0.malware_protection.#"] = "1"
+		attributes["datasources.0.malware_protection.0.scan_ec2_instance_with_findings.#"] = "1"
+		attributes["datasources.0.malware_protection.0.scan_ec2_instance_with_findings.0.ebs_volumes.#"] = "1"
+		attributes["datasources.0.malware_protection.0.scan_ec2_instance_with_findings.0.ebs_volumes.0.auto_enable"] = strconv.FormatBool(aws.ToBool(dataSources.MalwareProtection.ScanEc2InstanceWithFindings.EbsVolumes.AutoEnable))
 	}
 }
 
@@ -973,6 +1007,52 @@ func guardDutyOrganizationAdminAccountImportable(adminAccount guarddutytypes.Adm
 	return StringValue(adminAccount.AdminAccountId) != "" && adminAccount.AdminStatus == guarddutytypes.AdminStatusEnabled
 }
 
+func guardDutyMalwareProtectionPlansUnavailable(err error) bool {
+	if err == nil {
+		return false
+	}
+	var accessDenied *guarddutytypes.AccessDeniedException
+	if errors.As(err, &accessDenied) {
+		return true
+	}
+	var badRequest *guarddutytypes.BadRequestException
+	if !errors.As(err, &badRequest) {
+		return false
+	}
+	message := strings.ToLower(badRequest.ErrorMessage())
+	return strings.Contains(message, "malware") ||
+		strings.Contains(message, "protection plan") ||
+		strings.Contains(message, "permission") ||
+		strings.Contains(message, "not authorized") ||
+		strings.Contains(message, "not supported") ||
+		strings.Contains(message, "not enabled") ||
+		strings.Contains(message, "not available")
+}
+
+func guardDutyMemberListingUnavailable(err error) bool {
+	if err == nil {
+		return false
+	}
+	var accessDenied *guarddutytypes.AccessDeniedException
+	if errors.As(err, &accessDenied) {
+		return true
+	}
+	var badRequest *guarddutytypes.BadRequestException
+	if !errors.As(err, &badRequest) {
+		return false
+	}
+	message := strings.ToLower(badRequest.ErrorMessage())
+	if strings.Contains(message, "member account") && strings.Contains(message, "cannot") {
+		return true
+	}
+	if !strings.Contains(message, "administrator") && !strings.Contains(message, "master") {
+		return false
+	}
+	return strings.Contains(message, "not") ||
+		strings.Contains(message, "only") ||
+		strings.Contains(message, "must")
+}
+
 func guardDutyResourceNotFound(err error) bool {
 	if err == nil {
 		return false
@@ -995,6 +1075,10 @@ func guardDutyOrganizationResourceUnavailable(err error) bool {
 	if err == nil {
 		return false
 	}
+	var accessDenied *guarddutytypes.AccessDeniedException
+	if errors.As(err, &accessDenied) {
+		return true
+	}
 	var badRequest *guarddutytypes.BadRequestException
 	if !errors.As(err, &badRequest) {
 		return false
@@ -1003,6 +1087,7 @@ func guardDutyOrganizationResourceUnavailable(err error) bool {
 	return strings.Contains(message, "organization") &&
 		(strings.Contains(message, "administrator") ||
 			strings.Contains(message, "delegated") ||
+			strings.Contains(message, "management") ||
 			strings.Contains(message, "master") ||
 			strings.Contains(message, "member"))
 }

--- a/providers/aws/guardduty.go
+++ b/providers/aws/guardduty.go
@@ -200,9 +200,6 @@ func (g *GuardDutyGenerator) loadIPSets(svc *guardduty.Client, detectorID string
 	})
 	for paginator.HasMorePages() {
 		page, err := paginator.NextPage(context.TODO())
-		if guardDutyMemberListingUnavailable(err) {
-			return nil
-		}
 		if err != nil {
 			return err
 		}
@@ -270,6 +267,9 @@ func (g *GuardDutyGenerator) loadMembers(svc *guardduty.Client, detectorID strin
 	})
 	for paginator.HasMorePages() {
 		page, err := paginator.NextPage(context.TODO())
+		if guardDutyMemberListingUnavailable(err) {
+			return nil
+		}
 		if err != nil {
 			return err
 		}

--- a/providers/aws/guardduty_test.go
+++ b/providers/aws/guardduty_test.go
@@ -412,6 +412,17 @@ func TestGuardDutyOrganizationAdminAccountResource(t *testing.T) {
 func TestGuardDutyOrganizationConfigurationResource(t *testing.T) {
 	resource, ok := newGuardDutyOrganizationConfigurationResource(testGuardDutyDetectorID, &guardduty.DescribeOrganizationConfigurationOutput{
 		AutoEnableOrganizationMembers: guarddutytypes.AutoEnableMembersAll,
+		DataSources: &guarddutytypes.OrganizationDataSourceConfigurationsResult{
+			S3Logs: &guarddutytypes.OrganizationS3LogsConfigurationResult{AutoEnable: aws.Bool(true)},
+			Kubernetes: &guarddutytypes.OrganizationKubernetesConfigurationResult{
+				AuditLogs: &guarddutytypes.OrganizationKubernetesAuditLogsConfigurationResult{AutoEnable: aws.Bool(false)},
+			},
+			MalwareProtection: &guarddutytypes.OrganizationMalwareProtectionConfigurationResult{
+				ScanEc2InstanceWithFindings: &guarddutytypes.OrganizationScanEc2InstanceWithFindingsResult{
+					EbsVolumes: &guarddutytypes.OrganizationEbsVolumesResult{AutoEnable: aws.Bool(true)},
+				},
+			},
+		},
 	})
 	if !ok {
 		t.Fatal("expected organization configuration resource")
@@ -425,8 +436,18 @@ func TestGuardDutyOrganizationConfigurationResource(t *testing.T) {
 	}
 	attributes := resource.InstanceState.Attributes
 	for key, want := range map[string]string{
-		"auto_enable_organization_members": "ALL",
-		"detector_id":                      testGuardDutyDetectorID,
+		"auto_enable_organization_members":                                     "ALL",
+		"detector_id":                                                          testGuardDutyDetectorID,
+		"datasources.#":                                                        "1",
+		"datasources.0.s3_logs.#":                                              "1",
+		"datasources.0.s3_logs.0.auto_enable":                                  "true",
+		"datasources.0.kubernetes.#":                                           "1",
+		"datasources.0.kubernetes.0.audit_logs.#":                              "1",
+		"datasources.0.kubernetes.0.audit_logs.0.enable":                       "false",
+		"datasources.0.malware_protection.#":                                   "1",
+		"datasources.0.malware_protection.0.scan_ec2_instance_with_findings.#": "1",
+		"datasources.0.malware_protection.0.scan_ec2_instance_with_findings.0.ebs_volumes.#":             "1",
+		"datasources.0.malware_protection.0.scan_ec2_instance_with_findings.0.ebs_volumes.0.auto_enable": "true",
 	} {
 		if got := attributes[key]; got != want {
 			t.Fatalf("%s = %q, want %q", key, got, want)
@@ -690,12 +711,116 @@ func TestGuardDutyResourceNotFound(t *testing.T) {
 	}
 }
 
+func TestGuardDutyMalwareProtectionPlansUnavailable(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{
+			name: "access denied",
+			err:  &guarddutytypes.AccessDeniedException{Message: aws.String("User is not authorized to perform guardduty:ListMalwareProtectionPlans.")},
+			want: true,
+		},
+		{
+			name: "bad request missing malware feature",
+			err:  &guarddutytypes.BadRequestException{Message: aws.String("Malware Protection plan APIs are not supported in this account.")},
+			want: true,
+		},
+		{
+			name: "other bad request",
+			err:  &guarddutytypes.BadRequestException{Message: aws.String("The request is rejected because a parameter is invalid.")},
+			want: false,
+		},
+		{
+			name: "other error type",
+			err:  errors.New("boom"),
+			want: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := guardDutyMalwareProtectionPlansUnavailable(tt.err); got != tt.want {
+				t.Fatalf("malware protection plans unavailable = %t, want %t", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestGuardDutyMemberListingUnavailable(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{
+			name: "access denied",
+			err:  &guarddutytypes.AccessDeniedException{Message: aws.String("User is not authorized to perform guardduty:ListMembers.")},
+			want: true,
+		},
+		{
+			name: "not administrator",
+			err:  &guarddutytypes.BadRequestException{Message: aws.String("The request is rejected because the current account is not a GuardDuty administrator account.")},
+			want: true,
+		},
+		{
+			name: "administrator only",
+			err:  &guarddutytypes.BadRequestException{Message: aws.String("This API can only be called by the GuardDuty administrator account.")},
+			want: true,
+		},
+		{
+			name: "legacy not master",
+			err:  &guarddutytypes.BadRequestException{Message: aws.String("The request is rejected because the current account is not the master account.")},
+			want: true,
+		},
+		{
+			name: "member account cannot list",
+			err:  &guarddutytypes.BadRequestException{Message: aws.String("This operation cannot be called by a member account.")},
+			want: true,
+		},
+		{
+			name: "detector not owned is still not member listing",
+			err:  &guarddutytypes.BadRequestException{Message: aws.String("The request is rejected because the input detectorId is not owned by the current account.")},
+			want: false,
+		},
+		{
+			name: "other bad request",
+			err:  &guarddutytypes.BadRequestException{Message: aws.String("The request is rejected because a parameter is invalid.")},
+			want: false,
+		},
+		{
+			name: "other error type",
+			err:  errors.New("boom"),
+			want: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := guardDutyMemberListingUnavailable(tt.err); got != tt.want {
+				t.Fatalf("member listing unavailable = %t, want %t", got, tt.want)
+			}
+		})
+	}
+}
+
 func TestGuardDutyOrganizationResourceUnavailable(t *testing.T) {
 	tests := []struct {
 		name string
 		err  error
 		want bool
 	}{
+		{
+			name: "access denied",
+			err:  &guarddutytypes.AccessDeniedException{Message: aws.String("User is not authorized to perform guardduty:ListOrganizationAdminAccounts.")},
+			want: true,
+		},
+		{
+			name: "not management account",
+			err:  &guarddutytypes.BadRequestException{Message: aws.String("Only the organization's management account can run this API operation.")},
+			want: true,
+		},
 		{
 			name: "not delegated administrator",
 			err:  &guarddutytypes.BadRequestException{Message: aws.String("The request is rejected because the account is not the delegated administrator for this organization.")},

--- a/providers/aws/guardduty_test.go
+++ b/providers/aws/guardduty_test.go
@@ -711,6 +711,43 @@ func TestGuardDutyResourceNotFound(t *testing.T) {
 	}
 }
 
+func TestGuardDutyPublishingDestinationNotFound(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{
+			name: "shared not found",
+			err:  &guarddutytypes.ResourceNotFoundException{Message: aws.String("The requested resource does not exist.")},
+			want: true,
+		},
+		{
+			name: "stale destination invalid parameter",
+			err:  &guarddutytypes.BadRequestException{Message: aws.String("The request is rejected because one or more input parameters have invalid values.")},
+			want: true,
+		},
+		{
+			name: "other bad request",
+			err:  &guarddutytypes.BadRequestException{Message: aws.String("The request is rejected because a parameter is invalid.")},
+			want: false,
+		},
+		{
+			name: "other error type",
+			err:  errors.New("boom"),
+			want: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := guardDutyPublishingDestinationNotFound(tt.err); got != tt.want {
+				t.Fatalf("publishing destination not found = %t, want %t", got, tt.want)
+			}
+		})
+	}
+}
+
 func TestGuardDutyMalwareProtectionPlansUnavailable(t *testing.T) {
 	tests := []struct {
 		name string

--- a/providers/aws/guardduty_test.go
+++ b/providers/aws/guardduty_test.go
@@ -827,6 +827,11 @@ func TestGuardDutyOrganizationResourceUnavailable(t *testing.T) {
 			want: true,
 		},
 		{
+			name: "delegated administrator not enabled",
+			err:  &guarddutytypes.BadRequestException{Message: aws.String("delegated administrator account has not been enabled")},
+			want: true,
+		},
+		{
 			name: "not organization member",
 			err:  &guarddutytypes.BadRequestException{Message: aws.String("The request is rejected because the account is not a member of an organization.")},
 			want: true,

--- a/providers/aws/guardduty_test.go
+++ b/providers/aws/guardduty_test.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"errors"
 	"testing"
+	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/guardduty"
@@ -16,6 +17,10 @@ const (
 	testGuardDutyDetectorID       = "12abc34d567e8fa901bc2d34e56789f0"
 	testGuardDutyFilterName       = "CriticalFindings"
 	testGuardDutyIPSetID          = "ipset-1234567890abcdef"
+	testGuardDutyMemberAccountID  = "123456789012"
+	testGuardDutyOrganizationID   = "210987654321"
+	testGuardDutyPlanID           = "mpl-1234567890abcdef"
+	testGuardDutyPublishingID     = "publishing-1234567890abcdef"
 	testGuardDutyThreatIntelSetID = "threatintelset-1234567890abcdef"
 )
 
@@ -39,6 +44,31 @@ func TestGuardDutyResourceIDs(t *testing.T) {
 			name: "ip set",
 			got:  guardDutyChildResourceID(testGuardDutyDetectorID, testGuardDutyIPSetID),
 			want: testGuardDutyDetectorID + ":" + testGuardDutyIPSetID,
+		},
+		{
+			name: "malware protection plan",
+			got:  guardDutyMalwareProtectionPlanResourceID(testGuardDutyPlanID),
+			want: testGuardDutyPlanID,
+		},
+		{
+			name: "member",
+			got:  guardDutyMemberResourceID(testGuardDutyDetectorID, testGuardDutyMemberAccountID),
+			want: testGuardDutyDetectorID + ":" + testGuardDutyMemberAccountID,
+		},
+		{
+			name: "organization admin account",
+			got:  guardDutyOrganizationAdminAccountResourceID(testGuardDutyOrganizationID),
+			want: testGuardDutyOrganizationID,
+		},
+		{
+			name: "organization configuration",
+			got:  guardDutyOrganizationConfigurationResourceID(testGuardDutyDetectorID),
+			want: testGuardDutyDetectorID,
+		},
+		{
+			name: "publishing destination",
+			got:  guardDutyPublishingDestinationResourceID(testGuardDutyDetectorID, testGuardDutyPublishingID),
+			want: testGuardDutyDetectorID + ":" + testGuardDutyPublishingID,
 		},
 		{
 			name: "threat intel set",
@@ -262,6 +292,194 @@ func TestGuardDutyIPSetResource(t *testing.T) {
 	}
 }
 
+func TestGuardDutyMalwareProtectionPlanResource(t *testing.T) {
+	createdAt := time.Date(2024, 1, 2, 3, 4, 5, 0, time.UTC)
+	resource, ok := newGuardDutyMalwareProtectionPlanResource(testGuardDutyPlanID, &guardduty.GetMalwareProtectionPlanOutput{
+		Actions: &guarddutytypes.MalwareProtectionPlanActions{
+			Tagging: &guarddutytypes.MalwareProtectionPlanTaggingAction{Status: guarddutytypes.MalwareProtectionPlanTaggingActionStatusEnabled},
+		},
+		Arn:       aws.String("arn:aws:guardduty:us-east-1:123456789012:malware-protection-plan/" + testGuardDutyPlanID),
+		CreatedAt: &createdAt,
+		ProtectedResource: &guarddutytypes.CreateProtectedResource{
+			S3Bucket: &guarddutytypes.CreateS3BucketResource{
+				BucketName:     aws.String("scan-bucket"),
+				ObjectPrefixes: []string{"incoming/", "archive/"},
+			},
+		},
+		Role:   aws.String("arn:aws:iam::123456789012:role/GuardDutyS3MalwareProtection"),
+		Status: guarddutytypes.MalwareProtectionPlanStatusActive,
+	})
+	if !ok {
+		t.Fatal("expected malware protection plan resource")
+	}
+
+	if got, want := resource.InstanceState.ID, testGuardDutyPlanID; got != want {
+		t.Fatalf("resource ID = %q, want %q", got, want)
+	}
+	if got, want := resource.InstanceInfo.Type, guardDutyMalwareProtectionPlanResourceType; got != want {
+		t.Fatalf("resource type = %q, want %q", got, want)
+	}
+	attributes := resource.InstanceState.Attributes
+	for key, want := range map[string]string{
+		"actions.#":                        "1",
+		"actions.0.tagging.#":              "1",
+		"actions.0.tagging.0.status":       "ENABLED",
+		"arn":                              "arn:aws:guardduty:us-east-1:123456789012:malware-protection-plan/" + testGuardDutyPlanID,
+		"created_at":                       "2024-01-02T03:04:05Z",
+		"protected_resource.#":             "1",
+		"protected_resource.0.s3_bucket.#": "1",
+		"protected_resource.0.s3_bucket.0.bucket_name":       "scan-bucket",
+		"protected_resource.0.s3_bucket.0.object_prefixes.#": "2",
+		"protected_resource.0.s3_bucket.0.object_prefixes.0": "incoming/",
+		"protected_resource.0.s3_bucket.0.object_prefixes.1": "archive/",
+		"role":   "arn:aws:iam::123456789012:role/GuardDutyS3MalwareProtection",
+		"status": "ACTIVE",
+	} {
+		if got := attributes[key]; got != want {
+			t.Fatalf("%s = %q, want %q", key, got, want)
+		}
+	}
+}
+
+func TestGuardDutyMemberResource(t *testing.T) {
+	resource, ok := newGuardDutyMemberResource(testGuardDutyDetectorID, testGuardDutyMemberAccountID, &guarddutytypes.Member{
+		AccountId:          aws.String(testGuardDutyMemberAccountID),
+		Email:              aws.String("member@example.com"),
+		RelationshipStatus: aws.String(guardDutyMemberRelationshipStatusEnabled),
+	})
+	if !ok {
+		t.Fatal("expected member resource")
+	}
+
+	if got, want := resource.InstanceState.ID, testGuardDutyDetectorID+":"+testGuardDutyMemberAccountID; got != want {
+		t.Fatalf("resource ID = %q, want %q", got, want)
+	}
+	if got, want := resource.InstanceInfo.Type, guardDutyMemberResourceType; got != want {
+		t.Fatalf("resource type = %q, want %q", got, want)
+	}
+	attributes := resource.InstanceState.Attributes
+	for key, want := range map[string]string{
+		"account_id":  testGuardDutyMemberAccountID,
+		"detector_id": testGuardDutyDetectorID,
+		"email":       "member@example.com",
+		"invite":      "true",
+	} {
+		if got := attributes[key]; got != want {
+			t.Fatalf("%s = %q, want %q", key, got, want)
+		}
+	}
+
+	resource, ok = newGuardDutyMemberResource(testGuardDutyDetectorID, testGuardDutyMemberAccountID, &guarddutytypes.Member{
+		AccountId:          aws.String(testGuardDutyMemberAccountID),
+		Email:              aws.String("member@example.com"),
+		RelationshipStatus: aws.String(guardDutyMemberRelationshipStatusCreated),
+	})
+	if !ok {
+		t.Fatal("expected created member resource")
+	}
+	if got, want := resource.InstanceState.Attributes["invite"], "false"; got != want {
+		t.Fatalf("created member invite = %q, want %q", got, want)
+	}
+}
+
+func TestGuardDutyOrganizationAdminAccountResource(t *testing.T) {
+	resource, ok := newGuardDutyOrganizationAdminAccountResource(guarddutytypes.AdminAccount{
+		AdminAccountId: aws.String(testGuardDutyOrganizationID),
+		AdminStatus:    guarddutytypes.AdminStatusEnabled,
+	})
+	if !ok {
+		t.Fatal("expected organization admin account resource")
+	}
+
+	if got, want := resource.InstanceState.ID, testGuardDutyOrganizationID; got != want {
+		t.Fatalf("resource ID = %q, want %q", got, want)
+	}
+	if got, want := resource.InstanceInfo.Type, guardDutyOrganizationAdminAccountResourceType; got != want {
+		t.Fatalf("resource type = %q, want %q", got, want)
+	}
+	if got, want := resource.InstanceState.Attributes["admin_account_id"], testGuardDutyOrganizationID; got != want {
+		t.Fatalf("admin_account_id = %q, want %q", got, want)
+	}
+
+	if _, ok := newGuardDutyOrganizationAdminAccountResource(guarddutytypes.AdminAccount{
+		AdminAccountId: aws.String(testGuardDutyOrganizationID),
+		AdminStatus:    guarddutytypes.AdminStatusDisableInProgress,
+	}); ok {
+		t.Fatal("expected disabled organization admin account to skip")
+	}
+}
+
+func TestGuardDutyOrganizationConfigurationResource(t *testing.T) {
+	resource, ok := newGuardDutyOrganizationConfigurationResource(testGuardDutyDetectorID, &guardduty.DescribeOrganizationConfigurationOutput{
+		AutoEnableOrganizationMembers: guarddutytypes.AutoEnableMembersAll,
+	})
+	if !ok {
+		t.Fatal("expected organization configuration resource")
+	}
+
+	if got, want := resource.InstanceState.ID, testGuardDutyDetectorID; got != want {
+		t.Fatalf("resource ID = %q, want %q", got, want)
+	}
+	if got, want := resource.InstanceInfo.Type, guardDutyOrganizationConfigurationResourceType; got != want {
+		t.Fatalf("resource type = %q, want %q", got, want)
+	}
+	attributes := resource.InstanceState.Attributes
+	for key, want := range map[string]string{
+		"auto_enable_organization_members": "ALL",
+		"detector_id":                      testGuardDutyDetectorID,
+	} {
+		if got := attributes[key]; got != want {
+			t.Fatalf("%s = %q, want %q", key, got, want)
+		}
+	}
+}
+
+func TestGuardDutyPublishingDestinationResource(t *testing.T) {
+	resource, ok := newGuardDutyPublishingDestinationResource(testGuardDutyDetectorID, testGuardDutyPublishingID, &guardduty.DescribePublishingDestinationOutput{
+		DestinationId:   aws.String(testGuardDutyPublishingID),
+		DestinationType: guarddutytypes.DestinationTypeS3,
+		DestinationProperties: &guarddutytypes.DestinationProperties{
+			DestinationArn: aws.String("arn:aws:s3:::guardduty-findings"),
+			KmsKeyArn:      aws.String("arn:aws:kms:us-east-1:123456789012:key/00000000-0000-0000-0000-000000000000"),
+		},
+		Status: guarddutytypes.PublishingStatusPublishing,
+	})
+	if !ok {
+		t.Fatal("expected publishing destination resource")
+	}
+
+	if got, want := resource.InstanceState.ID, testGuardDutyDetectorID+":"+testGuardDutyPublishingID; got != want {
+		t.Fatalf("resource ID = %q, want %q", got, want)
+	}
+	if got, want := resource.InstanceInfo.Type, guardDutyPublishingDestinationResourceType; got != want {
+		t.Fatalf("resource type = %q, want %q", got, want)
+	}
+	attributes := resource.InstanceState.Attributes
+	for key, want := range map[string]string{
+		"destination_arn":  "arn:aws:s3:::guardduty-findings",
+		"destination_id":   testGuardDutyPublishingID,
+		"destination_type": "S3",
+		"detector_id":      testGuardDutyDetectorID,
+		"kms_key_arn":      "arn:aws:kms:us-east-1:123456789012:key/00000000-0000-0000-0000-000000000000",
+	} {
+		if got := attributes[key]; got != want {
+			t.Fatalf("%s = %q, want %q", key, got, want)
+		}
+	}
+
+	if _, ok := newGuardDutyPublishingDestinationResource(testGuardDutyDetectorID, testGuardDutyPublishingID, &guardduty.DescribePublishingDestinationOutput{
+		DestinationId:   aws.String(testGuardDutyPublishingID),
+		DestinationType: guarddutytypes.DestinationTypeS3,
+		DestinationProperties: &guarddutytypes.DestinationProperties{
+			DestinationArn: aws.String("arn:aws:s3:::guardduty-findings"),
+			KmsKeyArn:      aws.String("arn:aws:kms:us-east-1:123456789012:key/00000000-0000-0000-0000-000000000000"),
+		},
+		Status: guarddutytypes.PublishingStatusPendingVerification,
+	}); ok {
+		t.Fatal("expected pending publishing destination to skip")
+	}
+}
+
 func TestGuardDutyThreatIntelSetResource(t *testing.T) {
 	resource, ok := newGuardDutyThreatIntelSetResource(testGuardDutyDetectorID, testGuardDutyThreatIntelSetID, &guardduty.GetThreatIntelSetOutput{
 		Format:   guarddutytypes.ThreatIntelSetFormatStix,
@@ -306,8 +524,74 @@ func TestGuardDutyEmptyIdentifierSkipBehavior(t *testing.T) {
 	if _, ok := newGuardDutyIPSetResource(testGuardDutyDetectorID, "", &guardduty.GetIPSetOutput{}); ok {
 		t.Fatal("expected empty ipset ID to skip")
 	}
+	if _, ok := newGuardDutyMalwareProtectionPlanResource("", guardDutyTestMalwareProtectionPlan("scan-bucket")); ok {
+		t.Fatal("expected empty malware protection plan ID to skip")
+	}
+	if _, ok := newGuardDutyMemberResource("", testGuardDutyMemberAccountID, guardDutyTestMember(testGuardDutyMemberAccountID)); ok {
+		t.Fatal("expected empty member detector ID to skip")
+	}
+	if _, ok := newGuardDutyMemberResource(testGuardDutyDetectorID, "", guardDutyTestMember(testGuardDutyMemberAccountID)); ok {
+		t.Fatal("expected empty member account ID to skip")
+	}
+	if _, ok := newGuardDutyOrganizationAdminAccountResource(guarddutytypes.AdminAccount{}); ok {
+		t.Fatal("expected empty organization admin account ID to skip")
+	}
+	if _, ok := newGuardDutyOrganizationConfigurationResource("", &guardduty.DescribeOrganizationConfigurationOutput{AutoEnableOrganizationMembers: guarddutytypes.AutoEnableMembersAll}); ok {
+		t.Fatal("expected empty organization configuration detector ID to skip")
+	}
+	if _, ok := newGuardDutyPublishingDestinationResource(testGuardDutyDetectorID, "", guardDutyTestPublishingDestination(testGuardDutyPublishingID)); ok {
+		t.Fatal("expected empty publishing destination ID to skip")
+	}
 	if _, ok := newGuardDutyThreatIntelSetResource(testGuardDutyDetectorID, "", &guardduty.GetThreatIntelSetOutput{}); ok {
 		t.Fatal("expected empty threat intel set ID to skip")
+	}
+}
+
+func TestGuardDutyImportabilityPredicates(t *testing.T) {
+	if _, ok := newGuardDutyMalwareProtectionPlanResource(testGuardDutyPlanID, &guardduty.GetMalwareProtectionPlanOutput{
+		ProtectedResource: &guarddutytypes.CreateProtectedResource{
+			S3Bucket: &guarddutytypes.CreateS3BucketResource{BucketName: aws.String("scan-bucket")},
+		},
+		Role: aws.String("arn:aws:iam::123456789012:role/GuardDutyS3MalwareProtection"),
+	}); ok {
+		t.Fatal("expected malware protection plan with empty status to skip")
+	}
+	if _, ok := newGuardDutyMalwareProtectionPlanResource(testGuardDutyPlanID, &guardduty.GetMalwareProtectionPlanOutput{
+		ProtectedResource: &guarddutytypes.CreateProtectedResource{},
+		Role:              aws.String("arn:aws:iam::123456789012:role/GuardDutyS3MalwareProtection"),
+		Status:            guarddutytypes.MalwareProtectionPlanStatusActive,
+	}); ok {
+		t.Fatal("expected malware protection plan without S3 bucket to skip")
+	}
+	if _, ok := newGuardDutyMemberResource(testGuardDutyDetectorID, testGuardDutyMemberAccountID, &guarddutytypes.Member{
+		AccountId:          aws.String(testGuardDutyMemberAccountID),
+		RelationshipStatus: aws.String(guardDutyMemberRelationshipStatusEnabled),
+	}); ok {
+		t.Fatal("expected member without email to skip")
+	}
+	if _, ok := newGuardDutyMemberResource(testGuardDutyDetectorID, testGuardDutyMemberAccountID, &guarddutytypes.Member{
+		AccountId:          aws.String(testGuardDutyMemberAccountID),
+		Email:              aws.String("member@example.com"),
+		RelationshipStatus: aws.String("Removed"),
+	}); ok {
+		t.Fatal("expected member with unsupported relationship to skip")
+	}
+	if _, ok := newGuardDutyMemberResource(testGuardDutyDetectorID, testGuardDutyMemberAccountID, &guarddutytypes.Member{
+		AccountId:          aws.String("999999999999"),
+		Email:              aws.String("member@example.com"),
+		RelationshipStatus: aws.String(guardDutyMemberRelationshipStatusEnabled),
+	}); ok {
+		t.Fatal("expected member with mismatched account ID to skip")
+	}
+	if _, ok := newGuardDutyOrganizationConfigurationResource(testGuardDutyDetectorID, &guardduty.DescribeOrganizationConfigurationOutput{}); ok {
+		t.Fatal("expected organization configuration without auto-enable mode to skip")
+	}
+	if _, ok := newGuardDutyPublishingDestinationResource(testGuardDutyDetectorID, testGuardDutyPublishingID, &guardduty.DescribePublishingDestinationOutput{
+		DestinationId:   aws.String(testGuardDutyPublishingID),
+		DestinationType: guarddutytypes.DestinationTypeS3,
+		Status:          guarddutytypes.PublishingStatusPublishing,
+	}); ok {
+		t.Fatal("expected publishing destination without properties to skip")
 	}
 }
 
@@ -347,6 +631,17 @@ func TestGuardDutyResourceNamesDoNotCollapseJoinedParts(t *testing.T) {
 	if resourceOne.ResourceName == resourceTwo.ResourceName {
 		t.Fatalf("resource names collapsed after sanitize: %q", resourceOne.ResourceName)
 	}
+	memberOne, ok := newGuardDutyMemberResource("detector_a", "b", guardDutyTestMember("b"))
+	if !ok {
+		t.Fatal("expected first member resource")
+	}
+	memberTwo, ok := newGuardDutyMemberResource("detector", "a_b", guardDutyTestMember("a_b"))
+	if !ok {
+		t.Fatal("expected second member resource")
+	}
+	if memberOne.ResourceName == memberTwo.ResourceName {
+		t.Fatalf("member resource names collapsed after sanitize: %q", memberOne.ResourceName)
+	}
 }
 
 func TestGuardDutyResourceNotFound(t *testing.T) {
@@ -371,6 +666,11 @@ func TestGuardDutyResourceNotFound(t *testing.T) {
 			want: false,
 		},
 		{
+			name: "resource not found exception",
+			err:  &guarddutytypes.ResourceNotFoundException{Message: aws.String("The requested resource does not exist.")},
+			want: true,
+		},
+		{
 			name: "other error type",
 			err:  errors.New("boom"),
 			want: false,
@@ -381,6 +681,43 @@ func TestGuardDutyResourceNotFound(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			if got := guardDutyResourceNotFound(tt.err); got != tt.want {
 				t.Fatalf("not found = %t, want %t", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestGuardDutyOrganizationResourceUnavailable(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{
+			name: "not delegated administrator",
+			err:  &guarddutytypes.BadRequestException{Message: aws.String("The request is rejected because the account is not the delegated administrator for this organization.")},
+			want: true,
+		},
+		{
+			name: "not organization member",
+			err:  &guarddutytypes.BadRequestException{Message: aws.String("The request is rejected because the account is not a member of an organization.")},
+			want: true,
+		},
+		{
+			name: "not organization error",
+			err:  &guarddutytypes.BadRequestException{Message: aws.String("The request is rejected because a parameter is invalid.")},
+			want: false,
+		},
+		{
+			name: "other error type",
+			err:  errors.New("boom"),
+			want: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := guardDutyOrganizationResourceUnavailable(tt.err); got != tt.want {
+				t.Fatalf("organization unavailable = %t, want %t", got, tt.want)
 			}
 		})
 	}
@@ -397,5 +734,35 @@ func guardDutyTestFilter(name string) *guardduty.GetFilterOutput {
 		},
 		Name: aws.String(name),
 		Rank: &rank,
+	}
+}
+
+func guardDutyTestMalwareProtectionPlan(bucketName string) *guardduty.GetMalwareProtectionPlanOutput {
+	return &guardduty.GetMalwareProtectionPlanOutput{
+		ProtectedResource: &guarddutytypes.CreateProtectedResource{
+			S3Bucket: &guarddutytypes.CreateS3BucketResource{BucketName: aws.String(bucketName)},
+		},
+		Role:   aws.String("arn:aws:iam::123456789012:role/GuardDutyS3MalwareProtection"),
+		Status: guarddutytypes.MalwareProtectionPlanStatusActive,
+	}
+}
+
+func guardDutyTestMember(accountID string) *guarddutytypes.Member {
+	return &guarddutytypes.Member{
+		AccountId:          aws.String(accountID),
+		Email:              aws.String("member@example.com"),
+		RelationshipStatus: aws.String(guardDutyMemberRelationshipStatusEnabled),
+	}
+}
+
+func guardDutyTestPublishingDestination(destinationID string) *guardduty.DescribePublishingDestinationOutput {
+	return &guardduty.DescribePublishingDestinationOutput{
+		DestinationId:   aws.String(destinationID),
+		DestinationType: guarddutytypes.DestinationTypeS3,
+		DestinationProperties: &guarddutytypes.DestinationProperties{
+			DestinationArn: aws.String("arn:aws:s3:::guardduty-findings"),
+			KmsKeyArn:      aws.String("arn:aws:kms:us-east-1:123456789012:key/00000000-0000-0000-0000-000000000000"),
+		},
+		Status: guarddutytypes.PublishingStatusPublishing,
 	}
 }

--- a/providers/aws/guardduty_test.go
+++ b/providers/aws/guardduty_test.go
@@ -467,7 +467,7 @@ func TestGuardDutyPublishingDestinationResource(t *testing.T) {
 		}
 	}
 
-	if _, ok := newGuardDutyPublishingDestinationResource(testGuardDutyDetectorID, testGuardDutyPublishingID, &guardduty.DescribePublishingDestinationOutput{
+	resource, ok = newGuardDutyPublishingDestinationResource(testGuardDutyDetectorID, testGuardDutyPublishingID, &guardduty.DescribePublishingDestinationOutput{
 		DestinationId:   aws.String(testGuardDutyPublishingID),
 		DestinationType: guarddutytypes.DestinationTypeS3,
 		DestinationProperties: &guarddutytypes.DestinationProperties{
@@ -475,8 +475,12 @@ func TestGuardDutyPublishingDestinationResource(t *testing.T) {
 			KmsKeyArn:      aws.String("arn:aws:kms:us-east-1:123456789012:key/00000000-0000-0000-0000-000000000000"),
 		},
 		Status: guarddutytypes.PublishingStatusPendingVerification,
-	}); ok {
-		t.Fatal("expected pending publishing destination to skip")
+	})
+	if !ok {
+		t.Fatal("expected pending publishing destination resource")
+	}
+	if got, want := resource.InstanceState.ID, testGuardDutyDetectorID+":"+testGuardDutyPublishingID; got != want {
+		t.Fatalf("pending destination resource ID = %q, want %q", got, want)
 	}
 }
 

--- a/providers/aws/unsupported_resources.json
+++ b/providers/aws/unsupported_resources.json
@@ -37,6 +37,43 @@
       ]
     },
     {
+      "resource": "aws_guardduty_detector_feature",
+      "service_family": "guardduty",
+      "reason": "Terraform AWS provider does not support importing this resource, so Terraformer cannot seed a provider-recognized import state.",
+      "evidence": "The Terraform AWS provider aws_guardduty_detector_feature resource source has no ResourceImporter and the provider documentation has no Import section; its detector_id/name ID is only assigned during create.",
+      "status": "unsupported",
+      "references": [
+        "https://github.com/chenrui333/terraformer/issues/338",
+        "https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/guardduty_detector_feature",
+        "https://docs.aws.amazon.com/guardduty/latest/APIReference/API_GetDetector.html"
+      ]
+    },
+    {
+      "resource": "aws_guardduty_invite_accepter",
+      "service_family": "guardduty",
+      "reason": "The resource represents accepting a GuardDuty administrator invitation in a member account; discovery can see an existing administrator relationship but cannot safely infer Terraform ownership of the acceptance/disassociation lifecycle.",
+      "evidence": "Terraform AWS provider imports by member detector ID and reads GetMasterAccount, while create calls AcceptInvitation with invitation context. Emitting this from an existing relationship would assume ownership of side-effectful account association state.",
+      "status": "unsupported",
+      "references": [
+        "https://github.com/chenrui333/terraformer/issues/338",
+        "https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/guardduty_invite_accepter",
+        "https://docs.aws.amazon.com/guardduty/latest/APIReference/API_AcceptInvitation.html",
+        "https://docs.aws.amazon.com/guardduty/latest/APIReference/API_GetMasterAccount.html"
+      ]
+    },
+    {
+      "resource": "aws_guardduty_organization_configuration_feature",
+      "service_family": "guardduty",
+      "reason": "Terraform AWS provider does not support importing this resource, so Terraformer cannot seed a provider-recognized import state.",
+      "evidence": "The Terraform AWS provider aws_guardduty_organization_configuration_feature resource source has no ResourceImporter and the provider documentation has no Import section; its detector_id/name ID is only assigned during update/create.",
+      "status": "unsupported",
+      "references": [
+        "https://github.com/chenrui333/terraformer/issues/338",
+        "https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/guardduty_organization_configuration_feature",
+        "https://docs.aws.amazon.com/guardduty/latest/APIReference/API_DescribeOrganizationConfiguration.html"
+      ]
+    },
+    {
       "resource": "aws_ivs_playback_key_pair",
       "service_family": "ivs",
       "reason": "IVS playback key pairs require public_key, but IVS GetPlaybackKeyPair and ListPlaybackKeyPairs responses do not return the public key material needed to seed an imported resource.",


### PR DESCRIPTION
## Summary

- add GuardDuty follow-up import discovery for members, organization admin accounts, organization configurations, publishing destinations, and malware protection plans
- seed import IDs as detector_id:account_id, admin_account_id, detector_id, detector_id:publishing_destination_id, and malware_protection_plan_id
- update docs/aws.md for supported GuardDuty resources
- document unsupported GuardDuty detector feature, organization configuration feature, and invite accepter resources
- add unit tests for GuardDuty follow-up helper behavior

## References

- #338

## Validation

```bash
go test ./providers/aws -run 'Test.*GuardDuty|Test.*Guardduty|Test.*guardduty'
go test ./providers/aws/... ./terraformutils/...
go run ./tools/aws-gap-inventory \
  -docs docs/aws.md \
  -aws-dir providers/aws \
  -skip-list providers/aws/unsupported_resources.json \
  -format markdown
git diff --check
golangci-lint run --new-from-rev=main
```

## Notes

Skipped/deferred resources:
- aws_guardduty_detector_feature: Terraform AWS provider has no importer
- aws_guardduty_organization_configuration_feature: Terraform AWS provider has no importer
- aws_guardduty_invite_accepter: invitation acceptance/account relationship ownership is not safe to infer from discovery

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds GuardDuty follow-up imports for members, org admin accounts, org configuration, publishing destinations, and malware protection plans. Skips admin-only/org-only errors, keeps non-publishing destinations, and skips stale publishing destinations; updates docs, skip-list, and tests.

- **New Features**
  - Discover/import: `aws_guardduty_member` (ID: detector_id:account_id), `aws_guardduty_organization_admin_account` (ID: admin_account_id), `aws_guardduty_organization_configuration` (ID: detector_id), `aws_guardduty_publishing_destination` (ID: detector_id:publishing_destination_id), `aws_guardduty_malware_protection_plan` (ID: malware_protection_plan_id).
  - Import specifics: `aws_guardduty_publishing_destination` for all statuses with destination ARN, KMS key ARN, and destination type; `aws_guardduty_malware_protection_plan` only when status is Active/Warning/Error with role, S3 bucket name/prefixes, tagging action, status, and created_at; set member invite from relationship status.
  - Error handling: treat not-found responses gracefully; skip member listing when not an org admin; skip org-only APIs when not a management/delegated admin or when delegated admin isn’t enabled; ignore unavailable malware plan APIs; skip stale publishing destinations.

<sup>Written for commit 8ac8c1c572c7e8e2800e5349a915a2e363d274e1. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for five additional AWS GuardDuty resource types: malware protection plans, members, organization admin accounts, organization configurations, and publishing destinations.

* **Documentation**
  * Updated AWS supported services list to include the newly supported GuardDuty resources.

* **Chores**
  * Documented additional unsupported GuardDuty features and updated unsupported-resources list.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/chenrui333/terraformer/pull/429)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->