### PR TITLE
feat(datadog): add agentless scanning, CSM threats, and AppSec WAF imports

### DIFF
--- a/docs/datadog.md
+++ b/docs/datadog.md
@@ -83,11 +83,22 @@ Tag filters are order specific. For example, if your monitor has tags (in the or
 
 ## Supported Datadog resources
 
+*   `agentless_scanning_aws_scan_options`
+    * `datadog_agentless_scanning_aws_scan_options`
+*   `agentless_scanning_azure_scan_options`
+    * `datadog_agentless_scanning_azure_scan_options`
+        * **_NOTE:_** Requires DataDog/datadog provider 4.9.0 or newer.
+*   `agentless_scanning_gcp_scan_options`
+    * `datadog_agentless_scanning_gcp_scan_options`
 *   `apm_retention_filter`
     * `datadog_apm_retention_filter`
 *   `apm_retention_filter_order`
     * `datadog_apm_retention_filter_order`
         * **_NOTE:_** Importing a single retention filter order by ID accepts any value because the Datadog provider stores it as `filtersOrderID`, for example `--filter=apm_retention_filter_order=any-value`
+*   `appsec_waf_custom_rule`
+    * `datadog_appsec_waf_custom_rule`
+*   `appsec_waf_exclusion_filter`
+    * `datadog_appsec_waf_exclusion_filter`
 *   `aws_cur_config`
     * `datadog_aws_cur_config`
         * **_NOTE:_** Requires DataDog/datadog provider 3.39.0 or newer.
@@ -107,6 +118,11 @@ Tag filters are order specific. For example, if your monitor has tags (in the or
 *   `cost_budget`
     * `datadog_cost_budget`
         * **_NOTE:_** Requires DataDog/datadog provider 3.39.0 or newer.
+*   `csm_threats_agent_rule`
+    * `datadog_csm_threats_agent_rule`
+        * **_NOTE:_** For policy-scoped rules, filter IDs use `policy_id:rule_id` format, for example `--filter="csm_threats_agent_rule='policy-abc:rule-123'"`; unscoped rules accept bare rule IDs
+*   `csm_threats_policy`
+    * `datadog_csm_threats_policy`
 *   `custom_allocation_rule`
     * `datadog_custom_allocation_rule`
         * **_NOTE:_** Requires DataDog/datadog provider 3.39.0 or newer.

--- a/providers/datadog/agentless_scanning_aws_scan_options.go
+++ b/providers/datadog/agentless_scanning_aws_scan_options.go
@@ -1,0 +1,93 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package datadog
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/DataDog/datadog-api-client-go/v2/api/datadog"
+	"github.com/DataDog/datadog-api-client-go/v2/api/datadogV2"
+
+	"github.com/chenrui333/terraformer/terraformutils"
+)
+
+// AgentlessScanningAwsScanOptionsGenerator ...
+type AgentlessScanningAwsScanOptionsGenerator struct {
+	DatadogService
+}
+
+func (g *AgentlessScanningAwsScanOptionsGenerator) createResource(data datadogV2.AwsScanOptionsData) (terraformutils.Resource, error) {
+	id := data.GetId()
+	if id == "" {
+		return terraformutils.Resource{}, fmt.Errorf("agentless scanning AWS scan options missing id")
+	}
+
+	return terraformutils.NewResource(
+		id,
+		fmt.Sprintf("agentless_scanning_aws_scan_options_%s", id),
+		"datadog_agentless_scanning_aws_scan_options",
+		"datadog",
+		map[string]string{
+			"aws_account_id": id,
+		},
+		[]string{"lambda", "sensitive_data", "vuln_containers_os", "vuln_host_os"},
+		map[string]interface{}{},
+	), nil
+}
+
+func (g *AgentlessScanningAwsScanOptionsGenerator) createResources(items []datadogV2.AwsScanOptionsData) ([]terraformutils.Resource, error) {
+	var resources []terraformutils.Resource
+	for _, item := range items {
+		resource, err := g.createResource(item)
+		if err != nil {
+			return nil, err
+		}
+		resources = append(resources, resource)
+	}
+	return resources, nil
+}
+
+// InitResources Generate TerraformResources from Datadog API.
+func (g *AgentlessScanningAwsScanOptionsGenerator) InitResources() error {
+	datadogClient := g.Args["datadogClient"].(*datadog.APIClient)
+	auth := g.Args["auth"].(context.Context)
+	api := datadogV2.NewAgentlessScanningApi(datadogClient)
+
+	for _, filter := range g.Filter {
+		if filter.FieldPath == "id" && filter.IsApplicable("agentless_scanning_aws_scan_options") {
+			var resources []terraformutils.Resource
+			for _, value := range filter.AcceptableValues {
+				resp, httpResp, err := api.GetAwsScanOptions(auth, value)
+				if httpResp != nil && httpResp.Body != nil {
+					httpResp.Body.Close()
+				}
+				if err != nil {
+					return err
+				}
+				resource, err := g.createResource(resp.GetData())
+				if err != nil {
+					return err
+				}
+				resources = append(resources, resource)
+			}
+			g.Resources = resources
+			return nil
+		}
+	}
+
+	resp, httpResp, err := api.ListAwsScanOptions(auth)
+	if httpResp != nil && httpResp.Body != nil {
+		httpResp.Body.Close()
+	}
+	if err != nil {
+		return err
+	}
+
+	resources, err := g.createResources(resp.GetData())
+	if err != nil {
+		return err
+	}
+	g.Resources = resources
+	return nil
+}

--- a/providers/datadog/agentless_scanning_azure_scan_options.go
+++ b/providers/datadog/agentless_scanning_azure_scan_options.go
@@ -1,0 +1,93 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package datadog
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/DataDog/datadog-api-client-go/v2/api/datadog"
+	"github.com/DataDog/datadog-api-client-go/v2/api/datadogV2"
+
+	"github.com/chenrui333/terraformer/terraformutils"
+)
+
+// AgentlessScanningAzureScanOptionsGenerator ...
+type AgentlessScanningAzureScanOptionsGenerator struct {
+	DatadogService
+}
+
+func (g *AgentlessScanningAzureScanOptionsGenerator) createResource(data datadogV2.AzureScanOptionsData) (terraformutils.Resource, error) {
+	id := data.GetId()
+	if id == "" {
+		return terraformutils.Resource{}, fmt.Errorf("agentless scanning Azure scan options missing id")
+	}
+
+	return terraformutils.NewResource(
+		id,
+		fmt.Sprintf("agentless_scanning_azure_scan_options_%s", id),
+		"datadog_agentless_scanning_azure_scan_options",
+		"datadog",
+		map[string]string{
+			"azure_subscription_id": id,
+		},
+		[]string{"vuln_containers_os", "vuln_host_os"},
+		map[string]interface{}{},
+	), nil
+}
+
+func (g *AgentlessScanningAzureScanOptionsGenerator) createResources(items []datadogV2.AzureScanOptionsData) ([]terraformutils.Resource, error) {
+	var resources []terraformutils.Resource
+	for _, item := range items {
+		resource, err := g.createResource(item)
+		if err != nil {
+			return nil, err
+		}
+		resources = append(resources, resource)
+	}
+	return resources, nil
+}
+
+// InitResources Generate TerraformResources from Datadog API.
+func (g *AgentlessScanningAzureScanOptionsGenerator) InitResources() error {
+	datadogClient := g.Args["datadogClient"].(*datadog.APIClient)
+	auth := g.Args["auth"].(context.Context)
+	api := datadogV2.NewAgentlessScanningApi(datadogClient)
+
+	for _, filter := range g.Filter {
+		if filter.FieldPath == "id" && filter.IsApplicable("agentless_scanning_azure_scan_options") {
+			var resources []terraformutils.Resource
+			for _, value := range filter.AcceptableValues {
+				resp, httpResp, err := api.GetAzureScanOptions(auth, value)
+				if httpResp != nil && httpResp.Body != nil {
+					httpResp.Body.Close()
+				}
+				if err != nil {
+					return err
+				}
+				resource, err := g.createResource(resp.GetData())
+				if err != nil {
+					return err
+				}
+				resources = append(resources, resource)
+			}
+			g.Resources = resources
+			return nil
+		}
+	}
+
+	resp, httpResp, err := api.ListAzureScanOptions(auth)
+	if httpResp != nil && httpResp.Body != nil {
+		httpResp.Body.Close()
+	}
+	if err != nil {
+		return err
+	}
+
+	resources, err := g.createResources(resp.GetData())
+	if err != nil {
+		return err
+	}
+	g.Resources = resources
+	return nil
+}

