### PR TITLE
aws(longtail): add long-tail service imports

### DIFF
--- a/cmd/import.go
+++ b/cmd/import.go
@@ -54,6 +54,10 @@ type importValidator interface {
 	ValidateImport(resources []string) error
 }
 
+type importProviderConfigurer interface {
+	ConfigureImportProvider(*providerwrapper.ProviderWrapper) error
+}
+
 const DefaultPathPattern = "{output}/{provider}/{service}/"
 const DefaultPathOutput = "generated"
 const DefaultState = "local"
@@ -219,6 +223,12 @@ func initServiceResources(service string, provider terraformutils.ProviderGenera
 	if err != nil {
 		log.Printf("%s error initializing resources in service %s, err: %s\n", provider.GetName(), service, err)
 		return err
+	}
+	if configurer, ok := provider.GetService().(importProviderConfigurer); ok {
+		if err := configurer.ConfigureImportProvider(providerWrapper); err != nil {
+			log.Printf("%s error configuring import provider for service %s, err: %s\n", provider.GetName(), service, err)
+			return err
+		}
 	}
 
 	provider.GetService().PopulateIgnoreKeys(providerWrapper)

--- a/docs/aws.md
+++ b/docs/aws.md
@@ -610,7 +610,6 @@ For AWS provider gap audits and unsupported-resource skip-list maintenance, see 
     * `aws_pipes_pipe`
 *   `qldb`
     * `aws_qldb_ledger`
-    * `aws_qldb_stream`
 *   `rds`
     * `aws_db_instance`
     * `aws_db_instance_role_association`

--- a/docs/aws.md
+++ b/docs/aws.md
@@ -190,6 +190,7 @@ For AWS provider gap audits and unsupported-resource skip-list maintenance, see 
     * `aws_chimesdkvoice_voice_profile_domain`
 *   `cloud9`
     * `aws_cloud9_environment_ec2`
+    * `aws_cloud9_environment_membership`
 *   `cloudformation`
     * `aws_cloudformation_stack`
     * `aws_cloudformation_stack_set`
@@ -280,8 +281,14 @@ For AWS provider gap audits and unsupported-resource skip-list maintenance, see 
     * `aws_customerprofiles_domain`
 *   `datapipeline`
     * `aws_datapipeline_pipeline`
+    * `aws_datapipeline_pipeline_definition`
 *   `devicefarm`
+    * `aws_devicefarm_device_pool`
+    * `aws_devicefarm_instance_profile`
+    * `aws_devicefarm_network_profile`
     * `aws_devicefarm_project`
+    * `aws_devicefarm_test_grid_project`
+    * `aws_devicefarm_upload`
 *   `detective`
     * `aws_detective_graph`
     * `aws_detective_member`
@@ -520,6 +527,8 @@ For AWS provider gap audits and unsupported-resource skip-list maintenance, see 
     * `aws_cloudwatch_log_subscription_filter`
     * `aws_cloudwatch_log_transformer`
     * `aws_cloudwatch_query_definition`
+*   `media_convert`
+    * `aws_media_convert_queue`
 *   `media_package`
     * `aws_media_package_channel`
 *   `media_packagev2`
@@ -535,6 +544,7 @@ For AWS provider gap audits and unsupported-resource skip-list maintenance, see 
     * `aws_medialive_multiplex_program`
 *   `mq`
     * `aws_mq_broker`
+    * `aws_mq_configuration`
 *   `msk`
     * `aws_msk_cluster`
     * `aws_msk_cluster_policy`

--- a/docs/aws.md
+++ b/docs/aws.md
@@ -543,7 +543,6 @@ For AWS provider gap audits and unsupported-resource skip-list maintenance, see 
     * `aws_medialive_multiplex`
     * `aws_medialive_multiplex_program`
 *   `mq`
-    * `aws_mq_broker`
     * `aws_mq_configuration`
 *   `msk`
     * `aws_msk_cluster`

--- a/docs/aws.md
+++ b/docs/aws.md
@@ -611,6 +611,7 @@ For AWS provider gap audits and unsupported-resource skip-list maintenance, see 
     * `aws_pipes_pipe`
 *   `qldb`
     * `aws_qldb_ledger`
+    * `aws_qldb_stream`
 *   `rds`
     * `aws_db_instance`
     * `aws_db_instance_role_association`

--- a/go.mod
+++ b/go.mod
@@ -423,6 +423,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/ivschat v1.21.22
 	github.com/aws/aws-sdk-go-v2/service/kendra v1.60.23
 	github.com/aws/aws-sdk-go-v2/service/lakeformation v1.47.8
+	github.com/aws/aws-sdk-go-v2/service/mediaconvert v1.91.2
 	github.com/aws/aws-sdk-go-v2/service/mediapackagev2 v1.37.0
 	github.com/aws/aws-sdk-go-v2/service/mwaa v1.40.0
 	github.com/aws/aws-sdk-go-v2/service/notifications v1.7.22

--- a/go.sum
+++ b/go.sum
@@ -351,6 +351,8 @@ github.com/aws/aws-sdk-go-v2/service/lakeformation v1.47.8 h1:BtZujlNIGZJpz/6Zbh
 github.com/aws/aws-sdk-go-v2/service/lakeformation v1.47.8/go.mod h1:8ztA+uewolt+oJ2VEVUPIxhK5IW+4AVuDou6ju6wAAE=
 github.com/aws/aws-sdk-go-v2/service/lambda v1.90.1 h1:odCeJgHXfQoXEWQUIzPkKvsJTWcLMsaOWowNpovPFFw=
 github.com/aws/aws-sdk-go-v2/service/lambda v1.90.1/go.mod h1:NbtJVztitG7JkuoI4GSrDUlsB32zeXqKBvXj6bUxcMo=
+github.com/aws/aws-sdk-go-v2/service/mediaconvert v1.91.2 h1:h466gQU4HNXHgTdz7a45mGudKsB+NeyPVYr6hf9F4gM=
+github.com/aws/aws-sdk-go-v2/service/mediaconvert v1.91.2/go.mod h1:r/qoOppQk/ZTUHNBdj9S8R8k0JCV2iApiKfyxDyU42s=
 github.com/aws/aws-sdk-go-v2/service/medialive v1.96.0 h1:2A2YYpr3IDLZ9y2WRg/oXSmlrmDQA+KNvgcFGOWr+PY=
 github.com/aws/aws-sdk-go-v2/service/medialive v1.96.0/go.mod h1:YtEXuL0GNGkAeeFSs2wT/KTnaqykXJ52d+4MefPwJKg=
 github.com/aws/aws-sdk-go-v2/service/mediapackage v1.39.23 h1:ztbUtcql2vd65yqnEz/k+bTX8PBP1J4to32/ck5hLAA=

--- a/providers/aws/aws_facade.go
+++ b/providers/aws/aws_facade.go
@@ -78,3 +78,12 @@ func (s *AwsFacade) PostConvertHook() error {
 func (s *AwsFacade) PopulateIgnoreKeys(providerWrapper *providerwrapper.ProviderWrapper) {
 	s.service.PopulateIgnoreKeys(providerWrapper)
 }
+
+func (s *AwsFacade) ConfigureImportProvider(providerWrapper *providerwrapper.ProviderWrapper) error {
+	if configurer, ok := s.service.(interface {
+		ConfigureImportProvider(*providerwrapper.ProviderWrapper) error
+	}); ok {
+		return configurer.ConfigureImportProvider(providerWrapper)
+	}
+	return nil
+}

--- a/providers/aws/aws_facade_test.go
+++ b/providers/aws/aws_facade_test.go
@@ -1,0 +1,51 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package aws
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/chenrui333/terraformer/terraformutils"
+	"github.com/chenrui333/terraformer/terraformutils/providerwrapper"
+)
+
+type facadeImportProviderConfigurer struct {
+	terraformutils.Service
+	called bool
+	err    error
+}
+
+func (s *facadeImportProviderConfigurer) ConfigureImportProvider(_ *providerwrapper.ProviderWrapper) error {
+	s.called = true
+	return s.err
+}
+
+func TestAwsFacadeConfigureImportProviderForwardsToService(t *testing.T) {
+	service := &facadeImportProviderConfigurer{}
+	facade := &AwsFacade{service: service}
+
+	if err := facade.ConfigureImportProvider(nil); err != nil {
+		t.Fatalf("ConfigureImportProvider returned error: %v", err)
+	}
+	if !service.called {
+		t.Fatal("ConfigureImportProvider did not forward to wrapped service")
+	}
+}
+
+func TestAwsFacadeConfigureImportProviderReturnsWrappedError(t *testing.T) {
+	wantErr := errors.New("restart failed")
+	facade := &AwsFacade{service: &facadeImportProviderConfigurer{err: wantErr}}
+
+	if err := facade.ConfigureImportProvider(nil); !errors.Is(err, wantErr) {
+		t.Fatalf("ConfigureImportProvider error = %v, want %v", err, wantErr)
+	}
+}
+
+func TestAwsFacadeConfigureImportProviderNoop(t *testing.T) {
+	facade := &AwsFacade{service: &terraformutils.Service{}}
+
+	if err := facade.ConfigureImportProvider(nil); err != nil {
+		t.Fatalf("ConfigureImportProvider without wrapped configurer returned error: %v", err)
+	}
+}

--- a/providers/aws/aws_filter.go
+++ b/providers/aws/aws_filter.go
@@ -41,6 +41,16 @@ func awsHasTypedFilter(filters []terraformutils.ResourceFilter, serviceName stri
 	return false
 }
 
+func awsHasTypedNonIDFilter(filters []terraformutils.ResourceFilter, serviceName string) bool {
+	serviceName = strings.TrimPrefix(serviceName, "aws_")
+	for _, filter := range filters {
+		if filter.ServiceName == serviceName && filter.FieldPath != "id" {
+			return true
+		}
+	}
+	return false
+}
+
 func awsHasApplicableFilter(filters []terraformutils.ResourceFilter, serviceName string) bool {
 	serviceName = strings.TrimPrefix(serviceName, "aws_")
 	for _, filter := range filters {

--- a/providers/aws/aws_filter.go
+++ b/providers/aws/aws_filter.go
@@ -9,10 +9,14 @@ import (
 )
 
 func awsTypedIDFilterValues(filters []terraformutils.ResourceFilter, serviceName string) map[string]bool {
+	return awsTypedFilterValues(filters, serviceName, "id")
+}
+
+func awsTypedFilterValues(filters []terraformutils.ResourceFilter, serviceName, fieldPath string) map[string]bool {
 	serviceName = strings.TrimPrefix(serviceName, "aws_")
 	values := map[string]bool{}
 	for _, filter := range filters {
-		if filter.FieldPath != "id" || filter.ServiceName != serviceName || len(filter.AcceptableValues) == 0 {
+		if filter.FieldPath != fieldPath || filter.ServiceName != serviceName || len(filter.AcceptableValues) == 0 {
 			continue
 		}
 		for _, value := range filter.AcceptableValues {
@@ -25,6 +29,26 @@ func awsTypedIDFilterValues(filters []terraformutils.ResourceFilter, serviceName
 		return nil
 	}
 	return values
+}
+
+func awsHasTypedFilter(filters []terraformutils.ResourceFilter, serviceName string) bool {
+	serviceName = strings.TrimPrefix(serviceName, "aws_")
+	for _, filter := range filters {
+		if filter.ServiceName == serviceName {
+			return true
+		}
+	}
+	return false
+}
+
+func awsHasApplicableFilter(filters []terraformutils.ResourceFilter, serviceName string) bool {
+	serviceName = strings.TrimPrefix(serviceName, "aws_")
+	for _, filter := range filters {
+		if filter.IsApplicable(serviceName) {
+			return true
+		}
+	}
+	return false
 }
 
 func awsIDFilterAllows(values map[string]bool, value string) bool {

--- a/providers/aws/aws_filter.go
+++ b/providers/aws/aws_filter.go
@@ -51,6 +51,16 @@ func awsHasTypedNonIDFilter(filters []terraformutils.ResourceFilter, serviceName
 	return false
 }
 
+func awsHasApplicableNonIDFilter(filters []terraformutils.ResourceFilter, serviceName string) bool {
+	serviceName = strings.TrimPrefix(serviceName, "aws_")
+	for _, filter := range filters {
+		if filter.FieldPath != "id" && filter.IsApplicable(serviceName) {
+			return true
+		}
+	}
+	return false
+}
+
 func awsHasApplicableFilter(filters []terraformutils.ResourceFilter, serviceName string) bool {
 	serviceName = strings.TrimPrefix(serviceName, "aws_")
 	for _, filter := range filters {

--- a/providers/aws/aws_filter.go
+++ b/providers/aws/aws_filter.go
@@ -1,0 +1,32 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package aws
+
+import (
+	"strings"
+
+	"github.com/chenrui333/terraformer/terraformutils"
+)
+
+func awsTypedIDFilterValues(filters []terraformutils.ResourceFilter, serviceName string) map[string]bool {
+	serviceName = strings.TrimPrefix(serviceName, "aws_")
+	values := map[string]bool{}
+	for _, filter := range filters {
+		if filter.FieldPath != "id" || filter.ServiceName != serviceName || len(filter.AcceptableValues) == 0 {
+			continue
+		}
+		for _, value := range filter.AcceptableValues {
+			if value != "" {
+				values[value] = true
+			}
+		}
+	}
+	if len(values) == 0 {
+		return nil
+	}
+	return values
+}
+
+func awsIDFilterAllows(values map[string]bool, value string) bool {
+	return len(values) == 0 || values[value]
+}

--- a/providers/aws/aws_filter.go
+++ b/providers/aws/aws_filter.go
@@ -30,3 +30,16 @@ func awsTypedIDFilterValues(filters []terraformutils.ResourceFilter, serviceName
 func awsIDFilterAllows(values map[string]bool, value string) bool {
 	return len(values) == 0 || values[value]
 }
+
+func awsMergeIDFilterValues(filters ...map[string]bool) map[string]bool {
+	values := map[string]bool{}
+	for _, filter := range filters {
+		for value := range filter {
+			values[value] = true
+		}
+	}
+	if len(values) == 0 {
+		return nil
+	}
+	return values
+}

--- a/providers/aws/aws_filter_test.go
+++ b/providers/aws/aws_filter_test.go
@@ -1,0 +1,42 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package aws
+
+import (
+	"testing"
+
+	"github.com/chenrui333/terraformer/terraformutils"
+)
+
+func TestAWSTypedIDFilterValues(t *testing.T) {
+	service := terraformutils.Service{}
+	service.ParseFilters([]string{
+		"cloud9_environment_ec2=env-123:env-456",
+		"Name=id;Value=global-id",
+		"Type=qldb_ledger;Name=id;Value=ledger-a",
+		"Type=qldb_ledger;Name=name;Value=ignored",
+	})
+
+	cloud9IDs := awsTypedIDFilterValues(service.Filter, cloud9EnvironmentEC2ResourceType)
+	if !awsIDFilterAllows(cloud9IDs, "env-123") || !awsIDFilterAllows(cloud9IDs, "env-456") {
+		t.Fatalf("Cloud9 typed ID filter did not include expected environment IDs: %#v", cloud9IDs)
+	}
+	if awsIDFilterAllows(cloud9IDs, "env-789") {
+		t.Fatalf("Cloud9 typed ID filter allowed unrelated environment ID: %#v", cloud9IDs)
+	}
+
+	qldbIDs := awsTypedIDFilterValues(service.Filter, qldbLedgerResourceType)
+	if !awsIDFilterAllows(qldbIDs, "ledger-a") {
+		t.Fatalf("QLDB typed ID filter did not include expected ledger: %#v", qldbIDs)
+	}
+	if awsIDFilterAllows(qldbIDs, "ledger-b") {
+		t.Fatalf("QLDB typed ID filter allowed unrelated ledger: %#v", qldbIDs)
+	}
+
+	if dataPipelineIDs := awsTypedIDFilterValues(service.Filter, dataPipelinePipelineResourceType); dataPipelineIDs != nil {
+		t.Fatalf("unexpected Data Pipeline typed ID filters: %#v", dataPipelineIDs)
+	}
+	if !awsIDFilterAllows(nil, "anything") {
+		t.Fatal("missing typed ID filters should allow discovery")
+	}
+}

--- a/providers/aws/aws_filter_test.go
+++ b/providers/aws/aws_filter_test.go
@@ -78,6 +78,12 @@ func TestAWSTypedFilterValuesAndApplicability(t *testing.T) {
 	if !awsHasTypedFilter(service.Filter, cloud9EnvironmentMembershipResourceType) {
 		t.Fatal("expected Cloud9 membership typed filter")
 	}
+	if !awsHasTypedNonIDFilter(service.Filter, dataPipelinePipelineDefinitionResourceType) {
+		t.Fatal("expected Data Pipeline definition typed non-ID filter")
+	}
+	if awsHasTypedNonIDFilter(service.Filter, cloud9EnvironmentMembershipResourceType) {
+		t.Fatal("unexpected Cloud9 membership typed non-ID filter")
+	}
 	if awsHasTypedFilter(service.Filter, qldbLedgerResourceType) {
 		t.Fatal("unexpected QLDB ledger typed filter")
 	}

--- a/providers/aws/aws_filter_test.go
+++ b/providers/aws/aws_filter_test.go
@@ -64,6 +64,7 @@ func TestAWSTypedFilterValuesAndApplicability(t *testing.T) {
 	service := terraformutils.Service{}
 	service.ParseFilters([]string{
 		"Name=id;Value=global-id",
+		"Name=name;Value=global-name",
 		"Type=datapipeline_pipeline_definition;Name=pipeline_id;Value=df-123",
 		"Type=cloud9_environment_membership;Name=id;Value=env-123#arn:aws:iam::123456789012:user/alice",
 	})
@@ -80,6 +81,9 @@ func TestAWSTypedFilterValuesAndApplicability(t *testing.T) {
 	}
 	if !awsHasTypedNonIDFilter(service.Filter, dataPipelinePipelineDefinitionResourceType) {
 		t.Fatal("expected Data Pipeline definition typed non-ID filter")
+	}
+	if !awsHasApplicableNonIDFilter(service.Filter, qldbLedgerResourceType) {
+		t.Fatal("expected global non-ID filter to apply to QLDB ledger")
 	}
 	if awsHasTypedNonIDFilter(service.Filter, cloud9EnvironmentMembershipResourceType) {
 		t.Fatal("unexpected Cloud9 membership typed non-ID filter")

--- a/providers/aws/aws_filter_test.go
+++ b/providers/aws/aws_filter_test.go
@@ -59,3 +59,32 @@ func TestAWSMergeIDFilterValues(t *testing.T) {
 		t.Fatalf("empty merged ID filters = %#v, want nil", got)
 	}
 }
+
+func TestAWSTypedFilterValuesAndApplicability(t *testing.T) {
+	service := terraformutils.Service{}
+	service.ParseFilters([]string{
+		"Name=id;Value=global-id",
+		"Type=datapipeline_pipeline_definition;Name=pipeline_id;Value=df-123",
+		"Type=cloud9_environment_membership;Name=id;Value=env-123#arn:aws:iam::123456789012:user/alice",
+	})
+
+	pipelineIDs := awsTypedFilterValues(service.Filter, dataPipelinePipelineDefinitionResourceType, "pipeline_id")
+	if !awsIDFilterAllows(pipelineIDs, "df-123") {
+		t.Fatalf("Data Pipeline typed field filter did not include expected pipeline ID: %#v", pipelineIDs)
+	}
+	if awsIDFilterAllows(pipelineIDs, "df-456") {
+		t.Fatalf("Data Pipeline typed field filter allowed unrelated pipeline ID: %#v", pipelineIDs)
+	}
+	if !awsHasTypedFilter(service.Filter, cloud9EnvironmentMembershipResourceType) {
+		t.Fatal("expected Cloud9 membership typed filter")
+	}
+	if awsHasTypedFilter(service.Filter, qldbLedgerResourceType) {
+		t.Fatal("unexpected QLDB ledger typed filter")
+	}
+	if !awsHasApplicableFilter(service.Filter, qldbLedgerResourceType) {
+		t.Fatal("global filter should be applicable to QLDB ledger")
+	}
+	if !awsHasApplicableFilter(service.Filter, dataPipelinePipelineDefinitionResourceType) {
+		t.Fatal("typed Data Pipeline definition filter should be applicable to definitions")
+	}
+}

--- a/providers/aws/aws_filter_test.go
+++ b/providers/aws/aws_filter_test.go
@@ -40,3 +40,22 @@ func TestAWSTypedIDFilterValues(t *testing.T) {
 		t.Fatal("missing typed ID filters should allow discovery")
 	}
 }
+
+func TestAWSMergeIDFilterValues(t *testing.T) {
+	merged := awsMergeIDFilterValues(
+		map[string]bool{"first": true},
+		nil,
+		map[string]bool{"second": true},
+	)
+	for _, value := range []string{"first", "second"} {
+		if !awsIDFilterAllows(merged, value) {
+			t.Fatalf("merged ID filter should allow %q: %#v", value, merged)
+		}
+	}
+	if awsIDFilterAllows(merged, "third") {
+		t.Fatalf("merged ID filter allowed unrelated value: %#v", merged)
+	}
+	if got := awsMergeIDFilterValues(nil, map[string]bool{}); got != nil {
+		t.Fatalf("empty merged ID filters = %#v, want nil", got)
+	}
+}

--- a/providers/aws/aws_provider.go
+++ b/providers/aws/aws_provider.go
@@ -362,6 +362,7 @@ func (p *AWSProvider) GetSupportedService() map[string]terraformutils.ServiceGen
 		"lakeformation":         &AwsFacade{service: &LakeFormationGenerator{}},
 		"lambda":                &AwsFacade{service: &LambdaGenerator{}},
 		"logs":                  &AwsFacade{service: &LogsGenerator{}},
+		"media_convert":         &AwsFacade{service: &MediaConvertGenerator{}},
 		"media_package":         &AwsFacade{service: &MediaPackageGenerator{}},
 		"media_packagev2":       &AwsFacade{service: &MediaPackageV2Generator{}},
 		"media_store":           &AwsFacade{service: &MediaStoreGenerator{}},

--- a/providers/aws/cloud9.go
+++ b/providers/aws/cloud9.go
@@ -5,10 +5,17 @@ package aws
 import (
 	"context"
 	"fmt"
+	"log"
+	"strings"
 
 	"github.com/aws/aws-sdk-go-v2/service/cloud9"
 	"github.com/aws/aws-sdk-go-v2/service/cloud9/types"
 	"github.com/chenrui333/terraformer/terraformutils"
+)
+
+const (
+	cloud9EnvironmentEC2ResourceType        = "aws_cloud9_environment_ec2"
+	cloud9EnvironmentMembershipResourceType = "aws_cloud9_environment_membership"
 )
 
 var cloud9AllowEmptyValues = []string{"tags."}
@@ -23,27 +30,119 @@ func (g *Cloud9Generator) InitResources() error {
 		return e
 	}
 	svc := cloud9.NewFromConfig(config)
-	output, err := svc.ListEnvironments(context.TODO(), &cloud9.ListEnvironmentsInput{})
-	if err != nil {
-		return err
-	}
-	for _, environmentID := range output.EnvironmentIds {
-		details, err := svc.DescribeEnvironmentStatus(context.TODO(), &cloud9.DescribeEnvironmentStatusInput{
-			EnvironmentId: &environmentID,
-		})
+	p := cloud9.NewListEnvironmentsPaginator(svc, &cloud9.ListEnvironmentsInput{})
+	for p.HasMorePages() {
+		output, err := p.NextPage(context.TODO())
 		if err != nil {
-			return fmt.Errorf("describe Cloud9 environment status for %s: %w", environmentID, err)
+			return err
 		}
-		if details.Status == types.EnvironmentStatusError ||
-			details.Status == types.EnvironmentStatusDeleting {
-			continue
+		for _, environmentID := range output.EnvironmentIds {
+			if err := g.addEnvironment(svc, environmentID); err != nil {
+				return err
+			}
 		}
-		g.Resources = append(g.Resources, terraformutils.NewSimpleResource(
-			environmentID,
-			environmentID,
-			"aws_cloud9_environment_ec2",
-			"aws",
-			cloud9AllowEmptyValues))
 	}
+
 	return nil
+}
+
+func (g *Cloud9Generator) addEnvironment(svc *cloud9.Client, environmentID string) error {
+	if environmentID == "" {
+		return nil
+	}
+	if importable, err := cloud9EnvironmentImportable(svc, environmentID); err != nil {
+		return err
+	} else if !importable {
+		return nil
+	}
+	g.Resources = append(g.Resources, newCloud9EnvironmentEC2Resource(environmentID))
+	if err := g.loadEnvironmentMemberships(svc, environmentID); err != nil {
+		log.Printf("[WARN] Skipping Cloud9 environment memberships for %s: %v", environmentID, err)
+	}
+
+	return nil
+}
+
+func cloud9EnvironmentImportable(svc *cloud9.Client, environmentID string) (bool, error) {
+	details, err := svc.DescribeEnvironmentStatus(context.TODO(), &cloud9.DescribeEnvironmentStatusInput{
+		EnvironmentId: &environmentID,
+	})
+	if err != nil {
+		return false, fmt.Errorf("describe Cloud9 environment status for %s: %w", environmentID, err)
+	}
+	if details.Status == types.EnvironmentStatusError ||
+		details.Status == types.EnvironmentStatusDeleting {
+		return false, nil
+	}
+	return true, nil
+}
+
+func newCloud9EnvironmentEC2Resource(environmentID string) terraformutils.Resource {
+	return terraformutils.NewSimpleResource(
+		environmentID,
+		environmentID,
+		cloud9EnvironmentEC2ResourceType,
+		"aws",
+		cloud9AllowEmptyValues)
+}
+
+func (g *Cloud9Generator) loadEnvironmentMemberships(svc *cloud9.Client, environmentID string) error {
+	p := cloud9.NewDescribeEnvironmentMembershipsPaginator(svc, &cloud9.DescribeEnvironmentMembershipsInput{
+		EnvironmentId: &environmentID,
+	})
+	for p.HasMorePages() {
+		page, err := p.NextPage(context.TODO())
+		if err != nil {
+			return err
+		}
+		for _, membership := range page.Memberships {
+			if resource, ok := newCloud9EnvironmentMembershipResource(membership); ok {
+				g.Resources = append(g.Resources, resource)
+			}
+		}
+	}
+
+	return nil
+}
+
+func newCloud9EnvironmentMembershipResource(membership types.EnvironmentMember) (terraformutils.Resource, bool) {
+	environmentID := StringValue(membership.EnvironmentId)
+	userArn := StringValue(membership.UserArn)
+	if environmentID == "" || userArn == "" || !cloud9EnvironmentMembershipImportable(membership.Permissions) {
+		return terraformutils.Resource{}, false
+	}
+	permissions := string(membership.Permissions)
+	return terraformutils.NewResource(
+		cloud9EnvironmentMembershipImportID(environmentID, userArn),
+		cloud9ResourceName("membership", environmentID, userArn),
+		cloud9EnvironmentMembershipResourceType,
+		"aws",
+		map[string]string{
+			"environment_id": environmentID,
+			"permissions":    permissions,
+			"user_arn":       userArn,
+		},
+		cloud9AllowEmptyValues,
+		map[string]interface{}{}), true
+}
+
+func cloud9EnvironmentMembershipImportable(permissions types.Permissions) bool {
+	return permissions != ""
+}
+
+func cloud9EnvironmentMembershipImportID(environmentID, userArn string) string {
+	return fmt.Sprintf("%s#%s", environmentID, userArn)
+}
+
+func cloud9ResourceName(parts ...string) string {
+	cleanParts := []string{}
+	for _, part := range parts {
+		if part != "" {
+			cleanParts = append(cleanParts, fmt.Sprintf("%d/%s", len(part), part))
+		}
+	}
+	if len(cleanParts) == 0 {
+		return "cloud9-resource"
+	}
+	return strings.Join(cleanParts, "/")
 }

--- a/providers/aws/cloud9.go
+++ b/providers/aws/cloud9.go
@@ -30,6 +30,7 @@ func (g *Cloud9Generator) InitResources() error {
 		return e
 	}
 	svc := cloud9.NewFromConfig(config)
+	environmentIDFilter := awsTypedIDFilterValues(g.Filter, cloud9EnvironmentEC2ResourceType)
 	p := cloud9.NewListEnvironmentsPaginator(svc, &cloud9.ListEnvironmentsInput{})
 	for p.HasMorePages() {
 		output, err := p.NextPage(context.TODO())
@@ -37,6 +38,9 @@ func (g *Cloud9Generator) InitResources() error {
 			return err
 		}
 		for _, environmentID := range output.EnvironmentIds {
+			if !awsIDFilterAllows(environmentIDFilter, environmentID) {
+				continue
+			}
 			if err := g.addEnvironment(svc, environmentID); err != nil {
 				return err
 			}

--- a/providers/aws/cloud9.go
+++ b/providers/aws/cloud9.go
@@ -30,7 +30,7 @@ func (g *Cloud9Generator) InitResources() error {
 		return e
 	}
 	svc := cloud9.NewFromConfig(config)
-	environmentIDFilter := awsTypedIDFilterValues(g.Filter, cloud9EnvironmentEC2ResourceType)
+	environmentIDFilter := cloud9EnvironmentIDFilter(g.Filter)
 	p := cloud9.NewListEnvironmentsPaginator(svc, &cloud9.ListEnvironmentsInput{})
 	for p.HasMorePages() {
 		output, err := p.NextPage(context.TODO())
@@ -133,6 +133,29 @@ func newCloud9EnvironmentMembershipResource(membership types.EnvironmentMember) 
 func cloud9EnvironmentMembershipImportable(permissions types.Permissions) bool {
 	// Owner memberships are created by AWS for environment creators and are not independently managed by Terraform.
 	return permissions == types.PermissionsReadOnly || permissions == types.PermissionsReadWrite
+}
+
+func cloud9EnvironmentIDFilter(filters []terraformutils.ResourceFilter) map[string]bool {
+	membershipEnvironmentIDs, ok := cloud9EnvironmentIDsFromMembershipFilterValues(awsTypedIDFilterValues(filters, cloud9EnvironmentMembershipResourceType))
+	if !ok {
+		return nil
+	}
+	return awsMergeIDFilterValues(awsTypedIDFilterValues(filters, cloud9EnvironmentEC2ResourceType), membershipEnvironmentIDs)
+}
+
+func cloud9EnvironmentIDsFromMembershipFilterValues(membershipIDs map[string]bool) (map[string]bool, bool) {
+	if len(membershipIDs) == 0 {
+		return nil, true
+	}
+	environmentIDs := map[string]bool{}
+	for membershipID := range membershipIDs {
+		environmentID, _, ok := strings.Cut(membershipID, "#")
+		if !ok || environmentID == "" {
+			return nil, false
+		}
+		environmentIDs[environmentID] = true
+	}
+	return environmentIDs, true
 }
 
 func cloud9EnvironmentMembershipImportID(environmentID, userArn string) string {

--- a/providers/aws/cloud9.go
+++ b/providers/aws/cloud9.go
@@ -4,6 +4,7 @@ package aws
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log"
 	"strings"
@@ -75,6 +76,9 @@ func cloud9EnvironmentImportable(svc *cloud9.Client, environmentID string) (bool
 	details, err := svc.DescribeEnvironmentStatus(context.TODO(), &cloud9.DescribeEnvironmentStatusInput{
 		EnvironmentId: &environmentID,
 	})
+	if cloud9EnvironmentNotFound(err) {
+		return false, nil
+	}
 	if err != nil {
 		return false, fmt.Errorf("describe Cloud9 environment status for %s: %w", environmentID, err)
 	}
@@ -83,6 +87,11 @@ func cloud9EnvironmentImportable(svc *cloud9.Client, environmentID string) (bool
 		return false, nil
 	}
 	return true, nil
+}
+
+func cloud9EnvironmentNotFound(err error) bool {
+	var notFound *types.NotFoundException
+	return errors.As(err, &notFound)
 }
 
 func newCloud9EnvironmentEC2Resource(environmentID string) terraformutils.Resource {

--- a/providers/aws/cloud9.go
+++ b/providers/aws/cloud9.go
@@ -41,7 +41,7 @@ func (g *Cloud9Generator) InitResources() error {
 			if !awsIDFilterAllows(environmentIDFilter, environmentID) {
 				continue
 			}
-			if err := g.addEnvironment(svc, environmentID); err != nil {
+			if err := g.addEnvironment(svc, environmentID, cloud9ShouldEmitEnvironment(g.Filter, environmentID)); err != nil {
 				return err
 			}
 		}
@@ -50,7 +50,7 @@ func (g *Cloud9Generator) InitResources() error {
 	return nil
 }
 
-func (g *Cloud9Generator) addEnvironment(svc *cloud9.Client, environmentID string) error {
+func (g *Cloud9Generator) addEnvironment(svc *cloud9.Client, environmentID string, emitEnvironment bool) error {
 	if environmentID == "" {
 		return nil
 	}
@@ -59,9 +59,13 @@ func (g *Cloud9Generator) addEnvironment(svc *cloud9.Client, environmentID strin
 	} else if !importable {
 		return nil
 	}
-	g.Resources = append(g.Resources, newCloud9EnvironmentEC2Resource(environmentID))
-	if err := g.loadEnvironmentMemberships(svc, environmentID); err != nil {
-		log.Printf("[WARN] Skipping Cloud9 environment memberships for %s: %v", environmentID, err)
+	if emitEnvironment {
+		g.Resources = append(g.Resources, newCloud9EnvironmentEC2Resource(environmentID))
+	}
+	if cloud9ShouldLoadEnvironmentMemberships(g.Filter) {
+		if err := g.loadEnvironmentMemberships(svc, environmentID); err != nil {
+			log.Printf("[WARN] Skipping Cloud9 environment memberships for %s: %v", environmentID, err)
+		}
 	}
 
 	return nil
@@ -133,6 +137,25 @@ func newCloud9EnvironmentMembershipResource(membership types.EnvironmentMember) 
 func cloud9EnvironmentMembershipImportable(permissions types.Permissions) bool {
 	// Owner memberships are created by AWS for environment creators and are not independently managed by Terraform.
 	return permissions == types.PermissionsReadOnly || permissions == types.PermissionsReadWrite
+}
+
+func cloud9ShouldEmitEnvironment(filters []terraformutils.ResourceFilter, environmentID string) bool {
+	if !cloud9HasTypedFilter(filters) {
+		return true
+	}
+	if !awsHasApplicableFilter(filters, cloud9EnvironmentEC2ResourceType) {
+		return false
+	}
+	return awsIDFilterAllows(awsTypedIDFilterValues(filters, cloud9EnvironmentEC2ResourceType), environmentID)
+}
+
+func cloud9HasTypedFilter(filters []terraformutils.ResourceFilter) bool {
+	return awsHasTypedFilter(filters, cloud9EnvironmentEC2ResourceType) ||
+		awsHasTypedFilter(filters, cloud9EnvironmentMembershipResourceType)
+}
+
+func cloud9ShouldLoadEnvironmentMemberships(filters []terraformutils.ResourceFilter) bool {
+	return !cloud9HasTypedFilter(filters) || awsHasTypedFilter(filters, cloud9EnvironmentMembershipResourceType)
 }
 
 func cloud9EnvironmentIDFilter(filters []terraformutils.ResourceFilter) map[string]bool {

--- a/providers/aws/cloud9.go
+++ b/providers/aws/cloud9.go
@@ -159,11 +159,19 @@ func cloud9ShouldLoadEnvironmentMemberships(filters []terraformutils.ResourceFil
 }
 
 func cloud9EnvironmentIDFilter(filters []terraformutils.ResourceFilter) map[string]bool {
+	if cloud9HasEnvironmentScanAttributeFilter(filters) {
+		return nil
+	}
 	membershipEnvironmentIDs, ok := cloud9EnvironmentIDsFromMembershipFilterValues(awsTypedIDFilterValues(filters, cloud9EnvironmentMembershipResourceType))
 	if !ok {
 		return nil
 	}
 	return awsMergeIDFilterValues(awsTypedIDFilterValues(filters, cloud9EnvironmentEC2ResourceType), membershipEnvironmentIDs)
+}
+
+func cloud9HasEnvironmentScanAttributeFilter(filters []terraformutils.ResourceFilter) bool {
+	return awsHasApplicableNonIDFilter(filters, cloud9EnvironmentEC2ResourceType) ||
+		awsHasApplicableNonIDFilter(filters, cloud9EnvironmentMembershipResourceType)
 }
 
 func cloud9EnvironmentIDsFromMembershipFilterValues(membershipIDs map[string]bool) (map[string]bool, bool) {

--- a/providers/aws/cloud9.go
+++ b/providers/aws/cloud9.go
@@ -127,7 +127,7 @@ func newCloud9EnvironmentMembershipResource(membership types.EnvironmentMember) 
 }
 
 func cloud9EnvironmentMembershipImportable(permissions types.Permissions) bool {
-	return permissions != ""
+	return permissions == types.PermissionsReadOnly || permissions == types.PermissionsReadWrite
 }
 
 func cloud9EnvironmentMembershipImportID(environmentID, userArn string) string {

--- a/providers/aws/cloud9.go
+++ b/providers/aws/cloud9.go
@@ -127,6 +127,7 @@ func newCloud9EnvironmentMembershipResource(membership types.EnvironmentMember) 
 }
 
 func cloud9EnvironmentMembershipImportable(permissions types.Permissions) bool {
+	// Owner memberships are created by AWS for environment creators and are not independently managed by Terraform.
 	return permissions == types.PermissionsReadOnly || permissions == types.PermissionsReadWrite
 }
 

--- a/providers/aws/cloud9_test.go
+++ b/providers/aws/cloud9_test.go
@@ -1,0 +1,110 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package aws
+
+import (
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/cloud9/types"
+	"github.com/chenrui333/terraformer/terraformutils"
+)
+
+func TestNewCloud9EnvironmentEC2Resource(t *testing.T) {
+	resource := newCloud9EnvironmentEC2Resource("env-1234567890abcdef0")
+	assertCloud9Resource(t, resource, "env-1234567890abcdef0", "env-1234567890abcdef0", cloud9EnvironmentEC2ResourceType)
+}
+
+func TestNewCloud9EnvironmentMembershipResource(t *testing.T) {
+	userArn := "arn:aws:iam::123456789012:user/alice"
+	resource, ok := newCloud9EnvironmentMembershipResource(types.EnvironmentMember{
+		EnvironmentId: aws.String("env-1234567890abcdef0"),
+		Permissions:   types.PermissionsReadWrite,
+		UserArn:       aws.String(userArn),
+	})
+	assertCloud9ResourceOK(t, resource, ok, cloud9EnvironmentMembershipImportID("env-1234567890abcdef0", userArn), cloud9ResourceName("membership", "env-1234567890abcdef0", userArn), cloud9EnvironmentMembershipResourceType)
+	assertCloud9Attribute(t, resource, "environment_id", "env-1234567890abcdef0")
+	assertCloud9Attribute(t, resource, "permissions", "read-write")
+	assertCloud9Attribute(t, resource, "user_arn", userArn)
+}
+
+func TestCloud9EnvironmentMembershipImportID(t *testing.T) {
+	got := cloud9EnvironmentMembershipImportID("env-123", "arn:aws:iam::123456789012:user/alice")
+	want := "env-123#arn:aws:iam::123456789012:user/alice"
+	if got != want {
+		t.Fatalf("Cloud9 membership import ID = %q, want %q", got, want)
+	}
+}
+
+func TestCloud9EnvironmentMembershipImportable(t *testing.T) {
+	tests := []struct {
+		name        string
+		permissions types.Permissions
+		want        bool
+	}{
+		{name: "read only", permissions: types.PermissionsReadOnly, want: true},
+		{name: "read write", permissions: types.PermissionsReadWrite, want: true},
+		{name: "owner", permissions: types.PermissionsOwner, want: true},
+		{name: "empty", want: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := cloud9EnvironmentMembershipImportable(tt.permissions); got != tt.want {
+				t.Fatalf("cloud9EnvironmentMembershipImportable(%q) = %t, want %t", tt.permissions, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestCloud9MembershipSkipsEmptyIdentifiers(t *testing.T) {
+	if _, ok := newCloud9EnvironmentMembershipResource(types.EnvironmentMember{
+		Permissions: types.PermissionsReadOnly,
+		UserArn:     aws.String("arn:aws:iam::123456789012:user/alice"),
+	}); ok {
+		t.Fatal("membership with empty environment ID should be skipped")
+	}
+
+	if _, ok := newCloud9EnvironmentMembershipResource(types.EnvironmentMember{
+		EnvironmentId: aws.String("env-1234567890abcdef0"),
+		Permissions:   types.PermissionsReadOnly,
+	}); ok {
+		t.Fatal("membership with empty user ARN should be skipped")
+	}
+}
+
+func TestCloud9ResourceNamesPreserveSegmentBoundaries(t *testing.T) {
+	left := terraformutils.TfSanitize(cloud9ResourceName("membership", "a/b_c"))
+	right := terraformutils.TfSanitize(cloud9ResourceName("member", "ship/a_b_c"))
+	if left == right {
+		t.Fatalf("Cloud9 resource names collide: %q", left)
+	}
+}
+
+func assertCloud9ResourceOK(t *testing.T, resource terraformutils.Resource, ok bool, wantID, wantName, wantType string) {
+	t.Helper()
+	if !ok {
+		t.Fatal("resource was skipped")
+	}
+	assertCloud9Resource(t, resource, wantID, wantName, wantType)
+}
+
+func assertCloud9Resource(t *testing.T, resource terraformutils.Resource, wantID, wantName, wantType string) {
+	t.Helper()
+	if got := resource.InstanceState.ID; got != wantID {
+		t.Fatalf("resource ID = %q, want %q", got, wantID)
+	}
+	if got := resource.ResourceName; got != terraformutils.TfSanitize(wantName) {
+		t.Fatalf("resource name = %q, want %q", got, terraformutils.TfSanitize(wantName))
+	}
+	if got := resource.InstanceInfo.Type; got != wantType {
+		t.Fatalf("resource type = %q, want %q", got, wantType)
+	}
+}
+
+func assertCloud9Attribute(t *testing.T, resource terraformutils.Resource, key, want string) {
+	t.Helper()
+	if got := resource.InstanceState.Attributes[key]; got != want {
+		t.Fatalf("resource attribute %q = %q, want %q", key, got, want)
+	}
+}

--- a/providers/aws/cloud9_test.go
+++ b/providers/aws/cloud9_test.go
@@ -88,6 +88,44 @@ func TestCloud9EnvironmentIDFilterAllowsAllForUnparseableMembershipID(t *testing
 	}
 }
 
+func TestCloud9ShouldEmitEnvironmentSkipsMembershipOnlyFilters(t *testing.T) {
+	service := terraformutils.Service{}
+	service.ParseFilters([]string{"cloud9_environment_membership='env-child#arn:aws:iam::123456789012:user/alice'"})
+
+	if cloud9ShouldEmitEnvironment(service.Filter, "env-child") {
+		t.Fatal("membership-only filter should scan but not emit parent environment")
+	}
+}
+
+func TestCloud9ShouldEmitEnvironmentHonorsEnvironmentFilters(t *testing.T) {
+	service := terraformutils.Service{}
+	service.ParseFilters([]string{
+		"cloud9_environment_ec2=env-parent",
+		"cloud9_environment_membership='env-child#arn:aws:iam::123456789012:user/alice'",
+	})
+
+	if !cloud9ShouldEmitEnvironment(service.Filter, "env-parent") {
+		t.Fatal("environment filter should emit matching environment")
+	}
+	if cloud9ShouldEmitEnvironment(service.Filter, "env-child") {
+		t.Fatal("membership-derived parent should not be emitted when it is not requested by the environment filter")
+	}
+}
+
+func TestCloud9ShouldLoadMembershipsOnlyWhenRequested(t *testing.T) {
+	environmentService := terraformutils.Service{}
+	environmentService.ParseFilters([]string{"cloud9_environment_ec2=env-parent"})
+	if cloud9ShouldLoadEnvironmentMemberships(environmentService.Filter) {
+		t.Fatal("environment-only filter should not load membership resources")
+	}
+
+	membershipService := terraformutils.Service{}
+	membershipService.ParseFilters([]string{"cloud9_environment_membership='env-child#arn:aws:iam::123456789012:user/alice'"})
+	if !cloud9ShouldLoadEnvironmentMemberships(membershipService.Filter) {
+		t.Fatal("membership filter should load memberships")
+	}
+}
+
 func TestCloud9MembershipSkipsEmptyIdentifiers(t *testing.T) {
 	if _, ok := newCloud9EnvironmentMembershipResource(types.EnvironmentMember{
 		Permissions: types.PermissionsReadOnly,

--- a/providers/aws/cloud9_test.go
+++ b/providers/aws/cloud9_test.go
@@ -57,6 +57,37 @@ func TestCloud9EnvironmentMembershipImportable(t *testing.T) {
 	}
 }
 
+func TestCloud9EnvironmentIDFilterIncludesMembershipParents(t *testing.T) {
+	service := terraformutils.Service{}
+	service.ParseFilters([]string{
+		"cloud9_environment_ec2=env-parent",
+		"cloud9_environment_membership='env-child#arn:aws:iam::123456789012:user/alice'",
+	})
+
+	filter := cloud9EnvironmentIDFilter(service.Filter)
+	for _, environmentID := range []string{"env-parent", "env-child"} {
+		if !awsIDFilterAllows(filter, environmentID) {
+			t.Fatalf("Cloud9 environment filter should allow %q: %#v", environmentID, filter)
+		}
+	}
+	if awsIDFilterAllows(filter, "env-other") {
+		t.Fatalf("Cloud9 environment filter allowed unrelated environment: %#v", filter)
+	}
+}
+
+func TestCloud9EnvironmentIDFilterAllowsAllForUnparseableMembershipID(t *testing.T) {
+	service := terraformutils.Service{}
+	service.ParseFilters([]string{
+		"cloud9_environment_ec2=env-parent",
+		"cloud9_environment_membership=missing-separator",
+	})
+
+	filter := cloud9EnvironmentIDFilter(service.Filter)
+	if !awsIDFilterAllows(filter, "env-other") {
+		t.Fatalf("unparseable Cloud9 membership ID should disable parent prefilter: %#v", filter)
+	}
+}
+
 func TestCloud9MembershipSkipsEmptyIdentifiers(t *testing.T) {
 	if _, ok := newCloud9EnvironmentMembershipResource(types.EnvironmentMember{
 		Permissions: types.PermissionsReadOnly,

--- a/providers/aws/cloud9_test.go
+++ b/providers/aws/cloud9_test.go
@@ -88,6 +88,26 @@ func TestCloud9EnvironmentIDFilterAllowsAllForUnparseableMembershipID(t *testing
 	}
 }
 
+func TestCloud9EnvironmentIDFilterAllowsAllForAttributeFilters(t *testing.T) {
+	environmentService := terraformutils.Service{}
+	environmentService.ParseFilters([]string{
+		"Type=cloud9_environment_ec2;Name=name;Value=dev",
+		"cloud9_environment_membership='env-child#arn:aws:iam::123456789012:user/alice'",
+	})
+	if filter := cloud9EnvironmentIDFilter(environmentService.Filter); !awsIDFilterAllows(filter, "env-other") {
+		t.Fatalf("Cloud9 environment attribute filter should disable parent prefilter: %#v", filter)
+	}
+
+	membershipService := terraformutils.Service{}
+	membershipService.ParseFilters([]string{
+		"cloud9_environment_ec2=env-parent",
+		"Type=cloud9_environment_membership;Name=permissions;Value=read-write",
+	})
+	if filter := cloud9EnvironmentIDFilter(membershipService.Filter); !awsIDFilterAllows(filter, "env-other") {
+		t.Fatalf("Cloud9 membership attribute filter should disable parent prefilter: %#v", filter)
+	}
+}
+
 func TestCloud9ShouldEmitEnvironmentSkipsMembershipOnlyFilters(t *testing.T) {
 	service := terraformutils.Service{}
 	service.ParseFilters([]string{"cloud9_environment_membership='env-child#arn:aws:iam::123456789012:user/alice'"})

--- a/providers/aws/cloud9_test.go
+++ b/providers/aws/cloud9_test.go
@@ -44,7 +44,7 @@ func TestCloud9EnvironmentMembershipImportable(t *testing.T) {
 	}{
 		{name: "read only", permissions: types.PermissionsReadOnly, want: true},
 		{name: "read write", permissions: types.PermissionsReadWrite, want: true},
-		{name: "owner", permissions: types.PermissionsOwner, want: true},
+		{name: "owner", permissions: types.PermissionsOwner, want: false},
 		{name: "empty", want: false},
 	}
 

--- a/providers/aws/cloud9_test.go
+++ b/providers/aws/cloud9_test.go
@@ -3,6 +3,7 @@
 package aws
 
 import (
+	"errors"
 	"testing"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
@@ -52,6 +53,27 @@ func TestCloud9EnvironmentMembershipImportable(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			if got := cloud9EnvironmentMembershipImportable(tt.permissions); got != tt.want {
 				t.Fatalf("cloud9EnvironmentMembershipImportable(%q) = %t, want %t", tt.permissions, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestCloud9EnvironmentNotFound(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{name: "nil", want: false},
+		{name: "not found", err: &types.NotFoundException{}, want: true},
+		{name: "wrapped not found", err: errors.Join(errors.New("lookup failed"), &types.NotFoundException{}), want: true},
+		{name: "generic", err: errors.New("boom"), want: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := cloud9EnvironmentNotFound(tt.err); got != tt.want {
+				t.Fatalf("cloud9EnvironmentNotFound(%v) = %t, want %t", tt.err, got, tt.want)
 			}
 		})
 	}

--- a/providers/aws/datapipeline.go
+++ b/providers/aws/datapipeline.go
@@ -56,6 +56,35 @@ func (g *DataPipelineGenerator) InitResources() error {
 	return nil
 }
 
+func (g *DataPipelineGenerator) PostRefreshCleanup() {
+	if len(g.Filter) == 0 {
+		return
+	}
+	definitionsByPipelineID := map[string][]terraformutils.Resource{}
+	matchedPipelineIDs := map[string]bool{}
+	for _, resource := range g.Resources {
+		switch resource.InstanceInfo.Type {
+		case dataPipelinePipelineResourceType:
+			if dataPipelineResourceMatchesPostRefreshFilters(resource, g.Filter) {
+				matchedPipelineIDs[resource.InstanceState.ID] = true
+			}
+		case dataPipelinePipelineDefinitionResourceType:
+			if pipelineID := dataPipelineDefinitionPipelineID(resource); pipelineID != "" {
+				definitionsByPipelineID[pipelineID] = append(definitionsByPipelineID[pipelineID], resource)
+			}
+		}
+	}
+
+	terraformutils.FilterCleanup(&g.Service, false)
+	for pipelineID := range matchedPipelineIDs {
+		for _, resource := range definitionsByPipelineID[pipelineID] {
+			if !terraformutils.ContainsResource(g.Resources, resource) {
+				g.Resources = append(g.Resources, resource)
+			}
+		}
+	}
+}
+
 func getDataPipelinePipelineDefinitionResource(svc *datapipeline.Client, pipelineID, pipelineName string) (terraformutils.Resource, bool, error) {
 	if pipelineID == "" {
 		return terraformutils.Resource{}, false, nil
@@ -106,6 +135,28 @@ func newDataPipelinePipelineDefinitionResource(pipelineID, pipelineName string) 
 
 func dataPipelineDefinitionImportable(definition *datapipeline.GetPipelineDefinitionOutput) bool {
 	return definition != nil && len(definition.PipelineObjects) > 0
+}
+
+func dataPipelineResourceMatchesPostRefreshFilters(resource terraformutils.Resource, filters []terraformutils.ResourceFilter) bool {
+	matchedApplicableFilter := false
+	serviceName := strings.TrimPrefix(resource.InstanceInfo.Type, resource.Provider+"_")
+	for _, filter := range filters {
+		if filter.FieldPath == "id" || !filter.IsApplicable(serviceName) {
+			continue
+		}
+		matchedApplicableFilter = true
+		if !filter.Filter(resource) {
+			return false
+		}
+	}
+	return matchedApplicableFilter
+}
+
+func dataPipelineDefinitionPipelineID(resource terraformutils.Resource) string {
+	if resource.InstanceState == nil || resource.InstanceState.Attributes == nil {
+		return ""
+	}
+	return resource.InstanceState.Attributes["pipeline_id"]
 }
 
 func dataPipelinePipelineImportID(pipelineID string) string {

--- a/providers/aws/datapipeline.go
+++ b/providers/aws/datapipeline.go
@@ -19,6 +19,11 @@ const (
 
 var datapipelineAllowEmptyValues = []string{"tags."}
 
+var dataPipelineDefinitionAllowEmptyValues = []string{
+	`^parameter_object\.[^.]+\.attribute\.[^.]+\.string_value$`,
+	`^parameter_value\.[^.]+\.string_value$`,
+}
+
 type DataPipelineGenerator struct {
 	AWSService
 }
@@ -141,7 +146,7 @@ func newDataPipelinePipelineDefinitionResource(pipelineID, pipelineName string) 
 			"name":        pipelineName,
 			"pipeline_id": pipelineID,
 		},
-		datapipelineAllowEmptyValues,
+		dataPipelineDefinitionAllowEmptyValues,
 		map[string]interface{}{})
 }
 

--- a/providers/aws/datapipeline.go
+++ b/providers/aws/datapipeline.go
@@ -193,8 +193,12 @@ func dataPipelineDefinitionPipelineID(resource terraformutils.Resource) string {
 }
 
 func dataPipelinePipelineIDFilter(filters []terraformutils.ResourceFilter) map[string]bool {
+	pipelineIDs := awsTypedIDFilterValues(filters, dataPipelinePipelineResourceType)
+	if len(pipelineIDs) == 0 && awsHasApplicableNonIDFilter(filters, dataPipelinePipelineResourceType) {
+		return nil
+	}
 	return awsMergeIDFilterValues(
-		awsTypedIDFilterValues(filters, dataPipelinePipelineResourceType),
+		pipelineIDs,
 		dataPipelineDefinitionPipelineIDFilter(filters),
 	)
 }

--- a/providers/aws/datapipeline.go
+++ b/providers/aws/datapipeline.go
@@ -95,12 +95,13 @@ func (g *DataPipelineGenerator) PostRefreshCleanup() {
 	if dataPipelineShouldPruneDefinitionsToMatchedPipelines(g.Filter) {
 		g.Resources = dataPipelineResourcesWithDefinitionsForPipelineIDs(g.Resources, matchedPipelineIDs)
 	}
-	if !awsHasTypedFilter(g.Filter, dataPipelinePipelineDefinitionResourceType) {
-		for pipelineID := range matchedPipelineIDs {
-			for _, resource := range definitionsByPipelineID[pipelineID] {
-				if !terraformutils.ContainsResource(g.Resources, resource) {
-					g.Resources = append(g.Resources, resource)
-				}
+	for pipelineID := range matchedPipelineIDs {
+		if !dataPipelineShouldRestoreDefinitionForMatchedPipeline(g.Filter, pipelineID) {
+			continue
+		}
+		for _, resource := range definitionsByPipelineID[pipelineID] {
+			if !terraformutils.ContainsResource(g.Resources, resource) {
+				g.Resources = append(g.Resources, resource)
 			}
 		}
 	}
@@ -247,6 +248,14 @@ func dataPipelineShouldLoadDefinitions(filters []terraformutils.ResourceFilter) 
 func dataPipelineShouldPruneDefinitionsToMatchedPipelines(filters []terraformutils.ResourceFilter) bool {
 	return awsHasTypedNonIDFilter(filters, dataPipelinePipelineResourceType) &&
 		!awsHasTypedFilter(filters, dataPipelinePipelineDefinitionResourceType)
+}
+
+func dataPipelineShouldRestoreDefinitionForMatchedPipeline(filters []terraformutils.ResourceFilter, pipelineID string) bool {
+	if !awsHasTypedFilter(filters, dataPipelinePipelineDefinitionResourceType) {
+		return true
+	}
+	definitionPipelineIDs := dataPipelineDefinitionPipelineIDFilter(filters)
+	return len(definitionPipelineIDs) > 0 && definitionPipelineIDs[pipelineID]
 }
 
 func dataPipelinePipelineImportID(pipelineID string) string {

--- a/providers/aws/datapipeline.go
+++ b/providers/aws/datapipeline.go
@@ -83,10 +83,15 @@ func (g *DataPipelineGenerator) PostRefreshCleanup() {
 	if dataPipelineHasTypedFilter(g.Filter) && !awsHasApplicableFilter(g.Filter, dataPipelinePipelineResourceType) {
 		g.Resources = dataPipelineResourcesWithoutType(g.Resources, dataPipelinePipelineResourceType)
 	}
-	for pipelineID := range matchedPipelineIDs {
-		for _, resource := range definitionsByPipelineID[pipelineID] {
-			if !terraformutils.ContainsResource(g.Resources, resource) {
-				g.Resources = append(g.Resources, resource)
+	if dataPipelineShouldPruneDefinitionsToMatchedPipelines(g.Filter) {
+		g.Resources = dataPipelineResourcesWithDefinitionsForPipelineIDs(g.Resources, matchedPipelineIDs)
+	}
+	if !awsHasTypedFilter(g.Filter, dataPipelinePipelineDefinitionResourceType) {
+		for pipelineID := range matchedPipelineIDs {
+			for _, resource := range definitionsByPipelineID[pipelineID] {
+				if !terraformutils.ContainsResource(g.Resources, resource) {
+					g.Resources = append(g.Resources, resource)
+				}
 			}
 		}
 	}
@@ -169,6 +174,17 @@ func dataPipelineResourcesWithoutType(resources []terraformutils.Resource, resou
 	return filtered
 }
 
+func dataPipelineResourcesWithDefinitionsForPipelineIDs(resources []terraformutils.Resource, pipelineIDs map[string]bool) []terraformutils.Resource {
+	filtered := []terraformutils.Resource{}
+	for _, resource := range resources {
+		if resource.InstanceInfo.Type == dataPipelinePipelineDefinitionResourceType && !pipelineIDs[dataPipelineDefinitionPipelineID(resource)] {
+			continue
+		}
+		filtered = append(filtered, resource)
+	}
+	return filtered
+}
+
 func dataPipelineDefinitionPipelineID(resource terraformutils.Resource) string {
 	if resource.InstanceState == nil || resource.InstanceState.Attributes == nil {
 		return ""
@@ -203,6 +219,11 @@ func dataPipelineShouldEmitPipeline(filters []terraformutils.ResourceFilter, pip
 func dataPipelineHasTypedFilter(filters []terraformutils.ResourceFilter) bool {
 	return awsHasTypedFilter(filters, dataPipelinePipelineResourceType) ||
 		awsHasTypedFilter(filters, dataPipelinePipelineDefinitionResourceType)
+}
+
+func dataPipelineShouldPruneDefinitionsToMatchedPipelines(filters []terraformutils.ResourceFilter) bool {
+	return awsHasTypedNonIDFilter(filters, dataPipelinePipelineResourceType) &&
+		!awsHasTypedFilter(filters, dataPipelinePipelineDefinitionResourceType)
 }
 
 func dataPipelinePipelineImportID(pipelineID string) string {

--- a/providers/aws/datapipeline.go
+++ b/providers/aws/datapipeline.go
@@ -35,6 +35,7 @@ func (g *DataPipelineGenerator) InitResources() error {
 	}
 	svc := datapipeline.NewFromConfig(config)
 	pipelineIDFilter := dataPipelinePipelineIDFilter(g.Filter)
+	loadDefinitions := dataPipelineShouldLoadDefinitions(g.Filter)
 	p := datapipeline.NewListPipelinesPaginator(svc, &datapipeline.ListPipelinesInput{})
 	var resources []terraformutils.Resource
 	for p.HasMorePages() {
@@ -50,6 +51,9 @@ func (g *DataPipelineGenerator) InitResources() error {
 			}
 			if resource, ok := newDataPipelinePipelineResource(pipelineID, pipelineName); ok && dataPipelineShouldEmitPipeline(g.Filter, pipelineID) {
 				resources = append(resources, resource)
+			}
+			if !loadDefinitions {
+				continue
 			}
 			resource, ok, err := getDataPipelinePipelineDefinitionResource(svc, pipelineID, pipelineName)
 			if err != nil {
@@ -228,6 +232,16 @@ func dataPipelineShouldEmitPipeline(filters []terraformutils.ResourceFilter, pip
 func dataPipelineHasTypedFilter(filters []terraformutils.ResourceFilter) bool {
 	return awsHasTypedFilter(filters, dataPipelinePipelineResourceType) ||
 		awsHasTypedFilter(filters, dataPipelinePipelineDefinitionResourceType)
+}
+
+func dataPipelineShouldLoadDefinitions(filters []terraformutils.ResourceFilter) bool {
+	if !dataPipelineHasTypedFilter(filters) {
+		return true
+	}
+	if awsHasTypedFilter(filters, dataPipelinePipelineDefinitionResourceType) {
+		return true
+	}
+	return awsHasApplicableNonIDFilter(filters, dataPipelinePipelineResourceType)
 }
 
 func dataPipelineShouldPruneDefinitionsToMatchedPipelines(filters []terraformutils.ResourceFilter) bool {

--- a/providers/aws/datapipeline.go
+++ b/providers/aws/datapipeline.go
@@ -29,6 +29,7 @@ func (g *DataPipelineGenerator) InitResources() error {
 		return e
 	}
 	svc := datapipeline.NewFromConfig(config)
+	pipelineIDFilter := awsTypedIDFilterValues(g.Filter, dataPipelinePipelineResourceType)
 	p := datapipeline.NewListPipelinesPaginator(svc, &datapipeline.ListPipelinesInput{})
 	var resources []terraformutils.Resource
 	for p.HasMorePages() {
@@ -39,6 +40,9 @@ func (g *DataPipelineGenerator) InitResources() error {
 		for _, pipeline := range page.PipelineIdList {
 			pipelineID := StringValue(pipeline.Id)
 			pipelineName := StringValue(pipeline.Name)
+			if !awsIDFilterAllows(pipelineIDFilter, pipelineID) {
+				continue
+			}
 			if resource, ok := newDataPipelinePipelineResource(pipelineID, pipelineName); ok {
 				resources = append(resources, resource)
 			}

--- a/providers/aws/datapipeline.go
+++ b/providers/aws/datapipeline.go
@@ -97,6 +97,7 @@ func newDataPipelinePipelineDefinitionResource(pipelineID, pipelineName string) 
 		dataPipelinePipelineDefinitionResourceType,
 		"aws",
 		map[string]string{
+			"name":        pipelineName,
 			"pipeline_id": pipelineID,
 		},
 		datapipelineAllowEmptyValues,

--- a/providers/aws/datapipeline.go
+++ b/providers/aws/datapipeline.go
@@ -4,9 +4,17 @@ package aws
 
 import (
 	"context"
+	"fmt"
+	"log"
+	"strings"
 
 	"github.com/aws/aws-sdk-go-v2/service/datapipeline"
 	"github.com/chenrui333/terraformer/terraformutils"
+)
+
+const (
+	dataPipelinePipelineResourceType           = "aws_datapipeline_pipeline"
+	dataPipelinePipelineDefinitionResourceType = "aws_datapipeline_pipeline_definition"
 )
 
 var datapipelineAllowEmptyValues = []string{"tags."}
@@ -31,14 +39,91 @@ func (g *DataPipelineGenerator) InitResources() error {
 		for _, pipeline := range page.PipelineIdList {
 			pipelineID := StringValue(pipeline.Id)
 			pipelineName := StringValue(pipeline.Name)
-			resources = append(resources, terraformutils.NewSimpleResource(
-				pipelineID,
-				pipelineName,
-				"aws_datapipeline_pipeline",
-				"aws",
-				datapipelineAllowEmptyValues))
+			if resource, ok := newDataPipelinePipelineResource(pipelineID, pipelineName); ok {
+				resources = append(resources, resource)
+			}
+			resource, ok, err := getDataPipelinePipelineDefinitionResource(svc, pipelineID, pipelineName)
+			if err != nil {
+				log.Printf("[WARN] Skipping Data Pipeline definition for %s: %v", pipelineID, err)
+				continue
+			}
+			if ok {
+				resources = append(resources, resource)
+			}
 		}
 	}
 	g.Resources = resources
 	return nil
+}
+
+func getDataPipelinePipelineDefinitionResource(svc *datapipeline.Client, pipelineID, pipelineName string) (terraformutils.Resource, bool, error) {
+	if pipelineID == "" {
+		return terraformutils.Resource{}, false, nil
+	}
+	output, err := svc.GetPipelineDefinition(context.TODO(), &datapipeline.GetPipelineDefinitionInput{
+		PipelineId: &pipelineID,
+	})
+	if err != nil {
+		return terraformutils.Resource{}, false, err
+	}
+	if !dataPipelineDefinitionImportable(output) {
+		return terraformutils.Resource{}, false, nil
+	}
+	return newDataPipelinePipelineDefinitionResource(pipelineID, pipelineName), true, nil
+}
+
+func newDataPipelinePipelineResource(pipelineID, pipelineName string) (terraformutils.Resource, bool) {
+	if pipelineID == "" {
+		return terraformutils.Resource{}, false
+	}
+	if pipelineName == "" {
+		pipelineName = pipelineID
+	}
+	return terraformutils.NewSimpleResource(
+		dataPipelinePipelineImportID(pipelineID),
+		pipelineName,
+		dataPipelinePipelineResourceType,
+		"aws",
+		datapipelineAllowEmptyValues), true
+}
+
+func newDataPipelinePipelineDefinitionResource(pipelineID, pipelineName string) terraformutils.Resource {
+	if pipelineName == "" {
+		pipelineName = pipelineID
+	}
+	return terraformutils.NewResource(
+		dataPipelinePipelineDefinitionImportID(pipelineID),
+		dataPipelineResourceName("pipeline-definition", pipelineName, pipelineID),
+		dataPipelinePipelineDefinitionResourceType,
+		"aws",
+		map[string]string{
+			"pipeline_id": pipelineID,
+		},
+		datapipelineAllowEmptyValues,
+		map[string]interface{}{})
+}
+
+func dataPipelineDefinitionImportable(definition *datapipeline.GetPipelineDefinitionOutput) bool {
+	return definition != nil && len(definition.PipelineObjects) > 0
+}
+
+func dataPipelinePipelineImportID(pipelineID string) string {
+	return pipelineID
+}
+
+func dataPipelinePipelineDefinitionImportID(pipelineID string) string {
+	return pipelineID
+}
+
+func dataPipelineResourceName(parts ...string) string {
+	cleanParts := []string{}
+	for _, part := range parts {
+		if part != "" {
+			cleanParts = append(cleanParts, fmt.Sprintf("%d/%s", len(part), part))
+		}
+	}
+	if len(cleanParts) == 0 {
+		return "datapipeline-resource"
+	}
+	return strings.Join(cleanParts, "/")
 }

--- a/providers/aws/datapipeline.go
+++ b/providers/aws/datapipeline.go
@@ -43,7 +43,7 @@ func (g *DataPipelineGenerator) InitResources() error {
 			if !awsIDFilterAllows(pipelineIDFilter, pipelineID) {
 				continue
 			}
-			if resource, ok := newDataPipelinePipelineResource(pipelineID, pipelineName); ok {
+			if resource, ok := newDataPipelinePipelineResource(pipelineID, pipelineName); ok && dataPipelineShouldEmitPipeline(g.Filter, pipelineID) {
 				resources = append(resources, resource)
 			}
 			resource, ok, err := getDataPipelinePipelineDefinitionResource(svc, pipelineID, pipelineName)
@@ -80,6 +80,9 @@ func (g *DataPipelineGenerator) PostRefreshCleanup() {
 	}
 
 	terraformutils.FilterCleanup(&g.Service, false)
+	if dataPipelineHasTypedFilter(g.Filter) && !awsHasApplicableFilter(g.Filter, dataPipelinePipelineResourceType) {
+		g.Resources = dataPipelineResourcesWithoutType(g.Resources, dataPipelinePipelineResourceType)
+	}
 	for pipelineID := range matchedPipelineIDs {
 		for _, resource := range definitionsByPipelineID[pipelineID] {
 			if !terraformutils.ContainsResource(g.Resources, resource) {
@@ -156,6 +159,16 @@ func dataPipelineResourceMatchesPostRefreshFilters(resource terraformutils.Resou
 	return matchedApplicableFilter
 }
 
+func dataPipelineResourcesWithoutType(resources []terraformutils.Resource, resourceType string) []terraformutils.Resource {
+	filtered := []terraformutils.Resource{}
+	for _, resource := range resources {
+		if resource.InstanceInfo.Type != resourceType {
+			filtered = append(filtered, resource)
+		}
+	}
+	return filtered
+}
+
 func dataPipelineDefinitionPipelineID(resource terraformutils.Resource) string {
 	if resource.InstanceState == nil || resource.InstanceState.Attributes == nil {
 		return ""
@@ -166,8 +179,30 @@ func dataPipelineDefinitionPipelineID(resource terraformutils.Resource) string {
 func dataPipelinePipelineIDFilter(filters []terraformutils.ResourceFilter) map[string]bool {
 	return awsMergeIDFilterValues(
 		awsTypedIDFilterValues(filters, dataPipelinePipelineResourceType),
-		awsTypedIDFilterValues(filters, dataPipelinePipelineDefinitionResourceType),
+		dataPipelineDefinitionPipelineIDFilter(filters),
 	)
+}
+
+func dataPipelineDefinitionPipelineIDFilter(filters []terraformutils.ResourceFilter) map[string]bool {
+	return awsMergeIDFilterValues(
+		awsTypedIDFilterValues(filters, dataPipelinePipelineDefinitionResourceType),
+		awsTypedFilterValues(filters, dataPipelinePipelineDefinitionResourceType, "pipeline_id"),
+	)
+}
+
+func dataPipelineShouldEmitPipeline(filters []terraformutils.ResourceFilter, pipelineID string) bool {
+	if !dataPipelineHasTypedFilter(filters) {
+		return true
+	}
+	if !awsHasApplicableFilter(filters, dataPipelinePipelineResourceType) {
+		return false
+	}
+	return awsIDFilterAllows(awsTypedIDFilterValues(filters, dataPipelinePipelineResourceType), pipelineID)
+}
+
+func dataPipelineHasTypedFilter(filters []terraformutils.ResourceFilter) bool {
+	return awsHasTypedFilter(filters, dataPipelinePipelineResourceType) ||
+		awsHasTypedFilter(filters, dataPipelinePipelineDefinitionResourceType)
 }
 
 func dataPipelinePipelineImportID(pipelineID string) string {

--- a/providers/aws/datapipeline.go
+++ b/providers/aws/datapipeline.go
@@ -29,7 +29,7 @@ func (g *DataPipelineGenerator) InitResources() error {
 		return e
 	}
 	svc := datapipeline.NewFromConfig(config)
-	pipelineIDFilter := awsTypedIDFilterValues(g.Filter, dataPipelinePipelineResourceType)
+	pipelineIDFilter := dataPipelinePipelineIDFilter(g.Filter)
 	p := datapipeline.NewListPipelinesPaginator(svc, &datapipeline.ListPipelinesInput{})
 	var resources []terraformutils.Resource
 	for p.HasMorePages() {
@@ -161,6 +161,13 @@ func dataPipelineDefinitionPipelineID(resource terraformutils.Resource) string {
 		return ""
 	}
 	return resource.InstanceState.Attributes["pipeline_id"]
+}
+
+func dataPipelinePipelineIDFilter(filters []terraformutils.ResourceFilter) map[string]bool {
+	return awsMergeIDFilterValues(
+		awsTypedIDFilterValues(filters, dataPipelinePipelineResourceType),
+		awsTypedIDFilterValues(filters, dataPipelinePipelineDefinitionResourceType),
+	)
 }
 
 func dataPipelinePipelineImportID(pipelineID string) string {

--- a/providers/aws/datapipeline_test.go
+++ b/providers/aws/datapipeline_test.go
@@ -164,6 +164,32 @@ func TestDataPipelineShouldEmitPipelineHonorsPipelineFilters(t *testing.T) {
 	}
 }
 
+func TestDataPipelineShouldLoadDefinitionsOnlyWhenRequestedByTypedFilters(t *testing.T) {
+	tests := []struct {
+		name    string
+		filters []string
+		want    bool
+	}{
+		{name: "no filters", want: true},
+		{name: "global name filter", filters: []string{"Name=name;Value=daily-import"}, want: true},
+		{name: "typed pipeline ID only", filters: []string{"datapipeline_pipeline=df-123"}, want: false},
+		{name: "typed pipeline ID with global name filter", filters: []string{"datapipeline_pipeline=df-123", "Name=name;Value=daily-import"}, want: true},
+		{name: "typed pipeline name filter", filters: []string{"Type=datapipeline_pipeline;Name=name;Value=daily-import"}, want: true},
+		{name: "typed definition ID filter", filters: []string{"datapipeline_pipeline_definition=df-123"}, want: true},
+		{name: "typed definition pipeline ID filter", filters: []string{"Type=datapipeline_pipeline_definition;Name=pipeline_id;Value=df-123"}, want: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			service := terraformutils.Service{}
+			service.ParseFilters(tt.filters)
+			if got := dataPipelineShouldLoadDefinitions(service.Filter); got != tt.want {
+				t.Fatalf("dataPipelineShouldLoadDefinitions(%v) = %t, want %t", tt.filters, got, tt.want)
+			}
+		})
+	}
+}
+
 func TestDataPipelinePostRefreshCleanupKeepsDefinitionForMatchedPipelineName(t *testing.T) {
 	pipeline := dataPipelinePipelineResourceForCleanup("df-123", "daily-import")
 	otherPipeline := dataPipelinePipelineResourceForCleanup("df-456", "hourly-import")

--- a/providers/aws/datapipeline_test.go
+++ b/providers/aws/datapipeline_test.go
@@ -23,6 +23,7 @@ func TestNewDataPipelinePipelineResource(t *testing.T) {
 func TestNewDataPipelinePipelineDefinitionResource(t *testing.T) {
 	resource := newDataPipelinePipelineDefinitionResource("df-1234567890ABC", "daily-import")
 	assertDataPipelineResource(t, resource, true, "df-1234567890ABC", dataPipelineResourceName("pipeline-definition", "daily-import", "df-1234567890ABC"), dataPipelinePipelineDefinitionResourceType)
+	assertDataPipelineAttribute(t, resource, "name", "daily-import")
 	assertDataPipelineAttribute(t, resource, "pipeline_id", "df-1234567890ABC")
 }
 

--- a/providers/aws/datapipeline_test.go
+++ b/providers/aws/datapipeline_test.go
@@ -4,12 +4,14 @@ package aws
 
 import (
 	"reflect"
+	"regexp"
 	"testing"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/datapipeline"
 	datapipelinetypes "github.com/aws/aws-sdk-go-v2/service/datapipeline/types"
 	"github.com/chenrui333/terraformer/terraformutils"
+	"github.com/zclconf/go-cty/cty"
 )
 
 func TestNewDataPipelinePipelineResource(t *testing.T) {
@@ -26,6 +28,45 @@ func TestNewDataPipelinePipelineDefinitionResource(t *testing.T) {
 	assertDataPipelineResource(t, resource, true, "df-1234567890ABC", dataPipelineResourceName("pipeline-definition", "daily-import", "df-1234567890ABC"), dataPipelinePipelineDefinitionResourceType)
 	assertDataPipelineAttribute(t, resource, "name", "daily-import")
 	assertDataPipelineAttribute(t, resource, "pipeline_id", "df-1234567890ABC")
+}
+
+func TestDataPipelineDefinitionAllowEmptyValuesPreservesRequiredStringValues(t *testing.T) {
+	attributes := map[string]string{
+		"parameter_object.#":                              "1",
+		"parameter_object.100.attribute.#":                "1",
+		"parameter_object.100.attribute.200.key":          "param-key",
+		"parameter_object.100.attribute.200.string_value": "",
+		"parameter_object.100.id":                         "param-object",
+		"parameter_value.#":                               "1",
+		"parameter_value.300.id":                          "param-value",
+		"parameter_value.300.string_value":                "",
+		"pipeline_object.#":                               "1",
+		"pipeline_object.400.field.#":                     "1",
+		"pipeline_object.400.field.500.key":               "optional-empty",
+		"pipeline_object.400.field.500.string_value":      "",
+		"pipeline_object.400.id":                          "Default",
+		"pipeline_object.400.name":                        "Default",
+	}
+	parser := terraformutils.NewFlatmapParser(attributes, nil, dataPipelineAllowEmptyRegexes(dataPipelineDefinitionAllowEmptyValues))
+	result, err := parser.Parse(dataPipelineDefinitionTestType())
+	if err != nil {
+		t.Fatalf("Parse error: %v", err)
+	}
+
+	parameterValue := result["parameter_value"].([]interface{})[0].(map[string]interface{})
+	if got := parameterValue["string_value"]; got != "" {
+		t.Fatalf("parameter_value string_value = %v, want empty string", got)
+	}
+	parameterObject := result["parameter_object"].([]interface{})[0].(map[string]interface{})
+	attribute := parameterObject["attribute"].([]interface{})[0].(map[string]interface{})
+	if got := attribute["string_value"]; got != "" {
+		t.Fatalf("parameter_object attribute string_value = %v, want empty string", got)
+	}
+	pipelineObject := result["pipeline_object"].([]interface{})[0].(map[string]interface{})
+	field := pipelineObject["field"].([]interface{})[0].(map[string]interface{})
+	if _, ok := field["string_value"]; ok {
+		t.Fatal("optional pipeline_object field string_value should not be preserved when empty")
+	}
 }
 
 func TestDataPipelineDefinitionImportable(t *testing.T) {
@@ -206,6 +247,38 @@ func dataPipelineDefinitionResourceForCleanup(pipelineID, pipelineName string) t
 	resource := newDataPipelinePipelineDefinitionResource(pipelineID, pipelineName)
 	resource.InstanceState.Attributes = map[string]string{"pipeline_id": pipelineID}
 	return resource
+}
+
+func dataPipelineAllowEmptyRegexes(patterns []string) []*regexp.Regexp {
+	regexes := make([]*regexp.Regexp, 0, len(patterns))
+	for _, pattern := range patterns {
+		regexes = append(regexes, regexp.MustCompile(pattern))
+	}
+	return regexes
+}
+
+func dataPipelineDefinitionTestType() cty.Type {
+	return cty.Object(map[string]cty.Type{
+		"parameter_object": cty.Set(cty.Object(map[string]cty.Type{
+			"attribute": cty.Set(cty.Object(map[string]cty.Type{
+				"key":          cty.String,
+				"string_value": cty.String,
+			})),
+			"id": cty.String,
+		})),
+		"parameter_value": cty.Set(cty.Object(map[string]cty.Type{
+			"id":           cty.String,
+			"string_value": cty.String,
+		})),
+		"pipeline_object": cty.Set(cty.Object(map[string]cty.Type{
+			"field": cty.Set(cty.Object(map[string]cty.Type{
+				"key":          cty.String,
+				"string_value": cty.String,
+			})),
+			"id":   cty.String,
+			"name": cty.String,
+		})),
+	})
 }
 
 func assertDataPipelineResourceIDs(t *testing.T, resources []terraformutils.Resource, want []string) {

--- a/providers/aws/datapipeline_test.go
+++ b/providers/aws/datapipeline_test.go
@@ -66,6 +66,24 @@ func TestDataPipelineResourceNamesPreserveSegmentBoundaries(t *testing.T) {
 	}
 }
 
+func TestDataPipelinePipelineIDFilterIncludesDefinitionIDs(t *testing.T) {
+	service := terraformutils.Service{}
+	service.ParseFilters([]string{
+		"datapipeline_pipeline=df-parent",
+		"datapipeline_pipeline_definition=df-child",
+	})
+
+	filter := dataPipelinePipelineIDFilter(service.Filter)
+	for _, pipelineID := range []string{"df-parent", "df-child"} {
+		if !awsIDFilterAllows(filter, pipelineID) {
+			t.Fatalf("Data Pipeline filter should allow %q: %#v", pipelineID, filter)
+		}
+	}
+	if awsIDFilterAllows(filter, "df-other") {
+		t.Fatalf("Data Pipeline filter allowed unrelated pipeline: %#v", filter)
+	}
+}
+
 func TestDataPipelinePostRefreshCleanupKeepsDefinitionForMatchedPipelineName(t *testing.T) {
 	pipeline := dataPipelinePipelineResourceForCleanup("df-123", "daily-import")
 	otherPipeline := dataPipelinePipelineResourceForCleanup("df-456", "hourly-import")

--- a/providers/aws/datapipeline_test.go
+++ b/providers/aws/datapipeline_test.go
@@ -66,6 +66,69 @@ func TestDataPipelineResourceNamesPreserveSegmentBoundaries(t *testing.T) {
 	}
 }
 
+func TestDataPipelinePostRefreshCleanupKeepsDefinitionForMatchedPipelineName(t *testing.T) {
+	pipeline := dataPipelinePipelineResourceForCleanup("df-123", "daily-import")
+	otherPipeline := dataPipelinePipelineResourceForCleanup("df-456", "hourly-import")
+	definition := dataPipelineDefinitionResourceForCleanup("df-123", "daily-import")
+	otherDefinition := dataPipelineDefinitionResourceForCleanup("df-456", "hourly-import")
+	generator := &DataPipelineGenerator{}
+	generator.Resources = []terraformutils.Resource{pipeline, definition, otherPipeline, otherDefinition}
+	generator.ParseFilters([]string{"Name=name;Value=daily-import"})
+
+	generator.PostRefreshCleanup()
+
+	assertDataPipelineResourceIDs(t, generator.Resources, []string{
+		dataPipelinePipelineResourceType + "/df-123",
+		dataPipelinePipelineDefinitionResourceType + "/df-123",
+	})
+}
+
+func TestDataPipelinePostRefreshCleanupDoesNotBroadenDefinitionSpecificFilters(t *testing.T) {
+	pipeline := dataPipelinePipelineResourceForCleanup("df-123", "daily-import")
+	otherPipeline := dataPipelinePipelineResourceForCleanup("df-456", "hourly-import")
+	definition := dataPipelineDefinitionResourceForCleanup("df-123", "daily-import")
+	otherDefinition := dataPipelineDefinitionResourceForCleanup("df-456", "hourly-import")
+	generator := &DataPipelineGenerator{}
+	generator.Resources = []terraformutils.Resource{pipeline, definition, otherPipeline, otherDefinition}
+	generator.ParseFilters([]string{"Type=datapipeline_pipeline_definition;Name=pipeline_id;Value=df-123"})
+
+	generator.PostRefreshCleanup()
+
+	assertDataPipelineResourceIDs(t, generator.Resources, []string{
+		dataPipelinePipelineResourceType + "/df-123",
+		dataPipelinePipelineDefinitionResourceType + "/df-123",
+		dataPipelinePipelineResourceType + "/df-456",
+	})
+}
+
+func dataPipelinePipelineResourceForCleanup(pipelineID, pipelineName string) terraformutils.Resource {
+	resource, ok := newDataPipelinePipelineResource(pipelineID, pipelineName)
+	if !ok {
+		panic("expected Data Pipeline pipeline resource")
+	}
+	resource.InstanceState.Attributes = map[string]string{"name": pipelineName}
+	return resource
+}
+
+func dataPipelineDefinitionResourceForCleanup(pipelineID, pipelineName string) terraformutils.Resource {
+	resource := newDataPipelinePipelineDefinitionResource(pipelineID, pipelineName)
+	resource.InstanceState.Attributes = map[string]string{"pipeline_id": pipelineID}
+	return resource
+}
+
+func assertDataPipelineResourceIDs(t *testing.T, resources []terraformutils.Resource, want []string) {
+	t.Helper()
+	if len(resources) != len(want) {
+		t.Fatalf("resources len = %d, want %d: %#v", len(resources), len(want), resources)
+	}
+	for i, resource := range resources {
+		got := resource.InstanceInfo.Type + "/" + resource.InstanceState.ID
+		if got != want[i] {
+			t.Fatalf("resource[%d] = %q, want %q", i, got, want[i])
+		}
+	}
+}
+
 func assertDataPipelineResource(t *testing.T, resource terraformutils.Resource, ok bool, wantID, wantName, wantType string) {
 	t.Helper()
 	if !ok {

--- a/providers/aws/datapipeline_test.go
+++ b/providers/aws/datapipeline_test.go
@@ -207,6 +207,24 @@ func TestDataPipelinePostRefreshCleanupKeepsDefinitionForMatchedPipelineName(t *
 	})
 }
 
+func TestDataPipelinePostRefreshCleanupKeepsExplicitDefinitionForMatchedGlobalPipeline(t *testing.T) {
+	pipeline := dataPipelinePipelineResourceForCleanup("df-123", "daily-import")
+	definition := dataPipelineDefinitionResourceForCleanup("df-123", "daily-import")
+	generator := &DataPipelineGenerator{}
+	generator.Resources = []terraformutils.Resource{pipeline, definition}
+	generator.ParseFilters([]string{
+		"Name=name;Value=daily-import",
+		"datapipeline_pipeline_definition=df-123",
+	})
+
+	generator.PostRefreshCleanup()
+
+	assertDataPipelineResourceIDs(t, generator.Resources, []string{
+		dataPipelinePipelineResourceType + "/df-123",
+		dataPipelinePipelineDefinitionResourceType + "/df-123",
+	})
+}
+
 func TestDataPipelinePostRefreshCleanupPrunesDefinitionsForTypedPipelineNameFilter(t *testing.T) {
 	pipeline := dataPipelinePipelineResourceForCleanup("df-123", "daily-import")
 	otherPipeline := dataPipelinePipelineResourceForCleanup("df-456", "hourly-import")

--- a/providers/aws/datapipeline_test.go
+++ b/providers/aws/datapipeline_test.go
@@ -1,0 +1,89 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package aws
+
+import (
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/datapipeline"
+	datapipelinetypes "github.com/aws/aws-sdk-go-v2/service/datapipeline/types"
+	"github.com/chenrui333/terraformer/terraformutils"
+)
+
+func TestNewDataPipelinePipelineResource(t *testing.T) {
+	resource, ok := newDataPipelinePipelineResource("df-1234567890ABC", "daily-import")
+	assertDataPipelineResource(t, resource, ok, "df-1234567890ABC", "daily-import", dataPipelinePipelineResourceType)
+
+	if _, ok := newDataPipelinePipelineResource("", "missing-id"); ok {
+		t.Fatal("pipeline with empty ID should be skipped")
+	}
+}
+
+func TestNewDataPipelinePipelineDefinitionResource(t *testing.T) {
+	resource := newDataPipelinePipelineDefinitionResource("df-1234567890ABC", "daily-import")
+	assertDataPipelineResource(t, resource, true, "df-1234567890ABC", dataPipelineResourceName("pipeline-definition", "daily-import", "df-1234567890ABC"), dataPipelinePipelineDefinitionResourceType)
+	assertDataPipelineAttribute(t, resource, "pipeline_id", "df-1234567890ABC")
+}
+
+func TestDataPipelineDefinitionImportable(t *testing.T) {
+	tests := []struct {
+		name       string
+		definition *datapipeline.GetPipelineDefinitionOutput
+		want       bool
+	}{
+		{name: "nil", want: false},
+		{name: "empty", definition: &datapipeline.GetPipelineDefinitionOutput{}, want: false},
+		{name: "with objects", definition: &datapipeline.GetPipelineDefinitionOutput{
+			PipelineObjects: []datapipelinetypes.PipelineObject{{Id: aws.String("Default")}},
+		}, want: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := dataPipelineDefinitionImportable(tt.definition); got != tt.want {
+				t.Fatalf("dataPipelineDefinitionImportable(%#v) = %t, want %t", tt.definition, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestDataPipelineImportIDs(t *testing.T) {
+	if got, want := dataPipelinePipelineImportID("df-123"), "df-123"; got != want {
+		t.Fatalf("Data Pipeline import ID = %q, want %q", got, want)
+	}
+	if got, want := dataPipelinePipelineDefinitionImportID("df-123"), "df-123"; got != want {
+		t.Fatalf("Data Pipeline definition import ID = %q, want %q", got, want)
+	}
+}
+
+func TestDataPipelineResourceNamesPreserveSegmentBoundaries(t *testing.T) {
+	left := terraformutils.TfSanitize(dataPipelineResourceName("pipeline-definition", "a/b_c"))
+	right := terraformutils.TfSanitize(dataPipelineResourceName("pipeline", "definition/a_b_c"))
+	if left == right {
+		t.Fatalf("Data Pipeline resource names collide: %q", left)
+	}
+}
+
+func assertDataPipelineResource(t *testing.T, resource terraformutils.Resource, ok bool, wantID, wantName, wantType string) {
+	t.Helper()
+	if !ok {
+		t.Fatal("resource was skipped")
+	}
+	if got := resource.InstanceState.ID; got != wantID {
+		t.Fatalf("resource ID = %q, want %q", got, wantID)
+	}
+	if got := resource.ResourceName; got != terraformutils.TfSanitize(wantName) {
+		t.Fatalf("resource name = %q, want %q", got, terraformutils.TfSanitize(wantName))
+	}
+	if got := resource.InstanceInfo.Type; got != wantType {
+		t.Fatalf("resource type = %q, want %q", got, wantType)
+	}
+}
+
+func assertDataPipelineAttribute(t *testing.T, resource terraformutils.Resource, key, want string) {
+	t.Helper()
+	if got := resource.InstanceState.Attributes[key]; got != want {
+		t.Fatalf("resource attribute %q = %q, want %q", key, got, want)
+	}
+}

--- a/providers/aws/datapipeline_test.go
+++ b/providers/aws/datapipeline_test.go
@@ -85,6 +85,19 @@ func TestDataPipelinePipelineIDFilterIncludesDefinitionIDs(t *testing.T) {
 	}
 }
 
+func TestDataPipelinePipelineIDFilterAllowsAllForPipelineAttributeFilters(t *testing.T) {
+	service := terraformutils.Service{}
+	service.ParseFilters([]string{
+		"Type=datapipeline_pipeline;Name=name;Value=daily-import",
+		"Type=datapipeline_pipeline_definition;Name=pipeline_id;Value=df-456",
+	})
+
+	filter := dataPipelinePipelineIDFilter(service.Filter)
+	if !awsIDFilterAllows(filter, "df-123") {
+		t.Fatalf("Data Pipeline pipeline attribute filter should disable prefilter: %#v", filter)
+	}
+}
+
 func TestDataPipelineShouldEmitPipelineSkipsDefinitionOnlyFilters(t *testing.T) {
 	service := terraformutils.Service{}
 	service.ParseFilters([]string{"Type=datapipeline_pipeline_definition;Name=pipeline_id;Value=df-123"})

--- a/providers/aws/datapipeline_test.go
+++ b/providers/aws/datapipeline_test.go
@@ -126,6 +126,43 @@ func TestDataPipelinePostRefreshCleanupKeepsDefinitionForMatchedPipelineName(t *
 	})
 }
 
+func TestDataPipelinePostRefreshCleanupPrunesDefinitionsForTypedPipelineNameFilter(t *testing.T) {
+	pipeline := dataPipelinePipelineResourceForCleanup("df-123", "daily-import")
+	otherPipeline := dataPipelinePipelineResourceForCleanup("df-456", "hourly-import")
+	definition := dataPipelineDefinitionResourceForCleanup("df-123", "daily-import")
+	otherDefinition := dataPipelineDefinitionResourceForCleanup("df-456", "hourly-import")
+	generator := &DataPipelineGenerator{}
+	generator.Resources = []terraformutils.Resource{pipeline, definition, otherPipeline, otherDefinition}
+	generator.ParseFilters([]string{"Type=datapipeline_pipeline;Name=name;Value=daily-import"})
+
+	generator.PostRefreshCleanup()
+
+	assertDataPipelineResourceIDs(t, generator.Resources, []string{
+		dataPipelinePipelineResourceType + "/df-123",
+		dataPipelinePipelineDefinitionResourceType + "/df-123",
+	})
+}
+
+func TestDataPipelinePostRefreshCleanupPreservesExplicitDefinitionFilters(t *testing.T) {
+	pipeline := dataPipelinePipelineResourceForCleanup("df-123", "daily-import")
+	otherPipeline := dataPipelinePipelineResourceForCleanup("df-456", "hourly-import")
+	definition := dataPipelineDefinitionResourceForCleanup("df-123", "daily-import")
+	otherDefinition := dataPipelineDefinitionResourceForCleanup("df-456", "hourly-import")
+	generator := &DataPipelineGenerator{}
+	generator.Resources = []terraformutils.Resource{pipeline, definition, otherPipeline, otherDefinition}
+	generator.ParseFilters([]string{
+		"Type=datapipeline_pipeline;Name=name;Value=daily-import",
+		"Type=datapipeline_pipeline_definition;Name=pipeline_id;Value=df-456",
+	})
+
+	generator.PostRefreshCleanup()
+
+	assertDataPipelineResourceIDs(t, generator.Resources, []string{
+		dataPipelinePipelineResourceType + "/df-123",
+		dataPipelinePipelineDefinitionResourceType + "/df-456",
+	})
+}
+
 func TestDataPipelinePostRefreshCleanupDoesNotBroadenDefinitionSpecificFilters(t *testing.T) {
 	pipeline := dataPipelinePipelineResourceForCleanup("df-123", "daily-import")
 	otherPipeline := dataPipelinePipelineResourceForCleanup("df-456", "hourly-import")

--- a/providers/aws/datapipeline_test.go
+++ b/providers/aws/datapipeline_test.go
@@ -71,16 +71,41 @@ func TestDataPipelinePipelineIDFilterIncludesDefinitionIDs(t *testing.T) {
 	service.ParseFilters([]string{
 		"datapipeline_pipeline=df-parent",
 		"datapipeline_pipeline_definition=df-child",
+		"Type=datapipeline_pipeline_definition;Name=pipeline_id;Value=df-grandchild",
 	})
 
 	filter := dataPipelinePipelineIDFilter(service.Filter)
-	for _, pipelineID := range []string{"df-parent", "df-child"} {
+	for _, pipelineID := range []string{"df-parent", "df-child", "df-grandchild"} {
 		if !awsIDFilterAllows(filter, pipelineID) {
 			t.Fatalf("Data Pipeline filter should allow %q: %#v", pipelineID, filter)
 		}
 	}
 	if awsIDFilterAllows(filter, "df-other") {
 		t.Fatalf("Data Pipeline filter allowed unrelated pipeline: %#v", filter)
+	}
+}
+
+func TestDataPipelineShouldEmitPipelineSkipsDefinitionOnlyFilters(t *testing.T) {
+	service := terraformutils.Service{}
+	service.ParseFilters([]string{"Type=datapipeline_pipeline_definition;Name=pipeline_id;Value=df-123"})
+
+	if dataPipelineShouldEmitPipeline(service.Filter, "df-123") {
+		t.Fatal("definition-only filter should scan but not emit parent pipeline")
+	}
+}
+
+func TestDataPipelineShouldEmitPipelineHonorsPipelineFilters(t *testing.T) {
+	service := terraformutils.Service{}
+	service.ParseFilters([]string{
+		"datapipeline_pipeline=df-123",
+		"Type=datapipeline_pipeline_definition;Name=pipeline_id;Value=df-456",
+	})
+
+	if !dataPipelineShouldEmitPipeline(service.Filter, "df-123") {
+		t.Fatal("pipeline filter should emit matching pipeline")
+	}
+	if dataPipelineShouldEmitPipeline(service.Filter, "df-456") {
+		t.Fatal("definition-derived parent should not be emitted when it is not requested by the pipeline filter")
 	}
 }
 
@@ -113,9 +138,7 @@ func TestDataPipelinePostRefreshCleanupDoesNotBroadenDefinitionSpecificFilters(t
 	generator.PostRefreshCleanup()
 
 	assertDataPipelineResourceIDs(t, generator.Resources, []string{
-		dataPipelinePipelineResourceType + "/df-123",
 		dataPipelinePipelineDefinitionResourceType + "/df-123",
-		dataPipelinePipelineResourceType + "/df-456",
 	})
 }
 

--- a/providers/aws/datapipeline_test.go
+++ b/providers/aws/datapipeline_test.go
@@ -3,6 +3,7 @@
 package aws
 
 import (
+	"reflect"
 	"testing"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
@@ -212,11 +213,12 @@ func assertDataPipelineResourceIDs(t *testing.T, resources []terraformutils.Reso
 	if len(resources) != len(want) {
 		t.Fatalf("resources len = %d, want %d: %#v", len(resources), len(want), resources)
 	}
-	for i, resource := range resources {
-		got := resource.InstanceInfo.Type + "/" + resource.InstanceState.ID
-		if got != want[i] {
-			t.Fatalf("resource[%d] = %q, want %q", i, got, want[i])
-		}
+	got := make([]string, 0, len(resources))
+	for _, resource := range resources {
+		got = append(got, resource.InstanceInfo.Type+"/"+resource.InstanceState.ID)
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("resources = %v, want %v", got, want)
 	}
 }
 

--- a/providers/aws/devicefarm.go
+++ b/providers/aws/devicefarm.go
@@ -191,7 +191,7 @@ func newDeviceFarmProjectResource(project devicefarmtypes.Project) (terraformuti
 	}
 	return terraformutils.NewSimpleResource(
 		deviceFarmARNImportID(projectArn),
-		projectName,
+		deviceFarmResourceName("project", projectName, projectArn),
 		deviceFarmProjectResourceType,
 		"aws",
 		devicefarmAllowEmptyValues), true

--- a/providers/aws/devicefarm.go
+++ b/providers/aws/devicefarm.go
@@ -40,10 +40,10 @@ func (g *DeviceFarmGenerator) InitResources() error {
 		return err
 	}
 	if err := g.loadTestGridProjects(svc); err != nil {
-		return err
+		log.Printf("[WARN] Skipping Device Farm test grid projects: %v", err)
 	}
 	if err := g.loadInstanceProfiles(svc); err != nil {
-		return err
+		log.Printf("[WARN] Skipping Device Farm instance profiles: %v", err)
 	}
 
 	return nil

--- a/providers/aws/devicefarm.go
+++ b/providers/aws/devicefarm.go
@@ -35,21 +35,24 @@ func (g *DeviceFarmGenerator) InitResources() error {
 		return e
 	}
 	svc := devicefarm.NewFromConfig(config)
+	projectIDFilter := awsTypedIDFilterValues(g.Filter, deviceFarmProjectResourceType)
 
-	if err := g.loadProjects(svc); err != nil {
+	if err := g.loadProjects(svc, projectIDFilter); err != nil {
 		return err
 	}
-	if err := g.loadTestGridProjects(svc); err != nil {
-		log.Printf("[WARN] Skipping Device Farm test grid projects: %v", err)
-	}
-	if err := g.loadInstanceProfiles(svc); err != nil {
-		log.Printf("[WARN] Skipping Device Farm instance profiles: %v", err)
+	if len(projectIDFilter) == 0 {
+		if err := g.loadTestGridProjects(svc); err != nil {
+			log.Printf("[WARN] Skipping Device Farm test grid projects: %v", err)
+		}
+		if err := g.loadInstanceProfiles(svc); err != nil {
+			log.Printf("[WARN] Skipping Device Farm instance profiles: %v", err)
+		}
 	}
 
 	return nil
 }
 
-func (g *DeviceFarmGenerator) loadProjects(svc *devicefarm.Client) error {
+func (g *DeviceFarmGenerator) loadProjects(svc *devicefarm.Client, projectIDFilter map[string]bool) error {
 	p := devicefarm.NewListProjectsPaginator(svc, &devicefarm.ListProjectsInput{})
 	for p.HasMorePages() {
 		page, e := p.NextPage(context.TODO())
@@ -58,6 +61,9 @@ func (g *DeviceFarmGenerator) loadProjects(svc *devicefarm.Client) error {
 		}
 		for _, project := range page.Projects {
 			projectArn := StringValue(project.Arn)
+			if !awsIDFilterAllows(projectIDFilter, projectArn) {
+				continue
+			}
 			if resource, ok := newDeviceFarmProjectResource(project); ok {
 				g.Resources = append(g.Resources, resource)
 			}

--- a/providers/aws/devicefarm.go
+++ b/providers/aws/devicefarm.go
@@ -251,7 +251,7 @@ func deviceFarmShouldLoadInstanceProfiles(filters []terraformutils.ResourceFilte
 }
 
 func deviceFarmProjectIDFilter(filters []terraformutils.ResourceFilter) map[string]bool {
-	if deviceFarmHasProjectScopedChildAttributeFilter(filters) {
+	if deviceFarmHasProjectScanAttributeFilter(filters) {
 		return nil
 	}
 	projectARNs, ok := deviceFarmProjectARNsFromChildFilterValues(filters)
@@ -261,13 +261,14 @@ func deviceFarmProjectIDFilter(filters []terraformutils.ResourceFilter) map[stri
 	return awsMergeIDFilterValues(awsTypedIDFilterValues(filters, deviceFarmProjectResourceType), projectARNs)
 }
 
-func deviceFarmHasProjectScopedChildAttributeFilter(filters []terraformutils.ResourceFilter) bool {
+func deviceFarmHasProjectScanAttributeFilter(filters []terraformutils.ResourceFilter) bool {
 	for _, resourceType := range []string{
+		deviceFarmProjectResourceType,
 		deviceFarmDevicePoolResourceType,
 		deviceFarmNetworkProfileResourceType,
 		deviceFarmUploadResourceType,
 	} {
-		if awsHasTypedNonIDFilter(filters, resourceType) {
+		if awsHasApplicableNonIDFilter(filters, resourceType) {
 			return true
 		}
 	}

--- a/providers/aws/devicefarm.go
+++ b/providers/aws/devicefarm.go
@@ -251,11 +251,27 @@ func deviceFarmShouldLoadInstanceProfiles(filters []terraformutils.ResourceFilte
 }
 
 func deviceFarmProjectIDFilter(filters []terraformutils.ResourceFilter) map[string]bool {
+	if deviceFarmHasProjectScopedChildAttributeFilter(filters) {
+		return nil
+	}
 	projectARNs, ok := deviceFarmProjectARNsFromChildFilterValues(filters)
 	if !ok {
 		return nil
 	}
 	return awsMergeIDFilterValues(awsTypedIDFilterValues(filters, deviceFarmProjectResourceType), projectARNs)
+}
+
+func deviceFarmHasProjectScopedChildAttributeFilter(filters []terraformutils.ResourceFilter) bool {
+	for _, resourceType := range []string{
+		deviceFarmDevicePoolResourceType,
+		deviceFarmNetworkProfileResourceType,
+		deviceFarmUploadResourceType,
+	} {
+		if awsHasTypedNonIDFilter(filters, resourceType) {
+			return true
+		}
+	}
+	return false
 }
 
 func deviceFarmProjectARNsFromChildFilterValues(filters []terraformutils.ResourceFilter) (map[string]bool, bool) {

--- a/providers/aws/devicefarm.go
+++ b/providers/aws/devicefarm.go
@@ -35,15 +35,18 @@ func (g *DeviceFarmGenerator) InitResources() error {
 		return e
 	}
 	svc := devicefarm.NewFromConfig(config)
-	projectIDFilter := awsTypedIDFilterValues(g.Filter, deviceFarmProjectResourceType)
+	projectIDFilter := deviceFarmProjectIDFilter(g.Filter)
+	explicitProjectIDFilter := awsTypedIDFilterValues(g.Filter, deviceFarmProjectResourceType)
 
 	if err := g.loadProjects(svc, projectIDFilter); err != nil {
 		return err
 	}
-	if len(projectIDFilter) == 0 {
+	if len(explicitProjectIDFilter) == 0 || len(awsTypedIDFilterValues(g.Filter, deviceFarmTestGridProjectResourceType)) > 0 {
 		if err := g.loadTestGridProjects(svc); err != nil {
 			log.Printf("[WARN] Skipping Device Farm test grid projects: %v", err)
 		}
+	}
+	if len(explicitProjectIDFilter) == 0 || len(awsTypedIDFilterValues(g.Filter, deviceFarmInstanceProfileResourceType)) > 0 {
 		if err := g.loadInstanceProfiles(svc); err != nil {
 			log.Printf("[WARN] Skipping Device Farm instance profiles: %v", err)
 		}
@@ -184,6 +187,56 @@ func (g *DeviceFarmGenerator) loadInstanceProfiles(svc *devicefarm.Client) error
 	}
 
 	return nil
+}
+
+func deviceFarmProjectIDFilter(filters []terraformutils.ResourceFilter) map[string]bool {
+	projectARNs, ok := deviceFarmProjectARNsFromChildFilterValues(filters)
+	if !ok {
+		return nil
+	}
+	return awsMergeIDFilterValues(awsTypedIDFilterValues(filters, deviceFarmProjectResourceType), projectARNs)
+}
+
+func deviceFarmProjectARNsFromChildFilterValues(filters []terraformutils.ResourceFilter) (map[string]bool, bool) {
+	projectARNs := map[string]bool{}
+	for _, resourceType := range []string{
+		deviceFarmDevicePoolResourceType,
+		deviceFarmNetworkProfileResourceType,
+		deviceFarmUploadResourceType,
+	} {
+		for childARN := range awsTypedIDFilterValues(filters, resourceType) {
+			projectARN := deviceFarmProjectARNFromProjectScopedARN(childARN)
+			if projectARN == "" {
+				return nil, false
+			}
+			projectARNs[projectARN] = true
+		}
+	}
+	if len(projectARNs) == 0 {
+		return nil, true
+	}
+	return projectARNs, true
+}
+
+func deviceFarmProjectARNFromProjectScopedARN(childARN string) string {
+	parts := strings.SplitN(childARN, ":", 6)
+	if len(parts) != 6 {
+		return ""
+	}
+	resourceType, resourcePath, ok := strings.Cut(parts[5], ":")
+	if !ok {
+		return ""
+	}
+	switch resourceType {
+	case "devicepool", "networkprofile", "upload":
+	default:
+		return ""
+	}
+	projectID, _, ok := strings.Cut(resourcePath, "/")
+	if !ok || projectID == "" {
+		return ""
+	}
+	return strings.Join(parts[:5], ":") + ":project:" + projectID
 }
 
 func newDeviceFarmProjectResource(project devicefarmtypes.Project) (terraformutils.Resource, bool) {

--- a/providers/aws/devicefarm.go
+++ b/providers/aws/devicefarm.go
@@ -4,9 +4,23 @@ package aws
 
 import (
 	"context"
+	"fmt"
+	"log"
+	"strings"
 
+	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/devicefarm"
+	devicefarmtypes "github.com/aws/aws-sdk-go-v2/service/devicefarm/types"
 	"github.com/chenrui333/terraformer/terraformutils"
+)
+
+const (
+	deviceFarmProjectResourceType         = "aws_devicefarm_project"
+	deviceFarmDevicePoolResourceType      = "aws_devicefarm_device_pool"
+	deviceFarmNetworkProfileResourceType  = "aws_devicefarm_network_profile"
+	deviceFarmTestGridProjectResourceType = "aws_devicefarm_test_grid_project"
+	deviceFarmUploadResourceType          = "aws_devicefarm_upload"
+	deviceFarmInstanceProfileResourceType = "aws_devicefarm_instance_profile"
 )
 
 var devicefarmAllowEmptyValues = []string{"tags."}
@@ -21,8 +35,22 @@ func (g *DeviceFarmGenerator) InitResources() error {
 		return e
 	}
 	svc := devicefarm.NewFromConfig(config)
+
+	if err := g.loadProjects(svc); err != nil {
+		return err
+	}
+	if err := g.loadTestGridProjects(svc); err != nil {
+		return err
+	}
+	if err := g.loadInstanceProfiles(svc); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (g *DeviceFarmGenerator) loadProjects(svc *devicefarm.Client) error {
 	p := devicefarm.NewListProjectsPaginator(svc, &devicefarm.ListProjectsInput{})
-	var resources []terraformutils.Resource
 	for p.HasMorePages() {
 		page, e := p.NextPage(context.TODO())
 		if e != nil {
@@ -30,15 +58,206 @@ func (g *DeviceFarmGenerator) InitResources() error {
 		}
 		for _, project := range page.Projects {
 			projectArn := StringValue(project.Arn)
-			projectName := StringValue(project.Name)
-			resources = append(resources, terraformutils.NewSimpleResource(
-				projectArn,
-				projectName,
-				"aws_devicefarm_project",
-				"aws",
-				devicefarmAllowEmptyValues))
+			if resource, ok := newDeviceFarmProjectResource(project); ok {
+				g.Resources = append(g.Resources, resource)
+			}
+			if projectArn == "" {
+				continue
+			}
+			if err := g.loadDevicePools(svc, projectArn); err != nil {
+				log.Printf("[WARN] Skipping Device Farm device pools for project %s: %v", projectArn, err)
+			}
+			if err := g.loadNetworkProfiles(svc, projectArn); err != nil {
+				log.Printf("[WARN] Skipping Device Farm network profiles for project %s: %v", projectArn, err)
+			}
+			if err := g.loadUploads(svc, projectArn); err != nil {
+				log.Printf("[WARN] Skipping Device Farm uploads for project %s: %v", projectArn, err)
+			}
 		}
 	}
-	g.Resources = resources
+
 	return nil
+}
+
+func (g *DeviceFarmGenerator) loadDevicePools(svc *devicefarm.Client, projectArn string) error {
+	p := devicefarm.NewListDevicePoolsPaginator(svc, &devicefarm.ListDevicePoolsInput{
+		Arn:  aws.String(projectArn),
+		Type: devicefarmtypes.DevicePoolTypePrivate,
+	})
+	for p.HasMorePages() {
+		page, err := p.NextPage(context.TODO())
+		if err != nil {
+			return err
+		}
+		for _, devicePool := range page.DevicePools {
+			if resource, ok := newDeviceFarmDevicePoolResource(devicePool); ok {
+				g.Resources = append(g.Resources, resource)
+			}
+		}
+	}
+
+	return nil
+}
+
+func (g *DeviceFarmGenerator) loadNetworkProfiles(svc *devicefarm.Client, projectArn string) error {
+	input := &devicefarm.ListNetworkProfilesInput{
+		Arn:  aws.String(projectArn),
+		Type: devicefarmtypes.NetworkProfileTypePrivate,
+	}
+	for {
+		output, err := svc.ListNetworkProfiles(context.TODO(), input)
+		if err != nil {
+			return err
+		}
+		for _, networkProfile := range output.NetworkProfiles {
+			if resource, ok := newDeviceFarmNetworkProfileResource(networkProfile); ok {
+				g.Resources = append(g.Resources, resource)
+			}
+		}
+		if output.NextToken == nil {
+			break
+		}
+		input.NextToken = output.NextToken
+	}
+
+	return nil
+}
+
+func (g *DeviceFarmGenerator) loadUploads(svc *devicefarm.Client, projectArn string) error {
+	p := devicefarm.NewListUploadsPaginator(svc, &devicefarm.ListUploadsInput{
+		Arn: aws.String(projectArn),
+	})
+	for p.HasMorePages() {
+		page, err := p.NextPage(context.TODO())
+		if err != nil {
+			return err
+		}
+		for _, upload := range page.Uploads {
+			if resource, ok := newDeviceFarmUploadResource(upload); ok {
+				g.Resources = append(g.Resources, resource)
+			}
+		}
+	}
+
+	return nil
+}
+
+func (g *DeviceFarmGenerator) loadTestGridProjects(svc *devicefarm.Client) error {
+	p := devicefarm.NewListTestGridProjectsPaginator(svc, &devicefarm.ListTestGridProjectsInput{})
+	for p.HasMorePages() {
+		page, err := p.NextPage(context.TODO())
+		if err != nil {
+			return err
+		}
+		for _, project := range page.TestGridProjects {
+			if resource, ok := newDeviceFarmTestGridProjectResource(project); ok {
+				g.Resources = append(g.Resources, resource)
+			}
+		}
+	}
+
+	return nil
+}
+
+func (g *DeviceFarmGenerator) loadInstanceProfiles(svc *devicefarm.Client) error {
+	input := &devicefarm.ListInstanceProfilesInput{MaxResults: aws.Int32(100)}
+	for {
+		output, err := svc.ListInstanceProfiles(context.TODO(), input)
+		if err != nil {
+			return err
+		}
+		for _, profile := range output.InstanceProfiles {
+			if resource, ok := newDeviceFarmInstanceProfileResource(profile); ok {
+				g.Resources = append(g.Resources, resource)
+			}
+		}
+		if output.NextToken == nil {
+			break
+		}
+		input.NextToken = output.NextToken
+	}
+
+	return nil
+}
+
+func newDeviceFarmProjectResource(project devicefarmtypes.Project) (terraformutils.Resource, bool) {
+	projectArn := StringValue(project.Arn)
+	if projectArn == "" {
+		return terraformutils.Resource{}, false
+	}
+	projectName := StringValue(project.Name)
+	if projectName == "" {
+		projectName = projectArn
+	}
+	return terraformutils.NewSimpleResource(
+		deviceFarmARNImportID(projectArn),
+		projectName,
+		deviceFarmProjectResourceType,
+		"aws",
+		devicefarmAllowEmptyValues), true
+}
+
+func newDeviceFarmDevicePoolResource(devicePool devicefarmtypes.DevicePool) (terraformutils.Resource, bool) {
+	if !deviceFarmCustomerResource(devicePool.Type) {
+		return terraformutils.Resource{}, false
+	}
+	return newDeviceFarmARNResource(StringValue(devicePool.Arn), StringValue(devicePool.Name), "device-pool", deviceFarmDevicePoolResourceType)
+}
+
+func newDeviceFarmNetworkProfileResource(networkProfile devicefarmtypes.NetworkProfile) (terraformutils.Resource, bool) {
+	if !deviceFarmCustomerResource(networkProfile.Type) {
+		return terraformutils.Resource{}, false
+	}
+	return newDeviceFarmARNResource(StringValue(networkProfile.Arn), StringValue(networkProfile.Name), "network-profile", deviceFarmNetworkProfileResourceType)
+}
+
+func newDeviceFarmTestGridProjectResource(project devicefarmtypes.TestGridProject) (terraformutils.Resource, bool) {
+	return newDeviceFarmARNResource(StringValue(project.Arn), StringValue(project.Name), "test-grid-project", deviceFarmTestGridProjectResourceType)
+}
+
+func newDeviceFarmUploadResource(upload devicefarmtypes.Upload) (terraformutils.Resource, bool) {
+	if !deviceFarmCustomerResource(upload.Category) {
+		return terraformutils.Resource{}, false
+	}
+	return newDeviceFarmARNResource(StringValue(upload.Arn), StringValue(upload.Name), "upload", deviceFarmUploadResourceType)
+}
+
+func newDeviceFarmInstanceProfileResource(profile devicefarmtypes.InstanceProfile) (terraformutils.Resource, bool) {
+	return newDeviceFarmARNResource(StringValue(profile.Arn), StringValue(profile.Name), "instance-profile", deviceFarmInstanceProfileResourceType)
+}
+
+func newDeviceFarmARNResource(arn, name, family, resourceType string) (terraformutils.Resource, bool) {
+	if arn == "" {
+		return terraformutils.Resource{}, false
+	}
+	if name == "" {
+		name = arn
+	}
+	return terraformutils.NewSimpleResource(
+		deviceFarmARNImportID(arn),
+		deviceFarmResourceName(family, name, arn),
+		resourceType,
+		"aws",
+		devicefarmAllowEmptyValues), true
+}
+
+func deviceFarmARNImportID(arn string) string {
+	return arn
+}
+
+func deviceFarmCustomerResource[T ~string](resourceType T) bool {
+	return resourceType == "" || string(resourceType) == "PRIVATE"
+}
+
+func deviceFarmResourceName(parts ...string) string {
+	cleanParts := []string{}
+	for _, part := range parts {
+		if part != "" {
+			cleanParts = append(cleanParts, fmt.Sprintf("%d/%s", len(part), part))
+		}
+	}
+	if len(cleanParts) == 0 {
+		return "devicefarm-resource"
+	}
+	return strings.Join(cleanParts, "/")
 }

--- a/providers/aws/devicefarm.go
+++ b/providers/aws/devicefarm.go
@@ -36,17 +36,18 @@ func (g *DeviceFarmGenerator) InitResources() error {
 	}
 	svc := devicefarm.NewFromConfig(config)
 	projectIDFilter := deviceFarmProjectIDFilter(g.Filter)
-	explicitProjectIDFilter := awsTypedIDFilterValues(g.Filter, deviceFarmProjectResourceType)
 
-	if err := g.loadProjects(svc, projectIDFilter); err != nil {
-		return err
+	if deviceFarmShouldLoadProjects(g.Filter) {
+		if err := g.loadProjects(svc, projectIDFilter); err != nil {
+			return err
+		}
 	}
-	if len(explicitProjectIDFilter) == 0 || len(awsTypedIDFilterValues(g.Filter, deviceFarmTestGridProjectResourceType)) > 0 {
+	if deviceFarmShouldLoadTestGridProjects(g.Filter) {
 		if err := g.loadTestGridProjects(svc); err != nil {
 			log.Printf("[WARN] Skipping Device Farm test grid projects: %v", err)
 		}
 	}
-	if len(explicitProjectIDFilter) == 0 || len(awsTypedIDFilterValues(g.Filter, deviceFarmInstanceProfileResourceType)) > 0 {
+	if deviceFarmShouldLoadInstanceProfiles(g.Filter) {
 		if err := g.loadInstanceProfiles(svc); err != nil {
 			log.Printf("[WARN] Skipping Device Farm instance profiles: %v", err)
 		}
@@ -67,20 +68,26 @@ func (g *DeviceFarmGenerator) loadProjects(svc *devicefarm.Client, projectIDFilt
 			if !awsIDFilterAllows(projectIDFilter, projectArn) {
 				continue
 			}
-			if resource, ok := newDeviceFarmProjectResource(project); ok {
+			if resource, ok := newDeviceFarmProjectResource(project); ok && deviceFarmShouldEmitProject(g.Filter, projectArn) {
 				g.Resources = append(g.Resources, resource)
 			}
 			if projectArn == "" {
 				continue
 			}
-			if err := g.loadDevicePools(svc, projectArn); err != nil {
-				log.Printf("[WARN] Skipping Device Farm device pools for project %s: %v", projectArn, err)
+			if deviceFarmShouldLoadDevicePools(g.Filter) {
+				if err := g.loadDevicePools(svc, projectArn); err != nil {
+					log.Printf("[WARN] Skipping Device Farm device pools for project %s: %v", projectArn, err)
+				}
 			}
-			if err := g.loadNetworkProfiles(svc, projectArn); err != nil {
-				log.Printf("[WARN] Skipping Device Farm network profiles for project %s: %v", projectArn, err)
+			if deviceFarmShouldLoadNetworkProfiles(g.Filter) {
+				if err := g.loadNetworkProfiles(svc, projectArn); err != nil {
+					log.Printf("[WARN] Skipping Device Farm network profiles for project %s: %v", projectArn, err)
+				}
 			}
-			if err := g.loadUploads(svc, projectArn); err != nil {
-				log.Printf("[WARN] Skipping Device Farm uploads for project %s: %v", projectArn, err)
+			if deviceFarmShouldLoadUploads(g.Filter) {
+				if err := g.loadUploads(svc, projectArn); err != nil {
+					log.Printf("[WARN] Skipping Device Farm uploads for project %s: %v", projectArn, err)
+				}
 			}
 		}
 	}
@@ -187,6 +194,60 @@ func (g *DeviceFarmGenerator) loadInstanceProfiles(svc *devicefarm.Client) error
 	}
 
 	return nil
+}
+
+func deviceFarmHasTypedFilter(filters []terraformutils.ResourceFilter) bool {
+	for _, resourceType := range []string{
+		deviceFarmProjectResourceType,
+		deviceFarmDevicePoolResourceType,
+		deviceFarmNetworkProfileResourceType,
+		deviceFarmTestGridProjectResourceType,
+		deviceFarmUploadResourceType,
+		deviceFarmInstanceProfileResourceType,
+	} {
+		if awsHasTypedFilter(filters, resourceType) {
+			return true
+		}
+	}
+	return false
+}
+
+func deviceFarmShouldLoadProjects(filters []terraformutils.ResourceFilter) bool {
+	return !deviceFarmHasTypedFilter(filters) ||
+		awsHasTypedFilter(filters, deviceFarmProjectResourceType) ||
+		deviceFarmShouldLoadDevicePools(filters) ||
+		deviceFarmShouldLoadNetworkProfiles(filters) ||
+		deviceFarmShouldLoadUploads(filters)
+}
+
+func deviceFarmShouldEmitProject(filters []terraformutils.ResourceFilter, projectArn string) bool {
+	if !deviceFarmHasTypedFilter(filters) {
+		return true
+	}
+	if !awsHasApplicableFilter(filters, deviceFarmProjectResourceType) {
+		return false
+	}
+	return awsIDFilterAllows(awsTypedIDFilterValues(filters, deviceFarmProjectResourceType), projectArn)
+}
+
+func deviceFarmShouldLoadDevicePools(filters []terraformutils.ResourceFilter) bool {
+	return !deviceFarmHasTypedFilter(filters) || awsHasTypedFilter(filters, deviceFarmDevicePoolResourceType)
+}
+
+func deviceFarmShouldLoadNetworkProfiles(filters []terraformutils.ResourceFilter) bool {
+	return !deviceFarmHasTypedFilter(filters) || awsHasTypedFilter(filters, deviceFarmNetworkProfileResourceType)
+}
+
+func deviceFarmShouldLoadUploads(filters []terraformutils.ResourceFilter) bool {
+	return !deviceFarmHasTypedFilter(filters) || awsHasTypedFilter(filters, deviceFarmUploadResourceType)
+}
+
+func deviceFarmShouldLoadTestGridProjects(filters []terraformutils.ResourceFilter) bool {
+	return !deviceFarmHasTypedFilter(filters) || awsHasTypedFilter(filters, deviceFarmTestGridProjectResourceType)
+}
+
+func deviceFarmShouldLoadInstanceProfiles(filters []terraformutils.ResourceFilter) bool {
+	return !deviceFarmHasTypedFilter(filters) || awsHasTypedFilter(filters, deviceFarmInstanceProfileResourceType)
 }
 
 func deviceFarmProjectIDFilter(filters []terraformutils.ResourceFilter) map[string]bool {

--- a/providers/aws/devicefarm.go
+++ b/providers/aws/devicefarm.go
@@ -239,7 +239,7 @@ func deviceFarmShouldLoadNetworkProfiles(filters []terraformutils.ResourceFilter
 }
 
 func deviceFarmShouldLoadUploads(filters []terraformutils.ResourceFilter) bool {
-	return !deviceFarmHasTypedFilter(filters) || awsHasTypedFilter(filters, deviceFarmUploadResourceType)
+	return awsHasTypedFilter(filters, deviceFarmUploadResourceType)
 }
 
 func deviceFarmShouldLoadTestGridProjects(filters []terraformutils.ResourceFilter) bool {

--- a/providers/aws/devicefarm_test.go
+++ b/providers/aws/devicefarm_test.go
@@ -175,6 +175,22 @@ func TestDeviceFarmProjectIDFilterAllowsAllForUnparseableChildID(t *testing.T) {
 	}
 }
 
+func TestDeviceFarmProjectIDFilterAllowsAllForChildAttributeFilters(t *testing.T) {
+	service := terraformutils.Service{}
+	service.ParseFilters([]string{
+		"devicefarm_upload='arn:aws:devicefarm:us-west-2:123456789012:upload:project-upload/upload-id'",
+		"Type=devicefarm_device_pool;Name=name;Value=phones",
+	})
+
+	filter := deviceFarmProjectIDFilter(service.Filter)
+	if !awsIDFilterAllows(filter, "arn:aws:devicefarm:us-west-2:123456789012:project:project-other") {
+		t.Fatalf("Device Farm child attribute filters should disable project prefilter: %#v", filter)
+	}
+	if !deviceFarmShouldLoadDevicePools(service.Filter) || !deviceFarmShouldLoadUploads(service.Filter) {
+		t.Fatal("Device Farm child filters should load each requested child family")
+	}
+}
+
 func TestDeviceFarmTypedFiltersLoadOnlyRequestedFamilies(t *testing.T) {
 	service := terraformutils.Service{}
 	service.ParseFilters([]string{

--- a/providers/aws/devicefarm_test.go
+++ b/providers/aws/devicefarm_test.go
@@ -191,6 +191,32 @@ func TestDeviceFarmProjectIDFilterAllowsAllForChildAttributeFilters(t *testing.T
 	}
 }
 
+func TestDeviceFarmProjectIDFilterAllowsAllForProjectAttributeFilters(t *testing.T) {
+	service := terraformutils.Service{}
+	service.ParseFilters([]string{
+		"Type=devicefarm_project;Name=name;Value=core",
+		"devicefarm_device_pool='arn:aws:devicefarm:us-west-2:123456789012:devicepool:project-child/device-pool-id'",
+	})
+
+	filter := deviceFarmProjectIDFilter(service.Filter)
+	if !awsIDFilterAllows(filter, "arn:aws:devicefarm:us-west-2:123456789012:project:project-other") {
+		t.Fatalf("Device Farm project attribute filters should disable project prefilter: %#v", filter)
+	}
+}
+
+func TestDeviceFarmProjectIDFilterAllowsAllForGlobalAttributeFilters(t *testing.T) {
+	service := terraformutils.Service{}
+	service.ParseFilters([]string{
+		"Name=name;Value=core",
+		"devicefarm_device_pool='arn:aws:devicefarm:us-west-2:123456789012:devicepool:project-child/device-pool-id'",
+	})
+
+	filter := deviceFarmProjectIDFilter(service.Filter)
+	if !awsIDFilterAllows(filter, "arn:aws:devicefarm:us-west-2:123456789012:project:project-other") {
+		t.Fatalf("global Device Farm attribute filters should disable project prefilter: %#v", filter)
+	}
+}
+
 func TestDeviceFarmTypedFiltersLoadOnlyRequestedFamilies(t *testing.T) {
 	service := terraformutils.Service{}
 	service.ParseFilters([]string{

--- a/providers/aws/devicefarm_test.go
+++ b/providers/aws/devicefarm_test.go
@@ -137,6 +137,44 @@ func TestDeviceFarmARNImportID(t *testing.T) {
 	}
 }
 
+func TestDeviceFarmProjectIDFilterIncludesProjectScopedChildParents(t *testing.T) {
+	service := terraformutils.Service{}
+	service.ParseFilters([]string{
+		"devicefarm_project='arn:aws:devicefarm:us-west-2:123456789012:project:project-parent'",
+		"devicefarm_device_pool='arn:aws:devicefarm:us-west-2:123456789012:devicepool:project-child/device-pool-id'",
+		"devicefarm_network_profile='arn:aws:devicefarm:us-west-2:123456789012:networkprofile:project-network/profile-id'",
+		"devicefarm_upload='arn:aws:devicefarm:us-west-2:123456789012:upload:project-upload/upload-id'",
+	})
+
+	filter := deviceFarmProjectIDFilter(service.Filter)
+	for _, projectARN := range []string{
+		"arn:aws:devicefarm:us-west-2:123456789012:project:project-parent",
+		"arn:aws:devicefarm:us-west-2:123456789012:project:project-child",
+		"arn:aws:devicefarm:us-west-2:123456789012:project:project-network",
+		"arn:aws:devicefarm:us-west-2:123456789012:project:project-upload",
+	} {
+		if !awsIDFilterAllows(filter, projectARN) {
+			t.Fatalf("Device Farm project filter should allow %q: %#v", projectARN, filter)
+		}
+	}
+	if awsIDFilterAllows(filter, "arn:aws:devicefarm:us-west-2:123456789012:project:project-other") {
+		t.Fatalf("Device Farm project filter allowed unrelated project: %#v", filter)
+	}
+}
+
+func TestDeviceFarmProjectIDFilterAllowsAllForUnparseableChildID(t *testing.T) {
+	service := terraformutils.Service{}
+	service.ParseFilters([]string{
+		"devicefarm_project='arn:aws:devicefarm:us-west-2:123456789012:project:project-parent'",
+		"devicefarm_device_pool=malformed",
+	})
+
+	filter := deviceFarmProjectIDFilter(service.Filter)
+	if !awsIDFilterAllows(filter, "arn:aws:devicefarm:us-west-2:123456789012:project:project-other") {
+		t.Fatalf("unparseable Device Farm child ID should disable project prefilter: %#v", filter)
+	}
+}
+
 func TestDeviceFarmResourceNamesPreserveSegmentBoundaries(t *testing.T) {
 	left := terraformutils.TfSanitize(deviceFarmResourceName("device-pool", "a/b_c"))
 	right := terraformutils.TfSanitize(deviceFarmResourceName("device", "pool/a_b_c"))

--- a/providers/aws/devicefarm_test.go
+++ b/providers/aws/devicefarm_test.go
@@ -234,6 +234,24 @@ func TestDeviceFarmTypedFiltersLoadOnlyRequestedFamilies(t *testing.T) {
 	}
 }
 
+func TestDeviceFarmUploadsAreFilterOnly(t *testing.T) {
+	if deviceFarmShouldLoadUploads(nil) {
+		t.Fatal("default Device Farm discovery should not load upload artifacts")
+	}
+
+	globalService := terraformutils.Service{}
+	globalService.ParseFilters([]string{"Name=name;Value=app.apk"})
+	if deviceFarmShouldLoadUploads(globalService.Filter) {
+		t.Fatal("global filters should not load upload artifacts")
+	}
+
+	uploadService := terraformutils.Service{}
+	uploadService.ParseFilters([]string{"devicefarm_upload='arn:aws:devicefarm:us-west-2:123456789012:upload:project-id/upload-id'"})
+	if !deviceFarmShouldLoadUploads(uploadService.Filter) {
+		t.Fatal("upload-specific filters should load upload artifacts")
+	}
+}
+
 func TestDeviceFarmTypedFiltersUseParentsOnlyForRequestedChildren(t *testing.T) {
 	projectArn := "arn:aws:devicefarm:us-west-2:123456789012:project:project-child"
 	devicePoolArn := "arn:aws:devicefarm:us-west-2:123456789012:devicepool:project-child/device-pool-id"

--- a/providers/aws/devicefarm_test.go
+++ b/providers/aws/devicefarm_test.go
@@ -175,6 +175,65 @@ func TestDeviceFarmProjectIDFilterAllowsAllForUnparseableChildID(t *testing.T) {
 	}
 }
 
+func TestDeviceFarmTypedFiltersLoadOnlyRequestedFamilies(t *testing.T) {
+	service := terraformutils.Service{}
+	service.ParseFilters([]string{
+		"devicefarm_test_grid_project='arn:aws:devicefarm:us-west-2:123456789012:testgrid-project:grid-id'",
+	})
+
+	if deviceFarmShouldLoadProjects(service.Filter) {
+		t.Fatal("test-grid-only filter should not load project-scoped Device Farm resources")
+	}
+	if !deviceFarmShouldLoadTestGridProjects(service.Filter) {
+		t.Fatal("test-grid-only filter should load test grid projects")
+	}
+	if deviceFarmShouldLoadInstanceProfiles(service.Filter) {
+		t.Fatal("test-grid-only filter should not load instance profiles")
+	}
+}
+
+func TestDeviceFarmTypedFiltersUseParentsOnlyForRequestedChildren(t *testing.T) {
+	projectArn := "arn:aws:devicefarm:us-west-2:123456789012:project:project-child"
+	devicePoolArn := "arn:aws:devicefarm:us-west-2:123456789012:devicepool:project-child/device-pool-id"
+	service := terraformutils.Service{}
+	service.ParseFilters([]string{"devicefarm_device_pool='" + devicePoolArn + "'"})
+
+	if !deviceFarmShouldLoadProjects(service.Filter) {
+		t.Fatal("device-pool filter should scan parent projects")
+	}
+	if !deviceFarmShouldLoadDevicePools(service.Filter) {
+		t.Fatal("device-pool filter should load device pools")
+	}
+	if deviceFarmShouldLoadNetworkProfiles(service.Filter) || deviceFarmShouldLoadUploads(service.Filter) {
+		t.Fatal("device-pool filter should not load sibling project-scoped families")
+	}
+	if deviceFarmShouldEmitProject(service.Filter, projectArn) {
+		t.Fatal("device-pool-only filter should not emit parent project resources")
+	}
+	if !awsIDFilterAllows(deviceFarmProjectIDFilter(service.Filter), projectArn) {
+		t.Fatalf("device-pool filter should prefilter to parent project %q", projectArn)
+	}
+}
+
+func TestDeviceFarmProjectTypedFilterDoesNotLoadChildren(t *testing.T) {
+	projectArn := "arn:aws:devicefarm:us-west-2:123456789012:project:project-parent"
+	service := terraformutils.Service{}
+	service.ParseFilters([]string{"devicefarm_project='" + projectArn + "'"})
+
+	if !deviceFarmShouldLoadProjects(service.Filter) {
+		t.Fatal("project filter should load projects")
+	}
+	if !deviceFarmShouldEmitProject(service.Filter, projectArn) {
+		t.Fatal("project filter should emit matching project")
+	}
+	if deviceFarmShouldEmitProject(service.Filter, "arn:aws:devicefarm:us-west-2:123456789012:project:project-other") {
+		t.Fatal("project filter should not emit unrelated projects")
+	}
+	if deviceFarmShouldLoadDevicePools(service.Filter) || deviceFarmShouldLoadNetworkProfiles(service.Filter) || deviceFarmShouldLoadUploads(service.Filter) {
+		t.Fatal("project-only filter should not load project child families")
+	}
+}
+
 func TestDeviceFarmResourceNamesPreserveSegmentBoundaries(t *testing.T) {
 	left := terraformutils.TfSanitize(deviceFarmResourceName("device-pool", "a/b_c"))
 	right := terraformutils.TfSanitize(deviceFarmResourceName("device", "pool/a_b_c"))

--- a/providers/aws/devicefarm_test.go
+++ b/providers/aws/devicefarm_test.go
@@ -1,0 +1,169 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package aws
+
+import (
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	devicefarmtypes "github.com/aws/aws-sdk-go-v2/service/devicefarm/types"
+	"github.com/chenrui333/terraformer/terraformutils"
+)
+
+func TestNewDeviceFarmProjectResource(t *testing.T) {
+	arn := "arn:aws:devicefarm:us-west-2:123456789012:project:11111111-2222-3333-4444-555555555555"
+	resource, ok := newDeviceFarmProjectResource(devicefarmtypes.Project{
+		Arn:  aws.String(arn),
+		Name: aws.String("core"),
+	})
+	assertDeviceFarmResource(t, resource, ok, arn, "core", deviceFarmProjectResourceType)
+
+	if _, ok := newDeviceFarmProjectResource(devicefarmtypes.Project{}); ok {
+		t.Fatal("project with empty ARN should be skipped")
+	}
+}
+
+func TestNewDeviceFarmChildResources(t *testing.T) {
+	tests := []struct {
+		name      string
+		resource  terraformutils.Resource
+		ok        bool
+		wantID    string
+		wantType  string
+		wantName  string
+		skipEmpty bool
+	}{
+		{
+			name: "device pool",
+			resource: mustDeviceFarmResource(newDeviceFarmDevicePoolResource(devicefarmtypes.DevicePool{
+				Arn:  aws.String("arn:aws:devicefarm:us-west-2:123456789012:devicepool:project-id/device-pool-id"),
+				Name: aws.String("phones"),
+				Type: devicefarmtypes.DevicePoolTypePrivate,
+			})),
+			ok:       true,
+			wantID:   "arn:aws:devicefarm:us-west-2:123456789012:devicepool:project-id/device-pool-id",
+			wantType: deviceFarmDevicePoolResourceType,
+			wantName: deviceFarmResourceName("device-pool", "phones", "arn:aws:devicefarm:us-west-2:123456789012:devicepool:project-id/device-pool-id"),
+		},
+		{
+			name: "network profile",
+			resource: mustDeviceFarmResource(newDeviceFarmNetworkProfileResource(devicefarmtypes.NetworkProfile{
+				Arn:  aws.String("arn:aws:devicefarm:us-west-2:123456789012:networkprofile:project-id/profile-id"),
+				Name: aws.String("office-wifi"),
+				Type: devicefarmtypes.NetworkProfileTypePrivate,
+			})),
+			ok:       true,
+			wantID:   "arn:aws:devicefarm:us-west-2:123456789012:networkprofile:project-id/profile-id",
+			wantType: deviceFarmNetworkProfileResourceType,
+			wantName: deviceFarmResourceName("network-profile", "office-wifi", "arn:aws:devicefarm:us-west-2:123456789012:networkprofile:project-id/profile-id"),
+		},
+		{
+			name: "test grid project",
+			resource: mustDeviceFarmResource(newDeviceFarmTestGridProjectResource(devicefarmtypes.TestGridProject{
+				Arn:  aws.String("arn:aws:devicefarm:us-west-2:123456789012:testgrid-project:grid-id"),
+				Name: aws.String("browser-grid"),
+			})),
+			ok:       true,
+			wantID:   "arn:aws:devicefarm:us-west-2:123456789012:testgrid-project:grid-id",
+			wantType: deviceFarmTestGridProjectResourceType,
+			wantName: deviceFarmResourceName("test-grid-project", "browser-grid", "arn:aws:devicefarm:us-west-2:123456789012:testgrid-project:grid-id"),
+		},
+		{
+			name: "upload",
+			resource: mustDeviceFarmResource(newDeviceFarmUploadResource(devicefarmtypes.Upload{
+				Arn:      aws.String("arn:aws:devicefarm:us-west-2:123456789012:upload:project-id/upload-id"),
+				Name:     aws.String("app.apk"),
+				Category: devicefarmtypes.UploadCategoryPrivate,
+			})),
+			ok:       true,
+			wantID:   "arn:aws:devicefarm:us-west-2:123456789012:upload:project-id/upload-id",
+			wantType: deviceFarmUploadResourceType,
+			wantName: deviceFarmResourceName("upload", "app.apk", "arn:aws:devicefarm:us-west-2:123456789012:upload:project-id/upload-id"),
+		},
+		{
+			name: "instance profile",
+			resource: mustDeviceFarmResource(newDeviceFarmInstanceProfileResource(devicefarmtypes.InstanceProfile{
+				Arn:  aws.String("arn:aws:devicefarm:us-west-2:123456789012:instanceprofile:profile-id"),
+				Name: aws.String("private-devices"),
+			})),
+			ok:       true,
+			wantID:   "arn:aws:devicefarm:us-west-2:123456789012:instanceprofile:profile-id",
+			wantType: deviceFarmInstanceProfileResourceType,
+			wantName: deviceFarmResourceName("instance-profile", "private-devices", "arn:aws:devicefarm:us-west-2:123456789012:instanceprofile:profile-id"),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assertDeviceFarmResource(t, tt.resource, tt.ok, tt.wantID, tt.wantName, tt.wantType)
+		})
+	}
+}
+
+func TestDeviceFarmSkipsUnsafeOrEmptyIdentifiers(t *testing.T) {
+	if _, ok := newDeviceFarmDevicePoolResource(devicefarmtypes.DevicePool{
+		Arn:  aws.String("arn:aws:devicefarm:us-west-2:123456789012:devicepool:project-id/curated"),
+		Name: aws.String("curated"),
+		Type: devicefarmtypes.DevicePoolTypeCurated,
+	}); ok {
+		t.Fatal("curated device pool should be skipped")
+	}
+
+	if _, ok := newDeviceFarmNetworkProfileResource(devicefarmtypes.NetworkProfile{
+		Arn:  aws.String("arn:aws:devicefarm:us-west-2:123456789012:networkprofile:project-id/curated"),
+		Name: aws.String("curated"),
+		Type: devicefarmtypes.NetworkProfileTypeCurated,
+	}); ok {
+		t.Fatal("curated network profile should be skipped")
+	}
+
+	if _, ok := newDeviceFarmUploadResource(devicefarmtypes.Upload{
+		Arn:      aws.String("arn:aws:devicefarm:us-west-2:123456789012:upload:project-id/curated"),
+		Name:     aws.String("curated"),
+		Category: devicefarmtypes.UploadCategoryCurated,
+	}); ok {
+		t.Fatal("curated upload should be skipped")
+	}
+
+	if _, ok := newDeviceFarmInstanceProfileResource(devicefarmtypes.InstanceProfile{Name: aws.String("missing-arn")}); ok {
+		t.Fatal("instance profile with empty ARN should be skipped")
+	}
+}
+
+func TestDeviceFarmARNImportID(t *testing.T) {
+	arn := "arn:aws:devicefarm:us-west-2:123456789012:project:project-id"
+	if got := deviceFarmARNImportID(arn); got != arn {
+		t.Fatalf("Device Farm import ID = %q, want %q", got, arn)
+	}
+}
+
+func TestDeviceFarmResourceNamesPreserveSegmentBoundaries(t *testing.T) {
+	left := terraformutils.TfSanitize(deviceFarmResourceName("device-pool", "a/b_c"))
+	right := terraformutils.TfSanitize(deviceFarmResourceName("device", "pool/a_b_c"))
+	if left == right {
+		t.Fatalf("Device Farm resource names collide: %q", left)
+	}
+}
+
+func mustDeviceFarmResource(resource terraformutils.Resource, ok bool) terraformutils.Resource {
+	if !ok {
+		panic("expected Device Farm resource")
+	}
+	return resource
+}
+
+func assertDeviceFarmResource(t *testing.T, resource terraformutils.Resource, ok bool, wantID, wantName, wantType string) {
+	t.Helper()
+	if !ok {
+		t.Fatal("resource was skipped")
+	}
+	if got := resource.InstanceState.ID; got != wantID {
+		t.Fatalf("resource ID = %q, want %q", got, wantID)
+	}
+	if got := resource.ResourceName; got != terraformutils.TfSanitize(wantName) {
+		t.Fatalf("resource name = %q, want %q", got, terraformutils.TfSanitize(wantName))
+	}
+	if got := resource.InstanceInfo.Type; got != wantType {
+		t.Fatalf("resource type = %q, want %q", got, wantType)
+	}
+}

--- a/providers/aws/devicefarm_test.go
+++ b/providers/aws/devicefarm_test.go
@@ -16,7 +16,7 @@ func TestNewDeviceFarmProjectResource(t *testing.T) {
 		Arn:  aws.String(arn),
 		Name: aws.String("core"),
 	})
-	assertDeviceFarmResource(t, resource, ok, arn, "core", deviceFarmProjectResourceType)
+	assertDeviceFarmResource(t, resource, ok, arn, deviceFarmResourceName("project", "core", arn), deviceFarmProjectResourceType)
 
 	if _, ok := newDeviceFarmProjectResource(devicefarmtypes.Project{}); ok {
 		t.Fatal("project with empty ARN should be skipped")

--- a/providers/aws/media_convert.go
+++ b/providers/aws/media_convert.go
@@ -34,7 +34,7 @@ func (g *MediaConvertGenerator) loadQueues(svc *mediaconvert.Client) error {
 	p := mediaconvert.NewListQueuesPaginator(svc, &mediaconvert.ListQueuesInput{})
 	for p.HasMorePages() {
 		page, err := p.NextPage(context.TODO())
-		if mediaConvertQueueNotFound(err) {
+		if mediaConvertQueueDiscoverySkippable(err) {
 			return nil
 		}
 		if err != nil {
@@ -91,4 +91,18 @@ func mediaConvertResourceName(parts ...string) string {
 func mediaConvertQueueNotFound(err error) bool {
 	var notFound *mediaconverttypes.NotFoundException
 	return errors.As(err, &notFound)
+}
+
+func mediaConvertQueueDiscoverySkippable(err error) bool {
+	return mediaConvertQueueNotFound(err) || mediaConvertQueueEndpointUnavailable(err)
+}
+
+func mediaConvertQueueEndpointUnavailable(err error) bool {
+	var badRequest *mediaconverttypes.BadRequestException
+	if !errors.As(err, &badRequest) {
+		return false
+	}
+	message := strings.ToLower(StringValue(badRequest.Message))
+	return strings.Contains(message, "endpoint") &&
+		(strings.Contains(message, "customer") || strings.Contains(message, "account"))
 }

--- a/providers/aws/media_convert.go
+++ b/providers/aws/media_convert.go
@@ -56,9 +56,11 @@ func (g *MediaConvertGenerator) InitResources() error {
 		g.accountEndpoint = endpoint
 		g.previousEndpoint = previousEndpoint
 		g.hadPreviousEndpoint = hadPreviousEndpoint
-		return g.loadQueues(mediaconvert.NewFromConfig(config, func(o *mediaconvert.Options) {
+		if err := g.loadQueues(mediaconvert.NewFromConfig(config, func(o *mediaconvert.Options) {
 			o.BaseEndpoint = aws.String(endpoint)
-		}))
+		})); err != nil {
+			return errors.Join(err, g.restoreAccountEndpoint())
+		}
 	}
 	return nil
 }
@@ -69,14 +71,27 @@ func (g *MediaConvertGenerator) ConfigureImportProvider(providerWrapper *provide
 	}
 	// The Terraform AWS provider reads service endpoint environment variables when
 	// its plugin process starts, so refresh needs a restart after endpoint bootstrap.
-	return providerWrapper.Restart()
+	if err := providerWrapper.Restart(); err != nil {
+		return errors.Join(err, g.restoreAccountEndpoint())
+	}
+	return nil
 }
 
 func (g *MediaConvertGenerator) PostConvertHook() error {
+	return g.restoreAccountEndpoint()
+}
+
+func (g *MediaConvertGenerator) restoreAccountEndpoint() error {
 	if g.accountEndpoint == "" {
 		return nil
 	}
-	return mediaConvertRestoreAccountEndpoint(g.previousEndpoint, g.hadPreviousEndpoint)
+	if err := mediaConvertRestoreAccountEndpoint(g.previousEndpoint, g.hadPreviousEndpoint); err != nil {
+		return err
+	}
+	g.accountEndpoint = ""
+	g.previousEndpoint = ""
+	g.hadPreviousEndpoint = false
+	return nil
 }
 
 func (g *MediaConvertGenerator) loadQueues(svc *mediaconvert.Client) error {

--- a/providers/aws/media_convert.go
+++ b/providers/aws/media_convert.go
@@ -1,0 +1,94 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package aws
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/aws/aws-sdk-go-v2/service/mediaconvert"
+	mediaconverttypes "github.com/aws/aws-sdk-go-v2/service/mediaconvert/types"
+	"github.com/chenrui333/terraformer/terraformutils"
+)
+
+const mediaConvertQueueResourceType = "aws_media_convert_queue"
+
+var mediaConvertAllowEmptyValues = []string{"tags."}
+
+type MediaConvertGenerator struct {
+	AWSService
+}
+
+func (g *MediaConvertGenerator) InitResources() error {
+	config, e := g.generateConfig()
+	if e != nil {
+		return e
+	}
+	svc := mediaconvert.NewFromConfig(config)
+	return g.loadQueues(svc)
+}
+
+func (g *MediaConvertGenerator) loadQueues(svc *mediaconvert.Client) error {
+	p := mediaconvert.NewListQueuesPaginator(svc, &mediaconvert.ListQueuesInput{})
+	for p.HasMorePages() {
+		page, err := p.NextPage(context.TODO())
+		if mediaConvertQueueNotFound(err) {
+			return nil
+		}
+		if err != nil {
+			return err
+		}
+		for _, queue := range page.Queues {
+			if resource, ok := newMediaConvertQueueResource(queue); ok {
+				g.Resources = append(g.Resources, resource)
+			}
+		}
+	}
+
+	return nil
+}
+
+func newMediaConvertQueueResource(queue mediaconverttypes.Queue) (terraformutils.Resource, bool) {
+	queueName := StringValue(queue.Name)
+	if queueName == "" || !mediaConvertQueueImportable(queue) {
+		return terraformutils.Resource{}, false
+	}
+	return terraformutils.NewResource(
+		mediaConvertQueueImportID(queueName),
+		mediaConvertResourceName("queue", queueName),
+		mediaConvertQueueResourceType,
+		"aws",
+		map[string]string{
+			"name": queueName,
+		},
+		mediaConvertAllowEmptyValues,
+		map[string]interface{}{}), true
+}
+
+func mediaConvertQueueImportable(queue mediaconverttypes.Queue) bool {
+	return queue.Type != mediaconverttypes.TypeSystem
+}
+
+func mediaConvertQueueImportID(queueName string) string {
+	return queueName
+}
+
+func mediaConvertResourceName(parts ...string) string {
+	cleanParts := []string{}
+	for _, part := range parts {
+		if part != "" {
+			cleanParts = append(cleanParts, fmt.Sprintf("%d/%s", len(part), part))
+		}
+	}
+	if len(cleanParts) == 0 {
+		return "media-convert-resource"
+	}
+	return strings.Join(cleanParts, "/")
+}
+
+func mediaConvertQueueNotFound(err error) bool {
+	var notFound *mediaconverttypes.NotFoundException
+	return errors.As(err, &notFound)
+}

--- a/providers/aws/media_convert.go
+++ b/providers/aws/media_convert.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/mediaconvert"
 	mediaconverttypes "github.com/aws/aws-sdk-go-v2/service/mediaconvert/types"
 	"github.com/chenrui333/terraformer/terraformutils"
@@ -27,14 +28,31 @@ func (g *MediaConvertGenerator) InitResources() error {
 		return e
 	}
 	svc := mediaconvert.NewFromConfig(config)
-	return g.loadQueues(svc)
+	if err := g.loadQueues(svc); err != nil {
+		if !mediaConvertQueueEndpointUnavailable(err) {
+			return err
+		}
+		// Regional endpoints are preferred, but older accounts can require an
+		// existing account endpoint. GET_ONLY avoids creating one during discovery.
+		endpoint, endpointErr := mediaConvertAccountEndpoint(context.TODO(), svc)
+		if endpointErr != nil {
+			return endpointErr
+		}
+		if endpoint == "" {
+			return nil
+		}
+		return g.loadQueues(mediaconvert.NewFromConfig(config, func(o *mediaconvert.Options) {
+			o.BaseEndpoint = aws.String(endpoint)
+		}))
+	}
+	return nil
 }
 
 func (g *MediaConvertGenerator) loadQueues(svc *mediaconvert.Client) error {
 	p := mediaconvert.NewListQueuesPaginator(svc, &mediaconvert.ListQueuesInput{})
 	for p.HasMorePages() {
 		page, err := p.NextPage(context.TODO())
-		if mediaConvertQueueDiscoverySkippable(err) {
+		if mediaConvertQueueNotFound(err) {
 			return nil
 		}
 		if err != nil {
@@ -48,6 +66,27 @@ func (g *MediaConvertGenerator) loadQueues(svc *mediaconvert.Client) error {
 	}
 
 	return nil
+}
+
+func mediaConvertAccountEndpoint(ctx context.Context, svc mediaconvert.DescribeEndpointsAPIClient) (string, error) {
+	p := mediaconvert.NewDescribeEndpointsPaginator(svc, &mediaconvert.DescribeEndpointsInput{
+		Mode: mediaconverttypes.DescribeEndpointsModeGetOnly,
+	})
+	for p.HasMorePages() {
+		page, err := p.NextPage(ctx)
+		if mediaConvertQueueNotFound(err) {
+			return "", nil
+		}
+		if err != nil {
+			return "", err
+		}
+		for _, endpoint := range page.Endpoints {
+			if endpointURL := StringValue(endpoint.Url); endpointURL != "" {
+				return endpointURL, nil
+			}
+		}
+	}
+	return "", nil
 }
 
 func newMediaConvertQueueResource(queue mediaconverttypes.Queue) (terraformutils.Resource, bool) {
@@ -91,10 +130,6 @@ func mediaConvertResourceName(parts ...string) string {
 func mediaConvertQueueNotFound(err error) bool {
 	var notFound *mediaconverttypes.NotFoundException
 	return errors.As(err, &notFound)
-}
-
-func mediaConvertQueueDiscoverySkippable(err error) bool {
-	return mediaConvertQueueNotFound(err) || mediaConvertQueueEndpointUnavailable(err)
 }
 
 func mediaConvertQueueEndpointUnavailable(err error) bool {

--- a/providers/aws/media_convert.go
+++ b/providers/aws/media_convert.go
@@ -12,14 +12,19 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/mediaconvert"
 	mediaconverttypes "github.com/aws/aws-sdk-go-v2/service/mediaconvert/types"
 	"github.com/chenrui333/terraformer/terraformutils"
+	"github.com/chenrui333/terraformer/terraformutils/providerwrapper"
 )
 
-const mediaConvertQueueResourceType = "aws_media_convert_queue"
+const (
+	mediaConvertQueueResourceType = "aws_media_convert_queue"
+	mediaConvertEndpointEnvVar    = "AWS_ENDPOINT_URL_MEDIACONVERT"
+)
 
 var mediaConvertAllowEmptyValues = []string{"tags."}
 
 type MediaConvertGenerator struct {
 	AWSService
+	accountEndpoint string
 }
 
 func (g *MediaConvertGenerator) InitResources() error {
@@ -41,11 +46,24 @@ func (g *MediaConvertGenerator) InitResources() error {
 		if endpoint == "" {
 			return nil
 		}
+		if err := mediaConvertSetAccountEndpoint(endpoint); err != nil {
+			return err
+		}
+		g.accountEndpoint = endpoint
 		return g.loadQueues(mediaconvert.NewFromConfig(config, func(o *mediaconvert.Options) {
 			o.BaseEndpoint = aws.String(endpoint)
 		}))
 	}
 	return nil
+}
+
+func (g *MediaConvertGenerator) ConfigureImportProvider(providerWrapper *providerwrapper.ProviderWrapper) error {
+	if g.accountEndpoint == "" {
+		return nil
+	}
+	// The Terraform AWS provider reads service endpoint environment variables when
+	// its plugin process starts, so refresh needs a restart after endpoint bootstrap.
+	return providerWrapper.Restart()
 }
 
 func (g *MediaConvertGenerator) loadQueues(svc *mediaconvert.Client) error {
@@ -66,6 +84,10 @@ func (g *MediaConvertGenerator) loadQueues(svc *mediaconvert.Client) error {
 	}
 
 	return nil
+}
+
+func mediaConvertSetAccountEndpoint(endpoint string) error {
+	return terraformutils.SetEnv(mediaConvertEndpointEnvVar, endpoint)
 }
 
 func mediaConvertAccountEndpoint(ctx context.Context, svc mediaconvert.DescribeEndpointsAPIClient) (string, error) {

--- a/providers/aws/media_convert.go
+++ b/providers/aws/media_convert.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"os"
 	"strings"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
@@ -24,7 +25,9 @@ var mediaConvertAllowEmptyValues = []string{"tags."}
 
 type MediaConvertGenerator struct {
 	AWSService
-	accountEndpoint string
+	accountEndpoint     string
+	previousEndpoint    string
+	hadPreviousEndpoint bool
 }
 
 func (g *MediaConvertGenerator) InitResources() error {
@@ -46,10 +49,13 @@ func (g *MediaConvertGenerator) InitResources() error {
 		if endpoint == "" {
 			return nil
 		}
-		if err := mediaConvertSetAccountEndpoint(endpoint); err != nil {
+		previousEndpoint, hadPreviousEndpoint, err := mediaConvertSetAccountEndpoint(endpoint)
+		if err != nil {
 			return err
 		}
 		g.accountEndpoint = endpoint
+		g.previousEndpoint = previousEndpoint
+		g.hadPreviousEndpoint = hadPreviousEndpoint
 		return g.loadQueues(mediaconvert.NewFromConfig(config, func(o *mediaconvert.Options) {
 			o.BaseEndpoint = aws.String(endpoint)
 		}))
@@ -64,6 +70,13 @@ func (g *MediaConvertGenerator) ConfigureImportProvider(providerWrapper *provide
 	// The Terraform AWS provider reads service endpoint environment variables when
 	// its plugin process starts, so refresh needs a restart after endpoint bootstrap.
 	return providerWrapper.Restart()
+}
+
+func (g *MediaConvertGenerator) PostConvertHook() error {
+	if g.accountEndpoint == "" {
+		return nil
+	}
+	return mediaConvertRestoreAccountEndpoint(g.previousEndpoint, g.hadPreviousEndpoint)
 }
 
 func (g *MediaConvertGenerator) loadQueues(svc *mediaconvert.Client) error {
@@ -86,8 +99,19 @@ func (g *MediaConvertGenerator) loadQueues(svc *mediaconvert.Client) error {
 	return nil
 }
 
-func mediaConvertSetAccountEndpoint(endpoint string) error {
-	return terraformutils.SetEnv(mediaConvertEndpointEnvVar, endpoint)
+func mediaConvertSetAccountEndpoint(endpoint string) (string, bool, error) {
+	previousEndpoint, hadPreviousEndpoint := os.LookupEnv(mediaConvertEndpointEnvVar)
+	if err := terraformutils.SetEnv(mediaConvertEndpointEnvVar, endpoint); err != nil {
+		return "", false, err
+	}
+	return previousEndpoint, hadPreviousEndpoint, nil
+}
+
+func mediaConvertRestoreAccountEndpoint(previousEndpoint string, hadPreviousEndpoint bool) error {
+	if hadPreviousEndpoint {
+		return terraformutils.SetEnv(mediaConvertEndpointEnvVar, previousEndpoint)
+	}
+	return terraformutils.UnsetEnv(mediaConvertEndpointEnvVar)
 }
 
 func mediaConvertAccountEndpoint(ctx context.Context, svc mediaconvert.DescribeEndpointsAPIClient) (string, error) {

--- a/providers/aws/media_convert_test.go
+++ b/providers/aws/media_convert_test.go
@@ -128,7 +128,7 @@ func TestMediaConvertAccountEndpoint(t *testing.T) {
 		t.Fatalf("DescribeEndpoints calls = %d, want %d", got, want)
 	}
 	for _, input := range client.inputs {
-		if got, want := input.Mode, mediaconverttypes.DescribeEndpointsModeGetOnly; got != want {
+		if got, want := input.Mode, mediaconverttypes.DescribeEndpointsModeGetOnly; got != want { //nolint:staticcheck // Verifies the intentional GET_ONLY fallback mode.
 			t.Fatalf("DescribeEndpoints mode = %q, want %q", got, want)
 		}
 	}

--- a/providers/aws/media_convert_test.go
+++ b/providers/aws/media_convert_test.go
@@ -213,6 +213,51 @@ func TestMediaConvertSetAndRestoreAccountEndpoint(t *testing.T) {
 	})
 }
 
+func TestMediaConvertGeneratorRestoreAccountEndpoint(t *testing.T) {
+	t.Run("restores previous value and clears generator state", func(t *testing.T) {
+		preserveMediaConvertEndpointEnv(t)
+		previousEndpoint := "https://previous.mediaconvert.us-west-2.amazonaws.com"
+		endpoint := "https://abcd.mediaconvert.us-east-1.amazonaws.com"
+		if err := os.Setenv(mediaConvertEndpointEnvVar, endpoint); err != nil {
+			t.Fatalf("Setenv returned error: %v", err)
+		}
+		generator := &MediaConvertGenerator{
+			accountEndpoint:     endpoint,
+			previousEndpoint:    previousEndpoint,
+			hadPreviousEndpoint: true,
+		}
+
+		if err := generator.restoreAccountEndpoint(); err != nil {
+			t.Fatalf("restoreAccountEndpoint returned error: %v", err)
+		}
+		if got := os.Getenv(mediaConvertEndpointEnvVar); got != previousEndpoint {
+			t.Fatalf("%s = %q, want restored %q", mediaConvertEndpointEnvVar, got, previousEndpoint)
+		}
+		if generator.accountEndpoint != "" || generator.previousEndpoint != "" || generator.hadPreviousEndpoint {
+			t.Fatalf("generator endpoint state was not cleared: %#v", generator)
+		}
+	})
+
+	t.Run("unsets absent value", func(t *testing.T) {
+		preserveMediaConvertEndpointEnv(t)
+		endpoint := "https://abcd.mediaconvert.us-east-1.amazonaws.com"
+		if err := os.Setenv(mediaConvertEndpointEnvVar, endpoint); err != nil {
+			t.Fatalf("Setenv returned error: %v", err)
+		}
+		generator := &MediaConvertGenerator{accountEndpoint: endpoint}
+
+		if err := generator.restoreAccountEndpoint(); err != nil {
+			t.Fatalf("restoreAccountEndpoint returned error: %v", err)
+		}
+		if got, ok := os.LookupEnv(mediaConvertEndpointEnvVar); ok {
+			t.Fatalf("%s = %q, want unset", mediaConvertEndpointEnvVar, got)
+		}
+		if generator.accountEndpoint != "" {
+			t.Fatalf("generator endpoint state was not cleared: %#v", generator)
+		}
+	})
+}
+
 func preserveMediaConvertEndpointEnv(t *testing.T) {
 	t.Helper()
 	previousEndpoint, hadPreviousEndpoint := os.LookupEnv(mediaConvertEndpointEnvVar)

--- a/providers/aws/media_convert_test.go
+++ b/providers/aws/media_convert_test.go
@@ -5,6 +5,7 @@ package aws
 import (
 	"context"
 	"errors"
+	"os"
 	"testing"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
@@ -156,6 +157,17 @@ func TestMediaConvertAccountEndpointError(t *testing.T) {
 	}
 	if endpoint != "" {
 		t.Fatalf("MediaConvert account endpoint = %q, want empty", endpoint)
+	}
+}
+
+func TestMediaConvertSetAccountEndpoint(t *testing.T) {
+	t.Setenv(mediaConvertEndpointEnvVar, "")
+	endpoint := "https://abcd.mediaconvert.us-east-1.amazonaws.com"
+	if err := mediaConvertSetAccountEndpoint(endpoint); err != nil {
+		t.Fatalf("mediaConvertSetAccountEndpoint returned error: %v", err)
+	}
+	if got := os.Getenv(mediaConvertEndpointEnvVar); got != endpoint {
+		t.Fatalf("%s = %q, want %q", mediaConvertEndpointEnvVar, got, endpoint)
 	}
 }
 

--- a/providers/aws/media_convert_test.go
+++ b/providers/aws/media_convert_test.go
@@ -79,6 +79,30 @@ func TestMediaConvertQueueNotFound(t *testing.T) {
 	}
 }
 
+func TestMediaConvertQueueDiscoverySkippable(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{name: "nil", want: false},
+		{name: "not found", err: &mediaconverttypes.NotFoundException{}, want: true},
+		{name: "customer endpoint bad request", err: &mediaconverttypes.BadRequestException{Message: aws.String("You must use the customer-specific endpoint")}, want: true},
+		{name: "account endpoint bad request", err: &mediaconverttypes.BadRequestException{Message: aws.String("account endpoint is not available")}, want: true},
+		{name: "wrapped endpoint bad request", err: errors.Join(errors.New("list queues failed"), &mediaconverttypes.BadRequestException{Message: aws.String("use the account-specific endpoint")}), want: true},
+		{name: "other bad request", err: &mediaconverttypes.BadRequestException{Message: aws.String("invalid maxResults")}, want: false},
+		{name: "generic", err: errors.New("boom"), want: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := mediaConvertQueueDiscoverySkippable(tt.err); got != tt.want {
+				t.Fatalf("mediaConvertQueueDiscoverySkippable(%v) = %t, want %t", tt.err, got, tt.want)
+			}
+		})
+	}
+}
+
 func assertMediaConvertResource(t *testing.T, resource terraformutils.Resource, ok bool, wantID, wantName, wantType string) {
 	t.Helper()
 	if !ok {

--- a/providers/aws/media_convert_test.go
+++ b/providers/aws/media_convert_test.go
@@ -3,10 +3,12 @@
 package aws
 
 import (
+	"context"
 	"errors"
 	"testing"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/mediaconvert"
 	mediaconverttypes "github.com/aws/aws-sdk-go-v2/service/mediaconvert/types"
 	"github.com/chenrui333/terraformer/terraformutils"
 )
@@ -79,14 +81,14 @@ func TestMediaConvertQueueNotFound(t *testing.T) {
 	}
 }
 
-func TestMediaConvertQueueDiscoverySkippable(t *testing.T) {
+func TestMediaConvertQueueEndpointUnavailable(t *testing.T) {
 	tests := []struct {
 		name string
 		err  error
 		want bool
 	}{
 		{name: "nil", want: false},
-		{name: "not found", err: &mediaconverttypes.NotFoundException{}, want: true},
+		{name: "not found", err: &mediaconverttypes.NotFoundException{}, want: false},
 		{name: "customer endpoint bad request", err: &mediaconverttypes.BadRequestException{Message: aws.String("You must use the customer-specific endpoint")}, want: true},
 		{name: "account endpoint bad request", err: &mediaconverttypes.BadRequestException{Message: aws.String("account endpoint is not available")}, want: true},
 		{name: "wrapped endpoint bad request", err: errors.Join(errors.New("list queues failed"), &mediaconverttypes.BadRequestException{Message: aws.String("use the account-specific endpoint")}), want: true},
@@ -96,11 +98,85 @@ func TestMediaConvertQueueDiscoverySkippable(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := mediaConvertQueueDiscoverySkippable(tt.err); got != tt.want {
-				t.Fatalf("mediaConvertQueueDiscoverySkippable(%v) = %t, want %t", tt.err, got, tt.want)
+			if got := mediaConvertQueueEndpointUnavailable(tt.err); got != tt.want {
+				t.Fatalf("mediaConvertQueueEndpointUnavailable(%v) = %t, want %t", tt.err, got, tt.want)
 			}
 		})
 	}
+}
+
+func TestMediaConvertAccountEndpoint(t *testing.T) {
+	client := &mediaConvertDescribeEndpointsClient{
+		outputs: []*mediaconvert.DescribeEndpointsOutput{
+			{
+				Endpoints: []mediaconverttypes.Endpoint{{}},
+				NextToken: aws.String("next"),
+			},
+			{
+				Endpoints: []mediaconverttypes.Endpoint{{Url: aws.String("https://abcd.mediaconvert.us-east-1.amazonaws.com")}},
+			},
+		},
+	}
+	endpoint, err := mediaConvertAccountEndpoint(context.Background(), client)
+	if err != nil {
+		t.Fatalf("mediaConvertAccountEndpoint returned error: %v", err)
+	}
+	if got, want := endpoint, "https://abcd.mediaconvert.us-east-1.amazonaws.com"; got != want {
+		t.Fatalf("mediaConvert account endpoint = %q, want %q", got, want)
+	}
+	if got, want := len(client.inputs), 2; got != want {
+		t.Fatalf("DescribeEndpoints calls = %d, want %d", got, want)
+	}
+	for _, input := range client.inputs {
+		if got, want := input.Mode, mediaconverttypes.DescribeEndpointsModeGetOnly; got != want {
+			t.Fatalf("DescribeEndpoints mode = %q, want %q", got, want)
+		}
+	}
+}
+
+func TestMediaConvertAccountEndpointEmpty(t *testing.T) {
+	client := &mediaConvertDescribeEndpointsClient{
+		outputs: []*mediaconvert.DescribeEndpointsOutput{{}},
+	}
+	endpoint, err := mediaConvertAccountEndpoint(context.Background(), client)
+	if err != nil {
+		t.Fatalf("mediaConvertAccountEndpoint returned error: %v", err)
+	}
+	if endpoint != "" {
+		t.Fatalf("MediaConvert account endpoint = %q, want empty", endpoint)
+	}
+}
+
+func TestMediaConvertAccountEndpointError(t *testing.T) {
+	wantErr := errors.New("describe endpoints failed")
+	client := &mediaConvertDescribeEndpointsClient{errs: []error{wantErr}}
+	endpoint, err := mediaConvertAccountEndpoint(context.Background(), client)
+	if !errors.Is(err, wantErr) {
+		t.Fatalf("mediaConvertAccountEndpoint error = %v, want %v", err, wantErr)
+	}
+	if endpoint != "" {
+		t.Fatalf("MediaConvert account endpoint = %q, want empty", endpoint)
+	}
+}
+
+type mediaConvertDescribeEndpointsClient struct {
+	outputs []*mediaconvert.DescribeEndpointsOutput
+	errs    []error
+	inputs  []*mediaconvert.DescribeEndpointsInput
+	calls   int
+}
+
+func (c *mediaConvertDescribeEndpointsClient) DescribeEndpoints(_ context.Context, input *mediaconvert.DescribeEndpointsInput, _ ...func(*mediaconvert.Options)) (*mediaconvert.DescribeEndpointsOutput, error) {
+	c.inputs = append(c.inputs, input)
+	call := c.calls
+	c.calls++
+	if call < len(c.errs) && c.errs[call] != nil {
+		return nil, c.errs[call]
+	}
+	if call < len(c.outputs) {
+		return c.outputs[call], nil
+	}
+	return &mediaconvert.DescribeEndpointsOutput{}, nil
 }
 
 func assertMediaConvertResource(t *testing.T, resource terraformutils.Resource, ok bool, wantID, wantName, wantType string) {

--- a/providers/aws/media_convert_test.go
+++ b/providers/aws/media_convert_test.go
@@ -1,0 +1,103 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package aws
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	mediaconverttypes "github.com/aws/aws-sdk-go-v2/service/mediaconvert/types"
+	"github.com/chenrui333/terraformer/terraformutils"
+)
+
+func TestNewMediaConvertQueueResource(t *testing.T) {
+	resource, ok := newMediaConvertQueueResource(mediaconverttypes.Queue{
+		Name: aws.String("transcode"),
+		Type: mediaconverttypes.Type("CUSTOM"),
+	})
+	assertMediaConvertResource(t, resource, ok, "transcode", mediaConvertResourceName("queue", "transcode"), mediaConvertQueueResourceType)
+	assertMediaConvertAttribute(t, resource, "name", "transcode")
+
+	if _, ok := newMediaConvertQueueResource(mediaconverttypes.Queue{}); ok {
+		t.Fatal("queue with empty name should be skipped")
+	}
+}
+
+func TestMediaConvertQueueImportable(t *testing.T) {
+	tests := []struct {
+		name  string
+		queue mediaconverttypes.Queue
+		want  bool
+	}{
+		{name: "custom", queue: mediaconverttypes.Queue{Type: mediaconverttypes.Type("CUSTOM")}, want: true},
+		{name: "empty type", queue: mediaconverttypes.Queue{}, want: true},
+		{name: "system", queue: mediaconverttypes.Queue{Type: mediaconverttypes.TypeSystem}, want: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := mediaConvertQueueImportable(tt.queue); got != tt.want {
+				t.Fatalf("mediaConvertQueueImportable(%#v) = %t, want %t", tt.queue, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestMediaConvertQueueImportID(t *testing.T) {
+	if got, want := mediaConvertQueueImportID("transcode"), "transcode"; got != want {
+		t.Fatalf("MediaConvert queue import ID = %q, want %q", got, want)
+	}
+}
+
+func TestMediaConvertResourceNamesPreserveSegmentBoundaries(t *testing.T) {
+	left := terraformutils.TfSanitize(mediaConvertResourceName("queue", "a/b_c"))
+	right := terraformutils.TfSanitize(mediaConvertResourceName("que", "ue/a_b_c"))
+	if left == right {
+		t.Fatalf("MediaConvert resource names collide: %q", left)
+	}
+}
+
+func TestMediaConvertQueueNotFound(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{name: "nil", want: false},
+		{name: "not found", err: &mediaconverttypes.NotFoundException{}, want: true},
+		{name: "wrapped not found", err: errors.Join(errors.New("lookup failed"), &mediaconverttypes.NotFoundException{}), want: true},
+		{name: "generic", err: errors.New("boom"), want: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := mediaConvertQueueNotFound(tt.err); got != tt.want {
+				t.Fatalf("mediaConvertQueueNotFound(%v) = %t, want %t", tt.err, got, tt.want)
+			}
+		})
+	}
+}
+
+func assertMediaConvertResource(t *testing.T, resource terraformutils.Resource, ok bool, wantID, wantName, wantType string) {
+	t.Helper()
+	if !ok {
+		t.Fatal("resource was skipped")
+	}
+	if got := resource.InstanceState.ID; got != wantID {
+		t.Fatalf("resource ID = %q, want %q", got, wantID)
+	}
+	if got := resource.ResourceName; got != terraformutils.TfSanitize(wantName) {
+		t.Fatalf("resource name = %q, want %q", got, terraformutils.TfSanitize(wantName))
+	}
+	if got := resource.InstanceInfo.Type; got != wantType {
+		t.Fatalf("resource type = %q, want %q", got, wantType)
+	}
+}
+
+func assertMediaConvertAttribute(t *testing.T, resource terraformutils.Resource, key, want string) {
+	t.Helper()
+	if got := resource.InstanceState.Attributes[key]; got != want {
+		t.Fatalf("resource attribute %q = %q, want %q", key, got, want)
+	}
+}

--- a/providers/aws/media_convert_test.go
+++ b/providers/aws/media_convert_test.go
@@ -160,15 +160,69 @@ func TestMediaConvertAccountEndpointError(t *testing.T) {
 	}
 }
 
-func TestMediaConvertSetAccountEndpoint(t *testing.T) {
-	t.Setenv(mediaConvertEndpointEnvVar, "")
-	endpoint := "https://abcd.mediaconvert.us-east-1.amazonaws.com"
-	if err := mediaConvertSetAccountEndpoint(endpoint); err != nil {
-		t.Fatalf("mediaConvertSetAccountEndpoint returned error: %v", err)
-	}
-	if got := os.Getenv(mediaConvertEndpointEnvVar); got != endpoint {
-		t.Fatalf("%s = %q, want %q", mediaConvertEndpointEnvVar, got, endpoint)
-	}
+func TestMediaConvertSetAndRestoreAccountEndpoint(t *testing.T) {
+	t.Run("restores previous value", func(t *testing.T) {
+		preserveMediaConvertEndpointEnv(t)
+		previousEndpoint := "https://previous.mediaconvert.us-west-2.amazonaws.com"
+		endpoint := "https://abcd.mediaconvert.us-east-1.amazonaws.com"
+		if err := os.Setenv(mediaConvertEndpointEnvVar, previousEndpoint); err != nil {
+			t.Fatalf("Setenv returned error: %v", err)
+		}
+
+		gotPrevious, hadPrevious, err := mediaConvertSetAccountEndpoint(endpoint)
+		if err != nil {
+			t.Fatalf("mediaConvertSetAccountEndpoint returned error: %v", err)
+		}
+		if !hadPrevious || gotPrevious != previousEndpoint {
+			t.Fatalf("previous endpoint = %q, %t; want %q, true", gotPrevious, hadPrevious, previousEndpoint)
+		}
+		if got := os.Getenv(mediaConvertEndpointEnvVar); got != endpoint {
+			t.Fatalf("%s = %q, want %q", mediaConvertEndpointEnvVar, got, endpoint)
+		}
+		if err := mediaConvertRestoreAccountEndpoint(gotPrevious, hadPrevious); err != nil {
+			t.Fatalf("mediaConvertRestoreAccountEndpoint returned error: %v", err)
+		}
+		if got := os.Getenv(mediaConvertEndpointEnvVar); got != previousEndpoint {
+			t.Fatalf("%s = %q, want restored %q", mediaConvertEndpointEnvVar, got, previousEndpoint)
+		}
+	})
+
+	t.Run("unsets absent value", func(t *testing.T) {
+		preserveMediaConvertEndpointEnv(t)
+		endpoint := "https://abcd.mediaconvert.us-east-1.amazonaws.com"
+		if err := os.Unsetenv(mediaConvertEndpointEnvVar); err != nil {
+			t.Fatalf("Unsetenv returned error: %v", err)
+		}
+
+		gotPrevious, hadPrevious, err := mediaConvertSetAccountEndpoint(endpoint)
+		if err != nil {
+			t.Fatalf("mediaConvertSetAccountEndpoint returned error: %v", err)
+		}
+		if hadPrevious || gotPrevious != "" {
+			t.Fatalf("previous endpoint = %q, %t; want empty, false", gotPrevious, hadPrevious)
+		}
+		if got := os.Getenv(mediaConvertEndpointEnvVar); got != endpoint {
+			t.Fatalf("%s = %q, want %q", mediaConvertEndpointEnvVar, got, endpoint)
+		}
+		if err := mediaConvertRestoreAccountEndpoint(gotPrevious, hadPrevious); err != nil {
+			t.Fatalf("mediaConvertRestoreAccountEndpoint returned error: %v", err)
+		}
+		if got, ok := os.LookupEnv(mediaConvertEndpointEnvVar); ok {
+			t.Fatalf("%s = %q, want unset", mediaConvertEndpointEnvVar, got)
+		}
+	})
+}
+
+func preserveMediaConvertEndpointEnv(t *testing.T) {
+	t.Helper()
+	previousEndpoint, hadPreviousEndpoint := os.LookupEnv(mediaConvertEndpointEnvVar)
+	t.Cleanup(func() {
+		if hadPreviousEndpoint {
+			_ = os.Setenv(mediaConvertEndpointEnvVar, previousEndpoint)
+			return
+		}
+		_ = os.Unsetenv(mediaConvertEndpointEnvVar)
+	})
 }
 
 type mediaConvertDescribeEndpointsClient struct {

--- a/providers/aws/media_unsupported_test.go
+++ b/providers/aws/media_unsupported_test.go
@@ -24,8 +24,14 @@ func TestMediaUnsupportedResourceEntries(t *testing.T) {
 		t.Fatal("unsupported resources file is missing resources list")
 	}
 
+	wantEntries := map[string]string{
+		"aws_elastic_beanstalk_application_version":    "elastic_beanstalk",
+		"aws_elastic_beanstalk_configuration_template": "elastic_beanstalk",
+		"aws_ivs_playback_key_pair":                    "ivs",
+		"aws_qldb_stream":                              "qldb",
+	}
+	foundEntries := map[string]bool{}
 	resources := make([]string, 0, len(entries))
-	foundPlaybackKeyPair := false
 	for _, rawEntry := range entries {
 		entry, ok := rawEntry.(map[string]interface{})
 		if !ok {
@@ -33,24 +39,26 @@ func TestMediaUnsupportedResourceEntries(t *testing.T) {
 		}
 		resource, _ := entry["resource"].(string)
 		resources = append(resources, resource)
-		if resource == "aws_ivs_playback_key_pair" {
-			foundPlaybackKeyPair = true
-			if serviceFamily, _ := entry["service_family"].(string); serviceFamily != "ivs" {
-				t.Fatalf("playback key pair service family = %q, want ivs", serviceFamily)
+		if wantServiceFamily, ok := wantEntries[resource]; ok {
+			foundEntries[resource] = true
+			if serviceFamily, _ := entry["service_family"].(string); serviceFamily != wantServiceFamily {
+				t.Fatalf("%s service family = %q, want %s", resource, serviceFamily, wantServiceFamily)
 			}
 			if status, _ := entry["status"].(string); status != "unsupported" {
-				t.Fatalf("playback key pair status = %q, want unsupported", status)
+				t.Fatalf("%s status = %q, want unsupported", resource, status)
 			}
 			references, _ := entry["references"].([]interface{})
 			reason, _ := entry["reason"].(string)
 			evidence, _ := entry["evidence"].(string)
 			if reason == "" || evidence == "" || len(references) == 0 {
-				t.Fatal("playback key pair unsupported entry is missing reason, evidence, or references")
+				t.Fatalf("%s unsupported entry is missing reason, evidence, or references", resource)
 			}
 		}
 	}
-	if !foundPlaybackKeyPair {
-		t.Fatal("aws_ivs_playback_key_pair unsupported entry was not found")
+	for resource := range wantEntries {
+		if !foundEntries[resource] {
+			t.Fatalf("%s unsupported entry was not found", resource)
+		}
 	}
 	if !sort.StringsAreSorted(resources) {
 		t.Fatalf("unsupported resources are not sorted by resource: %v", resources)

--- a/providers/aws/media_unsupported_test.go
+++ b/providers/aws/media_unsupported_test.go
@@ -28,7 +28,6 @@ func TestMediaUnsupportedResourceEntries(t *testing.T) {
 		"aws_elastic_beanstalk_application_version":    "elastic_beanstalk",
 		"aws_elastic_beanstalk_configuration_template": "elastic_beanstalk",
 		"aws_ivs_playback_key_pair":                    "ivs",
-		"aws_qldb_stream":                              "qldb",
 	}
 	foundEntries := map[string]bool{}
 	resources := make([]string, 0, len(entries))

--- a/providers/aws/media_unsupported_test.go
+++ b/providers/aws/media_unsupported_test.go
@@ -28,6 +28,7 @@ func TestMediaUnsupportedResourceEntries(t *testing.T) {
 		"aws_elastic_beanstalk_application_version":    "elastic_beanstalk",
 		"aws_elastic_beanstalk_configuration_template": "elastic_beanstalk",
 		"aws_ivs_playback_key_pair":                    "ivs",
+		"aws_mq_broker":                                "mq",
 	}
 	foundEntries := map[string]bool{}
 	resources := make([]string, 0, len(entries))

--- a/providers/aws/mq.go
+++ b/providers/aws/mq.go
@@ -4,9 +4,18 @@ package aws
 
 import (
 	"context"
+	"fmt"
+	"strings"
 
+	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/mq"
+	mqtypes "github.com/aws/aws-sdk-go-v2/service/mq/types"
 	"github.com/chenrui333/terraformer/terraformutils"
+)
+
+const (
+	mqBrokerResourceType        = "aws_mq_broker"
+	mqConfigurationResourceType = "aws_mq_configuration"
 )
 
 var mqAllowEmptyValues = []string{"tags."}
@@ -23,15 +32,32 @@ func (g *MQGenerator) loadBrokers(svc *mq.Client) error {
 			return err
 		}
 		for _, broker := range page.BrokerSummaries {
-			resourceName := StringValue(broker.BrokerName)
-			g.Resources = append(g.Resources, terraformutils.NewSimpleResource(
-				resourceName,
-				resourceName,
-				"aws_mq_broker",
-				"aws",
-				mqAllowEmptyValues))
+			if resource, ok := newMQBrokerResource(broker); ok {
+				g.Resources = append(g.Resources, resource)
+			}
 		}
 	}
+	return nil
+}
+
+func (g *MQGenerator) loadConfigurations(svc *mq.Client) error {
+	input := &mq.ListConfigurationsInput{MaxResults: aws.Int32(100)}
+	for {
+		output, err := svc.ListConfigurations(context.TODO(), input)
+		if err != nil {
+			return err
+		}
+		for _, configuration := range output.Configurations {
+			if resource, ok := newMQConfigurationResource(configuration); ok {
+				g.Resources = append(g.Resources, resource)
+			}
+		}
+		if output.NextToken == nil {
+			break
+		}
+		input.NextToken = output.NextToken
+	}
+
 	return nil
 }
 
@@ -47,5 +73,65 @@ func (g *MQGenerator) InitResources() error {
 		return err
 	}
 
+	err = g.loadConfigurations(svc)
+	if err != nil {
+		return err
+	}
+
 	return nil
+}
+
+func newMQBrokerResource(broker mqtypes.BrokerSummary) (terraformutils.Resource, bool) {
+	brokerID := StringValue(broker.BrokerId)
+	if brokerID == "" {
+		return terraformutils.Resource{}, false
+	}
+	brokerName := StringValue(broker.BrokerName)
+	if brokerName == "" {
+		brokerName = brokerID
+	}
+	return terraformutils.NewSimpleResource(
+		mqBrokerImportID(brokerID),
+		brokerName,
+		mqBrokerResourceType,
+		"aws",
+		mqAllowEmptyValues), true
+}
+
+func newMQConfigurationResource(configuration mqtypes.Configuration) (terraformutils.Resource, bool) {
+	configurationID := StringValue(configuration.Id)
+	if configurationID == "" {
+		return terraformutils.Resource{}, false
+	}
+	configurationName := StringValue(configuration.Name)
+	if configurationName == "" {
+		configurationName = configurationID
+	}
+	return terraformutils.NewSimpleResource(
+		mqConfigurationImportID(configurationID),
+		mqResourceName("configuration", configurationName, configurationID),
+		mqConfigurationResourceType,
+		"aws",
+		mqAllowEmptyValues), true
+}
+
+func mqBrokerImportID(brokerID string) string {
+	return brokerID
+}
+
+func mqConfigurationImportID(configurationID string) string {
+	return configurationID
+}
+
+func mqResourceName(parts ...string) string {
+	cleanParts := []string{}
+	for _, part := range parts {
+		if part != "" {
+			cleanParts = append(cleanParts, fmt.Sprintf("%d/%s", len(part), part))
+		}
+	}
+	if len(cleanParts) == 0 {
+		return "mq-resource"
+	}
+	return strings.Join(cleanParts, "/")
 }

--- a/providers/aws/mq.go
+++ b/providers/aws/mq.go
@@ -14,7 +14,6 @@ import (
 )
 
 const (
-	mqBrokerResourceType        = "aws_mq_broker"
 	mqConfigurationResourceType = "aws_mq_configuration"
 )
 
@@ -22,22 +21,6 @@ var mqAllowEmptyValues = []string{"tags."}
 
 type MQGenerator struct {
 	AWSService
-}
-
-func (g *MQGenerator) loadBrokers(svc *mq.Client) error {
-	p := mq.NewListBrokersPaginator(svc, &mq.ListBrokersInput{})
-	for p.HasMorePages() {
-		page, err := p.NextPage(context.TODO())
-		if err != nil {
-			return err
-		}
-		for _, broker := range page.BrokerSummaries {
-			if resource, ok := newMQBrokerResource(broker); ok {
-				g.Resources = append(g.Resources, resource)
-			}
-		}
-	}
-	return nil
 }
 
 func (g *MQGenerator) loadConfigurations(svc *mq.Client) error {
@@ -68,34 +51,12 @@ func (g *MQGenerator) InitResources() error {
 	}
 	svc := mq.NewFromConfig(config)
 
-	err := g.loadBrokers(svc)
-	if err != nil {
-		return err
-	}
-
-	err = g.loadConfigurations(svc)
+	err := g.loadConfigurations(svc)
 	if err != nil {
 		return err
 	}
 
 	return nil
-}
-
-func newMQBrokerResource(broker mqtypes.BrokerSummary) (terraformutils.Resource, bool) {
-	brokerID := StringValue(broker.BrokerId)
-	if brokerID == "" {
-		return terraformutils.Resource{}, false
-	}
-	brokerName := StringValue(broker.BrokerName)
-	if brokerName == "" {
-		brokerName = brokerID
-	}
-	return terraformutils.NewSimpleResource(
-		mqBrokerImportID(brokerID),
-		brokerName,
-		mqBrokerResourceType,
-		"aws",
-		mqAllowEmptyValues), true
 }
 
 func newMQConfigurationResource(configuration mqtypes.Configuration) (terraformutils.Resource, bool) {
@@ -113,10 +74,6 @@ func newMQConfigurationResource(configuration mqtypes.Configuration) (terraformu
 		mqConfigurationResourceType,
 		"aws",
 		mqAllowEmptyValues), true
-}
-
-func mqBrokerImportID(brokerID string) string {
-	return brokerID
 }
 
 func mqConfigurationImportID(configurationID string) string {

--- a/providers/aws/mq_test.go
+++ b/providers/aws/mq_test.go
@@ -10,18 +10,6 @@ import (
 	"github.com/chenrui333/terraformer/terraformutils"
 )
 
-func TestNewMQBrokerResource(t *testing.T) {
-	resource, ok := newMQBrokerResource(mqtypes.BrokerSummary{
-		BrokerId:   aws.String("b-12345678-1234-1234-1234-123456789012"),
-		BrokerName: aws.String("orders"),
-	})
-	assertMQResource(t, resource, ok, "b-12345678-1234-1234-1234-123456789012", "orders", mqBrokerResourceType)
-
-	if _, ok := newMQBrokerResource(mqtypes.BrokerSummary{BrokerName: aws.String("missing-id")}); ok {
-		t.Fatal("broker with empty ID should be skipped")
-	}
-}
-
 func TestNewMQConfigurationResource(t *testing.T) {
 	resource, ok := newMQConfigurationResource(mqtypes.Configuration{
 		Id:   aws.String("c-12345678-1234-1234-1234-123456789012"),
@@ -35,9 +23,6 @@ func TestNewMQConfigurationResource(t *testing.T) {
 }
 
 func TestMQImportIDs(t *testing.T) {
-	if got, want := mqBrokerImportID("b-123"), "b-123"; got != want {
-		t.Fatalf("MQ broker import ID = %q, want %q", got, want)
-	}
 	if got, want := mqConfigurationImportID("c-123"), "c-123"; got != want {
 		t.Fatalf("MQ configuration import ID = %q, want %q", got, want)
 	}

--- a/providers/aws/mq_test.go
+++ b/providers/aws/mq_test.go
@@ -1,0 +1,68 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package aws
+
+import (
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	mqtypes "github.com/aws/aws-sdk-go-v2/service/mq/types"
+	"github.com/chenrui333/terraformer/terraformutils"
+)
+
+func TestNewMQBrokerResource(t *testing.T) {
+	resource, ok := newMQBrokerResource(mqtypes.BrokerSummary{
+		BrokerId:   aws.String("b-12345678-1234-1234-1234-123456789012"),
+		BrokerName: aws.String("orders"),
+	})
+	assertMQResource(t, resource, ok, "b-12345678-1234-1234-1234-123456789012", "orders", mqBrokerResourceType)
+
+	if _, ok := newMQBrokerResource(mqtypes.BrokerSummary{BrokerName: aws.String("missing-id")}); ok {
+		t.Fatal("broker with empty ID should be skipped")
+	}
+}
+
+func TestNewMQConfigurationResource(t *testing.T) {
+	resource, ok := newMQConfigurationResource(mqtypes.Configuration{
+		Id:   aws.String("c-12345678-1234-1234-1234-123456789012"),
+		Name: aws.String("rabbitmq-config"),
+	})
+	assertMQResource(t, resource, ok, "c-12345678-1234-1234-1234-123456789012", mqResourceName("configuration", "rabbitmq-config", "c-12345678-1234-1234-1234-123456789012"), mqConfigurationResourceType)
+
+	if _, ok := newMQConfigurationResource(mqtypes.Configuration{Name: aws.String("missing-id")}); ok {
+		t.Fatal("configuration with empty ID should be skipped")
+	}
+}
+
+func TestMQImportIDs(t *testing.T) {
+	if got, want := mqBrokerImportID("b-123"), "b-123"; got != want {
+		t.Fatalf("MQ broker import ID = %q, want %q", got, want)
+	}
+	if got, want := mqConfigurationImportID("c-123"), "c-123"; got != want {
+		t.Fatalf("MQ configuration import ID = %q, want %q", got, want)
+	}
+}
+
+func TestMQResourceNamesPreserveSegmentBoundaries(t *testing.T) {
+	left := terraformutils.TfSanitize(mqResourceName("configuration", "a/b_c"))
+	right := terraformutils.TfSanitize(mqResourceName("config", "uration/a_b_c"))
+	if left == right {
+		t.Fatalf("MQ resource names collide: %q", left)
+	}
+}
+
+func assertMQResource(t *testing.T, resource terraformutils.Resource, ok bool, wantID, wantName, wantType string) {
+	t.Helper()
+	if !ok {
+		t.Fatal("resource was skipped")
+	}
+	if got := resource.InstanceState.ID; got != wantID {
+		t.Fatalf("resource ID = %q, want %q", got, wantID)
+	}
+	if got := resource.ResourceName; got != terraformutils.TfSanitize(wantName) {
+		t.Fatalf("resource name = %q, want %q", got, terraformutils.TfSanitize(wantName))
+	}
+	if got := resource.InstanceInfo.Type; got != wantType {
+		t.Fatalf("resource type = %q, want %q", got, wantType)
+	}
+}

--- a/providers/aws/qldb.go
+++ b/providers/aws/qldb.go
@@ -5,19 +5,13 @@ package aws
 
 import (
 	"context"
-	"errors"
-	"fmt"
-	"log"
-	"strings"
 
 	"github.com/aws/aws-sdk-go-v2/service/qldb"
-	qldbtypes "github.com/aws/aws-sdk-go-v2/service/qldb/types"
 	"github.com/chenrui333/terraformer/terraformutils"
 )
 
 const (
 	qldbLedgerResourceType = "aws_qldb_ledger"
-	qldbStreamResourceType = "aws_qldb_stream"
 )
 
 var qldbAllowEmptyValues = []string{"tags."}
@@ -36,7 +30,7 @@ func (g *QLDBGenerator) InitResources() error {
 }
 
 func (g *QLDBGenerator) loadLedgers(svc *qldb.Client) error {
-	ledgerIDFilter := qldbLedgerIDFilter(g.Filter)
+	ledgerIDFilter := awsTypedIDFilterValues(g.Filter, qldbLedgerResourceType)
 	p := qldb.NewListLedgersPaginator(svc, &qldb.ListLedgersInput{})
 	for p.HasMorePages() {
 		page, err := p.NextPage(context.TODO())
@@ -48,41 +42,11 @@ func (g *QLDBGenerator) loadLedgers(svc *qldb.Client) error {
 			if !awsIDFilterAllows(ledgerIDFilter, ledgerName) {
 				continue
 			}
-			if resource, ok := newQLDBLedgerResource(ledgerName); ok && qldbShouldEmitLedger(g.Filter, ledgerName) {
-				g.Resources = append(g.Resources, resource)
-			}
-			if ledgerName == "" {
-				continue
-			}
-			if qldbShouldLoadStreams(g.Filter) {
-				if err := g.loadStreams(svc, ledgerName); err != nil {
-					log.Printf("[WARN] Skipping QLDB streams for ledger %s: %v", ledgerName, err)
-				}
-			}
-		}
-	}
-	return nil
-}
-
-func (g *QLDBGenerator) loadStreams(svc *qldb.Client, ledgerName string) error {
-	p := qldb.NewListJournalKinesisStreamsForLedgerPaginator(svc, &qldb.ListJournalKinesisStreamsForLedgerInput{
-		LedgerName: &ledgerName,
-	})
-	for p.HasMorePages() {
-		page, err := p.NextPage(context.TODO())
-		if qldbStreamNotFound(err) {
-			return nil
-		}
-		if err != nil {
-			return err
-		}
-		for _, stream := range page.Streams {
-			if resource, ok := newQLDBStreamResource(ledgerName, stream); ok {
+			if resource, ok := newQLDBLedgerResource(ledgerName); ok {
 				g.Resources = append(g.Resources, resource)
 			}
 		}
 	}
-
 	return nil
 }
 
@@ -98,85 +62,6 @@ func newQLDBLedgerResource(ledgerName string) (terraformutils.Resource, bool) {
 		qldbAllowEmptyValues), true
 }
 
-func newQLDBStreamResource(ledgerName string, stream qldbtypes.JournalKinesisStreamDescription) (terraformutils.Resource, bool) {
-	streamID := StringValue(stream.StreamId)
-	if ledgerName == "" || streamID == "" || !qldbStreamImportable(stream.Status) {
-		return terraformutils.Resource{}, false
-	}
-	streamName := StringValue(stream.StreamName)
-	if streamName == "" {
-		streamName = streamID
-	}
-	return terraformutils.NewResource(
-		qldbStreamImportID(streamID),
-		qldbResourceName("stream", ledgerName, streamName, streamID),
-		qldbStreamResourceType,
-		"aws",
-		map[string]string{
-			"ledger_name": ledgerName,
-			"stream_name": streamName,
-		},
-		qldbAllowEmptyValues,
-		map[string]interface{}{}), true
-}
-
-func qldbStreamImportable(status qldbtypes.StreamStatus) bool {
-	switch status {
-	case qldbtypes.StreamStatusCompleted, qldbtypes.StreamStatusCanceled, qldbtypes.StreamStatusFailed:
-		return false
-	default:
-		return true
-	}
-}
-
-func qldbShouldEmitLedger(filters []terraformutils.ResourceFilter, ledgerName string) bool {
-	if !qldbHasTypedFilter(filters) {
-		return true
-	}
-	if !awsHasApplicableFilter(filters, qldbLedgerResourceType) {
-		return false
-	}
-	return awsIDFilterAllows(awsTypedIDFilterValues(filters, qldbLedgerResourceType), ledgerName)
-}
-
-func qldbHasTypedFilter(filters []terraformutils.ResourceFilter) bool {
-	return awsHasTypedFilter(filters, qldbLedgerResourceType) ||
-		awsHasTypedFilter(filters, qldbStreamResourceType)
-}
-
-func qldbShouldLoadStreams(filters []terraformutils.ResourceFilter) bool {
-	return !qldbHasTypedFilter(filters) || awsHasTypedFilter(filters, qldbStreamResourceType)
-}
-
-func qldbLedgerIDFilter(filters []terraformutils.ResourceFilter) map[string]bool {
-	if len(awsTypedIDFilterValues(filters, qldbStreamResourceType)) > 0 {
-		return nil
-	}
-	return awsTypedIDFilterValues(filters, qldbLedgerResourceType)
-}
-
 func qldbLedgerImportID(ledgerName string) string {
 	return ledgerName
-}
-
-func qldbStreamImportID(streamID string) string {
-	return streamID
-}
-
-func qldbResourceName(parts ...string) string {
-	cleanParts := []string{}
-	for _, part := range parts {
-		if part != "" {
-			cleanParts = append(cleanParts, fmt.Sprintf("%d/%s", len(part), part))
-		}
-	}
-	if len(cleanParts) == 0 {
-		return "qldb-resource"
-	}
-	return strings.Join(cleanParts, "/")
-}
-
-func qldbStreamNotFound(err error) bool {
-	var notFound *qldbtypes.ResourceNotFoundException
-	return errors.As(err, &notFound)
 }

--- a/providers/aws/qldb.go
+++ b/providers/aws/qldb.go
@@ -48,14 +48,16 @@ func (g *QLDBGenerator) loadLedgers(svc *qldb.Client) error {
 			if !awsIDFilterAllows(ledgerIDFilter, ledgerName) {
 				continue
 			}
-			if resource, ok := newQLDBLedgerResource(ledgerName); ok {
+			if resource, ok := newQLDBLedgerResource(ledgerName); ok && qldbShouldEmitLedger(g.Filter, ledgerName) {
 				g.Resources = append(g.Resources, resource)
 			}
 			if ledgerName == "" {
 				continue
 			}
-			if err := g.loadStreams(svc, ledgerName); err != nil {
-				log.Printf("[WARN] Skipping QLDB streams for ledger %s: %v", ledgerName, err)
+			if qldbShouldLoadStreams(g.Filter) {
+				if err := g.loadStreams(svc, ledgerName); err != nil {
+					log.Printf("[WARN] Skipping QLDB streams for ledger %s: %v", ledgerName, err)
+				}
 			}
 		}
 	}
@@ -125,6 +127,25 @@ func qldbStreamImportable(status qldbtypes.StreamStatus) bool {
 	default:
 		return true
 	}
+}
+
+func qldbShouldEmitLedger(filters []terraformutils.ResourceFilter, ledgerName string) bool {
+	if !qldbHasTypedFilter(filters) {
+		return true
+	}
+	if !awsHasApplicableFilter(filters, qldbLedgerResourceType) {
+		return false
+	}
+	return awsIDFilterAllows(awsTypedIDFilterValues(filters, qldbLedgerResourceType), ledgerName)
+}
+
+func qldbHasTypedFilter(filters []terraformutils.ResourceFilter) bool {
+	return awsHasTypedFilter(filters, qldbLedgerResourceType) ||
+		awsHasTypedFilter(filters, qldbStreamResourceType)
+}
+
+func qldbShouldLoadStreams(filters []terraformutils.ResourceFilter) bool {
+	return !qldbHasTypedFilter(filters) || awsHasTypedFilter(filters, qldbStreamResourceType)
 }
 
 func qldbLedgerIDFilter(filters []terraformutils.ResourceFilter) map[string]bool {

--- a/providers/aws/qldb.go
+++ b/providers/aws/qldb.go
@@ -36,6 +36,7 @@ func (g *QLDBGenerator) InitResources() error {
 }
 
 func (g *QLDBGenerator) loadLedgers(svc *qldb.Client) error {
+	ledgerIDFilter := awsTypedIDFilterValues(g.Filter, qldbLedgerResourceType)
 	p := qldb.NewListLedgersPaginator(svc, &qldb.ListLedgersInput{})
 	for p.HasMorePages() {
 		page, err := p.NextPage(context.TODO())
@@ -44,6 +45,9 @@ func (g *QLDBGenerator) loadLedgers(svc *qldb.Client) error {
 		}
 		for _, ledger := range page.Ledgers {
 			ledgerName := StringValue(ledger.Name)
+			if !awsIDFilterAllows(ledgerIDFilter, ledgerName) {
+				continue
+			}
 			if resource, ok := newQLDBLedgerResource(ledgerName); ok {
 				g.Resources = append(g.Resources, resource)
 			}

--- a/providers/aws/qldb.go
+++ b/providers/aws/qldb.go
@@ -36,7 +36,7 @@ func (g *QLDBGenerator) InitResources() error {
 }
 
 func (g *QLDBGenerator) loadLedgers(svc *qldb.Client) error {
-	ledgerIDFilter := awsTypedIDFilterValues(g.Filter, qldbLedgerResourceType)
+	ledgerIDFilter := qldbLedgerIDFilter(g.Filter)
 	p := qldb.NewListLedgersPaginator(svc, &qldb.ListLedgersInput{})
 	for p.HasMorePages() {
 		page, err := p.NextPage(context.TODO())
@@ -125,6 +125,13 @@ func qldbStreamImportable(status qldbtypes.StreamStatus) bool {
 	default:
 		return true
 	}
+}
+
+func qldbLedgerIDFilter(filters []terraformutils.ResourceFilter) map[string]bool {
+	if len(awsTypedIDFilterValues(filters, qldbStreamResourceType)) > 0 {
+		return nil
+	}
+	return awsTypedIDFilterValues(filters, qldbLedgerResourceType)
 }
 
 func qldbLedgerImportID(ledgerName string) string {

--- a/providers/aws/qldb.go
+++ b/providers/aws/qldb.go
@@ -5,9 +5,19 @@ package aws
 
 import (
 	"context"
+	"errors"
+	"fmt"
+	"log"
+	"strings"
 
 	"github.com/aws/aws-sdk-go-v2/service/qldb"
+	qldbtypes "github.com/aws/aws-sdk-go-v2/service/qldb/types"
 	"github.com/chenrui333/terraformer/terraformutils"
+)
+
+const (
+	qldbLedgerResourceType = "aws_qldb_ledger"
+	qldbStreamResourceType = "aws_qldb_stream"
 )
 
 var qldbAllowEmptyValues = []string{"tags."}
@@ -22,8 +32,11 @@ func (g *QLDBGenerator) InitResources() error {
 		return e
 	}
 	svc := qldb.NewFromConfig(config)
+	return g.loadLedgers(svc)
+}
+
+func (g *QLDBGenerator) loadLedgers(svc *qldb.Client) error {
 	p := qldb.NewListLedgersPaginator(svc, &qldb.ListLedgersInput{})
-	var resources []terraformutils.Resource
 	for p.HasMorePages() {
 		page, err := p.NextPage(context.TODO())
 		if err != nil {
@@ -31,14 +44,107 @@ func (g *QLDBGenerator) InitResources() error {
 		}
 		for _, ledger := range page.Ledgers {
 			ledgerName := StringValue(ledger.Name)
-			resources = append(resources, terraformutils.NewSimpleResource(
-				ledgerName,
-				ledgerName,
-				"aws_qldb_ledger",
-				"aws",
-				qldbAllowEmptyValues))
+			if resource, ok := newQLDBLedgerResource(ledgerName); ok {
+				g.Resources = append(g.Resources, resource)
+			}
+			if ledgerName == "" {
+				continue
+			}
+			if err := g.loadStreams(svc, ledgerName); err != nil {
+				log.Printf("[WARN] Skipping QLDB streams for ledger %s: %v", ledgerName, err)
+			}
 		}
 	}
-	g.Resources = resources
 	return nil
+}
+
+func (g *QLDBGenerator) loadStreams(svc *qldb.Client, ledgerName string) error {
+	p := qldb.NewListJournalKinesisStreamsForLedgerPaginator(svc, &qldb.ListJournalKinesisStreamsForLedgerInput{
+		LedgerName: &ledgerName,
+	})
+	for p.HasMorePages() {
+		page, err := p.NextPage(context.TODO())
+		if qldbStreamNotFound(err) {
+			return nil
+		}
+		if err != nil {
+			return err
+		}
+		for _, stream := range page.Streams {
+			if resource, ok := newQLDBStreamResource(ledgerName, stream); ok {
+				g.Resources = append(g.Resources, resource)
+			}
+		}
+	}
+
+	return nil
+}
+
+func newQLDBLedgerResource(ledgerName string) (terraformutils.Resource, bool) {
+	if ledgerName == "" {
+		return terraformutils.Resource{}, false
+	}
+	return terraformutils.NewSimpleResource(
+		qldbLedgerImportID(ledgerName),
+		ledgerName,
+		qldbLedgerResourceType,
+		"aws",
+		qldbAllowEmptyValues), true
+}
+
+func newQLDBStreamResource(ledgerName string, stream qldbtypes.JournalKinesisStreamDescription) (terraformutils.Resource, bool) {
+	streamID := StringValue(stream.StreamId)
+	if ledgerName == "" || streamID == "" || !qldbStreamImportable(stream.Status) {
+		return terraformutils.Resource{}, false
+	}
+	streamName := StringValue(stream.StreamName)
+	if streamName == "" {
+		streamName = streamID
+	}
+	return terraformutils.NewResource(
+		qldbStreamImportID(streamID),
+		qldbResourceName("stream", ledgerName, streamName, streamID),
+		qldbStreamResourceType,
+		"aws",
+		map[string]string{
+			"ledger_name": ledgerName,
+			"stream_name": streamName,
+		},
+		qldbAllowEmptyValues,
+		map[string]interface{}{}), true
+}
+
+func qldbStreamImportable(status qldbtypes.StreamStatus) bool {
+	switch status {
+	case qldbtypes.StreamStatusCompleted, qldbtypes.StreamStatusCanceled, qldbtypes.StreamStatusFailed:
+		return false
+	default:
+		return true
+	}
+}
+
+func qldbLedgerImportID(ledgerName string) string {
+	return ledgerName
+}
+
+func qldbStreamImportID(streamID string) string {
+	return streamID
+}
+
+func qldbResourceName(parts ...string) string {
+	cleanParts := []string{}
+	for _, part := range parts {
+		if part != "" {
+			cleanParts = append(cleanParts, fmt.Sprintf("%d/%s", len(part), part))
+		}
+	}
+	if len(cleanParts) == 0 {
+		return "qldb-resource"
+	}
+	return strings.Join(cleanParts, "/")
+}
+
+func qldbStreamNotFound(err error) bool {
+	var notFound *qldbtypes.ResourceNotFoundException
+	return errors.As(err, &notFound)
 }

--- a/providers/aws/qldb_test.go
+++ b/providers/aws/qldb_test.go
@@ -3,11 +3,8 @@
 package aws
 
 import (
-	"errors"
 	"testing"
 
-	"github.com/aws/aws-sdk-go-v2/aws"
-	qldbtypes "github.com/aws/aws-sdk-go-v2/service/qldb/types"
 	"github.com/chenrui333/terraformer/terraformutils"
 )
 
@@ -20,156 +17,9 @@ func TestNewQLDBLedgerResource(t *testing.T) {
 	}
 }
 
-func TestNewQLDBStreamResource(t *testing.T) {
-	resource, ok := newQLDBStreamResource("ledger", qldbtypes.JournalKinesisStreamDescription{
-		StreamId:   aws.String("stream-id"),
-		StreamName: aws.String("journal-stream"),
-		Status:     qldbtypes.StreamStatusActive,
-	})
-	assertQLDBResource(t, resource, ok, "stream-id", qldbResourceName("stream", "ledger", "journal-stream", "stream-id"), qldbStreamResourceType)
-	assertQLDBAttribute(t, resource, "ledger_name", "ledger")
-	assertQLDBAttribute(t, resource, "stream_name", "journal-stream")
-}
-
-func TestQLDBStreamSkipsEmptyIdentifiers(t *testing.T) {
-	if _, ok := newQLDBStreamResource("", qldbtypes.JournalKinesisStreamDescription{
-		StreamId:   aws.String("stream-id"),
-		StreamName: aws.String("journal-stream"),
-		Status:     qldbtypes.StreamStatusActive,
-	}); ok {
-		t.Fatal("stream with empty ledger name should be skipped")
-	}
-
-	if _, ok := newQLDBStreamResource("ledger", qldbtypes.JournalKinesisStreamDescription{
-		StreamName: aws.String("journal-stream"),
-		Status:     qldbtypes.StreamStatusActive,
-	}); ok {
-		t.Fatal("stream with empty ID should be skipped")
-	}
-}
-
-func TestQLDBStreamImportable(t *testing.T) {
-	tests := []struct {
-		name   string
-		status qldbtypes.StreamStatus
-		want   bool
-	}{
-		{name: "active", status: qldbtypes.StreamStatusActive, want: true},
-		{name: "impaired", status: qldbtypes.StreamStatusImpaired, want: true},
-		{name: "empty", want: true},
-		{name: "completed", status: qldbtypes.StreamStatusCompleted, want: false},
-		{name: "canceled", status: qldbtypes.StreamStatusCanceled, want: false},
-		{name: "failed", status: qldbtypes.StreamStatusFailed, want: false},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			if got := qldbStreamImportable(tt.status); got != tt.want {
-				t.Fatalf("qldbStreamImportable(%q) = %t, want %t", tt.status, got, tt.want)
-			}
-		})
-	}
-}
-
 func TestQLDBImportIDs(t *testing.T) {
 	if got, want := qldbLedgerImportID("ledger"), "ledger"; got != want {
 		t.Fatalf("QLDB ledger import ID = %q, want %q", got, want)
-	}
-	if got, want := qldbStreamImportID("stream-id"), "stream-id"; got != want {
-		t.Fatalf("QLDB stream import ID = %q, want %q", got, want)
-	}
-}
-
-func TestQLDBResourceNamesPreserveSegmentBoundaries(t *testing.T) {
-	left := terraformutils.TfSanitize(qldbResourceName("stream", "ledger/a_b", "stream-id"))
-	right := terraformutils.TfSanitize(qldbResourceName("stream", "ledger", "a_b/stream-id"))
-	if left == right {
-		t.Fatalf("QLDB resource names collide: %q", left)
-	}
-}
-
-func TestQLDBLedgerIDFilterAllowsAllWhenStreamIDsAreRequested(t *testing.T) {
-	service := terraformutils.Service{}
-	service.ParseFilters([]string{
-		"qldb_ledger=ledger-a",
-		"qldb_stream=stream-b",
-	})
-
-	filter := qldbLedgerIDFilter(service.Filter)
-	if !awsIDFilterAllows(filter, "ledger-b") {
-		t.Fatalf("QLDB stream ID filter should disable ledger prefilter: %#v", filter)
-	}
-}
-
-func TestQLDBLedgerIDFilterRestrictsLedgerOnlyFilters(t *testing.T) {
-	service := terraformutils.Service{}
-	service.ParseFilters([]string{"qldb_ledger=ledger-a"})
-
-	filter := qldbLedgerIDFilter(service.Filter)
-	if !awsIDFilterAllows(filter, "ledger-a") {
-		t.Fatalf("QLDB ledger filter should allow ledger-a: %#v", filter)
-	}
-	if awsIDFilterAllows(filter, "ledger-b") {
-		t.Fatalf("QLDB ledger filter allowed unrelated ledger: %#v", filter)
-	}
-}
-
-func TestQLDBShouldEmitLedgerSkipsStreamOnlyFilters(t *testing.T) {
-	service := terraformutils.Service{}
-	service.ParseFilters([]string{"qldb_stream=stream-id"})
-
-	if qldbShouldEmitLedger(service.Filter, "ledger-a") {
-		t.Fatal("stream-only filter should scan but not emit ledger resources")
-	}
-}
-
-func TestQLDBShouldEmitLedgerHonorsLedgerFilters(t *testing.T) {
-	service := terraformutils.Service{}
-	service.ParseFilters([]string{
-		"qldb_ledger=ledger-a",
-		"qldb_stream=stream-id",
-	})
-
-	if !qldbShouldEmitLedger(service.Filter, "ledger-a") {
-		t.Fatal("ledger filter should emit matching ledger")
-	}
-	if qldbShouldEmitLedger(service.Filter, "ledger-b") {
-		t.Fatal("ledger filter should not emit unrelated ledgers")
-	}
-}
-
-func TestQLDBShouldLoadStreamsOnlyWhenRequested(t *testing.T) {
-	ledgerService := terraformutils.Service{}
-	ledgerService.ParseFilters([]string{"qldb_ledger=ledger-a"})
-	if qldbShouldLoadStreams(ledgerService.Filter) {
-		t.Fatal("ledger-only filter should not load stream resources")
-	}
-
-	streamService := terraformutils.Service{}
-	streamService.ParseFilters([]string{"qldb_stream=stream-id"})
-	if !qldbShouldLoadStreams(streamService.Filter) {
-		t.Fatal("stream filter should load stream resources")
-	}
-}
-
-func TestQLDBStreamNotFound(t *testing.T) {
-	tests := []struct {
-		name string
-		err  error
-		want bool
-	}{
-		{name: "nil", want: false},
-		{name: "resource not found", err: &qldbtypes.ResourceNotFoundException{}, want: true},
-		{name: "wrapped resource not found", err: errors.Join(errors.New("lookup failed"), &qldbtypes.ResourceNotFoundException{}), want: true},
-		{name: "generic", err: errors.New("boom"), want: false},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			if got := qldbStreamNotFound(tt.err); got != tt.want {
-				t.Fatalf("qldbStreamNotFound(%v) = %t, want %t", tt.err, got, tt.want)
-			}
-		})
 	}
 }
 
@@ -186,12 +36,5 @@ func assertQLDBResource(t *testing.T, resource terraformutils.Resource, ok bool,
 	}
 	if got := resource.InstanceInfo.Type; got != wantType {
 		t.Fatalf("resource type = %q, want %q", got, wantType)
-	}
-}
-
-func assertQLDBAttribute(t *testing.T, resource terraformutils.Resource, key, want string) {
-	t.Helper()
-	if got := resource.InstanceState.Attributes[key]; got != want {
-		t.Fatalf("resource attribute %q = %q, want %q", key, got, want)
 	}
 }

--- a/providers/aws/qldb_test.go
+++ b/providers/aws/qldb_test.go
@@ -1,0 +1,133 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package aws
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	qldbtypes "github.com/aws/aws-sdk-go-v2/service/qldb/types"
+	"github.com/chenrui333/terraformer/terraformutils"
+)
+
+func TestNewQLDBLedgerResource(t *testing.T) {
+	resource, ok := newQLDBLedgerResource("ledger")
+	assertQLDBResource(t, resource, ok, "ledger", "ledger", qldbLedgerResourceType)
+
+	if _, ok := newQLDBLedgerResource(""); ok {
+		t.Fatal("ledger with empty name should be skipped")
+	}
+}
+
+func TestNewQLDBStreamResource(t *testing.T) {
+	resource, ok := newQLDBStreamResource("ledger", qldbtypes.JournalKinesisStreamDescription{
+		StreamId:   aws.String("stream-id"),
+		StreamName: aws.String("journal-stream"),
+		Status:     qldbtypes.StreamStatusActive,
+	})
+	assertQLDBResource(t, resource, ok, "stream-id", qldbResourceName("stream", "ledger", "journal-stream", "stream-id"), qldbStreamResourceType)
+	assertQLDBAttribute(t, resource, "ledger_name", "ledger")
+	assertQLDBAttribute(t, resource, "stream_name", "journal-stream")
+}
+
+func TestQLDBStreamSkipsEmptyIdentifiers(t *testing.T) {
+	if _, ok := newQLDBStreamResource("", qldbtypes.JournalKinesisStreamDescription{
+		StreamId:   aws.String("stream-id"),
+		StreamName: aws.String("journal-stream"),
+		Status:     qldbtypes.StreamStatusActive,
+	}); ok {
+		t.Fatal("stream with empty ledger name should be skipped")
+	}
+
+	if _, ok := newQLDBStreamResource("ledger", qldbtypes.JournalKinesisStreamDescription{
+		StreamName: aws.String("journal-stream"),
+		Status:     qldbtypes.StreamStatusActive,
+	}); ok {
+		t.Fatal("stream with empty ID should be skipped")
+	}
+}
+
+func TestQLDBStreamImportable(t *testing.T) {
+	tests := []struct {
+		name   string
+		status qldbtypes.StreamStatus
+		want   bool
+	}{
+		{name: "active", status: qldbtypes.StreamStatusActive, want: true},
+		{name: "impaired", status: qldbtypes.StreamStatusImpaired, want: true},
+		{name: "empty", want: true},
+		{name: "completed", status: qldbtypes.StreamStatusCompleted, want: false},
+		{name: "canceled", status: qldbtypes.StreamStatusCanceled, want: false},
+		{name: "failed", status: qldbtypes.StreamStatusFailed, want: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := qldbStreamImportable(tt.status); got != tt.want {
+				t.Fatalf("qldbStreamImportable(%q) = %t, want %t", tt.status, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestQLDBImportIDs(t *testing.T) {
+	if got, want := qldbLedgerImportID("ledger"), "ledger"; got != want {
+		t.Fatalf("QLDB ledger import ID = %q, want %q", got, want)
+	}
+	if got, want := qldbStreamImportID("stream-id"), "stream-id"; got != want {
+		t.Fatalf("QLDB stream import ID = %q, want %q", got, want)
+	}
+}
+
+func TestQLDBResourceNamesPreserveSegmentBoundaries(t *testing.T) {
+	left := terraformutils.TfSanitize(qldbResourceName("stream", "ledger/a_b", "stream-id"))
+	right := terraformutils.TfSanitize(qldbResourceName("stream", "ledger", "a_b/stream-id"))
+	if left == right {
+		t.Fatalf("QLDB resource names collide: %q", left)
+	}
+}
+
+func TestQLDBStreamNotFound(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{name: "nil", want: false},
+		{name: "resource not found", err: &qldbtypes.ResourceNotFoundException{}, want: true},
+		{name: "wrapped resource not found", err: errors.Join(errors.New("lookup failed"), &qldbtypes.ResourceNotFoundException{}), want: true},
+		{name: "generic", err: errors.New("boom"), want: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := qldbStreamNotFound(tt.err); got != tt.want {
+				t.Fatalf("qldbStreamNotFound(%v) = %t, want %t", tt.err, got, tt.want)
+			}
+		})
+	}
+}
+
+func assertQLDBResource(t *testing.T, resource terraformutils.Resource, ok bool, wantID, wantName, wantType string) {
+	t.Helper()
+	if !ok {
+		t.Fatal("resource was skipped")
+	}
+	if got := resource.InstanceState.ID; got != wantID {
+		t.Fatalf("resource ID = %q, want %q", got, wantID)
+	}
+	if got := resource.ResourceName; got != terraformutils.TfSanitize(wantName) {
+		t.Fatalf("resource name = %q, want %q", got, terraformutils.TfSanitize(wantName))
+	}
+	if got := resource.InstanceInfo.Type; got != wantType {
+		t.Fatalf("resource type = %q, want %q", got, wantType)
+	}
+}
+
+func assertQLDBAttribute(t *testing.T, resource terraformutils.Resource, key, want string) {
+	t.Helper()
+	if got := resource.InstanceState.Attributes[key]; got != want {
+		t.Fatalf("resource attribute %q = %q, want %q", key, got, want)
+	}
+}

--- a/providers/aws/qldb_test.go
+++ b/providers/aws/qldb_test.go
@@ -114,6 +114,44 @@ func TestQLDBLedgerIDFilterRestrictsLedgerOnlyFilters(t *testing.T) {
 	}
 }
 
+func TestQLDBShouldEmitLedgerSkipsStreamOnlyFilters(t *testing.T) {
+	service := terraformutils.Service{}
+	service.ParseFilters([]string{"qldb_stream=stream-id"})
+
+	if qldbShouldEmitLedger(service.Filter, "ledger-a") {
+		t.Fatal("stream-only filter should scan but not emit ledger resources")
+	}
+}
+
+func TestQLDBShouldEmitLedgerHonorsLedgerFilters(t *testing.T) {
+	service := terraformutils.Service{}
+	service.ParseFilters([]string{
+		"qldb_ledger=ledger-a",
+		"qldb_stream=stream-id",
+	})
+
+	if !qldbShouldEmitLedger(service.Filter, "ledger-a") {
+		t.Fatal("ledger filter should emit matching ledger")
+	}
+	if qldbShouldEmitLedger(service.Filter, "ledger-b") {
+		t.Fatal("ledger filter should not emit unrelated ledgers")
+	}
+}
+
+func TestQLDBShouldLoadStreamsOnlyWhenRequested(t *testing.T) {
+	ledgerService := terraformutils.Service{}
+	ledgerService.ParseFilters([]string{"qldb_ledger=ledger-a"})
+	if qldbShouldLoadStreams(ledgerService.Filter) {
+		t.Fatal("ledger-only filter should not load stream resources")
+	}
+
+	streamService := terraformutils.Service{}
+	streamService.ParseFilters([]string{"qldb_stream=stream-id"})
+	if !qldbShouldLoadStreams(streamService.Filter) {
+		t.Fatal("stream filter should load stream resources")
+	}
+}
+
 func TestQLDBStreamNotFound(t *testing.T) {
 	tests := []struct {
 		name string

--- a/providers/aws/qldb_test.go
+++ b/providers/aws/qldb_test.go
@@ -88,6 +88,32 @@ func TestQLDBResourceNamesPreserveSegmentBoundaries(t *testing.T) {
 	}
 }
 
+func TestQLDBLedgerIDFilterAllowsAllWhenStreamIDsAreRequested(t *testing.T) {
+	service := terraformutils.Service{}
+	service.ParseFilters([]string{
+		"qldb_ledger=ledger-a",
+		"qldb_stream=stream-b",
+	})
+
+	filter := qldbLedgerIDFilter(service.Filter)
+	if !awsIDFilterAllows(filter, "ledger-b") {
+		t.Fatalf("QLDB stream ID filter should disable ledger prefilter: %#v", filter)
+	}
+}
+
+func TestQLDBLedgerIDFilterRestrictsLedgerOnlyFilters(t *testing.T) {
+	service := terraformutils.Service{}
+	service.ParseFilters([]string{"qldb_ledger=ledger-a"})
+
+	filter := qldbLedgerIDFilter(service.Filter)
+	if !awsIDFilterAllows(filter, "ledger-a") {
+		t.Fatalf("QLDB ledger filter should allow ledger-a: %#v", filter)
+	}
+	if awsIDFilterAllows(filter, "ledger-b") {
+		t.Fatalf("QLDB ledger filter allowed unrelated ledger: %#v", filter)
+	}
+}
+
 func TestQLDBStreamNotFound(t *testing.T) {
 	tests := []struct {
 		name string

--- a/providers/aws/unsupported_resources.json
+++ b/providers/aws/unsupported_resources.json
@@ -353,6 +353,19 @@
       ]
     },
     {
+      "resource": "aws_mq_broker",
+      "service_family": "mq",
+      "reason": "MQ brokers require sensitive user.password values, and LDAP brokers can require service_account_password; Amazon MQ APIs do not return those passwords for imported brokers.",
+      "evidence": "Terraform AWS provider marks user.password as required and sensitive, and its Read path only preserves user passwords from prior Terraform state while DescribeBroker/DescribeUser return user metadata without password values. Terraformer cannot seed those passwords during broad discovery.",
+      "status": "unsupported",
+      "references": [
+        "https://github.com/chenrui333/terraformer/issues/338",
+        "https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/mq_broker",
+        "https://docs.aws.amazon.com/amazon-mq/latest/api-reference/brokers-broker-id.html",
+        "https://docs.aws.amazon.com/amazon-mq/latest/api-reference/brokers-broker-id-users-username.html"
+      ]
+    },
+    {
       "resource": "aws_opensearch_package",
       "service_family": "opensearch",
       "reason": "OpenSearch packages require package_source.s3_bucket_name and package_source.s3_key, but DescribePackages does not return the source S3 location needed to seed valid Terraform configuration.",

--- a/providers/aws/unsupported_resources.json
+++ b/providers/aws/unsupported_resources.json
@@ -455,6 +455,18 @@
       ]
     },
     {
+      "resource": "aws_qldb_stream",
+      "service_family": "qldb",
+      "reason": "Terraform AWS provider v6.44.0 does not support importing QLDB streams, so Terraformer cannot seed a provider-recognized import state.",
+      "evidence": "The Terraform AWS provider aws_qldb_stream resource source has no ResourceImporter and the provider documentation has no Import section; its stream ID is assigned during Create.",
+      "status": "unsupported",
+      "references": [
+        "https://github.com/chenrui333/terraformer/issues/338",
+        "https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/qldb_stream",
+        "https://docs.aws.amazon.com/qldb/latest/developerguide/streams.html"
+      ]
+    },
+    {
       "resource": "aws_sagemaker_human_task_ui",
       "service_family": "sagemaker",
       "reason": "SageMaker Human Task UI imports cannot reconstruct the required ui_template.content field from SageMaker APIs.",

--- a/providers/aws/unsupported_resources.json
+++ b/providers/aws/unsupported_resources.json
@@ -215,6 +215,28 @@
       ]
     },
     {
+      "resource": "aws_elastic_beanstalk_application_version",
+      "service_family": "elastic_beanstalk",
+      "reason": "Elastic Beanstalk application versions are not importable by the Terraform AWS provider in the audited v6.44.0 source.",
+      "evidence": "The provider resource has no ResourceImporter and the read path depends on application and source bundle state that is not represented by an import ID.",
+      "status": "unsupported",
+      "references": [
+        "https://github.com/chenrui333/terraformer/issues/338",
+        "https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/elastic_beanstalk_application_version"
+      ]
+    },
+    {
+      "resource": "aws_elastic_beanstalk_configuration_template",
+      "service_family": "elastic_beanstalk",
+      "reason": "Elastic Beanstalk configuration templates are not importable by the Terraform AWS provider in the audited v6.44.0 source.",
+      "evidence": "The provider resource has no ResourceImporter and its read path requires application and template-name state rather than a standalone import ID.",
+      "status": "unsupported",
+      "references": [
+        "https://github.com/chenrui333/terraformer/issues/338",
+        "https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/elastic_beanstalk_configuration_template"
+      ]
+    },
+    {
       "resource": "aws_glue_partition",
       "service_family": "glue",
       "reason": "Glue partitions are high-cardinality table data objects; broad account discovery can produce very large Terraform output and needs an explicit filtered follow-up design.",

--- a/terraformutils/providerwrapper/provider.go
+++ b/terraformutils/providerwrapper/provider.go
@@ -310,14 +310,26 @@ func (p *ProviderWrapper) initProvider(verbose bool) error {
 }
 
 func (p *ProviderWrapper) Restart() error {
+	replacement := &ProviderWrapper{
+		providerName: p.providerName,
+		config:       p.config,
+		retryCount:   p.retryCount,
+		retrySleepMs: p.retrySleepMs,
+		verbose:      p.verbose,
+	}
+	if err := replacement.initProvider(p.verbose); err != nil {
+		replacement.Kill()
+		return err
+	}
+
 	if p.client != nil {
 		p.client.Kill()
 	}
-	p.Provider = nil
-	p.client = nil
-	p.rpcClient = nil
-	p.schema = nil
-	return p.initProvider(p.verbose)
+	p.Provider = replacement.Provider
+	p.client = replacement.client
+	p.rpcClient = replacement.rpcClient
+	p.schema = replacement.schema
+	return nil
 }
 
 func (p *ProviderWrapper) configureProvider() error {

--- a/terraformutils/providerwrapper/provider.go
+++ b/terraformutils/providerwrapper/provider.go
@@ -41,12 +41,14 @@ type ProviderWrapper struct {
 	schema       *providerproto.GetProviderSchemaResponse
 	retryCount   int
 	retrySleepMs int
+	verbose      bool
 }
 
 func NewProviderWrapper(providerName string, providerConfig cty.Value, verbose bool, options ...map[string]int) (*ProviderWrapper, error) {
 	p := &ProviderWrapper{retryCount: 5, retrySleepMs: 300}
 	p.providerName = providerName
 	p.config = providerConfig
+	p.verbose = verbose
 
 	if len(options) > 0 {
 		retryCount, hasOption := options[0]["retryCount"]
@@ -65,7 +67,9 @@ func NewProviderWrapper(providerName string, providerConfig cty.Value, verbose b
 }
 
 func (p *ProviderWrapper) Kill() {
-	p.client.Kill()
+	if p.client != nil {
+		p.client.Kill()
+	}
 }
 
 func (p *ProviderWrapper) GetSchema() *providerproto.GetProviderSchemaResponse {
@@ -302,6 +306,21 @@ func (p *ProviderWrapper) initProvider(verbose bool) error {
 
 	p.Provider = raw.(*providerproto.GRPCProvider)
 
+	return p.configureProvider()
+}
+
+func (p *ProviderWrapper) Restart() error {
+	if p.client != nil {
+		p.client.Kill()
+	}
+	p.Provider = nil
+	p.client = nil
+	p.rpcClient = nil
+	p.schema = nil
+	return p.initProvider(p.verbose)
+}
+
+func (p *ProviderWrapper) configureProvider() error {
 	config, err := p.GetSchema().Provider.Block.CoerceValue(p.config)
 	if err != nil {
 		return err
@@ -313,7 +332,6 @@ func (p *ProviderWrapper) initProvider(verbose bool) error {
 	if configureResp.Diagnostics.HasErrors() {
 		return configureResp.Diagnostics.Err()
 	}
-
 	return nil
 }
 

--- a/terraformutils/providerwrapper/provider_test.go
+++ b/terraformutils/providerwrapper/provider_test.go
@@ -11,9 +11,31 @@ import (
 
 	"github.com/chenrui333/terraformer/terraformutils/tfcompat"
 	"github.com/chenrui333/terraformer/terraformutils/tfcompat/configschema"
+	"github.com/chenrui333/terraformer/terraformutils/tfcompat/providerproto"
 	"github.com/chenrui333/terraformer/terraformutils/typedjson"
 	"github.com/zclconf/go-cty/cty"
 )
+
+func TestRestartPreservesCurrentProviderOnInitError(t *testing.T) {
+	currentProvider := &providerproto.GRPCProvider{}
+	currentSchema := &providerproto.GetProviderSchemaResponse{}
+	provider := &ProviderWrapper{
+		Provider:     currentProvider,
+		providerName: "missing-provider-for-restart-test",
+		config:       cty.EmptyObjectVal,
+		schema:       currentSchema,
+	}
+
+	if err := provider.Restart(); err == nil {
+		t.Fatal("Restart() error = nil, want provider initialization error")
+	}
+	if provider.Provider != currentProvider {
+		t.Fatal("Restart() replaced the current provider after initialization failed")
+	}
+	if provider.schema != currentSchema {
+		t.Fatal("Restart() replaced the current schema after initialization failed")
+	}
+}
 
 func TestIgnoredAttributes(t *testing.T) {
 	attributes := map[string]*configschema.Attribute{


### PR DESCRIPTION
## Summary

- add long-tail import discovery for Device Farm child resources, Cloud9 memberships, DataPipeline pipeline definitions, MQ configurations, and MediaConvert queues
- register media_convert and add the AWS SDK v2 MediaConvert dependency
- correct MQ broker discovery to use broker IDs for Terraform provider imports
- update docs/aws.md for the supported long-tail resources
- mark Elastic Beanstalk application versions/configuration templates and QLDB streams unsupported where the Terraform AWS provider has no importer
- add unit tests for import IDs, resource construction, skip behavior, resource-name uniqueness, and unsupported-resource metadata

## References

- #338

## Validation

~~~bash
go test ./providers/aws -run 'Test.*DeviceFarm|Test.*Devicefarm|Test.*devicefarm|Test.*Cloud9|Test.*cloud9|Test.*Beanstalk|Test.*beanstalk|Test.*MQ|Test.*Mq|Test.*mq|Test.*QLDB|Test.*Qldb|Test.*qldb|Test.*SWF|Test.*Swf|Test.*swf|Test.*DataPipeline|Test.*Datapipeline|Test.*datapipeline|Test.*OpsWorks|Test.*Opsworks|Test.*opsworks|Test.*MediaConvert|Test.*Mediaconvert|Test.*mediaconvert'
go test ./providers/aws/... ./terraformutils/...
go run ./tools/aws-gap-inventory \
  -docs docs/aws.md \
  -aws-dir providers/aws \
  -skip-list providers/aws/unsupported_resources.json \
  -format markdown
git diff --check
golangci-lint run --new-from-rev=main
~~~

## Notes

Skipped/deferred resources:
- aws_elastic_beanstalk_application_version: Terraform AWS provider v6.44.0 has no importer and the read path depends on application/source-bundle state rather than a standalone import ID
- aws_elastic_beanstalk_configuration_template: Terraform AWS provider v6.44.0 has no importer and the read path depends on application/template state rather than a standalone import ID
- aws_qldb_stream: Terraform AWS provider v6.44.0 has no importer and requires both ledger name and stream ID state
- Device Farm curated device pools/network profiles/uploads and MediaConvert system queues: AWS-managed resources are skipped; customer-created resources are imported
- OpsWorks: no OpsWorks resources are present in the audited Terraform AWS provider v6.44.0 schema, so existing Terraformer support was left unchanged

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds long‑tail imports for Cloud9 memberships, DataPipeline pipeline definitions (behind filters), Device Farm child resources, MediaConvert queues, MQ configurations, and QLDB ledgers. Registers `media_convert` with safe endpoint handling and improves filter and provider configuration behavior.

- **New Features**
  - Imports: Cloud9 environment memberships (skip owner and deleting/error), DataPipeline pipeline definitions (only when filtered; preserve empty strings), Device Farm device pools/network profiles/uploads/test grid projects/instance profiles, MediaConvert queues (skip system), MQ configurations, and QLDB ledgers.
  - Registers `media_convert`, adds `github.com/aws/aws-sdk-go-v2/service/mediaconvert`, updates docs, and expands the unsupported list (Elastic Beanstalk app versions/templates; MQ brokers; QLDB streams).

- **Bug Fixes**
  - MediaConvert: fall back to the account endpoint when regional endpoints need bootstrap; reconfigure the provider; restore endpoint overrides after import or failures; ignore NotFound/bootstrap errors.
  - DataPipeline: gate `aws_datapipeline_pipeline_definition` behind name/ID filters, preserve empty strings, and keep definitions for pipelines selected by those filters.
  - Discovery/provider: honor typed ID filters; prefilter parents by child IDs; keep scans open for mixed filters; forward `ConfigureImportProvider` via the AWS facade/CLI; make provider wrapper Kill nil‑safe and preserve the current provider when `Restart` fails.
  - Cloud9/Device Farm/QLDB: skip missing Cloud9 environments and owner memberships; only discover uploads when Device Farm project IDs are provided; skip QLDB stream imports (unsupported).

<sup>Written for commit fe025194a2913020b3071965b072c26d9da53728. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * AWS provider: import Cloud9 environment memberships, DataPipeline pipeline definitions, expanded Device Farm resources, MediaConvert queues, MQ configurations, and QLDB ledgers. Added per-service import-provider configuration support.

* **Documentation**
  * Updated supported AWS services list and refreshed unsupported-resources entries.

* **Tests**
  * Added extensive unit tests covering new resources, import rules, filters, error handling, and deterministic naming/import IDs.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/chenrui333/terraformer/pull/433)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->