### PR TITLE
docs: add Terraformer framework gotchas to provider maintenance guidance

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -749,3 +749,27 @@ go build -v
 - When review comments arrive, reproduce or inspect the exact code path before patching.
 - Add follow-up commits on squash-merge PR branches unless a force-push is explicitly needed.
 - After merge, refresh `main` before starting the next provider gap.
+
+## Terraformer Framework Gotchas
+
+Durable lessons from provider-gap implementation that prevent repeated review cycles.
+
+### AllowEmptyValues for Required Booleans
+
+Terraformer's flatmap parser drops zero-value attributes unless they appear in `AllowEmptyValues`. When a Terraform resource has required boolean fields that can legitimately be `false`, list them in `AllowEmptyValues` or the generated HCL omits required arguments and `terraform plan` fails.
+
+### AcceptableValues Rewrite for Composite ID Filters
+
+Terraformer's `InitialCleanup` compares `filter.AcceptableValues` against `resource.InstanceState.ID`. When a filter uses a composite format (e.g., `parent_id:child_id`) but the resource state ID is only the child part, rewrite `g.Filter[filterIndex].AcceptableValues` to bare IDs after parsing. See `rum_retention_filter.go` for the canonical pattern.
+
+### Terraformer Strips the id Attribute During HCL Conversion
+
+Terraformer unconditionally ignores `InstanceState.Attributes["id"]` when generating HCL. If a Terraform resource's only Required configuration argument is literally `id`, it cannot produce valid HCL through Terraformer. Mark such resources as unsupported with evidence.
+
+### Metadata-Only Key Imports
+
+API key, application key, and similar secret-bearing resources are importable when the Terraform provider marks the secret field as `Computed+Sensitive` (not `Required`). The provider refresh works without the original secret value; generated HCL contains only metadata (name, dates). Document this behavior in `docs/<provider>.md`. Never export actual key/secret values.
+
+### Unstable API Operations
+
+Some SDK endpoints are gated behind `configuration.SetUnstableOperationEnabled`. When a list/get API requires this, call it on the client configuration before creating the API instance. Document the unstable status in a code comment and test helper.


### PR DESCRIPTION
## Summary

Add a "Terraformer Framework Gotchas" section to CLAUDE.md documenting 5 durable lessons from recent provider-gap work (PRs #449-#456).

## Lessons captured

1. **AllowEmptyValues for required booleans** — zero-value booleans are dropped without this
2. **AcceptableValues rewrite for composite IDs** — InitialCleanup discards resources otherwise
3. **id attribute stripping** — resources requiring `id` as config arg are un-importable
4. **Metadata-only key imports** — safe when provider marks secret as Computed+Sensitive
5. **Unstable API operations** — must enable on SDK config before creating API instance

## Notes

- No provider behavior changes
- Only CLAUDE.md updated (repo-local guidance)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a “Terraformer Framework Gotchas” section to CLAUDE.md with five lessons from provider-gap work to prevent repeat review cycles. Covers AllowEmptyValues for required booleans; AcceptableValues rewrite for composite ID filters; Terraformer stripping the id attribute; metadata-only key imports; and enabling unstable API operations.

<sup>Written for commit 686987a73f0f0aadfd3ca3d86def17421f42bead. Summary will update on new commits. <a href="https://cubic.dev/pr/chenrui333/terraformer/pull/458?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

