### PR TITLE
feat(datadog): add synthetics and downtime leftover imports

### DIFF
--- a/docs/datadog.md
+++ b/docs/datadog.md
@@ -144,6 +144,9 @@ Tag filters are order specific. For example, if your monitor has tags (in the or
         * **_NOTE:_** Singleton resource. Only one domain allowlist per org.
 *   `downtime`
     * `datadog_downtime`
+*   `downtime_schedule`
+    * `datadog_downtime_schedule`
+        * **_NOTE:_** Requires DataDog/datadog provider 4.9.0 or newer.
 *   `gcp_uc_config`
     * `datadog_gcp_uc_config`
         * **_NOTE:_** Requires DataDog/datadog provider 3.39.0 or newer.
@@ -289,11 +292,18 @@ Tag filters are order specific. For example, if your monitor has tags (in the or
     * `datadog_slo_correction`
 *   `spans_metric`
     * `datadog_spans_metric`
+*   `synthetics_concurrency_cap`
+    * `datadog_synthetics_concurrency_cap`
+        * **_NOTE:_** Requires DataDog/datadog provider 4.9.0 or newer.
+        * **_NOTE:_** Singleton resource. The Datadog provider stores the import ID as `synthetics-concurrency-cap`.
 *   `synthetics_global_variable`
     * `datadog_synthetics_global_variable`
         * **_NOTE:_** Importing resource requires resource ID's to be passed via [Filter][1] option
 *   `synthetics_private_location`
     * `datadog_synthetics_private_location`
+*   `synthetics_suite`
+    * `datadog_synthetics_suite`
+        * **_NOTE:_** Requires DataDog/datadog provider 4.9.0 or newer.
 *   `synthetics_test`
     * `datadog_synthetics_test`
 *   `tag_pipeline_ruleset`

--- a/providers/datadog/datadog_provider.go
+++ b/providers/datadog/datadog_provider.go
@@ -188,6 +188,7 @@ func (p *DatadogProvider) GetSupportedService() map[string]terraformutils.Servic
 		"dashboard_v2":                             &DashboardV2Generator{},
 		"domain_allowlist":                         &DomainAllowlistGenerator{},
 		"downtime":                                 &DowntimeGenerator{},
+		"downtime_schedule":                        &DowntimeScheduleGenerator{},
 		"gcp_uc_config":                            &GCPUCConfigGenerator{},
 		"ip_allowlist":                             &IPAllowlistGenerator{},
 		"logs_archive":                             &LogsArchiveGenerator{},
@@ -244,9 +245,11 @@ func (p *DatadogProvider) GetSupportedService() map[string]terraformutils.Servic
 		"service_level_objective":                  &ServiceLevelObjectiveGenerator{},
 		"slo_correction":                           &SLOCorrectionGenerator{},
 		"spans_metric":                             &SpansMetricGenerator{},
-		"synthetics_test":                          &SyntheticsTestGenerator{},
+		"synthetics_concurrency_cap":               &SyntheticsConcurrencyCapGenerator{},
 		"synthetics_global_variable":               &SyntheticsGlobalVariableGenerator{},
 		"synthetics_private_location":              &SyntheticsPrivateLocationGenerator{},
+		"synthetics_suite":                         &SyntheticsSuiteGenerator{},
+		"synthetics_test":                          &SyntheticsTestGenerator{},
 		"tag_pipeline_ruleset":                     &TagPipelineRulesetGenerator{},
 		"team":                                     &TeamGenerator{},
 		"team_connection":                          &TeamConnectionGenerator{},
@@ -298,6 +301,14 @@ func (p DatadogProvider) GetResourceConnections() map[string]map[string][]string
 			},
 			"monitor_json": {
 				"monitor_id", "id",
+			},
+		},
+		"downtime_schedule": {
+			"monitor": {
+				"monitor_identifier.monitor_id", "id",
+			},
+			"monitor_json": {
+				"monitor_identifier.monitor_id", "id",
 			},
 		},
 		"on_call_escalation_policy": {
@@ -436,6 +447,11 @@ func (p DatadogProvider) GetResourceConnections() map[string]map[string][]string
 		"synthetics_test": {
 			"synthetics_private_location": {
 				"locations", "id",
+			},
+		},
+		"synthetics_suite": {
+			"synthetics_test": {
+				"tests.public_id", "id",
 			},
 		},
 		"synthetics_global_variable": {

--- a/providers/datadog/datadog_provider_test.go
+++ b/providers/datadog/datadog_provider_test.go
@@ -210,9 +210,43 @@ func TestDatadogProviderMonitorJSONConnections(t *testing.T) {
 	assertDatadogConnection(
 		t,
 		connections,
+		"downtime_schedule",
+		"monitor_json",
+		"monitor_identifier.monitor_id",
+		"id",
+	)
+	assertDatadogConnection(
+		t,
+		connections,
 		"service_level_objective",
 		"monitor_json",
 		"monitor_ids",
+		"id",
+	)
+}
+
+func TestDatadogProviderDowntimeScheduleConnections(t *testing.T) {
+	connections := DatadogProvider{}.GetResourceConnections()
+
+	assertDatadogConnection(
+		t,
+		connections,
+		"downtime_schedule",
+		"monitor",
+		"monitor_identifier.monitor_id",
+		"id",
+	)
+}
+
+func TestDatadogProviderSyntheticsSuiteConnections(t *testing.T) {
+	connections := DatadogProvider{}.GetResourceConnections()
+
+	assertDatadogConnection(
+		t,
+		connections,
+		"synthetics_suite",
+		"synthetics_test",
+		"tests.public_id",
 		"id",
 	)
 }

--- a/providers/datadog/downtime_schedule.go
+++ b/providers/datadog/downtime_schedule.go
@@ -18,8 +18,10 @@ import (
 const datadogDowntimeSchedulePageLimit = int64(100)
 
 const (
-	downtimeScheduleOneTimeKey   = "one_time_schedule"
-	downtimeScheduleRecurringKey = "recurring_schedule"
+	downtimeScheduleNotifyEndStatesKey = "notify_end_states"
+	downtimeScheduleNotifyEndTypesKey  = "notify_end_types"
+	downtimeScheduleOneTimeKey         = "one_time_schedule"
+	downtimeScheduleRecurringKey       = "recurring_schedule"
 )
 
 var (
@@ -51,6 +53,10 @@ func (g *DowntimeScheduleGenerator) PostConvertHook() error {
 	for i := range g.Resources {
 		resource := &g.Resources[i]
 		removeDowntimeScheduleEmptyAlternateItem(resource)
+		preserveDowntimeScheduleEmptyNotificationItems(resource)
+		if err := preserveDowntimeScheduleEmptyNotificationState(resource); err != nil {
+			return err
+		}
 		if err := removeDowntimeScheduleEmptyAlternateState(resource); err != nil {
 			return err
 		}
@@ -74,6 +80,70 @@ func removeDowntimeScheduleEmptyAlternateItem(resource *terraformutils.Resource)
 	if recurringScheduleHasValue && hasOneTimeSchedule && !oneTimeScheduleHasValue {
 		delete(resource.Item, downtimeScheduleOneTimeKey)
 	}
+}
+
+func preserveDowntimeScheduleEmptyNotificationItems(resource *terraformutils.Resource) {
+	if resource == nil {
+		return
+	}
+	if resource.Item == nil {
+		resource.Item = map[string]interface{}{}
+	}
+
+	for _, key := range []string{downtimeScheduleNotifyEndStatesKey, downtimeScheduleNotifyEndTypesKey} {
+		if value, ok := resource.Item[key]; ok && downtimeScheduleValueHasValue(value) {
+			continue
+		}
+		resource.Item[key] = []interface{}{}
+	}
+}
+
+func preserveDowntimeScheduleEmptyNotificationState(resource *terraformutils.Resource) error {
+	if resource == nil || resource.InstanceState == nil {
+		return nil
+	}
+	if resource.InstanceState.Attributes == nil {
+		resource.InstanceState.Attributes = map[string]string{}
+	}
+
+	typedAttributes := map[string]json.RawMessage{}
+	hasTypedAttributes := len(resource.InstanceState.TypedAttributes) > 0
+	if hasTypedAttributes {
+		if err := json.Unmarshal(resource.InstanceState.TypedAttributes, &typedAttributes); err != nil {
+			return fmt.Errorf("decode downtime schedule typed attributes: %w", err)
+		}
+	}
+
+	changedTypedAttributes := false
+	for _, key := range []string{downtimeScheduleNotifyEndStatesKey, downtimeScheduleNotifyEndTypesKey} {
+		rawValueHasValue := false
+		if rawValue, ok := typedAttributes[key]; ok {
+			var err error
+			rawValueHasValue, err = downtimeScheduleRawMessageHasValue(rawValue)
+			if err != nil {
+				return fmt.Errorf("decode downtime schedule %s state: %w", key, err)
+			}
+		}
+		if rawValueHasValue || downtimeScheduleFlatmapSetHasValue(resource, key) {
+			continue
+		}
+
+		resource.InstanceState.Attributes[key+".#"] = "0"
+		if hasTypedAttributes {
+			typedAttributes[key] = json.RawMessage("[]")
+			changedTypedAttributes = true
+		}
+	}
+
+	if !changedTypedAttributes {
+		return nil
+	}
+	rawAttributes, err := json.Marshal(typedAttributes)
+	if err != nil {
+		return fmt.Errorf("encode downtime schedule typed attributes: %w", err)
+	}
+	resource.InstanceState.SetTypedAttributes(rawAttributes)
+	return nil
 }
 
 func removeDowntimeScheduleEmptyAlternateState(resource *terraformutils.Resource) error {
@@ -130,6 +200,24 @@ func removeDowntimeScheduleStateAttributes(resource *terraformutils.Resource, bl
 			delete(resource.InstanceState.Attributes, key)
 		}
 	}
+}
+
+func downtimeScheduleFlatmapSetHasValue(resource *terraformutils.Resource, key string) bool {
+	if resource == nil || resource.InstanceState == nil || resource.InstanceState.Attributes == nil {
+		return false
+	}
+	if count, ok := resource.InstanceState.Attributes[key+".#"]; ok && count != "" && count != "0" {
+		return true
+	}
+	for attributeKey, attributeValue := range resource.InstanceState.Attributes {
+		if attributeKey == key+".#" || !strings.HasPrefix(attributeKey, key+".") {
+			continue
+		}
+		if attributeValue != "" {
+			return true
+		}
+	}
+	return false
 }
 
 func downtimeScheduleRawMessageHasValue(rawValue json.RawMessage) (bool, error) {

--- a/providers/datadog/downtime_schedule.go
+++ b/providers/datadog/downtime_schedule.go
@@ -3,8 +3,11 @@
 package datadog
 
 import (
+	"bytes"
 	"context"
+	"encoding/json"
 	"fmt"
+	"strings"
 
 	"github.com/DataDog/datadog-api-client-go/v2/api/datadog"
 	"github.com/DataDog/datadog-api-client-go/v2/api/datadogV2"
@@ -13,6 +16,11 @@ import (
 )
 
 const datadogDowntimeSchedulePageLimit = int64(100)
+
+const (
+	downtimeScheduleOneTimeKey   = "one_time_schedule"
+	downtimeScheduleRecurringKey = "recurring_schedule"
+)
 
 var (
 	// DowntimeScheduleAllowEmptyValues ...
@@ -37,6 +45,130 @@ func (g *DowntimeScheduleGenerator) createResource(downtime datadogV2.DowntimeRe
 		"datadog",
 		DowntimeScheduleAllowEmptyValues,
 	), nil
+}
+
+func (g *DowntimeScheduleGenerator) PostConvertHook() error {
+	for i := range g.Resources {
+		resource := &g.Resources[i]
+		removeDowntimeScheduleEmptyAlternateItem(resource)
+		if err := removeDowntimeScheduleEmptyAlternateState(resource); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func removeDowntimeScheduleEmptyAlternateItem(resource *terraformutils.Resource) {
+	if resource == nil || resource.Item == nil {
+		return
+	}
+
+	oneTimeSchedule, hasOneTimeSchedule := resource.Item[downtimeScheduleOneTimeKey]
+	recurringSchedule, hasRecurringSchedule := resource.Item[downtimeScheduleRecurringKey]
+	oneTimeScheduleHasValue := downtimeScheduleValueHasValue(oneTimeSchedule)
+	recurringScheduleHasValue := downtimeScheduleValueHasValue(recurringSchedule)
+
+	if oneTimeScheduleHasValue && hasRecurringSchedule && !recurringScheduleHasValue {
+		delete(resource.Item, downtimeScheduleRecurringKey)
+	}
+	if recurringScheduleHasValue && hasOneTimeSchedule && !oneTimeScheduleHasValue {
+		delete(resource.Item, downtimeScheduleOneTimeKey)
+	}
+}
+
+func removeDowntimeScheduleEmptyAlternateState(resource *terraformutils.Resource) error {
+	if resource == nil || resource.InstanceState == nil || len(resource.InstanceState.TypedAttributes) == 0 {
+		return nil
+	}
+
+	attributes := map[string]json.RawMessage{}
+	if err := json.Unmarshal(resource.InstanceState.TypedAttributes, &attributes); err != nil {
+		return fmt.Errorf("decode downtime schedule typed attributes: %w", err)
+	}
+
+	oneTimeSchedule, hasOneTimeSchedule := attributes[downtimeScheduleOneTimeKey]
+	recurringSchedule, hasRecurringSchedule := attributes[downtimeScheduleRecurringKey]
+
+	oneTimeScheduleHasValue, err := downtimeScheduleRawMessageHasValue(oneTimeSchedule)
+	if err != nil {
+		return fmt.Errorf("decode downtime schedule one_time_schedule state: %w", err)
+	}
+	recurringScheduleHasValue, err := downtimeScheduleRawMessageHasValue(recurringSchedule)
+	if err != nil {
+		return fmt.Errorf("decode downtime schedule recurring_schedule state: %w", err)
+	}
+
+	changed := false
+	if oneTimeScheduleHasValue && hasRecurringSchedule && !recurringScheduleHasValue {
+		delete(attributes, downtimeScheduleRecurringKey)
+		removeDowntimeScheduleStateAttributes(resource, downtimeScheduleRecurringKey)
+		changed = true
+	}
+	if recurringScheduleHasValue && hasOneTimeSchedule && !oneTimeScheduleHasValue {
+		delete(attributes, downtimeScheduleOneTimeKey)
+		removeDowntimeScheduleStateAttributes(resource, downtimeScheduleOneTimeKey)
+		changed = true
+	}
+	if !changed {
+		return nil
+	}
+
+	rawAttributes, err := json.Marshal(attributes)
+	if err != nil {
+		return fmt.Errorf("encode downtime schedule typed attributes: %w", err)
+	}
+	resource.InstanceState.SetTypedAttributes(rawAttributes)
+	return nil
+}
+
+func removeDowntimeScheduleStateAttributes(resource *terraformutils.Resource, blockName string) {
+	if resource == nil || resource.InstanceState == nil || resource.InstanceState.Attributes == nil {
+		return
+	}
+	for key := range resource.InstanceState.Attributes {
+		if key == blockName || strings.HasPrefix(key, blockName+".") {
+			delete(resource.InstanceState.Attributes, key)
+		}
+	}
+}
+
+func downtimeScheduleRawMessageHasValue(rawValue json.RawMessage) (bool, error) {
+	if len(bytes.TrimSpace(rawValue)) == 0 {
+		return false, nil
+	}
+
+	var value interface{}
+	decoder := json.NewDecoder(bytes.NewReader(rawValue))
+	decoder.UseNumber()
+	if err := decoder.Decode(&value); err != nil {
+		return false, err
+	}
+	return downtimeScheduleValueHasValue(value), nil
+}
+
+func downtimeScheduleValueHasValue(value interface{}) bool {
+	switch value := value.(type) {
+	case nil:
+		return false
+	case string:
+		return value != ""
+	case []interface{}:
+		for _, item := range value {
+			if downtimeScheduleValueHasValue(item) {
+				return true
+			}
+		}
+		return false
+	case map[string]interface{}:
+		for _, item := range value {
+			if downtimeScheduleValueHasValue(item) {
+				return true
+			}
+		}
+		return false
+	default:
+		return true
+	}
 }
 
 func (g *DowntimeScheduleGenerator) createResources(downtimes []datadogV2.DowntimeResponseData) ([]terraformutils.Resource, error) {

--- a/providers/datadog/downtime_schedule.go
+++ b/providers/datadog/downtime_schedule.go
@@ -18,6 +18,7 @@ import (
 const datadogDowntimeSchedulePageLimit = int64(100)
 
 const (
+	downtimeScheduleMessageKey         = "message"
 	downtimeScheduleNotifyEndStatesKey = "notify_end_states"
 	downtimeScheduleNotifyEndTypesKey  = "notify_end_types"
 	downtimeScheduleOneTimeKey         = "one_time_schedule"
@@ -26,7 +27,7 @@ const (
 
 var (
 	// DowntimeScheduleAllowEmptyValues ...
-	DowntimeScheduleAllowEmptyValues = []string{}
+	DowntimeScheduleAllowEmptyValues = []string{downtimeScheduleMessageKey}
 )
 
 // DowntimeScheduleGenerator ...

--- a/providers/datadog/downtime_schedule.go
+++ b/providers/datadog/downtime_schedule.go
@@ -1,0 +1,151 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package datadog
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/DataDog/datadog-api-client-go/v2/api/datadog"
+	"github.com/DataDog/datadog-api-client-go/v2/api/datadogV2"
+
+	"github.com/chenrui333/terraformer/terraformutils"
+)
+
+const datadogDowntimeSchedulePageLimit = int64(100)
+
+var (
+	// DowntimeScheduleAllowEmptyValues ...
+	DowntimeScheduleAllowEmptyValues = []string{}
+)
+
+// DowntimeScheduleGenerator ...
+type DowntimeScheduleGenerator struct {
+	DatadogService
+}
+
+func (g *DowntimeScheduleGenerator) createResource(downtime datadogV2.DowntimeResponseData) (terraformutils.Resource, error) {
+	downtimeID := downtime.GetId()
+	if downtimeID == "" {
+		return terraformutils.Resource{}, fmt.Errorf("downtime schedule missing id")
+	}
+
+	return terraformutils.NewSimpleResource(
+		downtimeID,
+		fmt.Sprintf("downtime_schedule_%s", downtimeID),
+		"datadog_downtime_schedule",
+		"datadog",
+		DowntimeScheduleAllowEmptyValues,
+	), nil
+}
+
+func (g *DowntimeScheduleGenerator) createResources(downtimes []datadogV2.DowntimeResponseData) ([]terraformutils.Resource, error) {
+	resources := []terraformutils.Resource{}
+	for _, downtime := range downtimes {
+		resource, err := g.createResource(downtime)
+		if err != nil {
+			return nil, err
+		}
+		resources = append(resources, resource)
+	}
+	return resources, nil
+}
+
+// InitResources Generate TerraformResources from Datadog API,
+// from each Datadog V2 downtime schedule create 1 TerraformResource.
+func (g *DowntimeScheduleGenerator) InitResources() error {
+	datadogClient := g.Args["datadogClient"].(*datadog.APIClient)
+	auth := g.Args["auth"].(context.Context)
+	api := datadogV2.NewDowntimesApi(datadogClient)
+
+	resources, filtered, err := g.filteredResources(auth, api)
+	if err != nil {
+		return err
+	}
+	if filtered {
+		g.Resources = resources
+		return nil
+	}
+
+	downtimes, err := listDowntimeSchedules(auth, api)
+	if err != nil {
+		return err
+	}
+	resources, err = g.createResources(downtimes)
+	if err != nil {
+		return err
+	}
+
+	g.Resources = resources
+	return nil
+}
+
+func (g *DowntimeScheduleGenerator) filteredResources(auth context.Context, api *datadogV2.DowntimesApi) ([]terraformutils.Resource, bool, error) {
+	resources := []terraformutils.Resource{}
+	filtered := false
+
+	for _, filter := range g.Filter {
+		if filter.FieldPath != "id" || !filter.IsApplicable("downtime_schedule") {
+			continue
+		}
+
+		filtered = true
+		for _, value := range filter.AcceptableValues {
+			downtime, err := getDowntimeSchedule(auth, api, value)
+			if err != nil {
+				return nil, true, err
+			}
+			resource, err := g.createResource(downtime)
+			if err != nil {
+				return nil, true, err
+			}
+			resources = append(resources, resource)
+		}
+	}
+
+	return resources, filtered, nil
+}
+
+func getDowntimeSchedule(auth context.Context, api *datadogV2.DowntimesApi, downtimeID string) (datadogV2.DowntimeResponseData, error) {
+	resp, httpResp, err := api.GetDowntime(auth, downtimeID)
+	closeDatadogResponseBody(httpResp)
+	if err != nil {
+		return datadogV2.DowntimeResponseData{}, err
+	}
+	if data, ok := resp.GetDataOk(); ok {
+		return *data, nil
+	}
+	return datadogV2.DowntimeResponseData{}, fmt.Errorf("downtime schedule %q not found", downtimeID)
+}
+
+func listDowntimeSchedules(auth context.Context, api *datadogV2.DowntimesApi) ([]datadogV2.DowntimeResponseData, error) {
+	downtimes := []datadogV2.DowntimeResponseData{}
+	offset := int64(0)
+
+	for {
+		optionalParams := datadogV2.NewListDowntimesOptionalParameters().
+			WithPageOffset(offset).
+			WithPageLimit(datadogDowntimeSchedulePageLimit)
+
+		resp, httpResp, err := api.ListDowntimes(auth, *optionalParams)
+		closeDatadogResponseBody(httpResp)
+		if err != nil {
+			return nil, err
+		}
+
+		pageDowntimes := resp.GetData()
+		downtimes = append(downtimes, pageDowntimes...)
+
+		if len(pageDowntimes) == 0 || len(pageDowntimes) < int(datadogDowntimeSchedulePageLimit) {
+			break
+		}
+		meta := resp.GetMeta()
+		page := meta.GetPage()
+		if total := page.GetTotalFilteredCount(); total > 0 && len(downtimes) >= int(total) {
+			break
+		}
+		offset += int64(len(pageDowntimes))
+	}
+
+	return downtimes, nil
+}

--- a/providers/datadog/downtime_schedule_test.go
+++ b/providers/datadog/downtime_schedule_test.go
@@ -8,13 +8,41 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"regexp"
 	"testing"
 
 	"github.com/DataDog/datadog-api-client-go/v2/api/datadog"
 	"github.com/DataDog/datadog-api-client-go/v2/api/datadogV2"
+	"github.com/zclconf/go-cty/cty"
 
 	"github.com/chenrui333/terraformer/terraformutils"
 )
+
+func TestDowntimeScheduleAllowEmptyValuesPreservesMessage(t *testing.T) {
+	allowEmptyValues := []*regexp.Regexp{}
+	for _, pattern := range DowntimeScheduleAllowEmptyValues {
+		allowEmptyValues = append(allowEmptyValues, regexp.MustCompile(pattern))
+	}
+
+	parser := terraformutils.NewFlatmapParser(map[string]string{
+		downtimeScheduleMessageKey: "",
+	}, nil, allowEmptyValues)
+	downtimeScheduleType := cty.Object(map[string]cty.Type{
+		downtimeScheduleMessageKey: cty.String,
+	})
+
+	result, err := parser.Parse(downtimeScheduleType)
+	if err != nil {
+		t.Fatalf("Parse returned error: %v", err)
+	}
+	message, ok := result[downtimeScheduleMessageKey].(string)
+	if !ok {
+		t.Fatalf("message = %T, want string", result[downtimeScheduleMessageKey])
+	}
+	if message != "" {
+		t.Fatalf("message = %q, want empty string", message)
+	}
+}
 
 func TestDowntimeScheduleCreateResource(t *testing.T) {
 	downtime := datadogV2.NewDowntimeResponseDataWithDefaults()

--- a/providers/datadog/downtime_schedule_test.go
+++ b/providers/datadog/downtime_schedule_test.go
@@ -1,0 +1,109 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package datadog
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/DataDog/datadog-api-client-go/v2/api/datadog"
+	"github.com/DataDog/datadog-api-client-go/v2/api/datadogV2"
+
+	"github.com/chenrui333/terraformer/terraformutils"
+)
+
+func TestDowntimeScheduleCreateResource(t *testing.T) {
+	downtime := datadogV2.NewDowntimeResponseDataWithDefaults()
+	downtime.SetId("downtime-123")
+
+	generator := &DowntimeScheduleGenerator{}
+	resource, err := generator.createResource(*downtime)
+	if err != nil {
+		t.Fatalf("createResource returned error: %v", err)
+	}
+
+	if resource.InstanceState.ID != "downtime-123" {
+		t.Fatalf("resource ID = %q, want %q", resource.InstanceState.ID, "downtime-123")
+	}
+	if resource.ResourceName != "tfer--downtime_schedule_downtime-123" {
+		t.Fatalf("resource name = %q, want %q", resource.ResourceName, "tfer--downtime_schedule_downtime-123")
+	}
+	if resource.InstanceInfo.Type != "datadog_downtime_schedule" {
+		t.Fatalf("resource type = %q, want %q", resource.InstanceInfo.Type, "datadog_downtime_schedule")
+	}
+}
+
+func TestDowntimeScheduleCreateResourceMissingID(t *testing.T) {
+	generator := &DowntimeScheduleGenerator{}
+	_, err := generator.createResource(datadogV2.DowntimeResponseData{})
+	if err == nil {
+		t.Fatal("createResource returned nil error, want missing id error")
+	}
+}
+
+func TestDowntimeScheduleCreateResources(t *testing.T) {
+	firstDowntime := datadogV2.NewDowntimeResponseDataWithDefaults()
+	firstDowntime.SetId("downtime-1")
+	secondDowntime := datadogV2.NewDowntimeResponseDataWithDefaults()
+	secondDowntime.SetId("downtime-2")
+
+	generator := &DowntimeScheduleGenerator{}
+	resources, err := generator.createResources([]datadogV2.DowntimeResponseData{*firstDowntime, *secondDowntime})
+	if err != nil {
+		t.Fatalf("createResources returned error: %v", err)
+	}
+
+	if len(resources) != 2 {
+		t.Fatalf("resource count = %d, want %d", len(resources), 2)
+	}
+	if resources[0].ResourceName == resources[1].ResourceName {
+		t.Fatalf("resource names should be unique, got %q", resources[0].ResourceName)
+	}
+}
+
+func TestDowntimeScheduleInitResourcesList(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/v2/downtime" {
+			t.Errorf("unexpected path %s", r.URL.Path)
+			http.NotFound(w, r)
+			return
+		}
+		if got := r.URL.Query().Get("page[offset]"); got != "0" {
+			t.Errorf("page[offset] query = %q, want %q", got, "0")
+		}
+		if got := r.URL.Query().Get("page[limit]"); got != fmt.Sprint(datadogDowntimeSchedulePageLimit) {
+			t.Errorf("page[limit] query = %q, want %q", got, fmt.Sprint(datadogDowntimeSchedulePageLimit))
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte("{\"data\":[{\"id\":\"downtime-1\",\"type\":\"downtime\"}],\"meta\":{\"page\":{\"total_filtered_count\":1}}}"))
+	}))
+	t.Cleanup(server.Close)
+
+	config := datadog.NewConfiguration()
+	config.Servers = datadog.ServerConfigurations{{URL: server.URL}}
+	config.HTTPClient = server.Client()
+
+	generator := &DowntimeScheduleGenerator{
+		DatadogService: DatadogService{
+			Service: terraformutils.Service{
+				Args: map[string]interface{}{
+					"auth":          context.Background(),
+					"datadogClient": datadog.NewAPIClient(config),
+				},
+			},
+		},
+	}
+
+	if err := generator.InitResources(); err != nil {
+		t.Fatalf("InitResources returned error: %v", err)
+	}
+	if len(generator.Resources) != 1 {
+		t.Fatalf("resource count = %d, want %d", len(generator.Resources), 1)
+	}
+	if generator.Resources[0].InstanceState.ID != "downtime-1" {
+		t.Fatalf("resource ID = %q, want %q", generator.Resources[0].InstanceState.ID, "downtime-1")
+	}
+}

--- a/providers/datadog/downtime_schedule_test.go
+++ b/providers/datadog/downtime_schedule_test.go
@@ -175,6 +175,59 @@ func TestDowntimeSchedulePostConvertHookRemovesEmptyOneTimeScheduleState(t *test
 	}
 }
 
+func TestDowntimeSchedulePostConvertHookPreservesEmptyNotificationDefaults(t *testing.T) {
+	resource := terraformutils.NewSimpleResource(
+		"downtime-3",
+		"downtime_schedule_downtime-3",
+		"datadog_downtime_schedule",
+		"datadog",
+		DowntimeScheduleAllowEmptyValues,
+	)
+	resource.Item = map[string]interface{}{
+		"id": "downtime-3",
+		downtimeScheduleOneTimeKey: map[string]interface{}{
+			"start": "2026-05-17T14:00:00Z",
+		},
+	}
+	resource.InstanceState.Attributes = map[string]string{
+		"id":                      "downtime-3",
+		"one_time_schedule.start": "2026-05-17T14:00:00Z",
+	}
+	resource.InstanceState.SetTypedAttributes(json.RawMessage("{\"display_timezone\":\"UTC\",\"id\":\"downtime-3\",\"notify_end_states\":null,\"one_time_schedule\":{\"end\":null,\"start\":\"2026-05-17T14:00:00Z\"}}"))
+
+	generator := &DowntimeScheduleGenerator{
+		DatadogService: DatadogService{
+			Service: terraformutils.Service{
+				Resources: []terraformutils.Resource{resource},
+			},
+		},
+	}
+
+	if err := generator.PostConvertHook(); err != nil {
+		t.Fatalf("PostConvertHook returned error: %v", err)
+	}
+
+	updatedResource := generator.Resources[0]
+	assertEmptyDowntimeScheduleItemList(t, updatedResource, downtimeScheduleNotifyEndStatesKey)
+	assertEmptyDowntimeScheduleItemList(t, updatedResource, downtimeScheduleNotifyEndTypesKey)
+	if got := updatedResource.InstanceState.Attributes["notify_end_states.#"]; got != "0" {
+		t.Fatalf("notify_end_states.# = %q, want 0", got)
+	}
+	if got := updatedResource.InstanceState.Attributes["notify_end_types.#"]; got != "0" {
+		t.Fatalf("notify_end_types.# = %q, want 0", got)
+	}
+	typedAttributes := decodeDowntimeScheduleTypedAttributes(t, updatedResource.InstanceState.TypedAttributes)
+	if got := string(typedAttributes[downtimeScheduleNotifyEndStatesKey]); got != "[]" {
+		t.Fatalf("typed notify_end_states = %s, want []", got)
+	}
+	if got := string(typedAttributes[downtimeScheduleNotifyEndTypesKey]); got != "[]" {
+		t.Fatalf("typed notify_end_types = %s, want []", got)
+	}
+	if _, ok := typedAttributes[downtimeScheduleOneTimeKey]; !ok {
+		t.Fatal("PostConvertHook removed active one_time_schedule typed state")
+	}
+}
+
 func TestDowntimeScheduleInitResourcesList(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path != "/api/v2/downtime" {
@@ -227,4 +280,16 @@ func decodeDowntimeScheduleTypedAttributes(t *testing.T, rawAttributes json.RawM
 		t.Fatalf("typed attributes unmarshal error: %v", err)
 	}
 	return attributes
+}
+
+func assertEmptyDowntimeScheduleItemList(t *testing.T, resource terraformutils.Resource, key string) {
+	t.Helper()
+
+	items, ok := resource.Item[key].([]interface{})
+	if !ok {
+		t.Fatalf("%s item type = %T, want []interface{}", key, resource.Item[key])
+	}
+	if len(items) != 0 {
+		t.Fatalf("%s length = %d, want 0", key, len(items))
+	}
 }

--- a/providers/datadog/downtime_schedule_test.go
+++ b/providers/datadog/downtime_schedule_test.go
@@ -4,6 +4,7 @@ package datadog
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
@@ -64,6 +65,116 @@ func TestDowntimeScheduleCreateResources(t *testing.T) {
 	}
 }
 
+func TestDowntimeSchedulePostConvertHookRemovesEmptyRecurringScheduleState(t *testing.T) {
+	resource := terraformutils.NewSimpleResource(
+		"downtime-1",
+		"downtime_schedule_downtime-1",
+		"datadog_downtime_schedule",
+		"datadog",
+		DowntimeScheduleAllowEmptyValues,
+	)
+	resource.Item = map[string]interface{}{
+		"id": "downtime-1",
+		downtimeScheduleOneTimeKey: map[string]interface{}{
+			"start": "2026-05-17T14:00:00Z",
+		},
+		downtimeScheduleRecurringKey: map[string]interface{}{},
+	}
+	resource.InstanceState.Attributes = map[string]string{
+		"id":                               "downtime-1",
+		"one_time_schedule.start":          "2026-05-17T14:00:00Z",
+		"recurring_schedule.recurrences.#": "0",
+		"recurring_schedule.timezone":      "",
+	}
+	resource.InstanceState.SetTypedAttributes(json.RawMessage("{\"display_timezone\":\"UTC\",\"id\":\"downtime-1\",\"one_time_schedule\":{\"end\":null,\"start\":\"2026-05-17T14:00:00Z\"},\"recurring_schedule\":{\"recurrences\":null,\"timezone\":null}}"))
+
+	generator := &DowntimeScheduleGenerator{
+		DatadogService: DatadogService{
+			Service: terraformutils.Service{
+				Resources: []terraformutils.Resource{resource},
+			},
+		},
+	}
+
+	if err := generator.PostConvertHook(); err != nil {
+		t.Fatalf("PostConvertHook returned error: %v", err)
+	}
+
+	updatedResource := generator.Resources[0]
+	if _, ok := updatedResource.Item[downtimeScheduleRecurringKey]; ok {
+		t.Fatal("PostConvertHook left empty recurring_schedule in generated item")
+	}
+	if _, ok := updatedResource.InstanceState.Attributes["recurring_schedule.recurrences.#"]; ok {
+		t.Fatal("PostConvertHook left recurring_schedule flatmap state")
+	}
+	typedAttributes := decodeDowntimeScheduleTypedAttributes(t, updatedResource.InstanceState.TypedAttributes)
+	if _, ok := typedAttributes[downtimeScheduleRecurringKey]; ok {
+		t.Fatal("PostConvertHook left empty recurring_schedule in typed state")
+	}
+	if _, ok := typedAttributes[downtimeScheduleOneTimeKey]; !ok {
+		t.Fatal("PostConvertHook removed active one_time_schedule typed state")
+	}
+}
+
+func TestDowntimeSchedulePostConvertHookRemovesEmptyOneTimeScheduleState(t *testing.T) {
+	resource := terraformutils.NewSimpleResource(
+		"downtime-2",
+		"downtime_schedule_downtime-2",
+		"datadog_downtime_schedule",
+		"datadog",
+		DowntimeScheduleAllowEmptyValues,
+	)
+	resource.Item = map[string]interface{}{
+		"id":                       "downtime-2",
+		downtimeScheduleOneTimeKey: map[string]interface{}{},
+		downtimeScheduleRecurringKey: map[string]interface{}{
+			"recurrences": []interface{}{
+				map[string]interface{}{
+					"duration": "1h",
+					"rrule":    "FREQ=DAILY",
+					"start":    "2026-05-17T14:00:00Z",
+				},
+			},
+			"timezone": "UTC",
+		},
+	}
+	resource.InstanceState.Attributes = map[string]string{
+		"id":                                     "downtime-2",
+		"one_time_schedule.start":                "",
+		"recurring_schedule.recurrences.#":       "1",
+		"recurring_schedule.recurrences.0.start": "2026-05-17T14:00:00Z",
+		"recurring_schedule.timezone":            "UTC",
+	}
+	resource.InstanceState.SetTypedAttributes(json.RawMessage("{\"display_timezone\":\"UTC\",\"id\":\"downtime-2\",\"one_time_schedule\":{\"end\":null,\"start\":null},\"recurring_schedule\":{\"recurrences\":[{\"duration\":\"1h\",\"rrule\":\"FREQ=DAILY\",\"start\":\"2026-05-17T14:00:00Z\"}],\"timezone\":\"UTC\"}}"))
+
+	generator := &DowntimeScheduleGenerator{
+		DatadogService: DatadogService{
+			Service: terraformutils.Service{
+				Resources: []terraformutils.Resource{resource},
+			},
+		},
+	}
+
+	if err := generator.PostConvertHook(); err != nil {
+		t.Fatalf("PostConvertHook returned error: %v", err)
+	}
+
+	updatedResource := generator.Resources[0]
+	if _, ok := updatedResource.Item[downtimeScheduleOneTimeKey]; ok {
+		t.Fatal("PostConvertHook left empty one_time_schedule in generated item")
+	}
+	if _, ok := updatedResource.InstanceState.Attributes["one_time_schedule.start"]; ok {
+		t.Fatal("PostConvertHook left one_time_schedule flatmap state")
+	}
+	typedAttributes := decodeDowntimeScheduleTypedAttributes(t, updatedResource.InstanceState.TypedAttributes)
+	if _, ok := typedAttributes[downtimeScheduleOneTimeKey]; ok {
+		t.Fatal("PostConvertHook left empty one_time_schedule in typed state")
+	}
+	if _, ok := typedAttributes[downtimeScheduleRecurringKey]; !ok {
+		t.Fatal("PostConvertHook removed active recurring_schedule typed state")
+	}
+}
+
 func TestDowntimeScheduleInitResourcesList(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path != "/api/v2/downtime" {
@@ -106,4 +217,14 @@ func TestDowntimeScheduleInitResourcesList(t *testing.T) {
 	if generator.Resources[0].InstanceState.ID != "downtime-1" {
 		t.Fatalf("resource ID = %q, want %q", generator.Resources[0].InstanceState.ID, "downtime-1")
 	}
+}
+
+func decodeDowntimeScheduleTypedAttributes(t *testing.T, rawAttributes json.RawMessage) map[string]json.RawMessage {
+	t.Helper()
+
+	attributes := map[string]json.RawMessage{}
+	if err := json.Unmarshal(rawAttributes, &attributes); err != nil {
+		t.Fatalf("typed attributes unmarshal error: %v", err)
+	}
+	return attributes
 }

--- a/providers/datadog/synthetics_concurrency_cap.go
+++ b/providers/datadog/synthetics_concurrency_cap.go
@@ -56,6 +56,12 @@ func (g *SyntheticsConcurrencyCapGenerator) createResource(resp datadogV2.OnDema
 // datadog_synthetics_concurrency_cap is a singleton; the provider read path
 // ignores the import ID and stores synthetics-concurrency-cap.
 func (g *SyntheticsConcurrencyCapGenerator) InitResources() error {
+	for i, filter := range g.Filter {
+		if filter.FieldPath == "id" && filter.IsApplicable("synthetics_concurrency_cap") {
+			g.Filter[i].AcceptableValues = []string{syntheticsConcurrencyCapID}
+		}
+	}
+
 	datadogClient := g.Args["datadogClient"].(*datadog.APIClient)
 	auth := g.Args["auth"].(context.Context)
 	api := datadogV2.NewSyntheticsApi(datadogClient)

--- a/providers/datadog/synthetics_concurrency_cap.go
+++ b/providers/datadog/synthetics_concurrency_cap.go
@@ -1,0 +1,75 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package datadog
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+
+	"github.com/DataDog/datadog-api-client-go/v2/api/datadog"
+	"github.com/DataDog/datadog-api-client-go/v2/api/datadogV2"
+
+	"github.com/chenrui333/terraformer/terraformutils"
+)
+
+const syntheticsConcurrencyCapID = "synthetics-concurrency-cap"
+
+var (
+	// SyntheticsConcurrencyCapAllowEmptyValues ...
+	SyntheticsConcurrencyCapAllowEmptyValues = []string{}
+)
+
+// SyntheticsConcurrencyCapGenerator ...
+type SyntheticsConcurrencyCapGenerator struct {
+	DatadogService
+}
+
+func (g *SyntheticsConcurrencyCapGenerator) createResource(resp datadogV2.OnDemandConcurrencyCapResponse) (terraformutils.Resource, error) {
+	data, ok := resp.GetDataOk()
+	if !ok {
+		return terraformutils.Resource{}, fmt.Errorf("synthetics concurrency cap missing data")
+	}
+	attrs, ok := data.GetAttributesOk()
+	if !ok {
+		return terraformutils.Resource{}, fmt.Errorf("synthetics concurrency cap missing attributes")
+	}
+	capValue, ok := attrs.GetOnDemandConcurrencyCapOk()
+	if !ok {
+		return terraformutils.Resource{}, fmt.Errorf("synthetics concurrency cap missing on_demand_concurrency_cap")
+	}
+
+	return terraformutils.NewResource(
+		syntheticsConcurrencyCapID,
+		"synthetics_concurrency_cap",
+		"datadog_synthetics_concurrency_cap",
+		"datadog",
+		map[string]string{
+			"on_demand_concurrency_cap": strconv.FormatInt(int64(*capValue), 10),
+		},
+		SyntheticsConcurrencyCapAllowEmptyValues,
+		map[string]interface{}{},
+	), nil
+}
+
+// InitResources Generate TerraformResources from Datadog API.
+// datadog_synthetics_concurrency_cap is a singleton; the provider read path
+// ignores the import ID and stores synthetics-concurrency-cap.
+func (g *SyntheticsConcurrencyCapGenerator) InitResources() error {
+	datadogClient := g.Args["datadogClient"].(*datadog.APIClient)
+	auth := g.Args["auth"].(context.Context)
+	api := datadogV2.NewSyntheticsApi(datadogClient)
+
+	resp, httpResp, err := api.GetOnDemandConcurrencyCap(auth)
+	closeDatadogResponseBody(httpResp)
+	if err != nil {
+		return err
+	}
+
+	resource, err := g.createResource(resp)
+	if err != nil {
+		return err
+	}
+	g.Resources = []terraformutils.Resource{resource}
+	return nil
+}

--- a/providers/datadog/synthetics_concurrency_cap.go
+++ b/providers/datadog/synthetics_concurrency_cap.go
@@ -13,7 +13,10 @@ import (
 	"github.com/chenrui333/terraformer/terraformutils"
 )
 
-const syntheticsConcurrencyCapID = "synthetics-concurrency-cap"
+const (
+	syntheticsConcurrencyCapID          = "synthetics-concurrency-cap"
+	syntheticsConcurrencyCapServiceName = "synthetics_concurrency_cap"
+)
 
 var (
 	// SyntheticsConcurrencyCapAllowEmptyValues ...
@@ -57,7 +60,7 @@ func (g *SyntheticsConcurrencyCapGenerator) createResource(resp datadogV2.OnDema
 // ignores the import ID and stores synthetics-concurrency-cap.
 func (g *SyntheticsConcurrencyCapGenerator) InitResources() error {
 	for i, filter := range g.Filter {
-		if filter.FieldPath == "id" && filter.IsApplicable("synthetics_concurrency_cap") {
+		if filter.FieldPath == "id" && filter.ServiceName == syntheticsConcurrencyCapServiceName {
 			g.Filter[i].AcceptableValues = []string{syntheticsConcurrencyCapID}
 		}
 	}

--- a/providers/datadog/synthetics_concurrency_cap_test.go
+++ b/providers/datadog/synthetics_concurrency_cap_test.go
@@ -113,7 +113,7 @@ func TestSyntheticsConcurrencyCapInitResourcesNormalizesIDFilter(t *testing.T) {
 				},
 				Filter: []terraformutils.ResourceFilter{
 					{
-						ServiceName:      "synthetics_concurrency_cap",
+						ServiceName:      syntheticsConcurrencyCapServiceName,
 						FieldPath:        "id",
 						AcceptableValues: []string{"this"},
 					},
@@ -133,5 +133,54 @@ func TestSyntheticsConcurrencyCapInitResourcesNormalizesIDFilter(t *testing.T) {
 	}
 	if !generator.Filter[0].Filter(generator.Resources[0]) {
 		t.Fatal("expected normalized ID filter to keep synthetics concurrency cap resource")
+	}
+}
+
+func TestSyntheticsConcurrencyCapInitResourcesDoesNotNormalizeGlobalIDFilter(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/v2/synthetics/settings/on_demand_concurrency_cap" {
+			t.Errorf("unexpected path %s", r.URL.Path)
+			http.NotFound(w, r)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte("{\"data\":{\"type\":\"on_demand_concurrency_cap\",\"attributes\":{\"on_demand_concurrency_cap\":3}}}"))
+	}))
+	t.Cleanup(server.Close)
+
+	config := datadog.NewConfiguration()
+	config.Servers = datadog.ServerConfigurations{{URL: server.URL}}
+	config.HTTPClient = server.Client()
+
+	generator := &SyntheticsConcurrencyCapGenerator{
+		DatadogService: DatadogService{
+			Service: terraformutils.Service{
+				Args: map[string]interface{}{
+					"auth":          context.Background(),
+					"datadogClient": datadog.NewAPIClient(config),
+				},
+				Filter: []terraformutils.ResourceFilter{
+					{
+						FieldPath:        "id",
+						AcceptableValues: []string{"some-monitor-id"},
+					},
+				},
+			},
+		},
+	}
+
+	if err := generator.InitResources(); err != nil {
+		t.Fatalf("InitResources returned error: %v", err)
+	}
+	if got := generator.Filter[0].AcceptableValues; len(got) != 1 || got[0] != "some-monitor-id" {
+		t.Fatalf("global id filter was rewritten to %v", got)
+	}
+	if len(generator.Resources) != 1 {
+		t.Fatalf("resource count before cleanup = %d, want %d", len(generator.Resources), 1)
+	}
+
+	generator.InitialCleanup()
+	if len(generator.Resources) != 0 {
+		t.Fatalf("resource count after cleanup = %d, want %d", len(generator.Resources), 0)
 	}
 }

--- a/providers/datadog/synthetics_concurrency_cap_test.go
+++ b/providers/datadog/synthetics_concurrency_cap_test.go
@@ -87,3 +87,51 @@ func TestSyntheticsConcurrencyCapInitResources(t *testing.T) {
 		t.Fatalf("resource ID = %q, want %q", generator.Resources[0].InstanceState.ID, syntheticsConcurrencyCapID)
 	}
 }
+
+func TestSyntheticsConcurrencyCapInitResourcesNormalizesIDFilter(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/v2/synthetics/settings/on_demand_concurrency_cap" {
+			t.Errorf("unexpected path %s", r.URL.Path)
+			http.NotFound(w, r)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte("{\"data\":{\"type\":\"on_demand_concurrency_cap\",\"attributes\":{\"on_demand_concurrency_cap\":3}}}"))
+	}))
+	t.Cleanup(server.Close)
+
+	config := datadog.NewConfiguration()
+	config.Servers = datadog.ServerConfigurations{{URL: server.URL}}
+	config.HTTPClient = server.Client()
+
+	generator := &SyntheticsConcurrencyCapGenerator{
+		DatadogService: DatadogService{
+			Service: terraformutils.Service{
+				Args: map[string]interface{}{
+					"auth":          context.Background(),
+					"datadogClient": datadog.NewAPIClient(config),
+				},
+				Filter: []terraformutils.ResourceFilter{
+					{
+						ServiceName:      "synthetics_concurrency_cap",
+						FieldPath:        "id",
+						AcceptableValues: []string{"this"},
+					},
+				},
+			},
+		},
+	}
+
+	if err := generator.InitResources(); err != nil {
+		t.Fatalf("InitResources returned error: %v", err)
+	}
+	if got := generator.Filter[0].AcceptableValues; len(got) != 1 || got[0] != syntheticsConcurrencyCapID {
+		t.Fatalf("rewritten id filter = %v, want [%s]", got, syntheticsConcurrencyCapID)
+	}
+	if len(generator.Resources) != 1 {
+		t.Fatalf("resource count = %d, want %d", len(generator.Resources), 1)
+	}
+	if !generator.Filter[0].Filter(generator.Resources[0]) {
+		t.Fatal("expected normalized ID filter to keep synthetics concurrency cap resource")
+	}
+}

--- a/providers/datadog/synthetics_concurrency_cap_test.go
+++ b/providers/datadog/synthetics_concurrency_cap_test.go
@@ -1,0 +1,89 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package datadog
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/DataDog/datadog-api-client-go/v2/api/datadog"
+	"github.com/DataDog/datadog-api-client-go/v2/api/datadogV2"
+
+	"github.com/chenrui333/terraformer/terraformutils"
+)
+
+func TestSyntheticsConcurrencyCapCreateResource(t *testing.T) {
+	attrs := datadogV2.NewOnDemandConcurrencyCapAttributesWithDefaults()
+	attrs.SetOnDemandConcurrencyCap(7)
+	data := datadogV2.NewOnDemandConcurrencyCapWithDefaults()
+	data.SetAttributes(*attrs)
+	resp := datadogV2.NewOnDemandConcurrencyCapResponseWithDefaults()
+	resp.SetData(*data)
+
+	generator := &SyntheticsConcurrencyCapGenerator{}
+	resource, err := generator.createResource(*resp)
+	if err != nil {
+		t.Fatalf("createResource returned error: %v", err)
+	}
+
+	if resource.InstanceState.ID != syntheticsConcurrencyCapID {
+		t.Fatalf("resource ID = %q, want %q", resource.InstanceState.ID, syntheticsConcurrencyCapID)
+	}
+	if resource.ResourceName != "tfer--synthetics_concurrency_cap" {
+		t.Fatalf("resource name = %q, want %q", resource.ResourceName, "tfer--synthetics_concurrency_cap")
+	}
+	if resource.InstanceInfo.Type != "datadog_synthetics_concurrency_cap" {
+		t.Fatalf("resource type = %q, want %q", resource.InstanceInfo.Type, "datadog_synthetics_concurrency_cap")
+	}
+	if resource.InstanceState.Attributes["on_demand_concurrency_cap"] != "7" {
+		t.Fatalf("on_demand_concurrency_cap = %q, want %q", resource.InstanceState.Attributes["on_demand_concurrency_cap"], "7")
+	}
+}
+
+func TestSyntheticsConcurrencyCapCreateResourceMissingValue(t *testing.T) {
+	generator := &SyntheticsConcurrencyCapGenerator{}
+	_, err := generator.createResource(datadogV2.OnDemandConcurrencyCapResponse{})
+	if err == nil {
+		t.Fatal("createResource returned nil error, want missing cap error")
+	}
+}
+
+func TestSyntheticsConcurrencyCapInitResources(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/v2/synthetics/settings/on_demand_concurrency_cap" {
+			t.Errorf("unexpected path %s", r.URL.Path)
+			http.NotFound(w, r)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte("{\"data\":{\"type\":\"on_demand_concurrency_cap\",\"attributes\":{\"on_demand_concurrency_cap\":3}}}"))
+	}))
+	t.Cleanup(server.Close)
+
+	config := datadog.NewConfiguration()
+	config.Servers = datadog.ServerConfigurations{{URL: server.URL}}
+	config.HTTPClient = server.Client()
+
+	generator := &SyntheticsConcurrencyCapGenerator{
+		DatadogService: DatadogService{
+			Service: terraformutils.Service{
+				Args: map[string]interface{}{
+					"auth":          context.Background(),
+					"datadogClient": datadog.NewAPIClient(config),
+				},
+			},
+		},
+	}
+
+	if err := generator.InitResources(); err != nil {
+		t.Fatalf("InitResources returned error: %v", err)
+	}
+	if len(generator.Resources) != 1 {
+		t.Fatalf("resource count = %d, want %d", len(generator.Resources), 1)
+	}
+	if generator.Resources[0].InstanceState.ID != syntheticsConcurrencyCapID {
+		t.Fatalf("resource ID = %q, want %q", generator.Resources[0].InstanceState.ID, syntheticsConcurrencyCapID)
+	}
+}

