### PR TITLE
aws: fix networking foundation correctness issues

### DIFF
--- a/providers/aws/route_table.go
+++ b/providers/aws/route_table.go
@@ -36,7 +36,7 @@ func (g *RouteTableGenerator) createRouteTablesResources(svc *ec2.Client) ([]ter
 			))
 
 			for _, assoc := range table.Associations {
-				if *assoc.Main {
+				if assoc.Main != nil && *assoc.Main {
 					// main route table association
 					resources = append(resources, terraformutils.NewResource(
 						StringValue(assoc.RouteTableAssociationId),

--- a/providers/aws/route_table.go
+++ b/providers/aws/route_table.go
@@ -9,12 +9,70 @@ import (
 	"github.com/chenrui333/terraformer/terraformutils"
 
 	"github.com/aws/aws-sdk-go-v2/service/ec2"
+	"github.com/aws/aws-sdk-go-v2/service/ec2/types"
 )
 
 var rtbAllowEmptyValues = []string{"tags."}
 
 type RouteTableGenerator struct {
 	AWSService
+}
+
+func (g *RouteTableGenerator) createResourcesFromTables(tables []types.RouteTable) []terraformutils.Resource {
+	var resources []terraformutils.Resource
+	for _, table := range tables {
+		resources = append(resources, terraformutils.NewSimpleResource(
+			StringValue(table.RouteTableId),
+			StringValue(table.RouteTableId),
+			"aws_route_table",
+			"aws",
+			rtbAllowEmptyValues,
+		))
+
+		for _, assoc := range table.Associations {
+			if assoc.Main != nil && *assoc.Main {
+				resources = append(resources, terraformutils.NewResource(
+					StringValue(assoc.RouteTableAssociationId),
+					StringValue(table.VpcId),
+					"aws_main_route_table_association",
+					"aws",
+					map[string]string{
+						"vpc_id":         StringValue(table.VpcId),
+						"route_table_id": StringValue(table.RouteTableId),
+					},
+					rtbAllowEmptyValues,
+					map[string]interface{}{},
+				))
+			} else if v := assoc.SubnetId; v != nil {
+				resources = append(resources, terraformutils.NewResource(
+					StringValue(assoc.RouteTableAssociationId),
+					StringValue(v),
+					"aws_route_table_association",
+					"aws",
+					map[string]string{
+						"subnet_id":      StringValue(v),
+						"route_table_id": StringValue(table.RouteTableId),
+					},
+					rtbAllowEmptyValues,
+					map[string]interface{}{},
+				))
+			} else if v := assoc.GatewayId; v != nil {
+				resources = append(resources, terraformutils.NewResource(
+					StringValue(assoc.RouteTableAssociationId),
+					StringValue(v),
+					"aws_route_table_association",
+					"aws",
+					map[string]string{
+						"gateway_id":     StringValue(v),
+						"route_table_id": StringValue(table.RouteTableId),
+					},
+					rtbAllowEmptyValues,
+					map[string]interface{}{},
+				))
+			}
+		}
+	}
+	return resources
 }
 
 func (g *RouteTableGenerator) createRouteTablesResources(svc *ec2.Client) ([]terraformutils.Resource, error) {
@@ -25,61 +83,7 @@ func (g *RouteTableGenerator) createRouteTablesResources(svc *ec2.Client) ([]ter
 		if err != nil {
 			return nil, fmt.Errorf("describe route tables: %w", err)
 		}
-		for _, table := range page.RouteTables {
-			// route table
-			resources = append(resources, terraformutils.NewSimpleResource(
-				StringValue(table.RouteTableId),
-				StringValue(table.RouteTableId),
-				"aws_route_table",
-				"aws",
-				rtbAllowEmptyValues,
-			))
-
-			for _, assoc := range table.Associations {
-				if assoc.Main != nil && *assoc.Main {
-					// main route table association
-					resources = append(resources, terraformutils.NewResource(
-						StringValue(assoc.RouteTableAssociationId),
-						StringValue(table.VpcId),
-						"aws_main_route_table_association",
-						"aws",
-						map[string]string{
-							"vpc_id":         StringValue(table.VpcId),
-							"route_table_id": StringValue(table.RouteTableId),
-						},
-						rtbAllowEmptyValues,
-						map[string]interface{}{},
-					))
-				} else if v := assoc.SubnetId; v != nil {
-					// subnet-specific route table association
-					resources = append(resources, terraformutils.NewResource(
-						StringValue(assoc.RouteTableAssociationId),
-						StringValue(v),
-						"aws_route_table_association",
-						"aws",
-						map[string]string{
-							"subnet_id":      StringValue(v),
-							"route_table_id": StringValue(table.RouteTableId),
-						},
-						rtbAllowEmptyValues,
-						map[string]interface{}{},
-					))
-				} else if v := assoc.GatewayId; v != nil {
-					resources = append(resources, terraformutils.NewResource(
-						StringValue(assoc.RouteTableAssociationId),
-						StringValue(v),
-						"aws_route_table_association",
-						"aws",
-						map[string]string{
-							"gateway_id":     StringValue(v),
-							"route_table_id": StringValue(table.RouteTableId),
-						},
-						rtbAllowEmptyValues,
-						map[string]interface{}{},
-					))
-				}
-			}
-		}
+		resources = append(resources, g.createResourcesFromTables(page.RouteTables)...)
 	}
 	return resources, nil
 }

--- a/providers/aws/route_table_test.go
+++ b/providers/aws/route_table_test.go
@@ -10,41 +10,75 @@ import (
 )
 
 func TestRouteTableAssociationNilMain(t *testing.T) {
-	// Verify that a nil Main field does not panic
-	assocs := []types.RouteTableAssociation{
+	g := RouteTableGenerator{}
+	tables := []types.RouteTable{
 		{
-			RouteTableAssociationId: aws.String("rtbassoc-nil"),
-			Main:                    nil,
-			SubnetId:                aws.String("subnet-123"),
-			RouteTableId:            aws.String("rtb-456"),
-		},
-		{
-			RouteTableAssociationId: aws.String("rtbassoc-false"),
-			Main:                    aws.Bool(false),
-			SubnetId:                aws.String("subnet-789"),
-			RouteTableId:            aws.String("rtb-456"),
-		},
-		{
-			RouteTableAssociationId: aws.String("rtbassoc-main"),
-			Main:                    aws.Bool(true),
-			RouteTableId:            aws.String("rtb-456"),
+			RouteTableId: aws.String("rtb-456"),
+			VpcId:        aws.String("vpc-abc"),
+			Associations: []types.RouteTableAssociation{
+				{
+					RouteTableAssociationId: aws.String("rtbassoc-nil"),
+					Main:                    nil,
+					SubnetId:                aws.String("subnet-123"),
+				},
+				{
+					RouteTableAssociationId: aws.String("rtbassoc-false"),
+					Main:                    aws.Bool(false),
+					SubnetId:                aws.String("subnet-789"),
+				},
+				{
+					RouteTableAssociationId: aws.String("rtbassoc-main"),
+					Main:                    aws.Bool(true),
+				},
+			},
 		},
 	}
 
-	// Simulate the guard logic from createRouteTablesResources
-	var mainCount, subnetCount int
-	for _, assoc := range assocs {
-		if assoc.Main != nil && *assoc.Main {
-			mainCount++
-		} else if assoc.SubnetId != nil {
-			subnetCount++
-		}
+	resources := g.createResourcesFromTables(tables)
+
+	// 1 route table + 1 main assoc + 2 subnet assocs = 4
+	if len(resources) != 4 {
+		t.Fatalf("expected 4 resources, got %d", len(resources))
+	}
+	if resources[0].InstanceInfo.Type != "aws_route_table" {
+		t.Errorf("expected aws_route_table, got %s", resources[0].InstanceInfo.Type)
+	}
+	if resources[1].InstanceInfo.Type != "aws_route_table_association" {
+		t.Errorf("expected aws_route_table_association for nil Main, got %s", resources[1].InstanceInfo.Type)
+	}
+	if resources[2].InstanceInfo.Type != "aws_route_table_association" {
+		t.Errorf("expected aws_route_table_association for false Main, got %s", resources[2].InstanceInfo.Type)
+	}
+	if resources[3].InstanceInfo.Type != "aws_main_route_table_association" {
+		t.Errorf("expected aws_main_route_table_association, got %s", resources[3].InstanceInfo.Type)
+	}
+}
+
+func TestRouteTableGatewayAssociation(t *testing.T) {
+	g := RouteTableGenerator{}
+	tables := []types.RouteTable{
+		{
+			RouteTableId: aws.String("rtb-100"),
+			Associations: []types.RouteTableAssociation{
+				{
+					RouteTableAssociationId: aws.String("rtbassoc-gw"),
+					Main:                    aws.Bool(false),
+					GatewayId:               aws.String("igw-999"),
+				},
+			},
+		},
 	}
 
-	if mainCount != 1 {
-		t.Errorf("expected 1 main association, got %d", mainCount)
+	resources := g.createResourcesFromTables(tables)
+
+	// 1 route table + 1 gateway assoc
+	if len(resources) != 2 {
+		t.Fatalf("expected 2 resources, got %d", len(resources))
 	}
-	if subnetCount != 2 {
-		t.Errorf("expected 2 subnet associations, got %d", subnetCount)
+	if resources[1].InstanceInfo.Type != "aws_route_table_association" {
+		t.Errorf("expected aws_route_table_association, got %s", resources[1].InstanceInfo.Type)
+	}
+	if resources[1].InstanceState.Attributes["gateway_id"] != "igw-999" {
+		t.Errorf("expected gateway_id=igw-999, got %s", resources[1].InstanceState.Attributes["gateway_id"])
 	}
 }

--- a/providers/aws/route_table_test.go
+++ b/providers/aws/route_table_test.go
@@ -1,0 +1,50 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package aws
+
+import (
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/ec2/types"
+)
+
+func TestRouteTableAssociationNilMain(t *testing.T) {
+	// Verify that a nil Main field does not panic
+	assocs := []types.RouteTableAssociation{
+		{
+			RouteTableAssociationId: aws.String("rtbassoc-nil"),
+			Main:                    nil,
+			SubnetId:                aws.String("subnet-123"),
+			RouteTableId:            aws.String("rtb-456"),
+		},
+		{
+			RouteTableAssociationId: aws.String("rtbassoc-false"),
+			Main:                    aws.Bool(false),
+			SubnetId:                aws.String("subnet-789"),
+			RouteTableId:            aws.String("rtb-456"),
+		},
+		{
+			RouteTableAssociationId: aws.String("rtbassoc-main"),
+			Main:                    aws.Bool(true),
+			RouteTableId:            aws.String("rtb-456"),
+		},
+	}
+
+	// Simulate the guard logic from createRouteTablesResources
+	var mainCount, subnetCount int
+	for _, assoc := range assocs {
+		if assoc.Main != nil && *assoc.Main {
+			mainCount++
+		} else if assoc.SubnetId != nil {
+			subnetCount++
+		}
+	}
+
+	if mainCount != 1 {
+		t.Errorf("expected 1 main association, got %d", mainCount)
+	}
+	if subnetCount != 2 {
+		t.Errorf("expected 2 subnet associations, got %d", subnetCount)
+	}
+}

--- a/providers/aws/transit_gateway.go
+++ b/providers/aws/transit_gateway.go
@@ -25,6 +25,9 @@ func (g *TransitGatewayGenerator) getTransitGateways(svc *ec2.Client) error {
 			return err
 		}
 		for _, tgw := range page.TransitGateways {
+			if tgw.State == types.TransitGatewayStateDeleted || tgw.State == types.TransitGatewayStateDeleting {
+				continue
+			}
 			g.Resources = append(g.Resources, terraformutils.NewSimpleResource(
 				StringValue(tgw.TransitGatewayId),
 				StringValue(tgw.TransitGatewayId),

--- a/providers/aws/vgw.go
+++ b/providers/aws/vgw.go
@@ -7,7 +7,9 @@ import (
 
 	"github.com/chenrui333/terraformer/terraformutils"
 
+	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/ec2"
+	"github.com/aws/aws-sdk-go-v2/service/ec2/types"
 )
 
 var VpnAllowEmptyValues = []string{"tags."}
@@ -16,9 +18,12 @@ type VpnGatewayGenerator struct {
 	AWSService
 }
 
-func (VpnGatewayGenerator) createResources(vpnGws *ec2.DescribeVpnGatewaysOutput) []terraformutils.Resource {
+func (g *VpnGatewayGenerator) createResources(vpnGws *ec2.DescribeVpnGatewaysOutput) []terraformutils.Resource {
 	var resources []terraformutils.Resource
 	for _, vpnGw := range vpnGws.VpnGateways {
+		if vpnGw.State == types.VpnStateDeleted || vpnGw.State == types.VpnStateDeleting {
+			continue
+		}
 		resources = append(resources, terraformutils.NewSimpleResource(
 			StringValue(vpnGw.VpnGatewayId),
 			StringValue(vpnGw.VpnGatewayId),
@@ -39,7 +44,14 @@ func (g *VpnGatewayGenerator) InitResources() error {
 		return e
 	}
 	svc := ec2.NewFromConfig(config)
-	vpnGws, err := svc.DescribeVpnGateways(context.TODO(), &ec2.DescribeVpnGatewaysInput{})
+	vpnGws, err := svc.DescribeVpnGateways(context.TODO(), &ec2.DescribeVpnGatewaysInput{
+		Filters: []types.Filter{
+			{
+				Name:   aws.String("state"),
+				Values: []string{"pending", "available"},
+			},
+		},
+	})
 	if err != nil {
 		return err
 	}

--- a/providers/aws/vgw_test.go
+++ b/providers/aws/vgw_test.go
@@ -1,0 +1,38 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package aws
+
+import (
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/ec2"
+	"github.com/aws/aws-sdk-go-v2/service/ec2/types"
+)
+
+func TestVpnGatewayFilterDeletedState(t *testing.T) {
+	g := VpnGatewayGenerator{}
+	output := &ec2.DescribeVpnGatewaysOutput{
+		VpnGateways: []types.VpnGateway{
+			{VpnGatewayId: aws.String("vgw-available"), State: types.VpnStateAvailable},
+			{VpnGatewayId: aws.String("vgw-pending"), State: types.VpnStatePending},
+			{VpnGatewayId: aws.String("vgw-deleted"), State: types.VpnStateDeleted},
+			{VpnGatewayId: aws.String("vgw-deleting"), State: types.VpnStateDeleting},
+		},
+	}
+
+	resources := g.createResources(output)
+
+	if len(resources) != 2 {
+		t.Fatalf("expected 2 resources, got %d", len(resources))
+	}
+	expectedIDs := map[string]bool{"vgw-available": false, "vgw-pending": false}
+	for _, r := range resources {
+		expectedIDs[r.InstanceState.ID] = true
+	}
+	for id, found := range expectedIDs {
+		if !found {
+			t.Errorf("expected resource %s not found", id)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

Validation PR for AWS network foundation (follows #442, #444). Fixes correctness bugs found by auditing the import workflow for all 15 networking resources.

## Bugs Found and Fixed

| Resource | Bug | Risk | Fix |
|----------|-----|------|-----|
| route_table | `*assoc.Main` nil pointer dereference | Panic on associations with nil Main field | Added nil guard |
| vgw (vpn_gateway) | No state filter — imports deleted VPN gateways | Invalid resources in generated HCL | Added API filter + code guard |
| transit_gateway | `getTransitGateways` imports deleted/deleting TGWs | Invalid resources, failed refresh | Added state filter |

## Tests Added
- `route_table_test.go`: Verifies nil Main field handling doesn't panic
- `vgw_test.go`: Verifies deleted/deleting VPN gateways are filtered out

## Validation

```bash
terraformer import aws \\
  --regions=us-east-1 \\
  --resources=vpc,subnet,route_table,igw,nat,eip,vpc_endpoint,vpc_peering,nacl,eni,customer_gateway,vpn_gateway,vpn_connection,transit_gateway,sg \\
  --path-output=/tmp/terraformer-aws-network-foundation
```

## Test Results
- `go build ./providers/aws/` ✓
- `go vet ./providers/aws/` ✓
- `go test ./providers/aws/` — 2144 tests pass
- `gofmt` — clean

## Resources Confirmed Complete (no further bugs found)
- vpc, subnet, igw, eip, nacl, eni, nat, sg

## Resources Intentionally Left Alone
- **nacl**: Inline rule management via refresh is correct; no split needed
- **eni**: PostConvertHook handles attachment cleanup correctly
- **sg**: Cycle detection and rule splitting works correctly
- **igw**: Skipping unattached IGWs is intentional existing behavior
- **eip**: DescribeAddresses only returns owned EIPs (no state filter needed)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes AWS network foundation import correctness by filtering deleted VPN/Transit Gateways and safely handling route table associations. Prevents panics and removes invalid resources from generated HCL and refresh.

- **Bug Fixes**
  - route_table: Guard nil `assoc.Main`; tests cover subnet and gateway associations.
  - vpn_gateway: Filter `deleted`/`deleting` gateways via API filter and code guard; unit test added.
  - transit_gateway: Skip `deleted`/`deleting` TGWs during discovery.

- **Refactors**
  - route_table: Extracted `createResourcesFromTables` to enable testing against production logic.

<sup>Written for commit 6938a727f39b47ecc854788bb18c4d04ae54d53f. Summary will update on new commits. <a href="https://cubic.dev/pr/chenrui333/terraformer/pull/446?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

