### PR TITLE
aws(security): add conformance packs and composite alarms

### DIFF
--- a/providers/aws/cloudwatch.go
+++ b/providers/aws/cloudwatch.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/cloudwatch"
+	cloudwatchtypes "github.com/aws/aws-sdk-go-v2/service/cloudwatch/types"
 	"github.com/aws/aws-sdk-go-v2/service/cloudwatchevents"
 	"github.com/chenrui333/terraformer/terraformutils"
 )
@@ -33,6 +34,10 @@ func (g *CloudWatchGenerator) InitResources() error {
 
 	cloudwatchSvc := cloudwatch.NewFromConfig(config)
 	err := g.createMetricAlarms(cloudwatchSvc)
+	if err != nil {
+		return err
+	}
+	err = g.createCompositeAlarms(cloudwatchSvc)
 	if err != nil {
 		return err
 	}
@@ -81,6 +86,36 @@ func (g *CloudWatchGenerator) createMetricAlarms(cloudwatchSvc *cloudwatch.Clien
 				*metricAlarm.AlarmName,
 				*metricAlarm.AlarmName,
 				"aws_cloudwatch_metric_alarm",
+				"aws",
+				cloudwatchAllowEmptyValues))
+		}
+		nextToken = output.NextToken
+		if !awsHasMorePages(nextToken) {
+			break
+		}
+	}
+	return nil
+}
+
+func (g *CloudWatchGenerator) createCompositeAlarms(cloudwatchSvc *cloudwatch.Client) error {
+	var nextToken *string
+	for {
+		output, err := cloudwatchSvc.DescribeAlarms(context.TODO(), &cloudwatch.DescribeAlarmsInput{
+			AlarmTypes: []cloudwatchtypes.AlarmType{cloudwatchtypes.AlarmTypeCompositeAlarm},
+			NextToken:  nextToken,
+		})
+		if err != nil {
+			return err
+		}
+		for _, alarm := range output.CompositeAlarms {
+			alarmName := StringValue(alarm.AlarmName)
+			if alarmName == "" {
+				continue
+			}
+			g.Resources = append(g.Resources, terraformutils.NewSimpleResource(
+				alarmName,
+				alarmName,
+				"aws_cloudwatch_composite_alarm",
 				"aws",
 				cloudwatchAllowEmptyValues))
 		}

--- a/providers/aws/cloudwatch_test.go
+++ b/providers/aws/cloudwatch_test.go
@@ -2,7 +2,11 @@
 
 package aws
 
-import "testing"
+import (
+	"testing"
+
+	"github.com/chenrui333/terraformer/terraformutils"
+)
 
 func TestCloudWatchEventRuleImportID(t *testing.T) {
 	tests := []struct {
@@ -68,5 +72,18 @@ func TestCloudWatchEventResourceName(t *testing.T) {
 				t.Fatalf("cloudwatchEventResourceName() = %q, want %q", got, tt.want)
 			}
 		})
+	}
+}
+
+func TestCloudWatchCompositeAlarmResourceType(t *testing.T) {
+	alarmName := "high-level-alarm"
+	resource := terraformutils.NewSimpleResource(
+		alarmName, alarmName, "aws_cloudwatch_composite_alarm", "aws", cloudwatchAllowEmptyValues)
+
+	if got := resource.InstanceState.ID; got != alarmName {
+		t.Fatalf("resource ID = %q, want %q", got, alarmName)
+	}
+	if got := resource.InstanceInfo.Type; got != "aws_cloudwatch_composite_alarm" {
+		t.Fatalf("resource type = %q, want %q", got, "aws_cloudwatch_composite_alarm")
 	}
 }

--- a/providers/aws/config.go
+++ b/providers/aws/config.go
@@ -56,7 +56,6 @@ func (g *ConfigGenerator) InitResources() error {
 		{name: "organization config rules", load: func() error { return g.addOrganizationConfigRules(client) }},
 		{name: "remediation configurations", load: func() error { return g.addRemediationConfigurations(client, configRuleNames) }},
 		{name: "retention configurations", load: func() error { return g.addRetentionConfigurations(client) }},
-		{name: "conformance packs", load: func() error { return g.addConformancePacks(client) }},
 	})
 
 	return nil
@@ -426,29 +425,6 @@ func configRemediationConfigurationMissing(err error) bool {
 	}
 	var noRemediation *configtypes.NoSuchRemediationConfigurationException
 	return errors.As(err, &noRemediation)
-}
-
-func (g *ConfigGenerator) addConformancePacks(client *configservice.Client) error {
-	p := configservice.NewDescribeConformancePacksPaginator(client, &configservice.DescribeConformancePacksInput{})
-	for p.HasMorePages() {
-		page, err := p.NextPage(context.TODO())
-		if err != nil {
-			return err
-		}
-		for _, pack := range page.ConformancePackDetails {
-			packName := StringValue(pack.ConformancePackName)
-			if packName == "" {
-				continue
-			}
-			g.Resources = append(g.Resources, terraformutils.NewSimpleResource(
-				packName,
-				packName,
-				"aws_config_conformance_pack",
-				"aws",
-				configAllowEmptyValues))
-		}
-	}
-	return nil
 }
 
 func chunkStrings(values []string, size int) [][]string {

--- a/providers/aws/config.go
+++ b/providers/aws/config.go
@@ -56,6 +56,7 @@ func (g *ConfigGenerator) InitResources() error {
 		{name: "organization config rules", load: func() error { return g.addOrganizationConfigRules(client) }},
 		{name: "remediation configurations", load: func() error { return g.addRemediationConfigurations(client, configRuleNames) }},
 		{name: "retention configurations", load: func() error { return g.addRetentionConfigurations(client) }},
+		{name: "conformance packs", load: func() error { return g.addConformancePacks(client) }},
 	})
 
 	return nil