--- a/providers/datadog/synthetics_suite.go
+++ b/providers/datadog/synthetics_suite.go
@@ -1,0 +1,152 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package datadog
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/DataDog/datadog-api-client-go/v2/api/datadog"
+	"github.com/DataDog/datadog-api-client-go/v2/api/datadogV2"
+
+	"github.com/chenrui333/terraformer/terraformutils"
+)
+
+const datadogSyntheticsSuitePageSize = int64(100)
+
+var (
+	// SyntheticsSuiteAllowEmptyValues ...
+	SyntheticsSuiteAllowEmptyValues = []string{"tags."}
+)
+
+// SyntheticsSuiteGenerator ...
+type SyntheticsSuiteGenerator struct {
+	DatadogService
+}
+
+func (g *SyntheticsSuiteGenerator) createResource(suiteID string) (terraformutils.Resource, error) {
+	if suiteID == "" {
+		return terraformutils.Resource{}, fmt.Errorf("synthetics suite missing id")
+	}
+
+	return terraformutils.NewSimpleResource(
+		suiteID,
+		fmt.Sprintf("synthetics_suite_%s", suiteID),
+		"datadog_synthetics_suite",
+		"datadog",
+		SyntheticsSuiteAllowEmptyValues,
+	), nil
+}
+
+func (g *SyntheticsSuiteGenerator) createResources(suites []datadogV2.SyntheticsSuite) ([]terraformutils.Resource, error) {
+	resources := []terraformutils.Resource{}
+	for _, suite := range suites {
+		resource, err := g.createResource(suite.GetPublicId())
+		if err != nil {
+			return nil, err
+		}
+		resources = append(resources, resource)
+	}
+	return resources, nil
+}
+
+// InitResources Generate TerraformResources from Datadog API,
+// from each Synthetics suite create 1 TerraformResource.
+func (g *SyntheticsSuiteGenerator) InitResources() error {
+	datadogClient := g.Args["datadogClient"].(*datadog.APIClient)
+	auth := g.Args["auth"].(context.Context)
+	api := datadogV2.NewSyntheticsApi(datadogClient)
+
+	resources, filtered, err := g.filteredResources(auth, api)
+	if err != nil {
+		return err
+	}
+	if filtered {
+		g.Resources = resources
+		return nil
+	}
+
+	suites, err := listSyntheticsSuites(auth, api)
+	if err != nil {
+		return err
+	}
+	resources, err = g.createResources(suites)
+	if err != nil {
+		return err
+	}
+
+	g.Resources = resources
+	return nil
+}
+
+func (g *SyntheticsSuiteGenerator) filteredResources(auth context.Context, api *datadogV2.SyntheticsApi) ([]terraformutils.Resource, bool, error) {
+	resources := []terraformutils.Resource{}
+	filtered := false
+
+	for _, filter := range g.Filter {
+		if filter.FieldPath != "id" || !filter.IsApplicable("synthetics_suite") {
+			continue
+		}
+
+		filtered = true
+		for _, value := range filter.AcceptableValues {
+			suite, err := getSyntheticsSuite(auth, api, value)
+			if err != nil {
+				return nil, true, err
+			}
+			data := suite.GetData()
+			resource, err := g.createResource(data.GetId())
+			if err != nil {
+				return nil, true, err
+			}
+			resources = append(resources, resource)
+		}
+	}
+
+	return resources, filtered, nil
+}
+
+func getSyntheticsSuite(auth context.Context, api *datadogV2.SyntheticsApi, suiteID string) (datadogV2.SyntheticsSuiteResponse, error) {
+	resp, httpResp, err := api.GetSyntheticsSuite(auth, suiteID)
+	closeDatadogResponseBody(httpResp)
+	if err != nil {
+		return datadogV2.SyntheticsSuiteResponse{}, err
+	}
+	data := resp.GetData()
+	if data.GetId() == "" {
+		return datadogV2.SyntheticsSuiteResponse{}, fmt.Errorf("synthetics suite %q not found", suiteID)
+	}
+	return resp, nil
+}
+
+func listSyntheticsSuites(auth context.Context, api *datadogV2.SyntheticsApi) ([]datadogV2.SyntheticsSuite, error) {
+	suites := []datadogV2.SyntheticsSuite{}
+	start := int64(0)
+
+	for {
+		optionalParams := datadogV2.NewSearchSuitesOptionalParameters().
+			WithStart(start).
+			WithCount(datadogSyntheticsSuitePageSize)
+
+		resp, httpResp, err := api.SearchSuites(auth, *optionalParams)
+		closeDatadogResponseBody(httpResp)
+		if err != nil {
+			return nil, err
+		}
+
+		data := resp.GetData()
+		attrs := data.GetAttributes()
+		pageSuites := attrs.GetSuites()
+		suites = append(suites, pageSuites...)
+
+		if len(pageSuites) == 0 || len(pageSuites) < int(datadogSyntheticsSuitePageSize) {
+			break
+		}
+		if total := attrs.GetTotal(); total > 0 && len(suites) >= int(total) {
+			break
+		}
+		start += int64(len(pageSuites))
+	}
+
+	return suites, nil
+}

