### PR TITLE
docs(datadog): sync resource metadata

### DIFF
--- a/docs/datadog.md
+++ b/docs/datadog.md
@@ -182,6 +182,8 @@ Tag filters are order specific. For example, if your monitor has tags (in the or
     * `datadog_logs_index_order`
 *   `logs_integration_pipeline`
     * `datadog_logs_integration_pipeline`
+*   `logs_metric`
+    * `datadog_logs_metric`
 *   `logs_pipeline_order`
     * `datadog_logs_pipeline_order`
 *   `logs_restriction_query`
@@ -326,5 +328,11 @@ The following Terraform provider resources have been evaluated and cannot be saf
 | `datadog_integration_fastly_account` | `api_key` is required and sensitive; read API does not return it. |
 | `datadog_integration_ms_teams_workflows_webhook_handle` | `url` is required and sensitive; read API does not return it. |
 | `datadog_integration_opsgenie_service_object` | `opsgenie_api_key` is required and sensitive; Datadog API explicitly never returns it. |
+| `datadog_app_key_registration` | Required `id` configuration attribute is stripped during Terraformer HCL conversion, producing an empty resource block that fails validation. |
+| `datadog_org_group_policy_override` | Delete resets the target org config value to the parent policy, and server-created overrides make broad discovery noisy and potentially ephemeral. |
+| `datadog_webhook_custom_variable` | Provider import seeds only `id`, but provider read looks up the variable by `name`; Terraformer cannot safely refresh the required name/value state from a broad ID import. |
+| `datadog_integration_aws_external_id` | Creates a short-lived external ID operation; provider read is a no-op and delete only removes Terraform state. |
+| `datadog_action_connection` | Deferred until a dedicated importer handles AWS versus HTTP credential-backed variants and the HTTP token-auth read path that omits sensitive token values. |
+| `datadog_cloud_workload_security_agent_rule` | Deprecated in favor of the already registered `datadog_csm_threats_agent_rule`, so broad import would risk duplicate ownership of the same agent rules. |
 
 [1]: https://github.com/chenrui333/terraformer/blob/main/README.md#filtering

--- a/providers/datadog/unsupported_resources.json
+++ b/providers/datadog/unsupported_resources.json
@@ -99,6 +99,50 @@
         "https://github.com/chenrui333/terraformer/issues/336",
         "https://registry.terraform.io/providers/DataDog/datadog/latest/docs/resources/org_group_policy_override"
       ]
+    },
+    {
+      "resource": "datadog_webhook_custom_variable",
+      "service_family": "webhook",
+      "reason": "Provider import does not seed the name required by the read path, and the required value is sensitive.",
+      "evidence": "The Terraform provider import only passes through id, but Read calls GetWebhooksIntegrationCustomVariable with state.name instead of id. Terraformer broad import would seed only the remote ID and cannot safely refresh the required name/value state, especially for secret custom variables.",
+      "status": "unsupported",
+      "references": [
+        "https://registry.terraform.io/providers/DataDog/datadog/latest/docs/resources/webhook_custom_variable",
+        "https://github.com/DataDog/terraform-provider-datadog/blob/master/datadog/fwprovider/resource_datadog_webhook_custom_variable.go"
+      ]
+    },
+    {
+      "resource": "datadog_integration_aws_external_id",
+      "service_family": "integration_aws",
+      "reason": "Resource creates a short-lived external ID operation rather than stable discoverable inventory.",
+      "evidence": "The Terraform provider Create path calls CreateNewAWSExternalID and warns that the value expires if not used within 48 hours. Read is a no-op and Delete only removes Terraform state, so broad import would record an operation result without a durable Datadog object to discover or reconcile.",
+      "status": "unsupported",
+      "references": [
+        "https://registry.terraform.io/providers/DataDog/datadog/latest/docs/resources/integration_aws_external_id",
+        "https://github.com/DataDog/terraform-provider-datadog/blob/master/datadog/fwprovider/resource_datadog_integration_aws_external_id.go"
+      ]
+    },
+    {
+      "resource": "datadog_action_connection",
+      "service_family": "action_connection",
+      "reason": "Connection variants need a dedicated importer because API/read behavior differs for AWS and HTTP credential-backed connections.",
+      "evidence": "The Terraform provider resource requires exactly one AWS or HTTP connection block, and HTTP token-auth connections can contain sensitive token values. Provider read reconstructs token names and types but not token values, and the data source is ID-based, so broad discovery needs variant-specific handling before Terraformer can emit reliable HCL.",
+      "status": "deferred",
+      "references": [
+        "https://registry.terraform.io/providers/DataDog/datadog/latest/docs/resources/action_connection",
+        "https://github.com/DataDog/terraform-provider-datadog/blob/master/datadog/fwprovider/resource_datadog_action_connection.go"
+      ]
+    },
+    {
+      "resource": "datadog_cloud_workload_security_agent_rule",
+      "service_family": "csm_threats",
+      "reason": "Deprecated resource duplicates the currently registered CSM threats agent rule ownership path.",
+      "evidence": "The Terraform provider marks datadog_cloud_workload_security_agent_rule deprecated in favor of datadog_csm_threats_agent_rule. Terraformer already registers csm_threats_agent_rule for the same CSM threats agent-rule API, so adding the deprecated resource would risk duplicate Terraform ownership for the same remote rules.",
+      "status": "deferred",
+      "references": [
+        "https://registry.terraform.io/providers/DataDog/datadog/latest/docs/resources/cloud_workload_security_agent_rule",
+        "https://registry.terraform.io/providers/DataDog/datadog/latest/docs/resources/csm_threats_agent_rule"
+      ]
     }
   ]
 }


### PR DESCRIPTION
Summary
- Add the registered Datadog `logs_metric` service to the supported resources docs.
- Sync the Datadog unsupported/deferred docs table with `unsupported_resources.json`.
- Add evidence-backed unsupported/deferred metadata for Datadog webhook custom variables, AWS external IDs, action connections, and deprecated CWS agent rules.

Notes
- Metadata/docs only; no importer implementation changes.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add Datadog `logs_metric` to supported resources and sync the unsupported/deferred docs with `unsupported_resources.json`.
Document unsupported/deferred status for `datadog_webhook_custom_variable`, `datadog_integration_aws_external_id`, `datadog_action_connection`, and deprecated `datadog_cloud_workload_security_agent_rule`; docs/metadata only, no importer changes.

<sup>Written for commit c76ebc9b1bbee513fd9bcb57abcae90344f4887f. Summary will update on new commits. <a href="https://cubic.dev/pr/chenrui333/terraformer/pull/460?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