--- a/providers/datadog/agentless_scanning_gcp_scan_options.go
+++ b/providers/datadog/agentless_scanning_gcp_scan_options.go
@@ -1,0 +1,93 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package datadog
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/DataDog/datadog-api-client-go/v2/api/datadog"
+	"github.com/DataDog/datadog-api-client-go/v2/api/datadogV2"
+
+	"github.com/chenrui333/terraformer/terraformutils"
+)
+
+// AgentlessScanningGcpScanOptionsGenerator ...
+type AgentlessScanningGcpScanOptionsGenerator struct {
+	DatadogService
+}
+
+func (g *AgentlessScanningGcpScanOptionsGenerator) createResource(data datadogV2.GcpScanOptionsData) (terraformutils.Resource, error) {
+	id := data.GetId()
+	if id == "" {
+		return terraformutils.Resource{}, fmt.Errorf("agentless scanning GCP scan options missing id")
+	}
+
+	return terraformutils.NewResource(
+		id,
+		fmt.Sprintf("agentless_scanning_gcp_scan_options_%s", id),
+		"datadog_agentless_scanning_gcp_scan_options",
+		"datadog",
+		map[string]string{
+			"gcp_project_id": id,
+		},
+		[]string{"vuln_containers_os", "vuln_host_os"},
+		map[string]interface{}{},
+	), nil
+}
+
+func (g *AgentlessScanningGcpScanOptionsGenerator) createResources(items []datadogV2.GcpScanOptionsData) ([]terraformutils.Resource, error) {
+	var resources []terraformutils.Resource
+	for _, item := range items {
+		resource, err := g.createResource(item)
+		if err != nil {
+			return nil, err
+		}
+		resources = append(resources, resource)
+	}
+	return resources, nil
+}
+
+// InitResources Generate TerraformResources from Datadog API.
+func (g *AgentlessScanningGcpScanOptionsGenerator) InitResources() error {
+	datadogClient := g.Args["datadogClient"].(*datadog.APIClient)
+	auth := g.Args["auth"].(context.Context)
+	api := datadogV2.NewAgentlessScanningApi(datadogClient)
+
+	for _, filter := range g.Filter {
+		if filter.FieldPath == "id" && filter.IsApplicable("agentless_scanning_gcp_scan_options") {
+			var resources []terraformutils.Resource
+			for _, value := range filter.AcceptableValues {
+				resp, httpResp, err := api.GetGcpScanOptions(auth, value)
+				if httpResp != nil && httpResp.Body != nil {
+					httpResp.Body.Close()
+				}
+				if err != nil {
+					return err
+				}
+				resource, err := g.createResource(resp.GetData())
+				if err != nil {
+					return err
+				}
+				resources = append(resources, resource)
+			}
+			g.Resources = resources
+			return nil
+		}
+	}
+
+	resp, httpResp, err := api.ListGcpScanOptions(auth)
+	if httpResp != nil && httpResp.Body != nil {
+		httpResp.Body.Close()
+	}
+	if err != nil {
+		return err
+	}
+
+	resources, err := g.createResources(resp.GetData())
+	if err != nil {
+		return err
+	}
+	g.Resources = resources
+	return nil
+}