--- a/providers/datadog/synthetics_suite.go
+++ b/providers/datadog/synthetics_suite.go
@@ -3,7 +3,9 @@
 package datadog
 
 import (
+	"bytes"
 	"context"
+	"encoding/json"
 	"fmt"
 
 	"github.com/DataDog/datadog-api-client-go/v2/api/datadog"
@@ -13,6 +15,8 @@ import (
 )
 
 const datadogSyntheticsSuitePageSize = int64(100)
+
+const syntheticsSuiteTagsKey = "tags"
 
 var (
 	// SyntheticsSuiteAllowEmptyValues ...
@@ -36,6 +40,136 @@ func (g *SyntheticsSuiteGenerator) createResource(suiteID string) (terraformutil
 		"datadog",
 		SyntheticsSuiteAllowEmptyValues,
 	), nil
+}
+
+func (g *SyntheticsSuiteGenerator) PostConvertHook() error {
+	for i := range g.Resources {
+		resource := &g.Resources[i]
+		if err := preserveSyntheticsSuiteEmptyTags(resource); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func preserveSyntheticsSuiteEmptyTags(resource *terraformutils.Resource) error {
+	hasEmptyTags, err := syntheticsSuiteStateHasEmptyTags(resource)
+	if err != nil {
+		return err
+	}
+	if !hasEmptyTags {
+		return nil
+	}
+	if resource.Item == nil {
+		resource.Item = map[string]interface{}{}
+	}
+	if value, ok := resource.Item[syntheticsSuiteTagsKey]; !ok || !syntheticsSuiteValueHasValue(value) {
+		resource.Item[syntheticsSuiteTagsKey] = []interface{}{}
+	}
+	return preserveSyntheticsSuiteEmptyTagsState(resource)
+}
+
+func syntheticsSuiteStateHasEmptyTags(resource *terraformutils.Resource) (bool, error) {
+	if resource == nil || resource.InstanceState == nil {
+		return false, nil
+	}
+	if resource.InstanceState.Attributes != nil {
+		if count, ok := resource.InstanceState.Attributes[syntheticsSuiteTagsKey+".#"]; ok && count == "0" {
+			return true, nil
+		}
+	}
+	if len(resource.InstanceState.TypedAttributes) == 0 {
+		return false, nil
+	}
+	typedAttributes := map[string]json.RawMessage{}
+	if err := json.Unmarshal(resource.InstanceState.TypedAttributes, &typedAttributes); err != nil {
+		return false, fmt.Errorf("decode synthetics suite typed attributes: %w", err)
+	}
+	rawTags, ok := typedAttributes[syntheticsSuiteTagsKey]
+	if !ok {
+		return false, nil
+	}
+	tagsHaveValue, err := syntheticsSuiteRawMessageHasValue(rawTags)
+	if err != nil {
+		return false, fmt.Errorf("decode synthetics suite tags state: %w", err)
+	}
+	return !tagsHaveValue, nil
+}
+
+func preserveSyntheticsSuiteEmptyTagsState(resource *terraformutils.Resource) error {
+	if resource == nil || resource.InstanceState == nil {
+		return nil
+	}
+	if resource.InstanceState.Attributes == nil {
+		resource.InstanceState.Attributes = map[string]string{}
+	}
+	resource.InstanceState.Attributes[syntheticsSuiteTagsKey+".#"] = "0"
+	if len(resource.InstanceState.TypedAttributes) == 0 {
+		return nil
+	}
+
+	typedAttributes := map[string]json.RawMessage{}
+	if err := json.Unmarshal(resource.InstanceState.TypedAttributes, &typedAttributes); err != nil {
+		return fmt.Errorf("decode synthetics suite typed attributes: %w", err)
+	}
+	rawTags, ok := typedAttributes[syntheticsSuiteTagsKey]
+	tagsHaveValue := false
+	if ok {
+		var err error
+		tagsHaveValue, err = syntheticsSuiteRawMessageHasValue(rawTags)
+		if err != nil {
+			return fmt.Errorf("decode synthetics suite tags state: %w", err)
+		}
+	}
+	if tagsHaveValue {
+		return nil
+	}
+	typedAttributes[syntheticsSuiteTagsKey] = json.RawMessage("[]")
+	rawAttributes, err := json.Marshal(typedAttributes)
+	if err != nil {
+		return fmt.Errorf("encode synthetics suite typed attributes: %w", err)
+	}
+	resource.InstanceState.SetTypedAttributes(rawAttributes)
+	return nil
+}
+
+func syntheticsSuiteRawMessageHasValue(rawValue json.RawMessage) (bool, error) {
+	if len(bytes.TrimSpace(rawValue)) == 0 {
+		return false, nil
+	}
+
+	var value interface{}
+	decoder := json.NewDecoder(bytes.NewReader(rawValue))
+	decoder.UseNumber()
+	if err := decoder.Decode(&value); err != nil {
+		return false, err
+	}
+	return syntheticsSuiteValueHasValue(value), nil
+}
+
+func syntheticsSuiteValueHasValue(value interface{}) bool {
+	switch value := value.(type) {
+	case nil:
+		return false
+	case string:
+		return value != ""
+	case []interface{}:
+		for _, item := range value {
+			if syntheticsSuiteValueHasValue(item) {
+				return true
+			}
+		}
+		return false
+	case map[string]interface{}:
+		for _, item := range value {
+			if syntheticsSuiteValueHasValue(item) {
+				return true
+			}
+		}
+		return false
+	default:
+		return true
+	}
 }
 
 func (g *SyntheticsSuiteGenerator) createResources(suites []datadogV2.SyntheticsSuite) ([]terraformutils.Resource, error) {

--- a/providers/datadog/synthetics_suite.go
+++ b/providers/datadog/synthetics_suite.go
@@ -16,11 +16,14 @@ import (
 
 const datadogSyntheticsSuitePageSize = int64(100)
 
-const syntheticsSuiteTagsKey = "tags"
+const (
+	syntheticsSuiteMessageKey = "message"
+	syntheticsSuiteTagsKey    = "tags"
+)
 
 var (
 	// SyntheticsSuiteAllowEmptyValues ...
-	SyntheticsSuiteAllowEmptyValues = []string{"tags."}
+	SyntheticsSuiteAllowEmptyValues = []string{"message", "tags."}
 )
 
 // SyntheticsSuiteGenerator ...
@@ -48,7 +51,92 @@ func (g *SyntheticsSuiteGenerator) PostConvertHook() error {
 		if err := preserveSyntheticsSuiteEmptyTags(resource); err != nil {
 			return err
 		}
+		if err := preserveSyntheticsSuiteEmptyMessage(resource); err != nil {
+			return err
+		}
 	}
+	return nil
+}
+
+func preserveSyntheticsSuiteEmptyMessage(resource *terraformutils.Resource) error {
+	hasEmptyMessage, err := syntheticsSuiteStateHasEmptyMessage(resource)
+	if err != nil {
+		return err
+	}
+	if !hasEmptyMessage {
+		return nil
+	}
+	if resource.Item == nil {
+		resource.Item = map[string]interface{}{}
+	}
+	if value, ok := resource.Item[syntheticsSuiteMessageKey]; !ok || !syntheticsSuiteValueHasValue(value) {
+		resource.Item[syntheticsSuiteMessageKey] = ""
+	}
+	return preserveSyntheticsSuiteEmptyMessageState(resource)
+}
+
+func syntheticsSuiteStateHasEmptyMessage(resource *terraformutils.Resource) (bool, error) {
+	if resource == nil || resource.InstanceState == nil {
+		return false, nil
+	}
+	if resource.InstanceState.Attributes != nil {
+		if message, ok := resource.InstanceState.Attributes[syntheticsSuiteMessageKey]; ok && message == "" {
+			return true, nil
+		}
+	}
+	if len(resource.InstanceState.TypedAttributes) == 0 {
+		return false, nil
+	}
+
+	typedAttributes := map[string]json.RawMessage{}
+	if err := json.Unmarshal(resource.InstanceState.TypedAttributes, &typedAttributes); err != nil {
+		return false, fmt.Errorf("decode synthetics suite typed attributes: %w", err)
+	}
+	rawMessage, ok := typedAttributes[syntheticsSuiteMessageKey]
+	if !ok {
+		return false, nil
+	}
+	messageIsEmpty, err := syntheticsSuiteRawMessageIsEmptyString(rawMessage)
+	if err != nil {
+		return false, fmt.Errorf("decode synthetics suite message state: %w", err)
+	}
+	return messageIsEmpty, nil
+}
+
+func preserveSyntheticsSuiteEmptyMessageState(resource *terraformutils.Resource) error {
+	if resource == nil || resource.InstanceState == nil {
+		return nil
+	}
+	if resource.InstanceState.Attributes == nil {
+		resource.InstanceState.Attributes = map[string]string{}
+	}
+	resource.InstanceState.Attributes[syntheticsSuiteMessageKey] = ""
+	if len(resource.InstanceState.TypedAttributes) == 0 {
+		return nil
+	}
+
+	typedAttributes := map[string]json.RawMessage{}
+	if err := json.Unmarshal(resource.InstanceState.TypedAttributes, &typedAttributes); err != nil {
+		return fmt.Errorf("decode synthetics suite typed attributes: %w", err)
+	}
+	rawMessage, ok := typedAttributes[syntheticsSuiteMessageKey]
+	messageHasValue := false
+	if ok {
+		var err error
+		messageHasValue, err = syntheticsSuiteRawMessageHasValue(rawMessage)
+		if err != nil {
+			return fmt.Errorf("decode synthetics suite message state: %w", err)
+		}
+	}
+	if messageHasValue {
+		return nil
+	}
+	typedAttributes[syntheticsSuiteMessageKey] = json.RawMessage("\"\"")
+	rawAttributes, err := json.Marshal(typedAttributes)
+	if err != nil {
+		return fmt.Errorf("encode synthetics suite typed attributes: %w", err)
+	}
+	resource.InstanceState.SetTypedAttributes(rawAttributes)
 	return nil
 }
 
@@ -145,6 +233,18 @@ func syntheticsSuiteRawMessageHasValue(rawValue json.RawMessage) (bool, error) {
 		return false, err
 	}
 	return syntheticsSuiteValueHasValue(value), nil
+}
+
+func syntheticsSuiteRawMessageIsEmptyString(rawValue json.RawMessage) (bool, error) {
+	if len(bytes.TrimSpace(rawValue)) == 0 {
+		return false, nil
+	}
+
+	var value *string
+	if err := json.Unmarshal(rawValue, &value); err != nil {
+		return false, err
+	}
+	return value != nil && *value == "", nil
 }
 
 func syntheticsSuiteValueHasValue(value interface{}) bool {

--- a/providers/datadog/synthetics_suite_test.go
+++ b/providers/datadog/synthetics_suite_test.go
@@ -4,6 +4,7 @@ package datadog
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
@@ -61,6 +62,54 @@ func TestSyntheticsSuiteCreateResources(t *testing.T) {
 	}
 }
 
+func TestSyntheticsSuitePostConvertHookPreservesEmptyTags(t *testing.T) {
+	resource := terraformutils.NewSimpleResource(
+		"suite-1",
+		"synthetics_suite_suite-1",
+		"datadog_synthetics_suite",
+		"datadog",
+		SyntheticsSuiteAllowEmptyValues,
+	)
+	resource.Item = map[string]interface{}{
+		"id":   "suite-1",
+		"name": "suite one",
+	}
+	resource.InstanceState.Attributes = map[string]string{
+		"id":     "suite-1",
+		"name":   "suite one",
+		"tags.#": "0",
+	}
+	resource.InstanceState.SetTypedAttributes(json.RawMessage("{\"id\":\"suite-1\",\"name\":\"suite one\",\"tags\":[]}"))
+
+	generator := &SyntheticsSuiteGenerator{
+		DatadogService: DatadogService{
+			Service: terraformutils.Service{
+				Resources: []terraformutils.Resource{resource},
+			},
+		},
+	}
+
+	if err := generator.PostConvertHook(); err != nil {
+		t.Fatalf("PostConvertHook returned error: %v", err)
+	}
+
+	updatedResource := generator.Resources[0]
+	tags, ok := updatedResource.Item[syntheticsSuiteTagsKey].([]interface{})
+	if !ok {
+		t.Fatalf("tags item type = %T, want []interface{}", updatedResource.Item[syntheticsSuiteTagsKey])
+	}
+	if len(tags) != 0 {
+		t.Fatalf("tags length = %d, want 0", len(tags))
+	}
+	if got := updatedResource.InstanceState.Attributes["tags.#"]; got != "0" {
+		t.Fatalf("tags.# = %q, want 0", got)
+	}
+	typedAttributes := decodeSyntheticsSuiteTypedAttributes(t, updatedResource.InstanceState.TypedAttributes)
+	if got := string(typedAttributes[syntheticsSuiteTagsKey]); got != "[]" {
+		t.Fatalf("typed tags = %s, want []", got)
+	}
+}
+
 func TestSyntheticsSuiteInitResourcesList(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path != "/api/v2/synthetics/suites/search" {
@@ -103,4 +152,14 @@ func TestSyntheticsSuiteInitResourcesList(t *testing.T) {
 	if generator.Resources[0].InstanceState.ID != "suite-1" {
 		t.Fatalf("resource ID = %q, want %q", generator.Resources[0].InstanceState.ID, "suite-1")
 	}
+}
+
+func decodeSyntheticsSuiteTypedAttributes(t *testing.T, rawAttributes json.RawMessage) map[string]json.RawMessage {
+	t.Helper()
+
+	attributes := map[string]json.RawMessage{}
+	if err := json.Unmarshal(rawAttributes, &attributes); err != nil {
+		t.Fatalf("typed attributes unmarshal error: %v", err)
+	}
+	return attributes
 }

--- a/providers/datadog/synthetics_suite_test.go
+++ b/providers/datadog/synthetics_suite_test.go
@@ -1,0 +1,106 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package datadog
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/DataDog/datadog-api-client-go/v2/api/datadog"
+	"github.com/DataDog/datadog-api-client-go/v2/api/datadogV2"
+
+	"github.com/chenrui333/terraformer/terraformutils"
+)
+
+func TestSyntheticsSuiteCreateResource(t *testing.T) {
+	generator := &SyntheticsSuiteGenerator{}
+	resource, err := generator.createResource("suite-123")
+	if err != nil {
+		t.Fatalf("createResource returned error: %v", err)
+	}
+
+	if resource.InstanceState.ID != "suite-123" {
+		t.Fatalf("resource ID = %q, want %q", resource.InstanceState.ID, "suite-123")
+	}
+	if resource.ResourceName != "tfer--synthetics_suite_suite-123" {
+		t.Fatalf("resource name = %q, want %q", resource.ResourceName, "tfer--synthetics_suite_suite-123")
+	}
+	if resource.InstanceInfo.Type != "datadog_synthetics_suite" {
+		t.Fatalf("resource type = %q, want %q", resource.InstanceInfo.Type, "datadog_synthetics_suite")
+	}
+}
+
+func TestSyntheticsSuiteCreateResourceMissingID(t *testing.T) {
+	generator := &SyntheticsSuiteGenerator{}
+	_, err := generator.createResource("")
+	if err == nil {
+		t.Fatal("createResource returned nil error, want missing id error")
+	}
+}
+
+func TestSyntheticsSuiteCreateResources(t *testing.T) {
+	firstSuite := datadogV2.NewSyntheticsSuiteWithDefaults()
+	firstSuite.SetPublicId("suite-1")
+	secondSuite := datadogV2.NewSyntheticsSuiteWithDefaults()
+	secondSuite.SetPublicId("suite-2")
+
+	generator := &SyntheticsSuiteGenerator{}
+	resources, err := generator.createResources([]datadogV2.SyntheticsSuite{*firstSuite, *secondSuite})
+	if err != nil {
+		t.Fatalf("createResources returned error: %v", err)
+	}
+
+	if len(resources) != 2 {
+		t.Fatalf("resource count = %d, want %d", len(resources), 2)
+	}
+	if resources[0].ResourceName == resources[1].ResourceName {
+		t.Fatalf("resource names should be unique, got %q", resources[0].ResourceName)
+	}
+}
+
+func TestSyntheticsSuiteInitResourcesList(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/v2/synthetics/suites/search" {
+			t.Errorf("unexpected path %s", r.URL.Path)
+			http.NotFound(w, r)
+			return
+		}
+		if got := r.URL.Query().Get("start"); got != "0" {
+			t.Errorf("start query = %q, want %q", got, "0")
+		}
+		if got := r.URL.Query().Get("count"); got != fmt.Sprint(datadogSyntheticsSuitePageSize) {
+			t.Errorf("count query = %q, want %q", got, fmt.Sprint(datadogSyntheticsSuitePageSize))
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte("{\"data\":{\"attributes\":{\"suites\":[{\"public_id\":\"suite-1\",\"name\":\"suite one\",\"options\":{\"alerting_threshold\":0.5},\"tests\":[],\"type\":\"suite\"}],\"total\":1},\"type\":\"suites_search\"}}"))
+	}))
+	t.Cleanup(server.Close)
+
+	config := datadog.NewConfiguration()
+	config.Servers = datadog.ServerConfigurations{{URL: server.URL}}
+	config.HTTPClient = server.Client()
+
+	generator := &SyntheticsSuiteGenerator{
+		DatadogService: DatadogService{
+			Service: terraformutils.Service{
+				Args: map[string]interface{}{
+					"auth":          context.Background(),
+					"datadogClient": datadog.NewAPIClient(config),
+				},
+			},
+		},
+	}
+
+	if err := generator.InitResources(); err != nil {
+		t.Fatalf("InitResources returned error: %v", err)
+	}
+	if len(generator.Resources) != 1 {
+		t.Fatalf("resource count = %d, want %d", len(generator.Resources), 1)
+	}
+	if generator.Resources[0].InstanceState.ID != "suite-1" {
+		t.Fatalf("resource ID = %q, want %q", generator.Resources[0].InstanceState.ID, "suite-1")
+	}
+}

