### PR TITLE
aws(edge): add Global Accelerator imports

### DIFF
--- a/docs/aws.md
+++ b/docs/aws.md
@@ -321,6 +321,14 @@ For AWS provider gap audits and unsupported-resource skip-list maintenance, see 
     * `aws_elasticsearch_domain`
 *   `firehose`
     * `aws_kinesis_firehose_delivery_stream`
+*   `globalaccelerator`
+    * `aws_globalaccelerator_accelerator`
+    * `aws_globalaccelerator_cross_account_attachment`
+    * `aws_globalaccelerator_custom_routing_accelerator`
+    * `aws_globalaccelerator_custom_routing_endpoint_group`
+    * `aws_globalaccelerator_custom_routing_listener`
+    * `aws_globalaccelerator_endpoint_group`
+    * `aws_globalaccelerator_listener`
 *   `glue`
     * `aws_glue_catalog_database`
     * `aws_glue_catalog_table`
@@ -681,6 +689,7 @@ List of global AWS services:
 *   `budgets`
 *   `cloudfront`
 *   `ecrpublic`
+*   `globalaccelerator`
 *   `iam`
 *   `organization`
 *   `route53`

--- a/go.mod
+++ b/go.mod
@@ -408,6 +408,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/bedrock v1.59.2
 	github.com/aws/aws-sdk-go-v2/service/bedrockagent v1.53.2
 	github.com/aws/aws-sdk-go-v2/service/directconnect v1.38.17
+	github.com/aws/aws-sdk-go-v2/service/globalaccelerator v1.35.18
 	github.com/aws/aws-sdk-go-v2/service/guardduty v1.75.4
 	github.com/aws/aws-sdk-go-v2/service/ivs v1.50.1
 	github.com/aws/aws-sdk-go-v2/service/ivschat v1.21.22

--- a/go.sum
+++ b/go.sum
@@ -295,6 +295,8 @@ github.com/aws/aws-sdk-go-v2/service/emr v1.59.2 h1:BR7dPfnYULtw1QMLTb4p67A5O7cO
 github.com/aws/aws-sdk-go-v2/service/emr v1.59.2/go.mod h1:cWxbjdU0/WUkpKZ+k03XbZiC5b8OVjCRzQ4wJlnO0Q4=
 github.com/aws/aws-sdk-go-v2/service/firehose v1.42.16 h1:nSg1UAENCjuryTr9JMPMOPXkYOkcpVwQjrrp5rkHUus=
 github.com/aws/aws-sdk-go-v2/service/firehose v1.42.16/go.mod h1:8atLs+8lOWcDaxiD+suvyvt63IuwLbT8zlU6Ti9qZiY=
+github.com/aws/aws-sdk-go-v2/service/globalaccelerator v1.35.18 h1:ZtOElW3+A7mbkToRg32CRvw2kmhLZH8RfOjis29ArzA=
+github.com/aws/aws-sdk-go-v2/service/globalaccelerator v1.35.18/go.mod h1:e2pOrIpl2zSGFiNvd0FvAP01z9XOKR9Y1aJ7dYiE2YM=
 github.com/aws/aws-sdk-go-v2/service/glue v1.141.0 h1:QeZdzcEB+eB76YvIHqZyxsmxH+f9f2kKDdz48UC4HCM=
 github.com/aws/aws-sdk-go-v2/service/glue v1.141.0/go.mod h1:FZCvt95CcJWRkZNRcmMW1uQkpDHmyUSkZfz3awyZgqg=
 github.com/aws/aws-sdk-go-v2/service/guardduty v1.75.4 h1:i/lHZlUwCvEiFU0Qbw2unKW4JsPezrIQEJe7K0dKVo8=

