### PR TITLE
aws(compute): add state filtering for EC2, RDS, and DynamoDB exports

### DIFF
--- a/providers/aws/dynamodb.go
+++ b/providers/aws/dynamodb.go
@@ -343,7 +343,7 @@ func dynamodbKinesisStreamingDestinationImportable(destination dynamodbtypes.Kin
 }
 
 func dynamodbTableExportImportable(export dynamodbtypes.ExportSummary) bool {
-	return export.ExportStatus != ""
+	return export.ExportStatus != "" && export.ExportStatus != dynamodbtypes.ExportStatusInProgress
 }
 
 func dynamodbGlobalTableStatusImportable(status dynamodbtypes.GlobalTableStatus) bool {

--- a/providers/aws/dynamodb_test.go
+++ b/providers/aws/dynamodb_test.go
@@ -118,6 +118,9 @@ func TestDynamoDBTableExportImportable(t *testing.T) {
 	if !dynamodbTableExportImportable(dynamodbtypes.ExportSummary{ExportStatus: dynamodbtypes.ExportStatusFailed}) {
 		t.Fatal("failed table export should be importable")
 	}
+	if dynamodbTableExportImportable(dynamodbtypes.ExportSummary{ExportStatus: dynamodbtypes.ExportStatusInProgress}) {
+		t.Fatal("in-progress table export should not be importable")
+	}
 	if dynamodbTableExportImportable(dynamodbtypes.ExportSummary{}) {
 		t.Fatal("empty table export status should not be importable")
 	}

--- a/providers/aws/ec2.go
+++ b/providers/aws/ec2.go
@@ -25,7 +25,12 @@ func (g *Ec2Generator) InitResources() error {
 		return e
 	}
 	svc := ec2.NewFromConfig(config)
-	var filters []types.Filter
+	filters := []types.Filter{
+		{
+			Name:   aws.String("instance-state-name"),
+			Values: []string{"running", "stopped"},
+		},
+	}
 	for _, filter := range g.Filter {
 		if strings.HasPrefix(filter.FieldPath, "tags.") && filter.IsApplicable("instance") {
 			filters = append(filters, types.Filter{

--- a/providers/aws/rds.go
+++ b/providers/aws/rds.go
@@ -33,6 +33,14 @@ func (g *RDSGenerator) loadOptionalResources(loaders []rdsOptionalResourceLoader
 	}
 }
 
+func rdsStatusImportable(status string) bool {
+	switch strings.ToLower(status) {
+	case "deleting", "creating", "failed", "migration-failed":
+		return false
+	}
+	return status != ""
+}
+
 func (g *RDSGenerator) loadDBClusters(svc *rds.Client) error {
 	p := rds.NewDescribeDBClustersPaginator(svc, &rds.DescribeDBClustersInput{})
 	for p.HasMorePages() {
@@ -42,7 +50,7 @@ func (g *RDSGenerator) loadDBClusters(svc *rds.Client) error {
 		}
 		for _, cluster := range page.DBClusters {
 			resourceName := StringValue(cluster.DBClusterIdentifier)
-			if resourceName == "" {
+			if resourceName == "" || !rdsStatusImportable(StringValue(cluster.Status)) {
 				continue
 			}
 			g.Resources = append(g.Resources, terraformutils.NewSimpleResource(
@@ -280,7 +288,7 @@ func (g *RDSGenerator) loadDBInstances(svc *rds.Client) error {
 		}
 		for _, db := range page.DBInstances {
 			resourceName := StringValue(db.DBInstanceIdentifier)
-			if resourceName == "" {
+			if resourceName == "" || !rdsStatusImportable(StringValue(db.DBInstanceStatus)) {
 				continue
 			}
 			r := terraformutils.NewSimpleResource(

--- a/providers/aws/rds_test.go
+++ b/providers/aws/rds_test.go
@@ -146,3 +146,26 @@ func TestRDSDefaultDBProxyTargetGroup(t *testing.T) {
 		t.Fatal("rdsDefaultDBProxyTargetGroup() = true for nil flag, want false")
 	}
 }
+
+func TestRDSStatusImportable(t *testing.T) {
+	tests := []struct {
+		status string
+		want   bool
+	}{
+		{"available", true},
+		{"backing-up", true},
+		{"stopped", true},
+		{"deleting", false},
+		{"creating", false},
+		{"failed", false},
+		{"migration-failed", false},
+		{"", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.status, func(t *testing.T) {
+			if got := rdsStatusImportable(tt.status); got != tt.want {
+				t.Fatalf("rdsStatusImportable(%q) = %v, want %v", tt.status, got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

Fix import correctness for compute/database runtime foundation by adding state filtering to prevent importing transient or terminated resources.

### Bugs fixed

| Service | Issue | Fix |
|---------|-------|-----|
| EC2 | Imports terminated/shutting-down instances that can't be managed | Filter to running/stopped only via DescribeInstances filter |
| RDS | Imports clusters/instances in deleting/creating/failed state | Add `rdsStatusImportable` predicate |
| DynamoDB | Imports IN_PROGRESS table exports (transient) | Skip non-terminal export status |

### Notes

- EC2 uses API-side filter (`instance-state-name`) for efficiency — terminated instances are never fetched
- RDS filter is code-side since DescribeDBClusters/Instances don't support status filters
- DynamoDB exports: COMPLETED and FAILED are both terminal and importable; only IN_PROGRESS is skipped
- No registration changes needed

### Deferred resources

| Resource | Reason |
|----------|--------|
| `aws_ebs_default_kms_key` / `aws_ebs_encryption_by_default` | Account singletons, already work correctly |
| ECS/Lambda/ECR/MSK | Already have proper state handling or are comprehensive |
| ElastiCache | Already has `elastiCacheStatusImportable` filter |
| OpenSearch connection lifecycle | Needs acceptance/handshake audit — separate PR |

### Validation

```bash
terraformer import aws --regions=us-east-1 --resources=rds,elasticache,es,ebs,efs,dynamodb,msk --path-output=/tmp/terraformer-aws-db-runtime-foundation
terraformer import aws --regions=us-east-1 --resources=ec2_instance,ecs,lambda,elb,ecr,ecrpublic --path-output=/tmp/terraformer-aws-compute-runtime-foundation
go test ./providers/aws/... -run "TestRDS|TestDynamoDB" -v
```

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add state-based filters for EC2, RDS, and DynamoDB exports to avoid importing transient or terminated resources. This improves import correctness and reduces noisy resources in the compute/database runtime foundation.

- **Bug Fixes**
  - EC2: Fetch only `running` and `stopped` instances via `instance-state-name` filter; skip terminated/shutting-down.
  - RDS: Add `rdsStatusImportable` and skip clusters/instances in `deleting`, `creating`, `failed`, `migration-failed`, or empty status.
  - DynamoDB: Import only terminal table export statuses; skip `IN_PROGRESS`.

<sup>Written for commit 8f4dc05733061ed6bb57e520da04c8108aa2d167. Summary will update on new commits. <a href="https://cubic.dev/pr/chenrui333/terraformer/pull/447?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