--- a/providers/datadog/synthetics_suite_test.go
+++ b/providers/datadog/synthetics_suite_test.go
@@ -110,6 +110,54 @@ func TestSyntheticsSuitePostConvertHookPreservesEmptyTags(t *testing.T) {
 	}
 }
 
+func TestSyntheticsSuitePostConvertHookPreservesEmptyMessage(t *testing.T) {
+	resource := terraformutils.NewSimpleResource(
+		"suite-2",
+		"synthetics_suite_suite-2",
+		"datadog_synthetics_suite",
+		"datadog",
+		SyntheticsSuiteAllowEmptyValues,
+	)
+	resource.Item = map[string]interface{}{
+		"id":   "suite-2",
+		"name": "suite two",
+	}
+	resource.InstanceState.Attributes = map[string]string{
+		"id":      "suite-2",
+		"message": "",
+		"name":    "suite two",
+	}
+	resource.InstanceState.SetTypedAttributes(json.RawMessage("{\"id\":\"suite-2\",\"message\":\"\",\"name\":\"suite two\"}"))
+
+	generator := &SyntheticsSuiteGenerator{
+		DatadogService: DatadogService{
+			Service: terraformutils.Service{
+				Resources: []terraformutils.Resource{resource},
+			},
+		},
+	}
+
+	if err := generator.PostConvertHook(); err != nil {
+		t.Fatalf("PostConvertHook returned error: %v", err)
+	}
+
+	updatedResource := generator.Resources[0]
+	message, ok := updatedResource.Item[syntheticsSuiteMessageKey].(string)
+	if !ok {
+		t.Fatalf("message item type = %T, want string", updatedResource.Item[syntheticsSuiteMessageKey])
+	}
+	if message != "" {
+		t.Fatalf("message = %q, want empty string", message)
+	}
+	if got := updatedResource.InstanceState.Attributes[syntheticsSuiteMessageKey]; got != "" {
+		t.Fatalf("state message = %q, want empty string", got)
+	}
+	typedAttributes := decodeSyntheticsSuiteTypedAttributes(t, updatedResource.InstanceState.TypedAttributes)
+	if got := string(typedAttributes[syntheticsSuiteMessageKey]); got != "\"\"" {
+		t.Fatalf("typed message = %s, want empty string", got)
+	}
+}
+
 func TestSyntheticsSuiteInitResourcesList(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path != "/api/v2/synthetics/suites/search" {


### PR DESCRIPTION
## Summary

Add Terraformer import support for three Datadog resources:

- `datadog_synthetics_concurrency_cap`
- `datadog_synthetics_suite`
- `datadog_downtime_schedule`

## Implementation

- `synthetics_concurrency_cap`: singleton import via `GetOnDemandConcurrencyCap`, using provider import ID `synthetics-concurrency-cap`.
- `synthetics_suite`: lists via V2 `SearchSuites`, reads/imports by suite public ID.
- `downtime_schedule`: lists via V2 `ListDowntimes`, reads/imports by downtime ID.

## Scope

This PR is intentionally limited to synthetics/downtime leftovers.

Not included:
- dashboard/powerpack resources
- secure embed
- unrelated Datadog resources

## Validation

- `go test ./providers/datadog`
- `git diff --check`

Ref: #336

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds Terraformer import support for Datadog `datadog_synthetics_concurrency_cap`, `datadog_synthetics_suite`, and `datadog_downtime_schedule`, with docs, graph connections, and tests. Normalizes import state to avoid diffs by removing empty alternate schedules and preserving empty defaults, including empty suite and downtime messages.

- **New Features**
  - `synthetics_concurrency_cap`: singleton import via V2 GetOnDemandConcurrencyCap; import ID `synthetics-concurrency-cap`; requires `DataDog/datadog` 4.9.0+.
  - `synthetics_suite`: lists via V2 SearchSuites; imports by suite public ID; adds connection to `synthetics_test`; requires `DataDog/datadog` 4.9.0+.
  - `downtime_schedule`: lists via V2 ListDowntimes; imports by downtime ID; adds connections to `monitor` and `monitor_json`; requires `DataDog/datadog` 4.9.0+.

- **Bug Fixes**
  - `downtime_schedule`: remove empty alternate schedule (`one_time_schedule` or `recurring_schedule`) from generated HCL and instance state to avoid import diffs.
  - Preserve empty defaults: `synthetics_suite.tags` (empty list), `synthetics_suite.message` (empty string), `downtime_schedule.notify_end_states` (empty list), `downtime_schedule.notify_end_types` (empty list), and `downtime_schedule.message` (empty string).
  - `synthetics_concurrency_cap`: normalize ID filters to `synthetics-concurrency-cap` only when the filter targets the `synthetics_concurrency_cap` service; do not rewrite global `id` filters.

<sup>Written for commit bb32b485b3aa74a0a2420242798c6051f21c91d1. Summary will update on new commits. <a href="https://cubic.dev/pr/chenrui333/terraformer/pull/461?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Datadog downtime schedule support for managing scheduled maintenance windows
  * Extended Synthetics resources with on-demand concurrency cap management
  * Synthetics suite resources now available for test organization

* **Documentation**
  * Updated supported Datadog resources list with new resource entries

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/chenrui333/terraformer/pull/461?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->