--- a/providers/aws/aws_provider.go
+++ b/providers/aws/aws_provider.go
@@ -27,6 +27,7 @@ var SupportedGlobalResources = []string{
 	"budgets",
 	"cloudfront",
 	"ecrpublic",
+	"globalaccelerator",
 	"iam",
 	"organization",
 	"route53",
@@ -78,6 +79,12 @@ func (p AWSProvider) GetResourceConnections() map[string]map[string][]string {
 		"elb": {
 			"sg":     []string{"security_groups", "id"},
 			"subnet": []string{"subnets", "id"},
+		},
+		"globalaccelerator": {
+			"globalaccelerator": []string{
+				"accelerator_arn", "id",
+				"listener_arn", "id",
+			},
 		},
 		"igw": {"vpc": []string{"vpc_id", "id"}},
 		"identitystore": {
@@ -311,6 +318,7 @@ func (p *AWSProvider) GetSupportedService() map[string]terraformutils.ServiceGen
 		"eni":               &AwsFacade{service: &EniGenerator{}},
 		"es":                &AwsFacade{service: &EsGenerator{}},
 		"firehose":          &AwsFacade{service: &FirehoseGenerator{}},
+		"globalaccelerator": &AwsFacade{service: &GlobalAcceleratorGenerator{}},
 		"glue":              &AwsFacade{service: &GlueGenerator{}},
 		"guardduty":         &AwsFacade{service: &GuardDutyGenerator{}},
 		"iam":               &AwsFacade{service: &IamGenerator{}},

--- a/providers/aws/globalaccelerator.go
+++ b/providers/aws/globalaccelerator.go
@@ -24,6 +24,7 @@ const (
 	globalAcceleratorCustomRoutingListenerResourceType      = "aws_globalaccelerator_custom_routing_listener"
 	globalAcceleratorCustomRoutingEndpointGroupResourceType = "aws_globalaccelerator_custom_routing_endpoint_group"
 	globalAcceleratorCrossAccountAttachmentResourceType     = "aws_globalaccelerator_cross_account_attachment"
+	globalAcceleratorControlPlaneRegion                     = "us-west-2"
 	globalAcceleratorListenerARNPart                        = "/listener/"
 	globalAcceleratorEndpointGroupARNPart                   = "/endpoint-group/"
 )
@@ -71,9 +72,7 @@ func (g *GlobalAcceleratorGenerator) loadOptionalResources(loaders []globalAccel
 
 func globalAcceleratorClientConfig(config aws.Config) aws.Config {
 	globalAcceleratorConfig := config.Copy()
-	if globalAcceleratorConfig.Region == "" || globalAcceleratorConfig.Region == GlobalRegion {
-		globalAcceleratorConfig.Region = MainRegionPublicPartition
-	}
+	globalAcceleratorConfig.Region = globalAcceleratorControlPlaneRegion
 	return globalAcceleratorConfig
 }
 
@@ -719,7 +718,7 @@ func globalAcceleratorPutCrossAccountResources(attributes map[string]string, res
 		prefix := "resource." + strconv.Itoa(i)
 		globalAcceleratorPutString(attributes, prefix+".endpoint_id", StringValue(resource.EndpointId))
 		globalAcceleratorPutString(attributes, prefix+".region", StringValue(resource.Region))
-		globalAcceleratorPutString(attributes, prefix+".cidr", StringValue(resource.Cidr))
+		globalAcceleratorPutString(attributes, prefix+".cidr_block", StringValue(resource.Cidr))
 	}
 }
 

--- a/providers/aws/globalaccelerator.go
+++ b/providers/aws/globalaccelerator.go
@@ -1,0 +1,829 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package aws
+
+import (
+	"context"
+	"errors"
+	"log"
+	"strconv"
+	"strings"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/globalaccelerator"
+	globalacceleratortypes "github.com/aws/aws-sdk-go-v2/service/globalaccelerator/types"
+	"github.com/aws/smithy-go"
+	"github.com/chenrui333/terraformer/terraformutils"
+)
+
+const (
+	globalAcceleratorAcceleratorResourceType                = "aws_globalaccelerator_accelerator"
+	globalAcceleratorListenerResourceType                   = "aws_globalaccelerator_listener"
+	globalAcceleratorEndpointGroupResourceType              = "aws_globalaccelerator_endpoint_group"
+	globalAcceleratorCustomRoutingAcceleratorResourceType   = "aws_globalaccelerator_custom_routing_accelerator"
+	globalAcceleratorCustomRoutingListenerResourceType      = "aws_globalaccelerator_custom_routing_listener"
+	globalAcceleratorCustomRoutingEndpointGroupResourceType = "aws_globalaccelerator_custom_routing_endpoint_group"
+	globalAcceleratorCrossAccountAttachmentResourceType     = "aws_globalaccelerator_cross_account_attachment"
+	globalAcceleratorListenerARNPart                        = "/listener/"
+	globalAcceleratorEndpointGroupARNPart                   = "/endpoint-group/"
+)
+
+var globalAcceleratorAllowEmptyValues = []string{"tags."}
+
+type globalAcceleratorOptionalResourceLoader struct {
+	name string
+	load func() error
+}
+
+type GlobalAcceleratorGenerator struct {
+	AWSService
+}
+
+func (g *GlobalAcceleratorGenerator) InitResources() error {
+	config, err := g.generateConfig()
+	if err != nil {
+		return err
+	}
+	svc := globalaccelerator.NewFromConfig(globalAcceleratorClientConfig(config))
+
+	if err := g.loadAccelerators(svc); err != nil {
+		return err
+	}
+
+	g.loadOptionalResources([]globalAcceleratorOptionalResourceLoader{
+		{name: "custom routing accelerators", load: func() error { return g.loadCustomRoutingAccelerators(svc) }},
+		{name: "cross-account attachments", load: func() error { return g.loadCrossAccountAttachments(svc) }},
+	})
+
+	return nil
+}
+
+func (g *GlobalAcceleratorGenerator) loadOptionalResources(loaders []globalAcceleratorOptionalResourceLoader) {
+	for _, loader := range loaders {
+		if err := loader.load(); err != nil {
+			if globalAcceleratorResourceNotFound(err) {
+				continue
+			}
+			log.Printf("Skipping Global Accelerator %s: %v", loader.name, err)
+		}
+	}
+}
+
+func globalAcceleratorClientConfig(config aws.Config) aws.Config {
+	globalAcceleratorConfig := config.Copy()
+	if globalAcceleratorConfig.Region == "" || globalAcceleratorConfig.Region == GlobalRegion {
+		globalAcceleratorConfig.Region = MainRegionPublicPartition
+	}
+	return globalAcceleratorConfig
+}
+
+func (g *GlobalAcceleratorGenerator) loadAccelerators(svc *globalaccelerator.Client) error {
+	p := globalaccelerator.NewListAcceleratorsPaginator(svc, &globalaccelerator.ListAcceleratorsInput{})
+	for p.HasMorePages() {
+		page, err := p.NextPage(context.TODO())
+		if err != nil {
+			return err
+		}
+		for _, acceleratorSummary := range page.Accelerators {
+			acceleratorARN := StringValue(acceleratorSummary.AcceleratorArn)
+			if acceleratorARN == "" {
+				continue
+			}
+			accelerator, err := getGlobalAcceleratorAccelerator(svc, acceleratorARN)
+			if globalAcceleratorResourceNotFound(err) {
+				continue
+			}
+			if err != nil {
+				return err
+			}
+			if resource, ok := newGlobalAcceleratorAcceleratorResource(accelerator); ok {
+				g.Resources = append(g.Resources, resource)
+			}
+			if globalAcceleratorAcceleratorImportable(accelerator) {
+				if err := g.loadListeners(svc, acceleratorARN); err != nil {
+					return err
+				}
+			}
+		}
+	}
+	return nil
+}
+
+func (g *GlobalAcceleratorGenerator) loadListeners(svc *globalaccelerator.Client, acceleratorARN string) error {
+	if acceleratorARN == "" {
+		return nil
+	}
+	p := globalaccelerator.NewListListenersPaginator(svc, &globalaccelerator.ListListenersInput{
+		AcceleratorArn: aws.String(acceleratorARN),
+	})
+	for p.HasMorePages() {
+		page, err := p.NextPage(context.TODO())
+		if globalAcceleratorResourceNotFound(err) {
+			return nil
+		}
+		if err != nil {
+			return err
+		}
+		for _, listenerSummary := range page.Listeners {
+			listenerARN := StringValue(listenerSummary.ListenerArn)
+			if listenerARN == "" {
+				continue
+			}
+			listener, err := getGlobalAcceleratorListener(svc, listenerARN)
+			if globalAcceleratorResourceNotFound(err) {
+				continue
+			}
+			if err != nil {
+				return err
+			}
+			if resource, ok := newGlobalAcceleratorListenerResource(listener); ok {
+				g.Resources = append(g.Resources, resource)
+			}
+			if globalAcceleratorListenerImportable(listener) {
+				if err := g.loadEndpointGroups(svc, listenerARN); err != nil {
+					return err
+				}
+			}
+		}
+	}
+	return nil
+}
+
+func (g *GlobalAcceleratorGenerator) loadEndpointGroups(svc *globalaccelerator.Client, listenerARN string) error {
+	if listenerARN == "" {
+		return nil
+	}
+	p := globalaccelerator.NewListEndpointGroupsPaginator(svc, &globalaccelerator.ListEndpointGroupsInput{
+		ListenerArn: aws.String(listenerARN),
+	})
+	for p.HasMorePages() {
+		page, err := p.NextPage(context.TODO())
+		if globalAcceleratorResourceNotFound(err) {
+			return nil
+		}
+		if err != nil {
+			return err
+		}
+		for _, endpointGroupSummary := range page.EndpointGroups {
+			endpointGroupARN := StringValue(endpointGroupSummary.EndpointGroupArn)
+			if endpointGroupARN == "" {
+				continue
+			}
+			endpointGroup, err := getGlobalAcceleratorEndpointGroup(svc, endpointGroupARN)
+			if globalAcceleratorResourceNotFound(err) {
+				continue
+			}
+			if err != nil {
+				return err
+			}
+			if resource, ok := newGlobalAcceleratorEndpointGroupResource(endpointGroup); ok {
+				g.Resources = append(g.Resources, resource)
+			}
+		}
+	}
+	return nil
+}
+
+func (g *GlobalAcceleratorGenerator) loadCustomRoutingAccelerators(svc *globalaccelerator.Client) error {
+	p := globalaccelerator.NewListCustomRoutingAcceleratorsPaginator(svc, &globalaccelerator.ListCustomRoutingAcceleratorsInput{})
+	for p.HasMorePages() {
+		page, err := p.NextPage(context.TODO())
+		if err != nil {
+			return err
+		}
+		for _, acceleratorSummary := range page.Accelerators {
+			acceleratorARN := StringValue(acceleratorSummary.AcceleratorArn)
+			if acceleratorARN == "" {
+				continue
+			}
+			accelerator, err := getGlobalAcceleratorCustomRoutingAccelerator(svc, acceleratorARN)
+			if globalAcceleratorResourceNotFound(err) {
+				continue
+			}
+			if err != nil {
+				return err
+			}
+			if resource, ok := newGlobalAcceleratorCustomRoutingAcceleratorResource(accelerator); ok {
+				g.Resources = append(g.Resources, resource)
+			}
+			if globalAcceleratorCustomRoutingAcceleratorImportable(accelerator) {
+				if err := g.loadCustomRoutingListeners(svc, acceleratorARN); err != nil {
+					return err
+				}
+			}
+		}
+	}
+	return nil
+}
+
+func (g *GlobalAcceleratorGenerator) loadCustomRoutingListeners(svc *globalaccelerator.Client, acceleratorARN string) error {
+	if acceleratorARN == "" {
+		return nil
+	}
+	p := globalaccelerator.NewListCustomRoutingListenersPaginator(svc, &globalaccelerator.ListCustomRoutingListenersInput{
+		AcceleratorArn: aws.String(acceleratorARN),
+	})
+	for p.HasMorePages() {
+		page, err := p.NextPage(context.TODO())
+		if globalAcceleratorResourceNotFound(err) {
+			return nil
+		}
+		if err != nil {
+			return err
+		}
+		for _, listenerSummary := range page.Listeners {
+			listenerARN := StringValue(listenerSummary.ListenerArn)
+			if listenerARN == "" {
+				continue
+			}
+			listener, err := getGlobalAcceleratorCustomRoutingListener(svc, listenerARN)
+			if globalAcceleratorResourceNotFound(err) {
+				continue
+			}
+			if err != nil {
+				return err
+			}
+			if resource, ok := newGlobalAcceleratorCustomRoutingListenerResource(listener); ok {
+				g.Resources = append(g.Resources, resource)
+			}
+			if globalAcceleratorCustomRoutingListenerImportable(listener) {
+				if err := g.loadCustomRoutingEndpointGroups(svc, listenerARN); err != nil {
+					return err
+				}
+			}
+		}
+	}
+	return nil
+}
+
+func (g *GlobalAcceleratorGenerator) loadCustomRoutingEndpointGroups(svc *globalaccelerator.Client, listenerARN string) error {
+	if listenerARN == "" {
+		return nil
+	}
+	p := globalaccelerator.NewListCustomRoutingEndpointGroupsPaginator(svc, &globalaccelerator.ListCustomRoutingEndpointGroupsInput{
+		ListenerArn: aws.String(listenerARN),
+	})
+	for p.HasMorePages() {
+		page, err := p.NextPage(context.TODO())
+		if globalAcceleratorResourceNotFound(err) {
+			return nil
+		}
+		if err != nil {
+			return err
+		}
+		for _, endpointGroupSummary := range page.EndpointGroups {
+			endpointGroupARN := StringValue(endpointGroupSummary.EndpointGroupArn)
+			if endpointGroupARN == "" {
+				continue
+			}
+			endpointGroup, err := getGlobalAcceleratorCustomRoutingEndpointGroup(svc, endpointGroupARN)
+			if globalAcceleratorResourceNotFound(err) {
+				continue
+			}
+			if err != nil {
+				return err
+			}
+			if resource, ok := newGlobalAcceleratorCustomRoutingEndpointGroupResource(endpointGroup); ok {
+				g.Resources = append(g.Resources, resource)
+			}
+		}
+	}
+	return nil
+}
+
+func (g *GlobalAcceleratorGenerator) loadCrossAccountAttachments(svc *globalaccelerator.Client) error {
+	p := globalaccelerator.NewListCrossAccountAttachmentsPaginator(svc, &globalaccelerator.ListCrossAccountAttachmentsInput{})
+	for p.HasMorePages() {
+		page, err := p.NextPage(context.TODO())
+		if err != nil {
+			return err
+		}
+		for _, attachmentSummary := range page.CrossAccountAttachments {
+			attachmentARN := StringValue(attachmentSummary.AttachmentArn)
+			if attachmentARN == "" {
+				continue
+			}
+			attachment, err := getGlobalAcceleratorCrossAccountAttachment(svc, attachmentARN)
+			if globalAcceleratorResourceNotFound(err) {
+				continue
+			}
+			if err != nil {
+				return err
+			}
+			if resource, ok := newGlobalAcceleratorCrossAccountAttachmentResource(attachment); ok {
+				g.Resources = append(g.Resources, resource)
+			}
+		}
+	}
+	return nil
+}
+
+func newGlobalAcceleratorAcceleratorResource(accelerator *globalacceleratortypes.Accelerator) (terraformutils.Resource, bool) {
+	if !globalAcceleratorAcceleratorImportable(accelerator) {
+		return terraformutils.Resource{}, false
+	}
+	acceleratorARN := StringValue(accelerator.AcceleratorArn)
+	attributes := map[string]string{
+		"name": StringValue(accelerator.Name),
+	}
+	globalAcceleratorPutBool(attributes, "enabled", accelerator.Enabled)
+	globalAcceleratorPutString(attributes, "ip_address_type", string(accelerator.IpAddressType))
+	return terraformutils.NewResource(
+		globalAcceleratorImportID(acceleratorARN),
+		globalAcceleratorResourceName("accelerator", StringValue(accelerator.Name), globalAcceleratorARNLastPart(acceleratorARN)),
+		globalAcceleratorAcceleratorResourceType,
+		"aws",
+		attributes,
+		globalAcceleratorAllowEmptyValues,
+		map[string]interface{}{},
+	), true
+}
+
+func newGlobalAcceleratorListenerResource(listener *globalacceleratortypes.Listener) (terraformutils.Resource, bool) {
+	if !globalAcceleratorListenerImportable(listener) {
+		return terraformutils.Resource{}, false
+	}
+	listenerARN := StringValue(listener.ListenerArn)
+	acceleratorARN := globalAcceleratorAcceleratorARNFromChildARN(listenerARN)
+	attributes := map[string]string{
+		"accelerator_arn": acceleratorARN,
+		"client_affinity": string(listener.ClientAffinity),
+		"protocol":        string(listener.Protocol),
+	}
+	globalAcceleratorPutPortRanges(attributes, "port_range", listener.PortRanges)
+	return terraformutils.NewResource(
+		globalAcceleratorImportID(listenerARN),
+		globalAcceleratorResourceName("listener", globalAcceleratorARNLastPart(acceleratorARN), globalAcceleratorARNLastPart(listenerARN)),
+		globalAcceleratorListenerResourceType,
+		"aws",
+		attributes,
+		globalAcceleratorAllowEmptyValues,
+		map[string]interface{}{},
+	), true
+}
+
+func newGlobalAcceleratorEndpointGroupResource(endpointGroup *globalacceleratortypes.EndpointGroup) (terraformutils.Resource, bool) {
+	if !globalAcceleratorEndpointGroupImportable(endpointGroup) {
+		return terraformutils.Resource{}, false
+	}
+	endpointGroupARN := StringValue(endpointGroup.EndpointGroupArn)
+	listenerARN := globalAcceleratorListenerARNFromEndpointGroupARN(endpointGroupARN)
+	attributes := map[string]string{
+		"endpoint_group_region": StringValue(endpointGroup.EndpointGroupRegion),
+		"listener_arn":          listenerARN,
+	}
+	globalAcceleratorPutInt32(attributes, "health_check_interval_seconds", endpointGroup.HealthCheckIntervalSeconds)
+	globalAcceleratorPutString(attributes, "health_check_path", StringValue(endpointGroup.HealthCheckPath))
+	globalAcceleratorPutInt32(attributes, "health_check_port", endpointGroup.HealthCheckPort)
+	globalAcceleratorPutString(attributes, "health_check_protocol", string(endpointGroup.HealthCheckProtocol))
+	globalAcceleratorPutFloat32(attributes, "traffic_dial_percentage", endpointGroup.TrafficDialPercentage)
+	globalAcceleratorPutInt32(attributes, "threshold_count", endpointGroup.ThresholdCount)
+	globalAcceleratorPutEndpointConfigurations(attributes, endpointGroup.EndpointDescriptions)
+	globalAcceleratorPutPortOverrides(attributes, endpointGroup.PortOverrides)
+	return terraformutils.NewResource(
+		globalAcceleratorImportID(endpointGroupARN),
+		globalAcceleratorResourceName("endpoint_group", globalAcceleratorARNLastPart(listenerARN), StringValue(endpointGroup.EndpointGroupRegion), globalAcceleratorARNLastPart(endpointGroupARN)),
+		globalAcceleratorEndpointGroupResourceType,
+		"aws",
+		attributes,
+		globalAcceleratorAllowEmptyValues,
+		map[string]interface{}{},
+	), true
+}
+
+func newGlobalAcceleratorCustomRoutingAcceleratorResource(accelerator *globalacceleratortypes.CustomRoutingAccelerator) (terraformutils.Resource, bool) {
+	if !globalAcceleratorCustomRoutingAcceleratorImportable(accelerator) {
+		return terraformutils.Resource{}, false
+	}
+	acceleratorARN := StringValue(accelerator.AcceleratorArn)
+	attributes := map[string]string{
+		"name": StringValue(accelerator.Name),
+	}
+	globalAcceleratorPutBool(attributes, "enabled", accelerator.Enabled)
+	globalAcceleratorPutString(attributes, "ip_address_type", string(accelerator.IpAddressType))
+	return terraformutils.NewResource(
+		globalAcceleratorImportID(acceleratorARN),
+		globalAcceleratorResourceName("custom_routing_accelerator", StringValue(accelerator.Name), globalAcceleratorARNLastPart(acceleratorARN)),
+		globalAcceleratorCustomRoutingAcceleratorResourceType,
+		"aws",
+		attributes,
+		globalAcceleratorAllowEmptyValues,
+		map[string]interface{}{},
+	), true
+}
+
+func newGlobalAcceleratorCustomRoutingListenerResource(listener *globalacceleratortypes.CustomRoutingListener) (terraformutils.Resource, bool) {
+	if !globalAcceleratorCustomRoutingListenerImportable(listener) {
+		return terraformutils.Resource{}, false
+	}
+	listenerARN := StringValue(listener.ListenerArn)
+	acceleratorARN := globalAcceleratorAcceleratorARNFromChildARN(listenerARN)
+	attributes := map[string]string{
+		"accelerator_arn": acceleratorARN,
+	}
+	globalAcceleratorPutPortRanges(attributes, "port_range", listener.PortRanges)
+	return terraformutils.NewResource(
+		globalAcceleratorImportID(listenerARN),
+		globalAcceleratorResourceName("custom_routing_listener", globalAcceleratorARNLastPart(acceleratorARN), globalAcceleratorARNLastPart(listenerARN)),
+		globalAcceleratorCustomRoutingListenerResourceType,
+		"aws",
+		attributes,
+		globalAcceleratorAllowEmptyValues,
+		map[string]interface{}{},
+	), true
+}
+
+func newGlobalAcceleratorCustomRoutingEndpointGroupResource(endpointGroup *globalacceleratortypes.CustomRoutingEndpointGroup) (terraformutils.Resource, bool) {
+	if !globalAcceleratorCustomRoutingEndpointGroupImportable(endpointGroup) {
+		return terraformutils.Resource{}, false
+	}
+	endpointGroupARN := StringValue(endpointGroup.EndpointGroupArn)
+	listenerARN := globalAcceleratorListenerARNFromEndpointGroupARN(endpointGroupARN)
+	attributes := map[string]string{
+		"endpoint_group_region": StringValue(endpointGroup.EndpointGroupRegion),
+		"listener_arn":          listenerARN,
+	}
+	globalAcceleratorPutCustomRoutingDestinationConfigurations(attributes, endpointGroup.DestinationDescriptions)
+	globalAcceleratorPutCustomRoutingEndpointConfigurations(attributes, endpointGroup.EndpointDescriptions)
+	return terraformutils.NewResource(
+		globalAcceleratorImportID(endpointGroupARN),
+		globalAcceleratorResourceName("custom_routing_endpoint_group", globalAcceleratorARNLastPart(listenerARN), StringValue(endpointGroup.EndpointGroupRegion), globalAcceleratorARNLastPart(endpointGroupARN)),
+		globalAcceleratorCustomRoutingEndpointGroupResourceType,
+		"aws",
+		attributes,
+		globalAcceleratorAllowEmptyValues,
+		map[string]interface{}{},
+	), true
+}
+
+func newGlobalAcceleratorCrossAccountAttachmentResource(attachment *globalacceleratortypes.Attachment) (terraformutils.Resource, bool) {
+	if !globalAcceleratorCrossAccountAttachmentImportable(attachment) {
+		return terraformutils.Resource{}, false
+	}
+	attachmentARN := StringValue(attachment.AttachmentArn)
+	attributes := map[string]string{
+		"name": StringValue(attachment.Name),
+	}
+	globalAcceleratorPutStringList(attributes, "principals", attachment.Principals)
+	globalAcceleratorPutCrossAccountResources(attributes, attachment.Resources)
+	return terraformutils.NewResource(
+		globalAcceleratorImportID(attachmentARN),
+		globalAcceleratorResourceName("cross_account_attachment", StringValue(attachment.Name), globalAcceleratorARNLastPart(attachmentARN)),
+		globalAcceleratorCrossAccountAttachmentResourceType,
+		"aws",
+		attributes,
+		globalAcceleratorAllowEmptyValues,
+		map[string]interface{}{},
+	), true
+}
+
+func globalAcceleratorAcceleratorImportable(accelerator *globalacceleratortypes.Accelerator) bool {
+	return accelerator != nil &&
+		StringValue(accelerator.AcceleratorArn) != "" &&
+		StringValue(accelerator.Name) != "" &&
+		accelerator.Status == globalacceleratortypes.AcceleratorStatusDeployed
+}
+
+func globalAcceleratorListenerImportable(listener *globalacceleratortypes.Listener) bool {
+	return listener != nil &&
+		StringValue(listener.ListenerArn) != "" &&
+		globalAcceleratorAcceleratorARNFromChildARN(StringValue(listener.ListenerArn)) != "" &&
+		listener.Protocol != "" &&
+		globalAcceleratorHasPortRange(listener.PortRanges)
+}
+
+func globalAcceleratorEndpointGroupImportable(endpointGroup *globalacceleratortypes.EndpointGroup) bool {
+	return endpointGroup != nil &&
+		StringValue(endpointGroup.EndpointGroupArn) != "" &&
+		StringValue(endpointGroup.EndpointGroupRegion) != "" &&
+		globalAcceleratorListenerARNFromEndpointGroupARN(StringValue(endpointGroup.EndpointGroupArn)) != ""
+}
+
+func globalAcceleratorCustomRoutingAcceleratorImportable(accelerator *globalacceleratortypes.CustomRoutingAccelerator) bool {
+	return accelerator != nil &&
+		StringValue(accelerator.AcceleratorArn) != "" &&
+		StringValue(accelerator.Name) != "" &&
+		accelerator.Status == globalacceleratortypes.CustomRoutingAcceleratorStatusDeployed
+}
+
+func globalAcceleratorCustomRoutingListenerImportable(listener *globalacceleratortypes.CustomRoutingListener) bool {
+	return listener != nil &&
+		StringValue(listener.ListenerArn) != "" &&
+		globalAcceleratorAcceleratorARNFromChildARN(StringValue(listener.ListenerArn)) != "" &&
+		globalAcceleratorHasPortRange(listener.PortRanges)
+}
+
+func globalAcceleratorCustomRoutingEndpointGroupImportable(endpointGroup *globalacceleratortypes.CustomRoutingEndpointGroup) bool {
+	return endpointGroup != nil &&
+		StringValue(endpointGroup.EndpointGroupArn) != "" &&
+		StringValue(endpointGroup.EndpointGroupRegion) != "" &&
+		globalAcceleratorListenerARNFromEndpointGroupARN(StringValue(endpointGroup.EndpointGroupArn)) != "" &&
+		globalAcceleratorHasCustomRoutingDestination(endpointGroup.DestinationDescriptions)
+}
+
+func globalAcceleratorCrossAccountAttachmentImportable(attachment *globalacceleratortypes.Attachment) bool {
+	return attachment != nil &&
+		StringValue(attachment.AttachmentArn) != "" &&
+		StringValue(attachment.Name) != ""
+}
+
+func globalAcceleratorHasPortRange(portRanges []globalacceleratortypes.PortRange) bool {
+	for _, portRange := range portRanges {
+		if portRange.FromPort != nil && portRange.ToPort != nil {
+			return true
+		}
+	}
+	return false
+}
+
+func globalAcceleratorHasCustomRoutingDestination(destinations []globalacceleratortypes.CustomRoutingDestinationDescription) bool {
+	for _, destination := range destinations {
+		if destination.FromPort != nil && destination.ToPort != nil && len(destination.Protocols) > 0 {
+			return true
+		}
+	}
+	return false
+}
+
+func globalAcceleratorImportID(id string) string {
+	return id
+}
+
+func globalAcceleratorResourceName(parts ...string) string {
+	var name strings.Builder
+	for _, part := range parts {
+		if part == "" {
+			continue
+		}
+		if name.Len() > 0 {
+			name.WriteString("_")
+		}
+		name.WriteString(strconv.Itoa(len(part)))
+		name.WriteString("_")
+		name.WriteString(part)
+	}
+	return name.String()
+}
+
+func globalAcceleratorARNLastPart(resourceARN string) string {
+	if resourceARN == "" {
+		return ""
+	}
+	parts := strings.Split(resourceARN, "/")
+	return parts[len(parts)-1]
+}
+
+func globalAcceleratorAcceleratorARNFromChildARN(childARN string) string {
+	return globalAcceleratorParentARN(childARN, globalAcceleratorListenerARNPart)
+}
+
+func globalAcceleratorListenerARNFromEndpointGroupARN(endpointGroupARN string) string {
+	return globalAcceleratorParentARN(endpointGroupARN, globalAcceleratorEndpointGroupARNPart)
+}
+
+func globalAcceleratorParentARN(childARN, childPart string) string {
+	if childARN == "" || childPart == "" {
+		return ""
+	}
+	index := strings.Index(childARN, childPart)
+	if index <= 0 {
+		return ""
+	}
+	return childARN[:index]
+}
+
+func globalAcceleratorPutString(attributes map[string]string, key, value string) {
+	if value != "" {
+		attributes[key] = value
+	}
+}
+
+func globalAcceleratorPutBool(attributes map[string]string, key string, value *bool) {
+	if value != nil {
+		attributes[key] = strconv.FormatBool(aws.ToBool(value))
+	}
+}
+
+func globalAcceleratorPutInt32(attributes map[string]string, key string, value *int32) {
+	if value != nil {
+		attributes[key] = strconv.Itoa(int(aws.ToInt32(value)))
+	}
+}
+
+func globalAcceleratorPutFloat32(attributes map[string]string, key string, value *float32) {
+	if value != nil {
+		attributes[key] = strconv.FormatFloat(float64(*value), 'f', -1, 32)
+	}
+}
+
+func globalAcceleratorPutStringList(attributes map[string]string, key string, values []string) {
+	filtered := make([]string, 0, len(values))
+	for _, value := range values {
+		if value != "" {
+			filtered = append(filtered, value)
+		}
+	}
+	attributes[key+".#"] = strconv.Itoa(len(filtered))
+	for i, value := range filtered {
+		attributes[key+"."+strconv.Itoa(i)] = value
+	}
+}
+
+func globalAcceleratorPutPortRanges(attributes map[string]string, key string, portRanges []globalacceleratortypes.PortRange) {
+	filtered := make([]globalacceleratortypes.PortRange, 0, len(portRanges))
+	for _, portRange := range portRanges {
+		if portRange.FromPort != nil && portRange.ToPort != nil {
+			filtered = append(filtered, portRange)
+		}
+	}
+	attributes[key+".#"] = strconv.Itoa(len(filtered))
+	for i, portRange := range filtered {
+		prefix := key + "." + strconv.Itoa(i)
+		globalAcceleratorPutInt32(attributes, prefix+".from_port", portRange.FromPort)
+		globalAcceleratorPutInt32(attributes, prefix+".to_port", portRange.ToPort)
+	}
+}
+
+func globalAcceleratorPutEndpointConfigurations(attributes map[string]string, endpoints []globalacceleratortypes.EndpointDescription) {
+	filtered := make([]globalacceleratortypes.EndpointDescription, 0, len(endpoints))
+	for _, endpoint := range endpoints {
+		if StringValue(endpoint.EndpointId) != "" {
+			filtered = append(filtered, endpoint)
+		}
+	}
+	attributes["endpoint_configuration.#"] = strconv.Itoa(len(filtered))
+	for i, endpoint := range filtered {
+		prefix := "endpoint_configuration." + strconv.Itoa(i)
+		globalAcceleratorPutString(attributes, prefix+".endpoint_id", StringValue(endpoint.EndpointId))
+		globalAcceleratorPutBool(attributes, prefix+".client_ip_preservation_enabled", endpoint.ClientIPPreservationEnabled)
+		globalAcceleratorPutInt32(attributes, prefix+".weight", endpoint.Weight)
+	}
+}
+
+func globalAcceleratorPutPortOverrides(attributes map[string]string, portOverrides []globalacceleratortypes.PortOverride) {
+	filtered := make([]globalacceleratortypes.PortOverride, 0, len(portOverrides))
+	for _, portOverride := range portOverrides {
+		if portOverride.EndpointPort != nil && portOverride.ListenerPort != nil {
+			filtered = append(filtered, portOverride)
+		}
+	}
+	attributes["port_override.#"] = strconv.Itoa(len(filtered))
+	for i, portOverride := range filtered {
+		prefix := "port_override." + strconv.Itoa(i)
+		globalAcceleratorPutInt32(attributes, prefix+".endpoint_port", portOverride.EndpointPort)
+		globalAcceleratorPutInt32(attributes, prefix+".listener_port", portOverride.ListenerPort)
+	}
+}
+
+func globalAcceleratorPutCustomRoutingDestinationConfigurations(attributes map[string]string, destinations []globalacceleratortypes.CustomRoutingDestinationDescription) {
+	filtered := make([]globalacceleratortypes.CustomRoutingDestinationDescription, 0, len(destinations))
+	for _, destination := range destinations {
+		if destination.FromPort != nil && destination.ToPort != nil && len(destination.Protocols) > 0 {
+			filtered = append(filtered, destination)
+		}
+	}
+	attributes["destination_configuration.#"] = strconv.Itoa(len(filtered))
+	for i, destination := range filtered {
+		prefix := "destination_configuration." + strconv.Itoa(i)
+		globalAcceleratorPutInt32(attributes, prefix+".from_port", destination.FromPort)
+		globalAcceleratorPutInt32(attributes, prefix+".to_port", destination.ToPort)
+		attributes[prefix+".protocols.#"] = strconv.Itoa(len(destination.Protocols))
+		for j, protocol := range destination.Protocols {
+			attributes[prefix+".protocols."+strconv.Itoa(j)] = string(protocol)
+		}
+	}
+}
+
+func globalAcceleratorPutCustomRoutingEndpointConfigurations(attributes map[string]string, endpoints []globalacceleratortypes.CustomRoutingEndpointDescription) {
+	filtered := make([]globalacceleratortypes.CustomRoutingEndpointDescription, 0, len(endpoints))
+	for _, endpoint := range endpoints {
+		if StringValue(endpoint.EndpointId) != "" {
+			filtered = append(filtered, endpoint)
+		}
+	}
+	attributes["endpoint_configuration.#"] = strconv.Itoa(len(filtered))
+	for i, endpoint := range filtered {
+		globalAcceleratorPutString(attributes, "endpoint_configuration."+strconv.Itoa(i)+".endpoint_id", StringValue(endpoint.EndpointId))
+	}
+}
+
+func globalAcceleratorPutCrossAccountResources(attributes map[string]string, resources []globalacceleratortypes.Resource) {
+	filtered := make([]globalacceleratortypes.Resource, 0, len(resources))
+	for _, resource := range resources {
+		if StringValue(resource.EndpointId) != "" || StringValue(resource.Cidr) != "" {
+			filtered = append(filtered, resource)
+		}
+	}
+	attributes["resource.#"] = strconv.Itoa(len(filtered))
+	for i, resource := range filtered {
+		prefix := "resource." + strconv.Itoa(i)
+		globalAcceleratorPutString(attributes, prefix+".endpoint_id", StringValue(resource.EndpointId))
+		globalAcceleratorPutString(attributes, prefix+".region", StringValue(resource.Region))
+		globalAcceleratorPutString(attributes, prefix+".cidr", StringValue(resource.Cidr))
+	}
+}
+
+func getGlobalAcceleratorAccelerator(svc *globalaccelerator.Client, arn string) (*globalacceleratortypes.Accelerator, error) {
+	output, err := svc.DescribeAccelerator(context.TODO(), &globalaccelerator.DescribeAcceleratorInput{
+		AcceleratorArn: aws.String(arn),
+	})
+	if err != nil || output == nil {
+		return nil, err
+	}
+	return output.Accelerator, nil
+}
+
+func getGlobalAcceleratorListener(svc *globalaccelerator.Client, arn string) (*globalacceleratortypes.Listener, error) {
+	output, err := svc.DescribeListener(context.TODO(), &globalaccelerator.DescribeListenerInput{
+		ListenerArn: aws.String(arn),
+	})
+	if err != nil || output == nil {
+		return nil, err
+	}
+	return output.Listener, nil
+}
+
+func getGlobalAcceleratorEndpointGroup(svc *globalaccelerator.Client, arn string) (*globalacceleratortypes.EndpointGroup, error) {
+	output, err := svc.DescribeEndpointGroup(context.TODO(), &globalaccelerator.DescribeEndpointGroupInput{
+		EndpointGroupArn: aws.String(arn),
+	})
+	if err != nil || output == nil {
+		return nil, err
+	}
+	return output.EndpointGroup, nil
+}
+
+func getGlobalAcceleratorCustomRoutingAccelerator(svc *globalaccelerator.Client, arn string) (*globalacceleratortypes.CustomRoutingAccelerator, error) {
+	output, err := svc.DescribeCustomRoutingAccelerator(context.TODO(), &globalaccelerator.DescribeCustomRoutingAcceleratorInput{
+		AcceleratorArn: aws.String(arn),
+	})
+	if err != nil || output == nil {
+		return nil, err
+	}
+	return output.Accelerator, nil
+}
+
+func getGlobalAcceleratorCustomRoutingListener(svc *globalaccelerator.Client, arn string) (*globalacceleratortypes.CustomRoutingListener, error) {
+	output, err := svc.DescribeCustomRoutingListener(context.TODO(), &globalaccelerator.DescribeCustomRoutingListenerInput{
+		ListenerArn: aws.String(arn),
+	})
+	if err != nil || output == nil {
+		return nil, err
+	}
+	return output.Listener, nil
+}
+
+func getGlobalAcceleratorCustomRoutingEndpointGroup(svc *globalaccelerator.Client, arn string) (*globalacceleratortypes.CustomRoutingEndpointGroup, error) {
+	output, err := svc.DescribeCustomRoutingEndpointGroup(context.TODO(), &globalaccelerator.DescribeCustomRoutingEndpointGroupInput{
+		EndpointGroupArn: aws.String(arn),
+	})
+	if err != nil || output == nil {
+		return nil, err
+	}
+	return output.EndpointGroup, nil
+}
+
+func getGlobalAcceleratorCrossAccountAttachment(svc *globalaccelerator.Client, arn string) (*globalacceleratortypes.Attachment, error) {
+	output, err := svc.DescribeCrossAccountAttachment(context.TODO(), &globalaccelerator.DescribeCrossAccountAttachmentInput{
+		AttachmentArn: aws.String(arn),
+	})
+	if err != nil || output == nil {
+		return nil, err
+	}
+	return output.CrossAccountAttachment, nil
+}
+
+func globalAcceleratorResourceNotFound(err error) bool {
+	if err == nil {
+		return false
+	}
+	var acceleratorNotFound *globalacceleratortypes.AcceleratorNotFoundException
+	if errors.As(err, &acceleratorNotFound) {
+		return true
+	}
+	var listenerNotFound *globalacceleratortypes.ListenerNotFoundException
+	if errors.As(err, &listenerNotFound) {
+		return true
+	}
+	var endpointGroupNotFound *globalacceleratortypes.EndpointGroupNotFoundException
+	if errors.As(err, &endpointGroupNotFound) {
+		return true
+	}
+	var attachmentNotFound *globalacceleratortypes.AttachmentNotFoundException
+	if errors.As(err, &attachmentNotFound) {
+		return true
+	}
+	var apiErr smithy.APIError
+	if !errors.As(err, &apiErr) {
+		return false
+	}
+	switch apiErr.ErrorCode() {
+	case "AcceleratorNotFoundException",
+		"ListenerNotFoundException",
+		"EndpointGroupNotFoundException",
+		"AttachmentNotFoundException":
+		return true
+	default:
+		return false
+	}
+}

--- a/providers/aws/globalaccelerator_test.go
+++ b/providers/aws/globalaccelerator_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/globalaccelerator/types"
+	"github.com/aws/smithy-go"
 	"github.com/chenrui333/terraformer/terraformutils"
 )
 
@@ -27,15 +28,15 @@ func TestGlobalAcceleratorImportID(t *testing.T) {
 	}
 }
 
-func TestGlobalAcceleratorClientConfigUsesConcreteRegionForGlobalImport(t *testing.T) {
+func TestGlobalAcceleratorClientConfigUsesControlPlaneRegion(t *testing.T) {
 	config := globalAcceleratorClientConfig(aws.Config{Region: GlobalRegion})
-	if got := config.Region; got != MainRegionPublicPartition {
-		t.Fatalf("Region = %q, want %q", got, MainRegionPublicPartition)
+	if got := config.Region; got != globalAcceleratorControlPlaneRegion {
+		t.Fatalf("Region = %q, want %q", got, globalAcceleratorControlPlaneRegion)
 	}
 
-	config = globalAcceleratorClientConfig(aws.Config{Region: "us-west-2"})
-	if got := config.Region; got != "us-west-2" {
-		t.Fatalf("Region = %q, want us-west-2", got)
+	config = globalAcceleratorClientConfig(aws.Config{Region: "eu-west-1"})
+	if got := config.Region; got != globalAcceleratorControlPlaneRegion {
+		t.Fatalf("Region = %q, want %q", got, globalAcceleratorControlPlaneRegion)
 	}
 }
 
@@ -313,8 +314,8 @@ func TestNewGlobalAcceleratorCrossAccountAttachmentResource(t *testing.T) {
 	if got, want := attrs["resource.0.region"], "us-east-1"; got != want {
 		t.Fatalf("resource.0.region = %q, want %q", got, want)
 	}
-	if got, want := attrs["resource.1.cidr"], "203.0.113.0/24"; got != want {
-		t.Fatalf("resource.1.cidr = %q, want %q", got, want)
+	if got, want := attrs["resource.1.cidr_block"], "203.0.113.0/24"; got != want {
+		t.Fatalf("resource.1.cidr_block = %q, want %q", got, want)
 	}
 }
 
@@ -337,6 +338,7 @@ func TestGlobalAcceleratorResourceNotFound(t *testing.T) {
 		{name: "listener", err: &types.ListenerNotFoundException{}, want: true},
 		{name: "endpoint group", err: &types.EndpointGroupNotFoundException{}, want: true},
 		{name: "attachment", err: &types.AttachmentNotFoundException{}, want: true},
+		{name: "api error fallback", err: &smithy.GenericAPIError{Code: "AcceleratorNotFoundException"}, want: true},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/providers/aws/globalaccelerator_test.go
+++ b/providers/aws/globalaccelerator_test.go
@@ -1,0 +1,348 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package aws
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/globalaccelerator/types"
+	"github.com/chenrui333/terraformer/terraformutils"
+)
+
+const (
+	testGlobalAcceleratorAcceleratorARN            = "arn:aws:globalaccelerator::123456789012:accelerator/accel-1"
+	testGlobalAcceleratorListenerARN               = testGlobalAcceleratorAcceleratorARN + "/listener/listener-1"
+	testGlobalAcceleratorEndpointGroupARN          = testGlobalAcceleratorListenerARN + "/endpoint-group/endpoint-group-1"
+	testGlobalAcceleratorCustomAcceleratorARN      = "arn:aws:globalaccelerator::123456789012:accelerator/custom-accel-1"
+	testGlobalAcceleratorCustomListenerARN         = testGlobalAcceleratorCustomAcceleratorARN + "/listener/custom-listener-1"
+	testGlobalAcceleratorCustomEndpointGroupARN    = testGlobalAcceleratorCustomListenerARN + "/endpoint-group/custom-endpoint-group-1"
+	testGlobalAcceleratorCrossAccountAttachmentARN = "arn:aws:globalaccelerator::123456789012:attachment/attachment-1"
+)
+
+func TestGlobalAcceleratorImportID(t *testing.T) {
+	if got := globalAcceleratorImportID(testGlobalAcceleratorAcceleratorARN); got != testGlobalAcceleratorAcceleratorARN {
+		t.Fatalf("globalAcceleratorImportID() = %q, want %q", got, testGlobalAcceleratorAcceleratorARN)
+	}
+}
+
+func TestGlobalAcceleratorClientConfigUsesConcreteRegionForGlobalImport(t *testing.T) {
+	config := globalAcceleratorClientConfig(aws.Config{Region: GlobalRegion})
+	if got := config.Region; got != MainRegionPublicPartition {
+		t.Fatalf("Region = %q, want %q", got, MainRegionPublicPartition)
+	}
+
+	config = globalAcceleratorClientConfig(aws.Config{Region: "us-west-2"})
+	if got := config.Region; got != "us-west-2" {
+		t.Fatalf("Region = %q, want us-west-2", got)
+	}
+}
+
+func TestGlobalAcceleratorARNHelpers(t *testing.T) {
+	if got, want := globalAcceleratorARNLastPart(testGlobalAcceleratorEndpointGroupARN), "endpoint-group-1"; got != want {
+		t.Fatalf("globalAcceleratorARNLastPart() = %q, want %q", got, want)
+	}
+	if got := globalAcceleratorAcceleratorARNFromChildARN(testGlobalAcceleratorListenerARN); got != testGlobalAcceleratorAcceleratorARN {
+		t.Fatalf("globalAcceleratorAcceleratorARNFromChildARN() = %q, want %q", got, testGlobalAcceleratorAcceleratorARN)
+	}
+	if got := globalAcceleratorListenerARNFromEndpointGroupARN(testGlobalAcceleratorEndpointGroupARN); got != testGlobalAcceleratorListenerARN {
+		t.Fatalf("globalAcceleratorListenerARNFromEndpointGroupARN() = %q, want %q", got, testGlobalAcceleratorListenerARN)
+	}
+	if got := globalAcceleratorAcceleratorARNFromChildARN("not-a-child"); got != "" {
+		t.Fatalf("globalAcceleratorAcceleratorARNFromChildARN(invalid) = %q, want empty", got)
+	}
+}
+
+func TestNewGlobalAcceleratorAcceleratorResource(t *testing.T) {
+	resource, ok := newGlobalAcceleratorAcceleratorResource(&types.Accelerator{
+		AcceleratorArn: aws.String(testGlobalAcceleratorAcceleratorARN),
+		Enabled:        aws.Bool(false),
+		IpAddressType:  types.IpAddressTypeDualStack,
+		Name:           aws.String("edge-main"),
+		Status:         types.AcceleratorStatusDeployed,
+	})
+	if !ok {
+		t.Fatal("newGlobalAcceleratorAcceleratorResource() ok = false, want true")
+	}
+	if resource.InstanceInfo.Type != globalAcceleratorAcceleratorResourceType {
+		t.Fatalf("resource type = %q, want %q", resource.InstanceInfo.Type, globalAcceleratorAcceleratorResourceType)
+	}
+	if resource.InstanceState.ID != testGlobalAcceleratorAcceleratorARN {
+		t.Fatalf("resource ID = %q, want %q", resource.InstanceState.ID, testGlobalAcceleratorAcceleratorARN)
+	}
+	if got, want := resource.InstanceState.Attributes["name"], "edge-main"; got != want {
+		t.Fatalf("name = %q, want %q", got, want)
+	}
+	if got, want := resource.InstanceState.Attributes["enabled"], "false"; got != want {
+		t.Fatalf("enabled = %q, want %q", got, want)
+	}
+	if got, want := resource.InstanceState.Attributes["ip_address_type"], "DUAL_STACK"; got != want {
+		t.Fatalf("ip_address_type = %q, want %q", got, want)
+	}
+	if got, want := resource.ResourceName, terraformutils.TfSanitize(globalAcceleratorResourceName("accelerator", "edge-main", "accel-1")); got != want {
+		t.Fatalf("resource name = %q, want %q", got, want)
+	}
+}
+
+func TestNewGlobalAcceleratorAcceleratorResourceSkipsUnsafeEntries(t *testing.T) {
+	tests := []struct {
+		name        string
+		accelerator *types.Accelerator
+	}{
+		{name: "nil", accelerator: nil},
+		{name: "missing arn", accelerator: &types.Accelerator{Name: aws.String("edge-main"), Status: types.AcceleratorStatusDeployed}},
+		{name: "missing name", accelerator: &types.Accelerator{AcceleratorArn: aws.String(testGlobalAcceleratorAcceleratorARN), Status: types.AcceleratorStatusDeployed}},
+		{name: "in progress", accelerator: &types.Accelerator{AcceleratorArn: aws.String(testGlobalAcceleratorAcceleratorARN), Name: aws.String("edge-main"), Status: types.AcceleratorStatusInProgress}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if _, ok := newGlobalAcceleratorAcceleratorResource(tt.accelerator); ok {
+				t.Fatal("newGlobalAcceleratorAcceleratorResource() ok = true, want false")
+			}
+		})
+	}
+}
+
+func TestNewGlobalAcceleratorListenerResource(t *testing.T) {
+	resource, ok := newGlobalAcceleratorListenerResource(&types.Listener{
+		ClientAffinity: types.ClientAffinitySourceIp,
+		ListenerArn:    aws.String(testGlobalAcceleratorListenerARN),
+		PortRanges: []types.PortRange{
+			{FromPort: aws.Int32(80), ToPort: aws.Int32(80)},
+			{FromPort: aws.Int32(443), ToPort: aws.Int32(443)},
+		},
+		Protocol: types.ProtocolTcp,
+	})
+	if !ok {
+		t.Fatal("newGlobalAcceleratorListenerResource() ok = false, want true")
+	}
+	attrs := resource.InstanceState.Attributes
+	if got := resource.InstanceState.ID; got != testGlobalAcceleratorListenerARN {
+		t.Fatalf("resource ID = %q, want %q", got, testGlobalAcceleratorListenerARN)
+	}
+	if got := attrs["accelerator_arn"]; got != testGlobalAcceleratorAcceleratorARN {
+		t.Fatalf("accelerator_arn = %q, want %q", got, testGlobalAcceleratorAcceleratorARN)
+	}
+	if got, want := attrs["protocol"], "TCP"; got != want {
+		t.Fatalf("protocol = %q, want %q", got, want)
+	}
+	if got, want := attrs["port_range.#"], "2"; got != want {
+		t.Fatalf("port_range.# = %q, want %q", got, want)
+	}
+	if got, want := attrs["port_range.1.from_port"], "443"; got != want {
+		t.Fatalf("port_range.1.from_port = %q, want %q", got, want)
+	}
+}
+
+func TestNewGlobalAcceleratorListenerResourceSkipsIncomplete(t *testing.T) {
+	tests := []struct {
+		name     string
+		listener *types.Listener
+	}{
+		{name: "nil", listener: nil},
+		{name: "missing arn", listener: &types.Listener{Protocol: types.ProtocolTcp, PortRanges: []types.PortRange{{FromPort: aws.Int32(80), ToPort: aws.Int32(80)}}}},
+		{name: "missing parent", listener: &types.Listener{ListenerArn: aws.String("arn:aws:globalaccelerator::123456789012:listener/listener-1"), Protocol: types.ProtocolTcp, PortRanges: []types.PortRange{{FromPort: aws.Int32(80), ToPort: aws.Int32(80)}}}},
+		{name: "missing protocol", listener: &types.Listener{ListenerArn: aws.String(testGlobalAcceleratorListenerARN), PortRanges: []types.PortRange{{FromPort: aws.Int32(80), ToPort: aws.Int32(80)}}}},
+		{name: "missing complete port range", listener: &types.Listener{ListenerArn: aws.String(testGlobalAcceleratorListenerARN), Protocol: types.ProtocolTcp, PortRanges: []types.PortRange{{FromPort: aws.Int32(80)}}}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if _, ok := newGlobalAcceleratorListenerResource(tt.listener); ok {
+				t.Fatal("newGlobalAcceleratorListenerResource() ok = true, want false")
+			}
+		})
+	}
+}
+
+func TestNewGlobalAcceleratorEndpointGroupResource(t *testing.T) {
+	trafficDial := float32(75.5)
+	resource, ok := newGlobalAcceleratorEndpointGroupResource(&types.EndpointGroup{
+		EndpointGroupArn:    aws.String(testGlobalAcceleratorEndpointGroupARN),
+		EndpointGroupRegion: aws.String("us-east-1"),
+		EndpointDescriptions: []types.EndpointDescription{
+			{
+				ClientIPPreservationEnabled: aws.Bool(false),
+				EndpointId:                  aws.String("arn:aws:elasticloadbalancing:us-east-1:123456789012:loadbalancer/app/app-lb/123"),
+				Weight:                      aws.Int32(0),
+			},
+		},
+		HealthCheckIntervalSeconds: aws.Int32(10),
+		HealthCheckPath:            aws.String("/healthz"),
+		HealthCheckPort:            aws.Int32(8080),
+		HealthCheckProtocol:        types.HealthCheckProtocolHttps,
+		PortOverrides: []types.PortOverride{
+			{EndpointPort: aws.Int32(8443), ListenerPort: aws.Int32(443)},
+		},
+		ThresholdCount:        aws.Int32(5),
+		TrafficDialPercentage: &trafficDial,
+	})
+	if !ok {
+		t.Fatal("newGlobalAcceleratorEndpointGroupResource() ok = false, want true")
+	}
+	attrs := resource.InstanceState.Attributes
+	if got := attrs["listener_arn"]; got != testGlobalAcceleratorListenerARN {
+		t.Fatalf("listener_arn = %q, want %q", got, testGlobalAcceleratorListenerARN)
+	}
+	if got, want := attrs["endpoint_group_region"], "us-east-1"; got != want {
+		t.Fatalf("endpoint_group_region = %q, want %q", got, want)
+	}
+	if got, want := attrs["endpoint_configuration.0.client_ip_preservation_enabled"], "false"; got != want {
+		t.Fatalf("endpoint_configuration.0.client_ip_preservation_enabled = %q, want %q", got, want)
+	}
+	if got, want := attrs["endpoint_configuration.0.weight"], "0"; got != want {
+		t.Fatalf("endpoint_configuration.0.weight = %q, want %q", got, want)
+	}
+	if got, want := attrs["traffic_dial_percentage"], "75.5"; got != want {
+		t.Fatalf("traffic_dial_percentage = %q, want %q", got, want)
+	}
+	if got, want := attrs["port_override.0.endpoint_port"], "8443"; got != want {
+		t.Fatalf("port_override.0.endpoint_port = %q, want %q", got, want)
+	}
+}
+
+func TestNewGlobalAcceleratorCustomRoutingAcceleratorResource(t *testing.T) {
+	resource, ok := newGlobalAcceleratorCustomRoutingAcceleratorResource(&types.CustomRoutingAccelerator{
+		AcceleratorArn: aws.String(testGlobalAcceleratorCustomAcceleratorARN),
+		Enabled:        aws.Bool(true),
+		IpAddressType:  types.IpAddressTypeIpv4,
+		Name:           aws.String("edge-custom"),
+		Status:         types.CustomRoutingAcceleratorStatusDeployed,
+	})
+	if !ok {
+		t.Fatal("newGlobalAcceleratorCustomRoutingAcceleratorResource() ok = false, want true")
+	}
+	if resource.InstanceInfo.Type != globalAcceleratorCustomRoutingAcceleratorResourceType {
+		t.Fatalf("resource type = %q, want %q", resource.InstanceInfo.Type, globalAcceleratorCustomRoutingAcceleratorResourceType)
+	}
+	if got, want := resource.InstanceState.Attributes["name"], "edge-custom"; got != want {
+		t.Fatalf("name = %q, want %q", got, want)
+	}
+}
+
+func TestNewGlobalAcceleratorCustomRoutingListenerResource(t *testing.T) {
+	resource, ok := newGlobalAcceleratorCustomRoutingListenerResource(&types.CustomRoutingListener{
+		ListenerArn: aws.String(testGlobalAcceleratorCustomListenerARN),
+		PortRanges: []types.PortRange{
+			{FromPort: aws.Int32(10000), ToPort: aws.Int32(10010)},
+		},
+	})
+	if !ok {
+		t.Fatal("newGlobalAcceleratorCustomRoutingListenerResource() ok = false, want true")
+	}
+	attrs := resource.InstanceState.Attributes
+	if resource.InstanceInfo.Type != globalAcceleratorCustomRoutingListenerResourceType {
+		t.Fatalf("resource type = %q, want %q", resource.InstanceInfo.Type, globalAcceleratorCustomRoutingListenerResourceType)
+	}
+	if got := attrs["accelerator_arn"]; got != testGlobalAcceleratorCustomAcceleratorARN {
+		t.Fatalf("accelerator_arn = %q, want %q", got, testGlobalAcceleratorCustomAcceleratorARN)
+	}
+	if got, want := attrs["port_range.0.to_port"], "10010"; got != want {
+		t.Fatalf("port_range.0.to_port = %q, want %q", got, want)
+	}
+}
+
+func TestNewGlobalAcceleratorCustomRoutingEndpointGroupResource(t *testing.T) {
+	resource, ok := newGlobalAcceleratorCustomRoutingEndpointGroupResource(&types.CustomRoutingEndpointGroup{
+		DestinationDescriptions: []types.CustomRoutingDestinationDescription{
+			{
+				FromPort:  aws.Int32(10000),
+				Protocols: []types.Protocol{types.ProtocolTcp, types.ProtocolUdp},
+				ToPort:    aws.Int32(10010),
+			},
+		},
+		EndpointDescriptions: []types.CustomRoutingEndpointDescription{
+			{EndpointId: aws.String("subnet-123")},
+		},
+		EndpointGroupArn:    aws.String(testGlobalAcceleratorCustomEndpointGroupARN),
+		EndpointGroupRegion: aws.String("us-west-2"),
+	})
+	if !ok {
+		t.Fatal("newGlobalAcceleratorCustomRoutingEndpointGroupResource() ok = false, want true")
+	}
+	attrs := resource.InstanceState.Attributes
+	if got := attrs["listener_arn"]; got != testGlobalAcceleratorCustomListenerARN {
+		t.Fatalf("listener_arn = %q, want %q", got, testGlobalAcceleratorCustomListenerARN)
+	}
+	if got, want := attrs["destination_configuration.#"], "1"; got != want {
+		t.Fatalf("destination_configuration.# = %q, want %q", got, want)
+	}
+	if got, want := attrs["destination_configuration.0.protocols.1"], "UDP"; got != want {
+		t.Fatalf("destination_configuration.0.protocols.1 = %q, want %q", got, want)
+	}
+	if got, want := attrs["endpoint_configuration.0.endpoint_id"], "subnet-123"; got != want {
+		t.Fatalf("endpoint_configuration.0.endpoint_id = %q, want %q", got, want)
+	}
+}
+
+func TestNewGlobalAcceleratorCustomRoutingEndpointGroupResourceSkipsIncompleteDestination(t *testing.T) {
+	if _, ok := newGlobalAcceleratorCustomRoutingEndpointGroupResource(&types.CustomRoutingEndpointGroup{
+		EndpointGroupArn:    aws.String(testGlobalAcceleratorCustomEndpointGroupARN),
+		EndpointGroupRegion: aws.String("us-west-2"),
+		DestinationDescriptions: []types.CustomRoutingDestinationDescription{
+			{FromPort: aws.Int32(10000), ToPort: aws.Int32(10010)},
+		},
+	}); ok {
+		t.Fatal("newGlobalAcceleratorCustomRoutingEndpointGroupResource() ok = true, want false")
+	}
+}
+
+func TestNewGlobalAcceleratorCrossAccountAttachmentResource(t *testing.T) {
+	resource, ok := newGlobalAcceleratorCrossAccountAttachmentResource(&types.Attachment{
+		AttachmentArn: aws.String(testGlobalAcceleratorCrossAccountAttachmentARN),
+		Name:          aws.String("shared-edge"),
+		Principals:    []string{"111111111111", "222222222222"},
+		Resources: []types.Resource{
+			{EndpointId: aws.String("arn:aws:elasticloadbalancing:us-east-1:123456789012:loadbalancer/net/nlb/123"), Region: aws.String("us-east-1")},
+			{Cidr: aws.String("203.0.113.0/24")},
+		},
+	})
+	if !ok {
+		t.Fatal("newGlobalAcceleratorCrossAccountAttachmentResource() ok = false, want true")
+	}
+	attrs := resource.InstanceState.Attributes
+	if resource.InstanceInfo.Type != globalAcceleratorCrossAccountAttachmentResourceType {
+		t.Fatalf("resource type = %q, want %q", resource.InstanceInfo.Type, globalAcceleratorCrossAccountAttachmentResourceType)
+	}
+	if got, want := attrs["principals.#"], "2"; got != want {
+		t.Fatalf("principals.# = %q, want %q", got, want)
+	}
+	if got, want := attrs["resource.#"], "2"; got != want {
+		t.Fatalf("resource.# = %q, want %q", got, want)
+	}
+	if got, want := attrs["resource.0.region"], "us-east-1"; got != want {
+		t.Fatalf("resource.0.region = %q, want %q", got, want)
+	}
+	if got, want := attrs["resource.1.cidr"], "203.0.113.0/24"; got != want {
+		t.Fatalf("resource.1.cidr = %q, want %q", got, want)
+	}
+}
+
+func TestGlobalAcceleratorResourceNameIncludesLengths(t *testing.T) {
+	name := globalAcceleratorResourceName("listener", "ab", "c_d")
+	if got, want := name, "8_listener_2_ab_3_c_d"; got != want {
+		t.Fatalf("globalAcceleratorResourceName() = %q, want %q", got, want)
+	}
+}
+
+func TestGlobalAcceleratorResourceNotFound(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{name: "nil", err: nil, want: false},
+		{name: "generic", err: errors.New("boom"), want: false},
+		{name: "accelerator", err: &types.AcceleratorNotFoundException{}, want: true},
+		{name: "listener", err: &types.ListenerNotFoundException{}, want: true},
+		{name: "endpoint group", err: &types.EndpointGroupNotFoundException{}, want: true},
+		{name: "attachment", err: &types.AttachmentNotFoundException{}, want: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := globalAcceleratorResourceNotFound(tt.err); got != tt.want {
+				t.Fatalf("globalAcceleratorResourceNotFound() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

- register `globalaccelerator` as a global AWS service
- add Global Accelerator import discovery for standard, custom-routing, and cross-account attachment resources
- seed ARN import IDs and parent attributes for listener and endpoint-group resources
- update `docs/aws.md` for supported Global Accelerator resources
- add unit tests for import IDs, resource construction, skip predicates, region handling, and not-found detection

## References

- #338

## Validation

```bash
go test ./providers/aws -run 'Test.*CloudFront|Test.*Cloudfront|Test.*cloudfront|Test.*GlobalAccelerator|Test.*Globalaccelerator|Test.*globalaccelerator'
go test ./providers/aws/... ./terraformutils/...
go test ./tools/aws-gap-inventory/...
go run ./tools/aws-gap-inventory -docs docs/aws.md -aws-dir providers/aws -skip-list providers/aws/unsupported_resources.json -format markdown
git diff --check
golangci-lint run --new-from-rev=main
```

## Notes

- CloudFront candidate resources are already supported on current `main`; this PR keeps the implementation focused on Global Accelerator.
- Follow-up CloudFront work should be schema-backed for newer provider resources such as anycast IP lists, connection resources, distribution tenants, multitenant distributions, and trust stores.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds Global Accelerator import support to the AWS provider, covering standard, custom-routing, and cross-account attachment resources. Corrects the control-plane region to `us-west-2` and updates docs and tests.

- **New Features**
  - Registers `globalaccelerator` as a global AWS service and wires it into provider connections.
  - Imports `aws_globalaccelerator_accelerator`, `aws_globalaccelerator_listener`, `aws_globalaccelerator_endpoint_group`, `aws_globalaccelerator_custom_routing_accelerator`, `aws_globalaccelerator_custom_routing_listener`, `aws_globalaccelerator_custom_routing_endpoint_group`, `aws_globalaccelerator_cross_account_attachment`.
  - Seeds parent attributes (`accelerator_arn`, `listener_arn`) and uses ARN-based IDs for imports.
  - Uses `us-west-2` for Global Accelerator API calls and safely skips not-found resources.
  - Updates `docs/aws.md` and adds unit tests for IDs, construction, skip predicates, region handling, and not-found detection.

- **Dependencies**
  - Adds `github.com/aws/aws-sdk-go-v2/service/globalaccelerator`.

<sup>Written for commit 9db0a9b32429c53839ce69318828acea58ca6d6a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * AWS Global Accelerator is now supported: import accelerators, listeners, endpoint groups, custom routing variants, and cross-account attachments.

* **Documentation**
  * Service docs updated to list Global Accelerator as a supported global (regionless) AWS service.

* **Tests**
  * Added comprehensive tests covering import IDs, ARN helpers, resource builders, discovery, and not-found handling.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/chenrui333/terraformer/pull/430)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->