### PR TITLE
docs: update provider gap maintenance guidance

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -363,16 +363,17 @@ Rules:
 - When the API omits an ID for a singleton resource, use a stable synthetic ID (e.g. `"ip-allowlist"`) only when the provider read path does not require a real ID.
 - Add tests for default-vs-non-default behavior.
 
-## Empty/Disabled State Preservation
+## Empty State Preservation
 
-When a resource has required fields that can be empty or false, Terraformer's flatmap conversion may strip them.
+When a resource has required fields that can be empty strings or zero-count lists, Terraformer's flatmap conversion may strip them.
 
 Rules:
 
-- Add field paths to `AllowEmptyValues` to preserve zero-valued booleans (e.g. `enabled=false`) and empty lists/blocks.
-- For required empty lists that `AllowEmptyValues` cannot preserve (zero-count lists are dropped before the allow check), use `PostConvertHook` to set the field to an empty slice.
+- Add field paths to `AllowEmptyValues` to preserve empty-string attributes that would otherwise be stripped. Note: boolean `"false"` is a non-empty string in flatmap and is NOT dropped — AllowEmptyValues is unnecessary for booleans.
+- For required empty lists that `AllowEmptyValues` cannot preserve (zero-count lists are dropped before the allow check), use `PostConvertHook` to set the field to an empty slice (see `IntegrationAWSLogCollectionGenerator` pattern).
 - Seed required attributes via `NewResource` when provider refresh depends on context not derivable from the import ID alone (e.g. `org_group_id`, `sink_org_id`, `connection_types`).
-- Test that disabled/empty configurations produce valid HCL, not omitted blocks.
+- For resources where the only required configuration field is `id`, verify whether `AdditionalFields` or `PostConvertHook` can inject it before marking the resource unsupported.
+- Test that empty configurations produce valid HCL, not omitted blocks.
 
 ## Mutually Exclusive Nested Blocks
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -360,7 +360,19 @@ Rules:
 - Emit singletons only when explicitly configured or when provider semantics require owning the default state.
 - Skip default service-managed settings unless the provider represents them as intentional configuration.
 - Use preserve-ID metadata when provider read paths normalize singleton IDs differently from Terraformer seed IDs.
+- When the API omits an ID for a singleton resource, use a stable synthetic ID (e.g. `"ip-allowlist"`) only when the provider read path does not require a real ID.
 - Add tests for default-vs-non-default behavior.
+
+## Empty/Disabled State Preservation
+
+When a resource has required fields that can be empty or false, Terraformer's flatmap conversion may strip them.
+
+Rules:
+
+- Add field paths to `AllowEmptyValues` to preserve zero-valued booleans (e.g. `enabled=false`) and empty lists/blocks.
+- For required empty lists that `AllowEmptyValues` cannot preserve (zero-count lists are dropped before the allow check), use `PostConvertHook` to set the field to an empty slice.
+- Seed required attributes via `NewResource` when provider refresh depends on context not derivable from the import ID alone (e.g. `org_group_id`, `sink_org_id`, `connection_types`).
+- Test that disabled/empty configurations produce valid HCL, not omitted blocks.
 
 ## Mutually Exclusive Nested Blocks
 
@@ -411,6 +423,7 @@ Every list/describe API used for broad discovery must be checked for pagination.
 Rules:
 
 - Use paginators where available.
+- Verify the pagination base per API; do not assume page 1 — some APIs use zero-based page numbers.
 - Add pagination tests for child-resource discovery when a previous implementation used a single page.
 - Do not assume child-resource lists fit in one response.
 - When an API has nested pagination under each parent, test parent and child pagination together.


### PR DESCRIPTION
## Summary

Update repo-local provider maintenance guidance with durable lessons from recent Datadog org-control import work (PR #452).

## Changes

- **Singleton section**: Add synthetic ID rule for APIs that omit IDs
- **Pagination section**: Add zero-based page number warning
- **New section**: Empty/Disabled State Preservation — covers AllowEmptyValues, PostConvertHook, and NewResource seeding for provider refresh

## Notes

- No provider behavior changes.
- Only CLAUDE.md touched (13 lines added).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Update CLAUDE.md with concrete guidance from the Datadog org-controls import: stable synthetic IDs for singletons when APIs omit IDs, empty/disabled state preservation via `AllowEmptyValues` (boolean 'false' isn't stripped), `PostConvertHook`, and `NewResource`, `AdditionalFields`/`PostConvertHook` for injecting `id` on id-only resources, and zero-based pagination checks. Docs-only; no provider behavior changes.

<sup>Written for commit e34c8b57ecdafe03138f9a0538e2e3ce8f89aca6. Summary will update on new commits. <a href="https://cubic.dev/pr/chenrui333/terraformer/pull/459?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