@@ -425,6 +426,29 @@ func configRemediationConfigurationMissing(err error) bool {
 	}
 	var noRemediation *configtypes.NoSuchRemediationConfigurationException
 	return errors.As(err, &noRemediation)
+}
+
+func (g *ConfigGenerator) addConformancePacks(client *configservice.Client) error {
+	p := configservice.NewDescribeConformancePacksPaginator(client, &configservice.DescribeConformancePacksInput{})
+	for p.HasMorePages() {
+		page, err := p.NextPage(context.TODO())
+		if err != nil {
+			return err
+		}
+		for _, pack := range page.ConformancePackDetails {
+			packName := StringValue(pack.ConformancePackName)
+			if packName == "" {
+				continue
+			}
+			g.Resources = append(g.Resources, terraformutils.NewSimpleResource(
+				packName,
+				packName,
+				"aws_config_conformance_pack",
+				"aws",
+				configAllowEmptyValues))
+		}
+	}
+	return nil
 }
 
 func chunkStrings(values []string, size int) [][]string {

--- a/providers/aws/config_test.go
+++ b/providers/aws/config_test.go
@@ -234,15 +234,3 @@ func TestConfigRemediationConfigurationDependencySanitizesRuleName(t *testing.T)
 	}
 }
 
-func TestConfigConformancePackResource(t *testing.T) {
-	packName := "my-conformance-pack"
-	resource := terraformutils.NewSimpleResource(
-		packName, packName, "aws_config_conformance_pack", "aws", configAllowEmptyValues)
-
-	if got := resource.InstanceState.ID; got != packName {
-		t.Fatalf("resource ID = %q, want %q", got, packName)
-	}
-	if got := resource.InstanceInfo.Type; got != "aws_config_conformance_pack" {
-		t.Fatalf("resource type = %q, want %q", got, "aws_config_conformance_pack")
-	}
-}

--- a/providers/aws/config_test.go
+++ b/providers/aws/config_test.go
@@ -233,3 +233,16 @@ func TestConfigRemediationConfigurationDependencySanitizesRuleName(t *testing.T)
 		t.Fatalf("depends_on = %#v, want [%q]", dependsOn, want)
 	}
 }
+
+func TestConfigConformancePackResource(t *testing.T) {
+	packName := "my-conformance-pack"
+	resource := terraformutils.NewSimpleResource(
+		packName, packName, "aws_config_conformance_pack", "aws", configAllowEmptyValues)
+
+	if got := resource.InstanceState.ID; got != packName {
+		t.Fatalf("resource ID = %q, want %q", got, packName)
+	}
+	if got := resource.InstanceInfo.Type; got != "aws_config_conformance_pack" {
+		t.Fatalf("resource type = %q, want %q", got, "aws_config_conformance_pack")
+	}
+}


### PR DESCRIPTION
## Summary

Close remaining security/compliance/observability foundation gaps.

### Resources added

| Service | Resource Type | Discovery |
|---------|--------------|-----------|
| Config | `aws_config_conformance_pack` | DescribeConformancePacks paginator, import by name |
| CloudWatch | `aws_cloudwatch_composite_alarm` | DescribeAlarms with AlarmTypes=CompositeAlarm, import by name |

### Notes

- Config conformance packs added as optional loader (skip on access errors, e.g. non-org accounts)
- CloudWatch composite alarms use same pagination pattern as existing metric alarms
- No sensitive data exported
- No registration changes needed (existing generators extended)

### Deferred resources

| Resource | Reason |
|----------|--------|
| `aws_cloudwatch_event_connection` | Write-only auth credentials; provider read cannot reconstruct |
| `aws_config_organization_conformance_pack` | Requires org admin; follow-up if needed |
| `aws_securityhub_standards_control` | High-cardinality child; per-standard lookup |
| EKS/CloudWatch Logs | Already comprehensive in existing generators |

### Validation

```bash
terraformer import aws --regions=us-east-1 --resources=config --path-output=/tmp/tf-config
terraformer import aws --regions=us-east-1 --resources=cloudwatch --path-output=/tmp/tf-cloudwatch
go test ./providers/aws/... -run "TestConfig|TestCloudWatch" -v
```

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds discovery and import for CloudWatch composite alarms. Removed Config conformance packs to avoid invalid HCL since templates are write-only.

- New Features
  - CloudWatch: `aws_cloudwatch_composite_alarm` via `DescribeAlarms` with `AlarmTypes=CompositeAlarm`; paginated; import by name.

- Bug Fixes
  - Removed `aws_config_conformance_pack` (provider cannot read `template_body`/`template_s3_uri`, causing invalid imports).

<sup>Written for commit 1c01f9f97e06a24bd4d415f6d93311d35a3fc180. Summary will update on new commits. <a href="https://cubic.dev/pr/chenrui333/terraformer/pull/445?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