--- a/providers/datadog/agentless_scanning_test.go
+++ b/providers/datadog/agentless_scanning_test.go
@@ -1,0 +1,124 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package datadog
+
+import (
+	"testing"
+
+	"github.com/DataDog/datadog-api-client-go/v2/api/datadogV2"
+)
+
+func TestAgentlessScanningAwsCreateResource(t *testing.T) {
+	data := datadogV2.NewAwsScanOptionsDataWithDefaults()
+	data.SetId("123456789012")
+
+	generator := &AgentlessScanningAwsScanOptionsGenerator{}
+	resource, err := generator.createResource(*data)
+	if err != nil {
+		t.Fatalf("createResource returned error: %v", err)
+	}
+
+	if resource.InstanceState.ID != "123456789012" {
+		t.Fatalf("resource ID = %q, want %q", resource.InstanceState.ID, "123456789012")
+	}
+	if resource.InstanceInfo.Type != "datadog_agentless_scanning_aws_scan_options" {
+		t.Fatalf("resource type = %q, want %q", resource.InstanceInfo.Type, "datadog_agentless_scanning_aws_scan_options")
+	}
+	if v := resource.InstanceState.Attributes["aws_account_id"]; v != "123456789012" {
+		t.Fatalf("aws_account_id = %q, want %q", v, "123456789012")
+	}
+}
+
+func TestAgentlessScanningAwsCreateResourceMissingID(t *testing.T) {
+	generator := &AgentlessScanningAwsScanOptionsGenerator{}
+	_, err := generator.createResource(datadogV2.AwsScanOptionsData{})
+	if err == nil {
+		t.Fatal("createResource returned nil error, want missing id error")
+	}
+}
+
+func TestAgentlessScanningAwsCreateResources(t *testing.T) {
+	first := datadogV2.NewAwsScanOptionsDataWithDefaults()
+	first.SetId("111111111111")
+	second := datadogV2.NewAwsScanOptionsDataWithDefaults()
+	second.SetId("222222222222")
+
+	generator := &AgentlessScanningAwsScanOptionsGenerator{}
+	resources, err := generator.createResources([]datadogV2.AwsScanOptionsData{*first, *second})
+	if err != nil {
+		t.Fatalf("createResources returned error: %v", err)
+	}
+	if len(resources) != 2 {
+		t.Fatalf("resource count = %d, want %d", len(resources), 2)
+	}
+	if resources[0].InstanceState.ID == resources[1].InstanceState.ID {
+		t.Fatal("resource IDs should be unique")
+	}
+}
+
+func TestAgentlessScanningAwsCreateResourcesEmpty(t *testing.T) {
+	generator := &AgentlessScanningAwsScanOptionsGenerator{}
+	resources, err := generator.createResources(nil)
+	if err != nil {
+		t.Fatalf("createResources returned error: %v", err)
+	}
+	if len(resources) != 0 {
+		t.Fatalf("resource count = %d, want %d", len(resources), 0)
+	}
+}
+
+func TestAgentlessScanningAzureCreateResource(t *testing.T) {
+	data := datadogV2.NewAzureScanOptionsData("sub-id-123", datadogV2.AZURESCANOPTIONSDATATYPE_AZURE_SCAN_OPTIONS)
+
+	generator := &AgentlessScanningAzureScanOptionsGenerator{}
+	resource, err := generator.createResource(*data)
+	if err != nil {
+		t.Fatalf("createResource returned error: %v", err)
+	}
+
+	if resource.InstanceState.ID != "sub-id-123" {
+		t.Fatalf("resource ID = %q, want %q", resource.InstanceState.ID, "sub-id-123")
+	}
+	if resource.InstanceInfo.Type != "datadog_agentless_scanning_azure_scan_options" {
+		t.Fatalf("resource type = %q, want %q", resource.InstanceInfo.Type, "datadog_agentless_scanning_azure_scan_options")
+	}
+	if v := resource.InstanceState.Attributes["azure_subscription_id"]; v != "sub-id-123" {
+		t.Fatalf("azure_subscription_id = %q, want %q", v, "sub-id-123")
+	}
+}
+
+func TestAgentlessScanningAzureCreateResourceMissingID(t *testing.T) {
+	generator := &AgentlessScanningAzureScanOptionsGenerator{}
+	_, err := generator.createResource(datadogV2.AzureScanOptionsData{})
+	if err == nil {
+		t.Fatal("createResource returned nil error, want missing id error")
+	}
+}
+
+func TestAgentlessScanningGcpCreateResource(t *testing.T) {
+	data := datadogV2.NewGcpScanOptionsData("my-project-123", datadogV2.GCPSCANOPTIONSDATATYPE_GCP_SCAN_OPTIONS)
+
+	generator := &AgentlessScanningGcpScanOptionsGenerator{}
+	resource, err := generator.createResource(*data)
+	if err != nil {
+		t.Fatalf("createResource returned error: %v", err)
+	}
+
+	if resource.InstanceState.ID != "my-project-123" {
+		t.Fatalf("resource ID = %q, want %q", resource.InstanceState.ID, "my-project-123")
+	}
+	if resource.InstanceInfo.Type != "datadog_agentless_scanning_gcp_scan_options" {
+		t.Fatalf("resource type = %q, want %q", resource.InstanceInfo.Type, "datadog_agentless_scanning_gcp_scan_options")
+	}
+	if v := resource.InstanceState.Attributes["gcp_project_id"]; v != "my-project-123" {
+		t.Fatalf("gcp_project_id = %q, want %q", v, "my-project-123")
+	}
+}
+
+func TestAgentlessScanningGcpCreateResourceMissingID(t *testing.T) {
+	generator := &AgentlessScanningGcpScanOptionsGenerator{}
+	_, err := generator.createResource(datadogV2.GcpScanOptionsData{})
+	if err == nil {
+		t.Fatal("createResource returned nil error, want missing id error")
+	}
+}

