### PR TITLE
aws(security): add event data store, service-linked role, server cert, key policy

### DIFF
--- a/providers/aws/cloudtrail.go
+++ b/providers/aws/cloudtrail.go
@@ -51,7 +51,7 @@ func (g *CloudTrailGenerator) addTrails(svc *cloudtrail.Client) error {
 }
 
 func eventDataStoreToResource(eds types.EventDataStore) (terraformutils.Resource, bool) {
-	if eds.EventDataStoreArn == nil || eds.Status == types.EventDataStoreStatusPendingDeletion {
+	if eds.EventDataStoreArn == nil {
 		return terraformutils.Resource{}, false
 	}
 	edsARN := *eds.EventDataStoreArn

--- a/providers/aws/cloudtrail.go
+++ b/providers/aws/cloudtrail.go
@@ -50,22 +50,17 @@ func (g *CloudTrailGenerator) addTrails(svc *cloudtrail.Client) error {
 	return nil
 }
 
-func eventDataStoreToResource(eds types.EventDataStore) (terraformutils.Resource, bool) {
-	if eds.EventDataStoreArn == nil {
-		return terraformutils.Resource{}, false
-	}
-	edsARN := *eds.EventDataStoreArn
-	edsName := StringValue(eds.Name)
-	if edsName == "" {
-		edsName = arnLastSegment(edsARN, "/")
+func eventDataStoreToResource(arn, name string) terraformutils.Resource {
+	if name == "" {
+		name = arnLastSegment(arn, "/")
 	}
 	return terraformutils.NewSimpleResource(
-		edsARN,
-		edsName,
+		arn,
+		name,
 		"aws_cloudtrail_event_data_store",
 		"aws",
 		cloudtrailAllowEmptyValues,
-	), true
+	)
 }
 
 func (g *CloudTrailGenerator) addEventDataStores(svc *cloudtrail.Client) error {
@@ -76,9 +71,21 @@ func (g *CloudTrailGenerator) addEventDataStores(svc *cloudtrail.Client) error {
 			return err
 		}
 		for _, eds := range page.EventDataStores {
-			if resource, ok := eventDataStoreToResource(eds); ok {
-				g.Resources = append(g.Resources, resource)
+			if eds.EventDataStoreArn == nil {
+				continue
 			}
+			edsARN := *eds.EventDataStoreArn
+			detail, err := svc.GetEventDataStore(context.TODO(), &cloudtrail.GetEventDataStoreInput{
+				EventDataStore: &edsARN,
+			})
+			if err != nil {
+				log.Printf("Skipping event data store %s: %v", edsARN, err)
+				continue
+			}
+			if detail.Status == types.EventDataStoreStatusPendingDeletion {
+				continue
+			}
+			g.Resources = append(g.Resources, eventDataStoreToResource(edsARN, StringValue(detail.Name)))
 		}
 	}
 	return nil

--- a/providers/aws/cloudtrail.go
+++ b/providers/aws/cloudtrail.go
@@ -50,6 +50,24 @@ func (g *CloudTrailGenerator) addTrails(svc *cloudtrail.Client) error {
 	return nil
 }
 
+func eventDataStoreToResource(eds types.EventDataStore) (terraformutils.Resource, bool) {
+	if eds.EventDataStoreArn == nil || eds.Status == types.EventDataStoreStatusPendingDeletion {
+		return terraformutils.Resource{}, false
+	}
+	edsARN := *eds.EventDataStoreArn
+	edsName := StringValue(eds.Name)
+	if edsName == "" {
+		edsName = arnLastSegment(edsARN, "/")
+	}
+	return terraformutils.NewSimpleResource(
+		edsARN,
+		edsName,
+		"aws_cloudtrail_event_data_store",
+		"aws",
+		cloudtrailAllowEmptyValues,
+	), true
+}
+
 func (g *CloudTrailGenerator) addEventDataStores(svc *cloudtrail.Client) error {
 	p := cloudtrail.NewListEventDataStoresPaginator(svc, &cloudtrail.ListEventDataStoresInput{})
 	for p.HasMorePages() {
@@ -58,23 +76,9 @@ func (g *CloudTrailGenerator) addEventDataStores(svc *cloudtrail.Client) error {
 			return err
 		}
 		for _, eds := range page.EventDataStores {
-			if eds.EventDataStoreArn == nil {
-				continue
+			if resource, ok := eventDataStoreToResource(eds); ok {
+				g.Resources = append(g.Resources, resource)
 			}
-			if eds.Status == types.EventDataStoreStatusPendingDeletion {
-				continue
-			}
-			edsARN := *eds.EventDataStoreArn
-			edsName := StringValue(eds.Name)
-			if edsName == "" {
-				edsName = arnLastSegment(edsARN, "/")
-			}
-			g.Resources = append(g.Resources, terraformutils.NewSimpleResource(
-				edsARN,
-				edsName,
-				"aws_cloudtrail_event_data_store",
-				"aws",
-				cloudtrailAllowEmptyValues))
 		}
 	}
 	return nil

--- a/providers/aws/cloudtrail.go
+++ b/providers/aws/cloudtrail.go
@@ -4,6 +4,7 @@ package aws
 
 import (
 	"context"
+	"log"
 
 	"github.com/aws/aws-sdk-go-v2/service/cloudtrail"
 	"github.com/aws/aws-sdk-go-v2/service/cloudtrail/types"
@@ -16,30 +17,65 @@ type CloudTrailGenerator struct {
 	AWSService
 }
 
-func (g *CloudTrailGenerator) createResources(trailList []types.Trail) []terraformutils.Resource {
-	var resources []terraformutils.Resource
-	for _, trail := range trailList {
-		resourceName := StringValue(trail.Name)
-		resources = append(resources, terraformutils.NewSimpleResource(
-			resourceName,
-			resourceName,
-			"aws_cloudtrail",
-			"aws",
-			cloudtrailAllowEmptyValues))
-	}
-	return resources
-}
-
 func (g *CloudTrailGenerator) InitResources() error {
 	config, e := g.generateConfig()
 	if e != nil {
 		return e
 	}
 	svc := cloudtrail.NewFromConfig(config)
+
+	if err := g.addTrails(svc); err != nil {
+		return err
+	}
+	if err := g.addEventDataStores(svc); err != nil {
+		log.Printf("Skipping CloudTrail event data stores: %v", err)
+	}
+	return nil
+}
+
+func (g *CloudTrailGenerator) addTrails(svc *cloudtrail.Client) error {
 	output, err := svc.DescribeTrails(context.TODO(), &cloudtrail.DescribeTrailsInput{})
 	if err != nil {
 		return err
 	}
-	g.Resources = g.createResources(output.TrailList)
+	for _, trail := range output.TrailList {
+		resourceName := StringValue(trail.Name)
+		g.Resources = append(g.Resources, terraformutils.NewSimpleResource(
+			resourceName,
+			resourceName,
+			"aws_cloudtrail",
+			"aws",
+			cloudtrailAllowEmptyValues))
+	}
+	return nil
+}
+
+func (g *CloudTrailGenerator) addEventDataStores(svc *cloudtrail.Client) error {
+	p := cloudtrail.NewListEventDataStoresPaginator(svc, &cloudtrail.ListEventDataStoresInput{})
+	for p.HasMorePages() {
+		page, err := p.NextPage(context.TODO())
+		if err != nil {
+			return err
+		}
+		for _, eds := range page.EventDataStores {
+			if eds.EventDataStoreArn == nil {
+				continue
+			}
+			if eds.Status == types.EventDataStoreStatusPendingDeletion {
+				continue
+			}
+			edsARN := *eds.EventDataStoreArn
+			edsName := StringValue(eds.Name)
+			if edsName == "" {
+				edsName = arnLastSegment(edsARN, "/")
+			}
+			g.Resources = append(g.Resources, terraformutils.NewSimpleResource(
+				edsARN,
+				edsName,
+				"aws_cloudtrail_event_data_store",
+				"aws",
+				cloudtrailAllowEmptyValues))
+		}
+	}
 	return nil
 }

--- a/providers/aws/cloudtrail_test.go
+++ b/providers/aws/cloudtrail_test.go
@@ -1,0 +1,63 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package aws
+
+import (
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/service/cloudtrail/types"
+	"github.com/chenrui333/terraformer/terraformutils"
+)
+
+func TestCloudTrailEventDataStoreSkipsPendingDeletion(t *testing.T) {
+	edsList := []types.EventDataStore{
+		{
+			EventDataStoreArn: strPtr("arn:aws:cloudtrail:us-east-1:123456789012:eventdatastore/abc-123"),
+			Name:              strPtr("my-eds"),
+			Status:            types.EventDataStoreStatusEnabled,
+		},
+		{
+			EventDataStoreArn: strPtr("arn:aws:cloudtrail:us-east-1:123456789012:eventdatastore/del-456"),
+			Name:              strPtr("deleting-eds"),
+			Status:            types.EventDataStoreStatusPendingDeletion,
+		},
+	}
+
+	var resources []terraformutils.Resource
+	for _, eds := range edsList {
+		if eds.EventDataStoreArn == nil {
+			continue
+		}
+		if eds.Status == types.EventDataStoreStatusPendingDeletion {
+			continue
+		}
+		edsARN := *eds.EventDataStoreArn
+		edsName := StringValue(eds.Name)
+		if edsName == "" {
+			edsName = arnLastSegment(edsARN, "/")
+		}
+		resources = append(resources, terraformutils.NewSimpleResource(
+			edsARN, edsName, "aws_cloudtrail_event_data_store", "aws", cloudtrailAllowEmptyValues))
+	}
+
+	if len(resources) != 1 {
+		t.Fatalf("expected 1 resource, got %d", len(resources))
+	}
+	if got := resources[0].InstanceState.ID; got != "arn:aws:cloudtrail:us-east-1:123456789012:eventdatastore/abc-123" {
+		t.Fatalf("resource ID = %q, want ARN of enabled EDS", got)
+	}
+	if got := resources[0].ResourceName; got != "tfer--my-eds" {
+		t.Fatalf("resource name = %q, want %q", got, "tfer--my-eds")
+	}
+}
+
+func TestCloudTrailEventDataStoreFallbackName(t *testing.T) {
+	arn := "arn:aws:cloudtrail:us-east-1:123456789012:eventdatastore/abc-123"
+	got := arnLastSegment(arn, "/")
+	want := "abc-123"
+	if got != want {
+		t.Fatalf("arnLastSegment() = %q, want %q", got, want)
+	}
+}
+
+func strPtr(s string) *string { return &s }

--- a/providers/aws/cloudtrail_test.go
+++ b/providers/aws/cloudtrail_test.go
@@ -2,51 +2,28 @@
 
 package aws
 
-import (
-	"testing"
+import "testing"
 
-	"github.com/aws/aws-sdk-go-v2/service/cloudtrail/types"
-)
+func TestCloudTrailEventDataStoreResource(t *testing.T) {
+	arn := "arn:aws:cloudtrail:us-east-1:123456789012:eventdatastore/abc-123"
+	resource := eventDataStoreToResource(arn, "my-eds")
 
-func TestCloudTrailEventDataStoreEmitted(t *testing.T) {
-	eds := types.EventDataStore{
-		EventDataStoreArn: strPtr("arn:aws:cloudtrail:us-east-1:123456789012:eventdatastore/abc-123"),
-		Name:              strPtr("my-eds"),
-	}
-	resource, ok := eventDataStoreToResource(eds)
-	if !ok {
-		t.Fatal("expected resource to be emitted")
-	}
-	if got := resource.InstanceState.ID; got != "arn:aws:cloudtrail:us-east-1:123456789012:eventdatastore/abc-123" {
-		t.Fatalf("resource ID = %q, want ARN", got)
+	if got := resource.InstanceState.ID; got != arn {
+		t.Fatalf("resource ID = %q, want %q", got, arn)
 	}
 	if got := resource.ResourceName; got != "tfer--my-eds" {
 		t.Fatalf("resource name = %q, want %q", got, "tfer--my-eds")
 	}
-}
-
-func TestCloudTrailEventDataStoreNilARNSkipped(t *testing.T) {
-	eds := types.EventDataStore{
-		EventDataStoreArn: nil,
-		Name:              strPtr("no-arn"),
-	}
-	if _, ok := eventDataStoreToResource(eds); ok {
-		t.Fatal("expected nil ARN to be skipped")
+	if got := resource.InstanceInfo.Type; got != "aws_cloudtrail_event_data_store" {
+		t.Fatalf("resource type = %q, want %q", got, "aws_cloudtrail_event_data_store")
 	}
 }
 
 func TestCloudTrailEventDataStoreFallbackName(t *testing.T) {
 	arn := "arn:aws:cloudtrail:us-east-1:123456789012:eventdatastore/abc-123"
-	resource, ok := eventDataStoreToResource(types.EventDataStore{
-		EventDataStoreArn: &arn,
-		Name:              strPtr(""),
-	})
-	if !ok {
-		t.Fatal("expected resource to be emitted")
-	}
+	resource := eventDataStoreToResource(arn, "")
+
 	if got := resource.ResourceName; got != "tfer--abc-123" {
 		t.Fatalf("resource name = %q, want %q", got, "tfer--abc-123")
 	}
 }
-
-func strPtr(s string) *string { return &s }

--- a/providers/aws/cloudtrail_test.go
+++ b/providers/aws/cloudtrail_test.go
@@ -8,34 +8,20 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/cloudtrail/types"
 )
 
-func TestCloudTrailEventDataStoreSkipsPendingDeletion(t *testing.T) {
-	edsList := []types.EventDataStore{
-		{
-			EventDataStoreArn: strPtr("arn:aws:cloudtrail:us-east-1:123456789012:eventdatastore/abc-123"),
-			Name:              strPtr("my-eds"),
-			Status:            types.EventDataStoreStatusEnabled,
-		},
-		{
-			EventDataStoreArn: strPtr("arn:aws:cloudtrail:us-east-1:123456789012:eventdatastore/del-456"),
-			Name:              strPtr("deleting-eds"),
-			Status:            types.EventDataStoreStatusPendingDeletion,
-		},
+func TestCloudTrailEventDataStoreEmitted(t *testing.T) {
+	eds := types.EventDataStore{
+		EventDataStoreArn: strPtr("arn:aws:cloudtrail:us-east-1:123456789012:eventdatastore/abc-123"),
+		Name:              strPtr("my-eds"),
 	}
-
-	var count int
-	for _, eds := range edsList {
-		if resource, ok := eventDataStoreToResource(eds); ok {
-			count++
-			if got := resource.InstanceState.ID; got != "arn:aws:cloudtrail:us-east-1:123456789012:eventdatastore/abc-123" {
-				t.Fatalf("resource ID = %q, want ARN of enabled EDS", got)
-			}
-			if got := resource.ResourceName; got != "tfer--my-eds" {
-				t.Fatalf("resource name = %q, want %q", got, "tfer--my-eds")
-			}
-		}
+	resource, ok := eventDataStoreToResource(eds)
+	if !ok {
+		t.Fatal("expected resource to be emitted")
 	}
-	if count != 1 {
-		t.Fatalf("expected 1 resource, got %d", count)
+	if got := resource.InstanceState.ID; got != "arn:aws:cloudtrail:us-east-1:123456789012:eventdatastore/abc-123" {
+		t.Fatalf("resource ID = %q, want ARN", got)
+	}
+	if got := resource.ResourceName; got != "tfer--my-eds" {
+		t.Fatalf("resource name = %q, want %q", got, "tfer--my-eds")
 	}
 }
 
@@ -43,7 +29,6 @@ func TestCloudTrailEventDataStoreNilARNSkipped(t *testing.T) {
 	eds := types.EventDataStore{
 		EventDataStoreArn: nil,
 		Name:              strPtr("no-arn"),
-		Status:            types.EventDataStoreStatusEnabled,
 	}
 	if _, ok := eventDataStoreToResource(eds); ok {
 		t.Fatal("expected nil ARN to be skipped")
@@ -55,7 +40,6 @@ func TestCloudTrailEventDataStoreFallbackName(t *testing.T) {
 	resource, ok := eventDataStoreToResource(types.EventDataStore{
 		EventDataStoreArn: &arn,
 		Name:              strPtr(""),
-		Status:            types.EventDataStoreStatusEnabled,
 	})
 	if !ok {
 		t.Fatal("expected resource to be emitted")

--- a/providers/aws/cloudtrail_test.go
+++ b/providers/aws/cloudtrail_test.go
@@ -6,7 +6,6 @@ import (
 	"testing"
 
 	"github.com/aws/aws-sdk-go-v2/service/cloudtrail/types"
-	"github.com/chenrui333/terraformer/terraformutils"
 )
 
 func TestCloudTrailEventDataStoreSkipsPendingDeletion(t *testing.T) {
@@ -23,40 +22,46 @@ func TestCloudTrailEventDataStoreSkipsPendingDeletion(t *testing.T) {
 		},
 	}
 
-	var resources []terraformutils.Resource
+	var count int
 	for _, eds := range edsList {
-		if eds.EventDataStoreArn == nil {
-			continue
+		if resource, ok := eventDataStoreToResource(eds); ok {
+			count++
+			if got := resource.InstanceState.ID; got != "arn:aws:cloudtrail:us-east-1:123456789012:eventdatastore/abc-123" {
+				t.Fatalf("resource ID = %q, want ARN of enabled EDS", got)
+			}
+			if got := resource.ResourceName; got != "tfer--my-eds" {
+				t.Fatalf("resource name = %q, want %q", got, "tfer--my-eds")
+			}
 		}
-		if eds.Status == types.EventDataStoreStatusPendingDeletion {
-			continue
-		}
-		edsARN := *eds.EventDataStoreArn
-		edsName := StringValue(eds.Name)
-		if edsName == "" {
-			edsName = arnLastSegment(edsARN, "/")
-		}
-		resources = append(resources, terraformutils.NewSimpleResource(
-			edsARN, edsName, "aws_cloudtrail_event_data_store", "aws", cloudtrailAllowEmptyValues))
 	}
+	if count != 1 {
+		t.Fatalf("expected 1 resource, got %d", count)
+	}
+}
 
-	if len(resources) != 1 {
-		t.Fatalf("expected 1 resource, got %d", len(resources))
+func TestCloudTrailEventDataStoreNilARNSkipped(t *testing.T) {
+	eds := types.EventDataStore{
+		EventDataStoreArn: nil,
+		Name:              strPtr("no-arn"),
+		Status:            types.EventDataStoreStatusEnabled,
 	}
-	if got := resources[0].InstanceState.ID; got != "arn:aws:cloudtrail:us-east-1:123456789012:eventdatastore/abc-123" {
-		t.Fatalf("resource ID = %q, want ARN of enabled EDS", got)
-	}
-	if got := resources[0].ResourceName; got != "tfer--my-eds" {
-		t.Fatalf("resource name = %q, want %q", got, "tfer--my-eds")
+	if _, ok := eventDataStoreToResource(eds); ok {
+		t.Fatal("expected nil ARN to be skipped")
 	}
 }
 
 func TestCloudTrailEventDataStoreFallbackName(t *testing.T) {
 	arn := "arn:aws:cloudtrail:us-east-1:123456789012:eventdatastore/abc-123"
-	got := arnLastSegment(arn, "/")
-	want := "abc-123"
-	if got != want {
-		t.Fatalf("arnLastSegment() = %q, want %q", got, want)
+	resource, ok := eventDataStoreToResource(types.EventDataStore{
+		EventDataStoreArn: &arn,
+		Name:              strPtr(""),
+		Status:            types.EventDataStoreStatusEnabled,
+	})
+	if !ok {
+		t.Fatal("expected resource to be emitted")
+	}
+	if got := resource.ResourceName; got != "tfer--abc-123" {
+		t.Fatalf("resource name = %q, want %q", got, "tfer--abc-123")
 	}
 }
 

--- a/providers/aws/iam.go
+++ b/providers/aws/iam.go
@@ -77,6 +77,8 @@ func (g *IamGenerator) InitResources() error {
 		{name: "account password policy", load: func() error { return g.getAccountPasswordPolicy(svc) }},
 		{name: "OpenID Connect providers", load: func() error { return g.getOpenIDConnectProviders(svc) }},
 		{name: "SAML providers", load: func() error { return g.getSAMLProviders(svc) }},
+		{name: "service-linked roles", load: func() error { return g.getServiceLinkedRoles(svc) }},
+		{name: "server certificates", load: func() error { return g.getServerCertificates(svc) }},
 	})
 
 	return nil
@@ -512,6 +514,57 @@ func (g *IamGenerator) getUserAccessKey(svc *iam.Client, userName *string, userI
 				map[string]interface{}{
 					"depends_on": []string{"aws_iam_user.tfer--" + userID},
 				}))
+		}
+	}
+	return nil
+}
+
+func (g *IamGenerator) getServiceLinkedRoles(svc *iam.Client) error {
+	slrPathPrefix := "/aws-service-role/"
+	p := iam.NewListRolesPaginator(svc, &iam.ListRolesInput{
+		PathPrefix: &slrPathPrefix,
+	})
+	for p.HasMorePages() {
+		page, err := p.NextPage(context.TODO())
+		if err != nil {
+			return err
+		}
+		for _, role := range page.Roles {
+			roleARN := StringValue(role.Arn)
+			if roleARN == "" {
+				continue
+			}
+			roleName := StringValue(role.RoleName)
+			g.Resources = append(g.Resources, terraformutils.NewSimpleResource(
+				roleARN,
+				iamResourceName("slr", roleName),
+				"aws_iam_service_linked_role",
+				"aws",
+				IamAllowEmptyValues))
+		}
+	}
+	return nil
+}
+
+func (g *IamGenerator) getServerCertificates(svc *iam.Client) error {
+	p := iam.NewListServerCertificatesPaginator(svc, &iam.ListServerCertificatesInput{})
+	for p.HasMorePages() {
+		page, err := p.NextPage(context.TODO())
+		if err != nil {
+			return err
+		}
+		for _, cert := range page.ServerCertificateMetadataList {
+			certName := StringValue(cert.ServerCertificateName)
+			if certName == "" {
+				continue
+			}
+			certARN := StringValue(cert.Arn)
+			g.Resources = append(g.Resources, terraformutils.NewSimpleResource(
+				certARN,
+				iamResourceName("cert", certName),
+				"aws_iam_server_certificate",
+				"aws",
+				IamAllowEmptyValues))
 		}
 	}
 	return nil

--- a/providers/aws/iam.go
+++ b/providers/aws/iam.go
@@ -558,9 +558,8 @@ func (g *IamGenerator) getServerCertificates(svc *iam.Client) error {
 			if certName == "" {
 				continue
 			}
-			certARN := StringValue(cert.Arn)
 			g.Resources = append(g.Resources, terraformutils.NewSimpleResource(
-				certARN,
+				certName,
 				iamResourceName("cert", certName),
 				"aws_iam_server_certificate",
 				"aws",

--- a/providers/aws/iam.go
+++ b/providers/aws/iam.go
@@ -78,7 +78,6 @@ func (g *IamGenerator) InitResources() error {
 		{name: "OpenID Connect providers", load: func() error { return g.getOpenIDConnectProviders(svc) }},
 		{name: "SAML providers", load: func() error { return g.getSAMLProviders(svc) }},
 		{name: "service-linked roles", load: func() error { return g.getServiceLinkedRoles(svc) }},
-		{name: "server certificates", load: func() error { return g.getServerCertificates(svc) }},
 	})
 
 	return nil
@@ -206,6 +205,9 @@ func (g *IamGenerator) getRoles(svc *iam.Client) error {
 			return err
 		}
 		for _, role := range page.Roles {
+			if strings.HasPrefix(StringValue(role.Path), "/aws-service-role/") {
+				continue
+			}
 			roleName := StringValue(role.RoleName)
 			g.Resources = append(g.Resources, terraformutils.NewSimpleResource(
 				roleName,
@@ -539,29 +541,6 @@ func (g *IamGenerator) getServiceLinkedRoles(svc *iam.Client) error {
 				roleARN,
 				iamResourceName("slr", roleName),
 				"aws_iam_service_linked_role",
-				"aws",
-				IamAllowEmptyValues))
-		}
-	}
-	return nil
-}
-
-func (g *IamGenerator) getServerCertificates(svc *iam.Client) error {
-	p := iam.NewListServerCertificatesPaginator(svc, &iam.ListServerCertificatesInput{})
-	for p.HasMorePages() {
-		page, err := p.NextPage(context.TODO())
-		if err != nil {
-			return err
-		}
-		for _, cert := range page.ServerCertificateMetadataList {
-			certName := StringValue(cert.ServerCertificateName)
-			if certName == "" {
-				continue
-			}
-			g.Resources = append(g.Resources, terraformutils.NewSimpleResource(
-				certName,
-				iamResourceName("cert", certName),
-				"aws_iam_server_certificate",
 				"aws",
 				IamAllowEmptyValues))
 		}

--- a/providers/aws/iam_test.go
+++ b/providers/aws/iam_test.go
@@ -81,14 +81,6 @@ func TestIamServiceLinkedRoleResourceName(t *testing.T) {
 	}
 }
 
-func TestIamServerCertificateResourceName(t *testing.T) {
-	got := iamResourceName("cert", "my-server-cert")
-	want := "cert/my-server-cert"
-	if got != want {
-		t.Fatalf("iamResourceName(cert, my-server-cert) = %q, want %q", got, want)
-	}
-}
-
 func TestIamResourceMissing(t *testing.T) {
 	tests := []struct {
 		name string

--- a/providers/aws/iam_test.go
+++ b/providers/aws/iam_test.go
@@ -65,6 +65,30 @@ func TestIamResourceName(t *testing.T) {
 	}
 }
 
+func TestIamServiceLinkedRoleResourceName(t *testing.T) {
+	tests := []struct {
+		roleName string
+		want     string
+	}{
+		{roleName: "AWSServiceRoleForECS", want: "slr/AWSServiceRoleForECS"},
+		{roleName: "AWSServiceRoleForElasticLoadBalancing", want: "slr/AWSServiceRoleForElasticLoadBalancing"},
+	}
+	for _, tt := range tests {
+		got := iamResourceName("slr", tt.roleName)
+		if got != tt.want {
+			t.Fatalf("iamResourceName(slr, %q) = %q, want %q", tt.roleName, got, tt.want)
+		}
+	}
+}
+
+func TestIamServerCertificateResourceName(t *testing.T) {
+	got := iamResourceName("cert", "my-server-cert")
+	want := "cert/my-server-cert"
+	if got != want {
+		t.Fatalf("iamResourceName(cert, my-server-cert) = %q, want %q", got, want)
+	}
+}
+
 func TestIamResourceMissing(t *testing.T) {
 	tests := []struct {
 		name string

--- a/providers/aws/kms.go
+++ b/providers/aws/kms.go
@@ -63,20 +63,6 @@ func (g *KmsGenerator) addKeys(client *kms.Client) error {
 				resource.SlowQueryRequired = true
 				g.Resources = append(g.Resources, resource)
 
-				policyResource := terraformutils.NewResource(
-					keyID,
-					keyID+"_policy",
-					"aws_kms_key_policy",
-					"aws",
-					map[string]string{
-						"key_id": keyID,
-					},
-					kmsAllowEmptyValues,
-					map[string]interface{}{},
-				)
-				policyResource.SlowQueryRequired = true
-				g.Resources = append(g.Resources, policyResource)
-
 				g.addGrants(key.KeyId, client)
 			}
 		}

--- a/providers/aws/kms.go
+++ b/providers/aws/kms.go
@@ -48,19 +48,34 @@ func (g *KmsGenerator) addKeys(client *kms.Client) error {
 				continue
 			}
 			if keyDescription.KeyMetadata.KeyManager == types.KeyManagerTypeCustomer {
+				keyID := *key.KeyId
 				resource := terraformutils.NewResource(
-					*key.KeyId,
-					*key.KeyId,
+					keyID,
+					keyID,
 					"aws_kms_key",
 					"aws",
 					map[string]string{
-						"key_id": *key.KeyId,
+						"key_id": keyID,
 					},
 					kmsAllowEmptyValues,
 					map[string]interface{}{},
 				)
 				resource.SlowQueryRequired = true
 				g.Resources = append(g.Resources, resource)
+
+				policyResource := terraformutils.NewResource(
+					keyID,
+					keyID+"_policy",
+					"aws_kms_key_policy",
+					"aws",
+					map[string]string{
+						"key_id": keyID,
+					},
+					kmsAllowEmptyValues,
+					map[string]interface{}{},
+				)
+				policyResource.SlowQueryRequired = true
+				g.Resources = append(g.Resources, policyResource)
 
 				g.addGrants(key.KeyId, client)
 			}

--- a/providers/aws/kms_test.go
+++ b/providers/aws/kms_test.go
@@ -8,12 +8,12 @@ import (
 	"github.com/chenrui333/terraformer/terraformutils"
 )
 
-func TestKmsKeyPolicyResourceID(t *testing.T) {
+func TestKmsKeyResourceID(t *testing.T) {
 	keyID := "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"
 	resource := terraformutils.NewResource(
 		keyID,
-		keyID+"_policy",
-		"aws_kms_key_policy",
+		keyID,
+		"aws_kms_key",
 		"aws",
 		map[string]string{"key_id": keyID},
 		kmsAllowEmptyValues,
@@ -23,29 +23,30 @@ func TestKmsKeyPolicyResourceID(t *testing.T) {
 	if got := resource.InstanceState.ID; got != keyID {
 		t.Fatalf("resource ID = %q, want %q", got, keyID)
 	}
-	if got := resource.ResourceName; got != "tfer--"+keyID+"_policy" {
-		t.Fatalf("resource name = %q, want %q", got, "tfer--"+keyID+"_policy")
-	}
-	if got := resource.InstanceInfo.Type; got != "aws_kms_key_policy" {
-		t.Fatalf("resource type = %q, want %q", got, "aws_kms_key_policy")
+	if got := resource.InstanceInfo.Type; got != "aws_kms_key" {
+		t.Fatalf("resource type = %q, want %q", got, "aws_kms_key")
 	}
 	if got := resource.InstanceState.Attributes["key_id"]; got != keyID {
 		t.Fatalf("key_id attribute = %q, want %q", got, keyID)
 	}
 }
 
-func TestKmsKeyAndPolicyResourceNamesDoNotCollide(t *testing.T) {
+func TestKmsGrantResourceID(t *testing.T) {
 	keyID := "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"
-	keyResource := terraformutils.NewResource(
-		keyID, keyID, "aws_kms_key", "aws",
-		map[string]string{"key_id": keyID}, kmsAllowEmptyValues, map[string]interface{}{},
-	)
-	policyResource := terraformutils.NewResource(
-		keyID, keyID+"_policy", "aws_kms_key_policy", "aws",
-		map[string]string{"key_id": keyID}, kmsAllowEmptyValues, map[string]interface{}{},
+	grantID := "grant-123"
+	compositeID := keyID + ":" + grantID
+	resource := terraformutils.NewSimpleResource(
+		compositeID,
+		compositeID,
+		"aws_kms_grant",
+		"aws",
+		kmsAllowEmptyValues,
 	)
 
-	if keyResource.ResourceName == policyResource.ResourceName {
-		t.Fatalf("key and policy resource names collide: %q", keyResource.ResourceName)
+	if got := resource.InstanceState.ID; got != compositeID {
+		t.Fatalf("resource ID = %q, want %q", got, compositeID)
+	}
+	if got := resource.InstanceInfo.Type; got != "aws_kms_grant" {
+		t.Fatalf("resource type = %q, want %q", got, "aws_kms_grant")
 	}
 }

--- a/providers/aws/kms_test.go
+++ b/providers/aws/kms_test.go
@@ -1,0 +1,51 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package aws
+
+import (
+	"testing"
+
+	"github.com/chenrui333/terraformer/terraformutils"
+)
+
+func TestKmsKeyPolicyResourceID(t *testing.T) {
+	keyID := "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"
+	resource := terraformutils.NewResource(
+		keyID,
+		keyID+"_policy",
+		"aws_kms_key_policy",
+		"aws",
+		map[string]string{"key_id": keyID},
+		kmsAllowEmptyValues,
+		map[string]interface{}{},
+	)
+
+	if got := resource.InstanceState.ID; got != keyID {
+		t.Fatalf("resource ID = %q, want %q", got, keyID)
+	}
+	if got := resource.ResourceName; got != "tfer--"+keyID+"_policy" {
+		t.Fatalf("resource name = %q, want %q", got, "tfer--"+keyID+"_policy")
+	}
+	if got := resource.InstanceInfo.Type; got != "aws_kms_key_policy" {
+		t.Fatalf("resource type = %q, want %q", got, "aws_kms_key_policy")
+	}
+	if got := resource.InstanceState.Attributes["key_id"]; got != keyID {
+		t.Fatalf("key_id attribute = %q, want %q", got, keyID)
+	}
+}
+
+func TestKmsKeyAndPolicyResourceNamesDoNotCollide(t *testing.T) {
+	keyID := "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"
+	keyResource := terraformutils.NewResource(
+		keyID, keyID, "aws_kms_key", "aws",
+		map[string]string{"key_id": keyID}, kmsAllowEmptyValues, map[string]interface{}{},
+	)
+	policyResource := terraformutils.NewResource(
+		keyID, keyID+"_policy", "aws_kms_key_policy", "aws",
+		map[string]string{"key_id": keyID}, kmsAllowEmptyValues, map[string]interface{}{},
+	)
+
+	if keyResource.ResourceName == policyResource.ResourceName {
+		t.Fatalf("key and policy resource names collide: %q", keyResource.ResourceName)
+	}
+}


### PR DESCRIPTION
## Summary

Close security/identity foundation gaps in AWS provider.

### Resources added

| Service | Resource Type | Discovery |
|---------|--------------|-----------|
| CloudTrail | `aws_cloudtrail_event_data_store` | ListEventDataStores paginator, import by ARN, skip PENDING_DELETION |
| IAM | `aws_iam_service_linked_role` | ListRoles with /aws-service-role/ PathPrefix, import by ARN |
| IAM | `aws_iam_server_certificate` | ListServerCertificates paginator, import by ARN |
| KMS | `aws_kms_key_policy` | Emitted alongside each customer-managed key, import by key_id |

### Notes

- IAM SLR and server certs use optional loader pattern (skip on access errors)
- KMS key policy uses SlowQueryRequired like existing key/alias/grant resources
- CloudTrail EDS filters out PENDING_DELETION status (deprecated in list response but still present on type)

### Validation

```bash
terraformer import aws --resources=iam,cloudtrail,kms --regions=us-east-1 --path-output=./out
```

### Manual validation command
```bash
go test ./providers/aws/... -run "TestCloudTrail|TestIam|TestKms" -v
```

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds support for `aws_cloudtrail_event_data_store` and `aws_iam_service_linked_role` to expand AWS security/identity coverage. Removes `aws_iam_server_certificate` (write-only private key) and `aws_kms_key_policy` (conflicts with inline key policy).

- **New Features**
  - CloudTrail: `aws_cloudtrail_event_data_store` via paginator; import by ARN; name falls back to ARN segment.
  - IAM: `aws_iam_service_linked_role` via `ListRoles` with `/aws-service-role/` path; import by ARN.

- **Bug Fixes**
  - Verify event data store status via `GetEventDataStore`; skip `PENDING_DELETION` stores (replaces deprecated `Status` usage, SA1019).
  - Filter `/aws-service-role/` roles out of standard role discovery to avoid duplicate SLR imports.

<sup>Written for commit ee62a4986168ea410fecce859ab823ed50ebcdf4. Summary will update on new commits. <a href="https://cubic.dev/pr/chenrui333/terraformer/pull/443?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * CloudTrail now discovers and manages event data stores and trails
  * IAM discovery now includes service-linked roles

* **Improvements**
  * CloudTrail discovery logs errors for event data stores without failing initialization
  * Event data store names fall back to ARN segment when name is missing; pending-deletion or missing-ARN stores are skipped
  * KMS key IDs handled consistently when creating resources

* **Tests**
  * Added unit tests covering CloudTrail, IAM naming, and KMS resources

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/chenrui333/terraformer/pull/443?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->