--- a/providers/datadog/appsec_waf_custom_rule.go
+++ b/providers/datadog/appsec_waf_custom_rule.go
@@ -1,0 +1,89 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package datadog
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/DataDog/datadog-api-client-go/v2/api/datadog"
+	"github.com/DataDog/datadog-api-client-go/v2/api/datadogV2"
+
+	"github.com/chenrui333/terraformer/terraformutils"
+)
+
+// AppSecWafCustomRuleGenerator ...
+type AppSecWafCustomRuleGenerator struct {
+	DatadogService
+}
+
+func (g *AppSecWafCustomRuleGenerator) createResource(data datadogV2.ApplicationSecurityWafCustomRuleData) (terraformutils.Resource, error) {
+	id := data.GetId()
+	if id == "" {
+		return terraformutils.Resource{}, fmt.Errorf("AppSec WAF custom rule missing id")
+	}
+
+	return terraformutils.NewSimpleResource(
+		id,
+		fmt.Sprintf("appsec_waf_custom_rule_%s", id),
+		"datadog_appsec_waf_custom_rule",
+		"datadog",
+		[]string{"blocking", "enabled"},
+	), nil
+}
+
+func (g *AppSecWafCustomRuleGenerator) createResources(items []datadogV2.ApplicationSecurityWafCustomRuleData) ([]terraformutils.Resource, error) {
+	var resources []terraformutils.Resource
+	for _, item := range items {
+		resource, err := g.createResource(item)
+		if err != nil {
+			return nil, err
+		}
+		resources = append(resources, resource)
+	}
+	return resources, nil
+}
+
+// InitResources Generate TerraformResources from Datadog API.
+func (g *AppSecWafCustomRuleGenerator) InitResources() error {
+	datadogClient := g.Args["datadogClient"].(*datadog.APIClient)
+	auth := g.Args["auth"].(context.Context)
+	api := datadogV2.NewApplicationSecurityApi(datadogClient)
+
+	for _, filter := range g.Filter {
+		if filter.FieldPath == "id" && filter.IsApplicable("appsec_waf_custom_rule") {
+			var resources []terraformutils.Resource
+			for _, value := range filter.AcceptableValues {
+				resp, httpResp, err := api.GetApplicationSecurityWafCustomRule(auth, value)
+				if httpResp != nil && httpResp.Body != nil {
+					httpResp.Body.Close()
+				}
+				if err != nil {
+					return err
+				}
+				resource, err := g.createResource(resp.GetData())
+				if err != nil {
+					return err
+				}
+				resources = append(resources, resource)
+			}
+			g.Resources = resources
+			return nil
+		}
+	}
+
+	resp, httpResp, err := api.ListApplicationSecurityWAFCustomRules(auth)
+	if httpResp != nil && httpResp.Body != nil {
+		httpResp.Body.Close()
+	}
+	if err != nil {
+		return err
+	}
+
+	resources, err := g.createResources(resp.GetData())
+	if err != nil {
+		return err
+	}
+	g.Resources = resources
+	return nil
+}

--- a/providers/datadog/appsec_waf_exclusion_filter.go
+++ b/providers/datadog/appsec_waf_exclusion_filter.go
@@ -1,0 +1,89 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package datadog
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/DataDog/datadog-api-client-go/v2/api/datadog"
+	"github.com/DataDog/datadog-api-client-go/v2/api/datadogV2"
+
+	"github.com/chenrui333/terraformer/terraformutils"
+)
+
+// AppSecWafExclusionFilterGenerator ...
+type AppSecWafExclusionFilterGenerator struct {
+	DatadogService
+}
+
+func (g *AppSecWafExclusionFilterGenerator) createResource(data datadogV2.ApplicationSecurityWafExclusionFilterResource) (terraformutils.Resource, error) {
+	id := data.GetId()
+	if id == "" {
+		return terraformutils.Resource{}, fmt.Errorf("AppSec WAF exclusion filter missing id")
+	}
+
+	return terraformutils.NewSimpleResource(
+		id,
+		fmt.Sprintf("appsec_waf_exclusion_filter_%s", id),
+		"datadog_appsec_waf_exclusion_filter",
+		"datadog",
+		[]string{"enabled"},
+	), nil
+}
+
+func (g *AppSecWafExclusionFilterGenerator) createResources(items []datadogV2.ApplicationSecurityWafExclusionFilterResource) ([]terraformutils.Resource, error) {
+	var resources []terraformutils.Resource
+	for _, item := range items {
+		resource, err := g.createResource(item)
+		if err != nil {
+			return nil, err
+		}
+		resources = append(resources, resource)
+	}
+	return resources, nil
+}
+
+// InitResources Generate TerraformResources from Datadog API.
+func (g *AppSecWafExclusionFilterGenerator) InitResources() error {
+	datadogClient := g.Args["datadogClient"].(*datadog.APIClient)
+	auth := g.Args["auth"].(context.Context)
+	api := datadogV2.NewApplicationSecurityApi(datadogClient)
+
+	for _, filter := range g.Filter {
+		if filter.FieldPath == "id" && filter.IsApplicable("appsec_waf_exclusion_filter") {
+			var resources []terraformutils.Resource
+			for _, value := range filter.AcceptableValues {
+				resp, httpResp, err := api.GetApplicationSecurityWafExclusionFilter(auth, value)
+				if httpResp != nil && httpResp.Body != nil {
+					httpResp.Body.Close()
+				}
+				if err != nil {
+					return err
+				}
+				resource, err := g.createResource(resp.GetData())
+				if err != nil {
+					return err
+				}
+				resources = append(resources, resource)
+			}
+			g.Resources = resources
+			return nil
+		}
+	}
+
+	resp, httpResp, err := api.ListApplicationSecurityWafExclusionFilters(auth)
+	if httpResp != nil && httpResp.Body != nil {
+		httpResp.Body.Close()
+	}
+	if err != nil {
+		return err
+	}
+
+	resources, err := g.createResources(resp.GetData())
+	if err != nil {
+		return err
+	}
+	g.Resources = resources
+	return nil
+}

--- a/providers/datadog/appsec_waf_test.go
+++ b/providers/datadog/appsec_waf_test.go
@@ -1,0 +1,104 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package datadog
+
+import (
+	"testing"
+
+	"github.com/DataDog/datadog-api-client-go/v2/api/datadogV2"
+)
+
+func TestAppSecWafCustomRuleCreateResource(t *testing.T) {
+	data := datadogV2.NewApplicationSecurityWafCustomRuleDataWithDefaults()
+	data.SetId("custom-rule-abc")
+
+	generator := &AppSecWafCustomRuleGenerator{}
+	resource, err := generator.createResource(*data)
+	if err != nil {
+		t.Fatalf("createResource returned error: %v", err)
+	}
+
+	if resource.InstanceState.ID != "custom-rule-abc" {
+		t.Fatalf("resource ID = %q, want %q", resource.InstanceState.ID, "custom-rule-abc")
+	}
+	if resource.InstanceInfo.Type != "datadog_appsec_waf_custom_rule" {
+		t.Fatalf("resource type = %q, want %q", resource.InstanceInfo.Type, "datadog_appsec_waf_custom_rule")
+	}
+}
+
+func TestAppSecWafCustomRuleCreateResourceMissingID(t *testing.T) {
+	generator := &AppSecWafCustomRuleGenerator{}
+	_, err := generator.createResource(datadogV2.ApplicationSecurityWafCustomRuleData{})
+	if err == nil {
+		t.Fatal("createResource returned nil error, want missing id error")
+	}
+}
+
+func TestAppSecWafCustomRuleCreateResources(t *testing.T) {
+	first := datadogV2.NewApplicationSecurityWafCustomRuleDataWithDefaults()
+	first.SetId("rule-1")
+	second := datadogV2.NewApplicationSecurityWafCustomRuleDataWithDefaults()
+	second.SetId("rule-2")
+
+	generator := &AppSecWafCustomRuleGenerator{}
+	resources, err := generator.createResources([]datadogV2.ApplicationSecurityWafCustomRuleData{*first, *second})
+	if err != nil {
+		t.Fatalf("createResources returned error: %v", err)
+	}
+	if len(resources) != 2 {
+		t.Fatalf("resource count = %d, want %d", len(resources), 2)
+	}
+}
+
+func TestAppSecWafCustomRuleCreateResourcesEmpty(t *testing.T) {
+	generator := &AppSecWafCustomRuleGenerator{}
+	resources, err := generator.createResources(nil)
+	if err != nil {
+		t.Fatalf("createResources returned error: %v", err)
+	}
+	if len(resources) != 0 {
+		t.Fatalf("resource count = %d, want %d", len(resources), 0)
+	}
+}
+
+func TestAppSecWafExclusionFilterCreateResource(t *testing.T) {
+	data := datadogV2.NewApplicationSecurityWafExclusionFilterResourceWithDefaults()
+	data.SetId("exclusion-filter-xyz")
+
+	generator := &AppSecWafExclusionFilterGenerator{}
+	resource, err := generator.createResource(*data)
+	if err != nil {
+		t.Fatalf("createResource returned error: %v", err)
+	}
+
+	if resource.InstanceState.ID != "exclusion-filter-xyz" {
+		t.Fatalf("resource ID = %q, want %q", resource.InstanceState.ID, "exclusion-filter-xyz")
+	}
+	if resource.InstanceInfo.Type != "datadog_appsec_waf_exclusion_filter" {
+		t.Fatalf("resource type = %q, want %q", resource.InstanceInfo.Type, "datadog_appsec_waf_exclusion_filter")
+	}
+}
+
+func TestAppSecWafExclusionFilterCreateResourceMissingID(t *testing.T) {
+	generator := &AppSecWafExclusionFilterGenerator{}
+	_, err := generator.createResource(datadogV2.ApplicationSecurityWafExclusionFilterResource{})
+	if err == nil {
+		t.Fatal("createResource returned nil error, want missing id error")
+	}
+}
+
+func TestAppSecWafExclusionFilterCreateResources(t *testing.T) {
+	first := datadogV2.NewApplicationSecurityWafExclusionFilterResourceWithDefaults()
+	first.SetId("filter-1")
+	second := datadogV2.NewApplicationSecurityWafExclusionFilterResourceWithDefaults()
+	second.SetId("filter-2")
+
+	generator := &AppSecWafExclusionFilterGenerator{}
+	resources, err := generator.createResources([]datadogV2.ApplicationSecurityWafExclusionFilterResource{*first, *second})
+	if err != nil {
+		t.Fatalf("createResources returned error: %v", err)
+	}
+	if len(resources) != 2 {
+		t.Fatalf("resource count = %d, want %d", len(resources), 2)
+	}
+}

--- a/providers/datadog/csm_threats_agent_rule.go
+++ b/providers/datadog/csm_threats_agent_rule.go
@@ -1,0 +1,136 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package datadog
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/DataDog/datadog-api-client-go/v2/api/datadog"
+	"github.com/DataDog/datadog-api-client-go/v2/api/datadogV2"
+
+	"github.com/chenrui333/terraformer/terraformutils"
+)
+
+// CSMThreatsAgentRuleGenerator ...
+type CSMThreatsAgentRuleGenerator struct {
+	DatadogService
+}
+
+func (g *CSMThreatsAgentRuleGenerator) createResource(ruleID, policyID string) (terraformutils.Resource, error) {
+	if ruleID == "" {
+		return terraformutils.Resource{}, fmt.Errorf("CSM threats agent rule missing id")
+	}
+
+	attrs := map[string]string{}
+	resourceName := fmt.Sprintf("csm_threats_agent_rule_%s", ruleID)
+	if policyID != "" {
+		attrs["policy_id"] = policyID
+		resourceName = fmt.Sprintf("csm_threats_agent_rule_%s_%s", policyID, ruleID)
+	}
+
+	return terraformutils.NewResource(
+		ruleID,
+		resourceName,
+		"datadog_csm_threats_agent_rule",
+		"datadog",
+		attrs,
+		[]string{},
+		map[string]interface{}{},
+	), nil
+}
+
+// InitResources Generate TerraformResources from Datadog API.
+func (g *CSMThreatsAgentRuleGenerator) InitResources() error {
+	datadogClient := g.Args["datadogClient"].(*datadog.APIClient)
+	auth := g.Args["auth"].(context.Context)
+	api := datadogV2.NewCSMThreatsApi(datadogClient)
+
+	for filterIndex, filter := range g.Filter {
+		if filter.FieldPath == "id" && filter.IsApplicable("csm_threats_agent_rule") {
+			var resources []terraformutils.Resource
+			var ruleIDs []string
+			for _, value := range filter.AcceptableValues {
+				policyID, ruleID := parseCSMThreatsAgentRuleFilterID(value)
+				resource, err := g.createResource(ruleID, policyID)
+				if err != nil {
+					return err
+				}
+				resources = append(resources, resource)
+				ruleIDs = append(ruleIDs, ruleID)
+			}
+			g.Filter[filterIndex].AcceptableValues = ruleIDs
+			g.Resources = resources
+			return nil
+		}
+	}
+
+	// List all rules (includes unscoped rules not tied to any policy)
+	rulesResp, httpResp, err := api.ListCSMThreatsAgentRules(auth)
+	if httpResp != nil && httpResp.Body != nil {
+		httpResp.Body.Close()
+	}
+	if err != nil {
+		return err
+	}
+
+	var resources []terraformutils.Resource
+	for _, rule := range rulesResp.GetData() {
+		ruleID := rule.GetId()
+		if ruleID == "" {
+			continue
+		}
+		policies := csmThreatsAgentRulePolicies(rule)
+		if len(policies) == 0 {
+			resource, err := g.createResource(ruleID, "")
+			if err != nil {
+				return err
+			}
+			resources = append(resources, resource)
+		} else {
+			for _, policyID := range policies {
+				resource, err := g.createResource(ruleID, policyID)
+				if err != nil {
+					return err
+				}
+				resources = append(resources, resource)
+			}
+		}
+	}
+
+	g.Resources = resources
+	return nil
+}
+
+func csmThreatsAgentRulePolicies(rule datadogV2.CloudWorkloadSecurityAgentRuleData) []string {
+	attrs := rule.GetAttributes()
+	seen := map[string]struct{}{}
+	var policies []string
+	for _, id := range attrs.GetBlocking() {
+		if _, ok := seen[id]; !ok {
+			seen[id] = struct{}{}
+			policies = append(policies, id)
+		}
+	}
+	for _, id := range attrs.GetMonitoring() {
+		if _, ok := seen[id]; !ok {
+			seen[id] = struct{}{}
+			policies = append(policies, id)
+		}
+	}
+	for _, id := range attrs.GetDisabled() {
+		if _, ok := seen[id]; !ok {
+			seen[id] = struct{}{}
+			policies = append(policies, id)
+		}
+	}
+	return policies
+}
+
+func parseCSMThreatsAgentRuleFilterID(value string) (policyID, ruleID string) {
+	if idx := strings.IndexByte(value, ':'); idx >= 0 {
+		return value[:idx], value[idx+1:]
+	}
+	return "", value
+}

--- a/providers/datadog/csm_threats_policy.go
+++ b/providers/datadog/csm_threats_policy.go
@@ -1,0 +1,89 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package datadog
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/DataDog/datadog-api-client-go/v2/api/datadog"
+	"github.com/DataDog/datadog-api-client-go/v2/api/datadogV2"
+
+	"github.com/chenrui333/terraformer/terraformutils"
+)
+
+// CSMThreatsPolicyGenerator ...
+type CSMThreatsPolicyGenerator struct {
+	DatadogService
+}
+
+func (g *CSMThreatsPolicyGenerator) createResource(data datadogV2.CloudWorkloadSecurityAgentPolicyData) (terraformutils.Resource, error) {
+	id := data.GetId()
+	if id == "" {
+		return terraformutils.Resource{}, fmt.Errorf("CSM threats policy missing id")
+	}
+
+	return terraformutils.NewSimpleResource(
+		id,
+		fmt.Sprintf("csm_threats_policy_%s", id),
+		"datadog_csm_threats_policy",
+		"datadog",
+		[]string{},
+	), nil
+}
+
+func (g *CSMThreatsPolicyGenerator) createResources(items []datadogV2.CloudWorkloadSecurityAgentPolicyData) ([]terraformutils.Resource, error) {
+	var resources []terraformutils.Resource
+	for _, item := range items {
+		resource, err := g.createResource(item)
+		if err != nil {
+			return nil, err
+		}
+		resources = append(resources, resource)
+	}
+	return resources, nil
+}
+
+// InitResources Generate TerraformResources from Datadog API.
+func (g *CSMThreatsPolicyGenerator) InitResources() error {
+	datadogClient := g.Args["datadogClient"].(*datadog.APIClient)
+	auth := g.Args["auth"].(context.Context)
+	api := datadogV2.NewCSMThreatsApi(datadogClient)
+
+	for _, filter := range g.Filter {
+		if filter.FieldPath == "id" && filter.IsApplicable("csm_threats_policy") {
+			var resources []terraformutils.Resource
+			for _, value := range filter.AcceptableValues {
+				resp, httpResp, err := api.GetCSMThreatsAgentPolicy(auth, value)
+				if httpResp != nil && httpResp.Body != nil {
+					httpResp.Body.Close()
+				}
+				if err != nil {
+					return err
+				}
+				resource, err := g.createResource(resp.GetData())
+				if err != nil {
+					return err
+				}
+				resources = append(resources, resource)
+			}
+			g.Resources = resources
+			return nil
+		}
+	}
+
+	resp, httpResp, err := api.ListCSMThreatsAgentPolicies(auth)
+	if httpResp != nil && httpResp.Body != nil {
+		httpResp.Body.Close()
+	}
+	if err != nil {
+		return err
+	}
+
+	resources, err := g.createResources(resp.GetData())
+	if err != nil {
+		return err
+	}
+	g.Resources = resources
+	return nil
+}

--- a/providers/datadog/csm_threats_test.go
+++ b/providers/datadog/csm_threats_test.go
@@ -1,0 +1,111 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package datadog
+
+import (
+	"testing"
+
+	"github.com/DataDog/datadog-api-client-go/v2/api/datadogV2"
+)
+
+func TestCSMThreatsAgentRuleCreateResourceWithPolicy(t *testing.T) {
+	generator := &CSMThreatsAgentRuleGenerator{}
+	resource, err := generator.createResource("rule-123", "policy-abc")
+	if err != nil {
+		t.Fatalf("createResource returned error: %v", err)
+	}
+
+	if resource.InstanceState.ID != "rule-123" {
+		t.Fatalf("resource ID = %q, want %q", resource.InstanceState.ID, "rule-123")
+	}
+	if resource.InstanceInfo.Type != "datadog_csm_threats_agent_rule" {
+		t.Fatalf("resource type = %q, want %q", resource.InstanceInfo.Type, "datadog_csm_threats_agent_rule")
+	}
+	if v := resource.InstanceState.Attributes["policy_id"]; v != "policy-abc" {
+		t.Fatalf("policy_id = %q, want %q", v, "policy-abc")
+	}
+}
+
+func TestCSMThreatsAgentRuleCreateResourceWithoutPolicy(t *testing.T) {
+	generator := &CSMThreatsAgentRuleGenerator{}
+	resource, err := generator.createResource("rule-123", "")
+	if err != nil {
+		t.Fatalf("createResource returned error: %v", err)
+	}
+
+	if resource.InstanceState.ID != "rule-123" {
+		t.Fatalf("resource ID = %q, want %q", resource.InstanceState.ID, "rule-123")
+	}
+	if _, ok := resource.InstanceState.Attributes["policy_id"]; ok {
+		t.Fatal("policy_id should not be set for unscoped rules")
+	}
+}
+
+func TestCSMThreatsAgentRuleCreateResourceMissingID(t *testing.T) {
+	generator := &CSMThreatsAgentRuleGenerator{}
+	_, err := generator.createResource("", "policy-abc")
+	if err == nil {
+		t.Fatal("createResource returned nil error, want missing id error")
+	}
+}
+
+func TestParseCSMThreatsAgentRuleFilterID(t *testing.T) {
+	tests := []struct {
+		input      string
+		wantPolicy string
+		wantRule   string
+	}{
+		{"policy-id:rule-id", "policy-id", "rule-id"},
+		{"a:b:c", "a", "b:c"},
+		{"rule-id-only", "", "rule-id-only"},
+	}
+	for _, tt := range tests {
+		policyID, ruleID := parseCSMThreatsAgentRuleFilterID(tt.input)
+		if policyID != tt.wantPolicy || ruleID != tt.wantRule {
+			t.Errorf("parseCSMThreatsAgentRuleFilterID(%q) = (%q, %q), want (%q, %q)",
+				tt.input, policyID, ruleID, tt.wantPolicy, tt.wantRule)
+		}
+	}
+}
+
+func TestCSMThreatsPolicyCreateResource(t *testing.T) {
+	data := datadogV2.NewCloudWorkloadSecurityAgentPolicyDataWithDefaults()
+	data.SetId("policy-xyz-456")
+
+	generator := &CSMThreatsPolicyGenerator{}
+	resource, err := generator.createResource(*data)
+	if err != nil {
+		t.Fatalf("createResource returned error: %v", err)
+	}
+
+	if resource.InstanceState.ID != "policy-xyz-456" {
+		t.Fatalf("resource ID = %q, want %q", resource.InstanceState.ID, "policy-xyz-456")
+	}
+	if resource.InstanceInfo.Type != "datadog_csm_threats_policy" {
+		t.Fatalf("resource type = %q, want %q", resource.InstanceInfo.Type, "datadog_csm_threats_policy")
+	}
+}
+
+func TestCSMThreatsPolicyCreateResourceMissingID(t *testing.T) {
+	generator := &CSMThreatsPolicyGenerator{}
+	_, err := generator.createResource(datadogV2.CloudWorkloadSecurityAgentPolicyData{})
+	if err == nil {
+		t.Fatal("createResource returned nil error, want missing id error")
+	}
+}
+
+func TestCSMThreatsPolicyCreateResources(t *testing.T) {
+	first := datadogV2.NewCloudWorkloadSecurityAgentPolicyDataWithDefaults()
+	first.SetId("policy-1")
+	second := datadogV2.NewCloudWorkloadSecurityAgentPolicyDataWithDefaults()
+	second.SetId("policy-2")
+
+	generator := &CSMThreatsPolicyGenerator{}
+	resources, err := generator.createResources([]datadogV2.CloudWorkloadSecurityAgentPolicyData{*first, *second})
+	if err != nil {
+		t.Fatalf("createResources returned error: %v", err)
+	}
+	if len(resources) != 2 {
+		t.Fatalf("resource count = %d, want %d", len(resources), 2)
+	}
+}

--- a/providers/datadog/datadog_provider.go
+++ b/providers/datadog/datadog_provider.go
@@ -165,12 +165,19 @@ func (p *DatadogProvider) InitService(serviceName string, verbose bool) error {
 // GetSupportedService return map of support service for Datadog
 func (p *DatadogProvider) GetSupportedService() map[string]terraformutils.ServiceGenerator {
 	return map[string]terraformutils.ServiceGenerator{
+		"agentless_scanning_aws_scan_options":      &AgentlessScanningAwsScanOptionsGenerator{},
+		"agentless_scanning_azure_scan_options":    &AgentlessScanningAzureScanOptionsGenerator{},
+		"agentless_scanning_gcp_scan_options":      &AgentlessScanningGcpScanOptionsGenerator{},
 		"apm_retention_filter":                     &APMRetentionFilterGenerator{},
 		"apm_retention_filter_order":               &APMRetentionFilterOrderGenerator{},
+		"appsec_waf_custom_rule":                   &AppSecWafCustomRuleGenerator{},
+		"appsec_waf_exclusion_filter":              &AppSecWafExclusionFilterGenerator{},
 		"aws_cur_config":                           &AwsCURConfigGenerator{},
 		"azure_uc_config":                          &AzureUCConfigGenerator{},
 		"cloud_inventory_sync_config":              &CloudInventorySyncConfigGenerator{},
 		"cost_budget":                              &CostBudgetGenerator{},
+		"csm_threats_agent_rule":                   &CSMThreatsAgentRuleGenerator{},
+		"csm_threats_policy":                       &CSMThreatsPolicyGenerator{},
 		"custom_allocation_rule":                   &CustomAllocationRuleGenerator{},
 		"dashboard_list":                           &DashboardListGenerator{},
 		"dashboard":                                &DashboardGenerator{},


### PR DESCRIPTION
Adds 7 Datadog security resource importers covering Agentless Scanning, CSM Threats, and AppSec WAF.

## Resources

| Service key | Terraform resource |
|---|---|
| `agentless_scanning_aws_scan_options` | `datadog_agentless_scanning_aws_scan_options` |
| `agentless_scanning_azure_scan_options` | `datadog_agentless_scanning_azure_scan_options` |
| `agentless_scanning_gcp_scan_options` | `datadog_agentless_scanning_gcp_scan_options` |
| `csm_threats_agent_rule` | `datadog_csm_threats_agent_rule` |
| `csm_threats_policy` | `datadog_csm_threats_policy` |
| `appsec_waf_custom_rule` | `datadog_appsec_waf_custom_rule` |
| `appsec_waf_exclusion_filter` | `datadog_appsec_waf_exclusion_filter` |

All resources use typed v2 API client list/get endpoints with ID filter support.
No pagination needed (APIs return full lists). No sensitive fields.

Ref: #336

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds 7 Datadog security importers for Agentless Scanning (AWS/Azure/GCP), CSM Threats, and AppSec WAF to import existing configs into Terraform. Also fixes agent rule import/state and seeds cloud IDs for reliable provider refresh.

- **New Features**
  - Agentless Scanning: `datadog_agentless_scanning_aws_scan_options`, `datadog_agentless_scanning_azure_scan_options`, `datadog_agentless_scanning_gcp_scan_options`
  - CSM Threats: `datadog_csm_threats_agent_rule`, `datadog_csm_threats_policy`
  - AppSec WAF: `datadog_appsec_waf_custom_rule`, `datadog_appsec_waf_exclusion_filter`
  - Uses typed `datadogV2` list/get endpoints with ID filter support; no pagination; no sensitive fields
  - Docs: updated `docs/datadog.md` (Azure scan options require `DataDog/datadog` >= 4.9.0; `csm_threats_agent_rule` filter supports `policy_id:rule_id`); registered in `GetSupportedService`

- **Bug Fixes**
  - Agentless scanning: seed `aws_account_id`, `azure_subscription_id`, and `gcp_project_id` so the provider can read on refresh
  - CSM agent rules: state ID is `rule_id`; list all rules (includes unscoped); derive and seed `policy_id`; filter accepts `policy_id:rule_id` or bare `rule_id`; rewrite acceptable filter values to bare `rule_id`s; emit one resource per `(rule_id, policy_id)` association

<sup>Written for commit 55f84984461c208ede9221b1a0ec9474f4578d30. Summary will update on new commits. <a href="https://cubic.dev/pr/chenrui333/terraformer/pull/450?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for Datadog agentless scanning resources (AWS, Azure, GCP), AppSec WAF custom rules and exclusion filters, CSM Threats agent rules and policies, and cloud inventory sync config.
* **Documentation**
  * Updated Datadog “Supported resources” docs with the new resource mappings and notes.
* **Tests**
  * Added comprehensive unit tests covering the new resource generators.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/chenrui333/terraformer/pull/450?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->