### PR TITLE
feat(cloudflare): import storage child resources

### DIFF
--- a/docs/cloudflare.md
+++ b/docs/cloudflare.md
@@ -76,7 +76,14 @@ List of supported Cloudflare services:
 * `storage`
   * `cloudflare_d1_database`
   * `cloudflare_queue`
+  * `cloudflare_queue_consumer`
   * `cloudflare_r2_bucket`
+  * `cloudflare_r2_bucket_cors`
+  * `cloudflare_r2_bucket_event_notification`
+  * `cloudflare_r2_bucket_lifecycle`
+  * `cloudflare_r2_bucket_lock`
+  * `cloudflare_r2_custom_domain`
+  * `cloudflare_r2_data_catalog`
   * `cloudflare_workers_kv_namespace`
 * `turnstile`
   * `cloudflare_turnstile_widget`

--- a/docs/unsupported-resources.md
+++ b/docs/unsupported-resources.md
@@ -66,7 +66,7 @@ Examples in this repository:
 
 - [AWS](../providers/aws/unsupported_resources.json) records resources with import/read reconstruction issues, duplicate ownership, and unsupported provider semantics.
 - [Datadog](../providers/datadog/unsupported_resources.json) records integration resources where generator ownership and provider schema behavior need dedicated handling.
-- [Cloudflare](../providers/cloudflare/unsupported_resources.json) records account, zone, and managed resources that need follow-up or should remain provider-managed.
+- [Cloudflare](../providers/cloudflare/unsupported_resources.json) records account, zone, storage, platform, and managed resources that need follow-up or should remain provider-managed.
 - [Kubernetes](../providers/kubernetes/unsupported_resources.json) records native APIs that are runtime-generated, policy-skipped, or not importable as Terraform-managed configuration.
 - [LaunchDarkly](../providers/launchdarkly/unsupported_resources.json) records beta, singleton, and event/report resources that need scoped follow-up.
 

--- a/providers/cloudflare/storage.go
+++ b/providers/cloudflare/storage.go
@@ -7,6 +7,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"log"
 	"net/http"
 	"net/url"
 	"strconv"
@@ -74,6 +75,23 @@ type cloudflareR2DataCatalog struct {
 	ID               string `json:"id"`
 	Name             string `json:"name"`
 	Status           string `json:"status"`
+}
+
+type cloudflareStorageChildDiscovery struct {
+	name     string
+	parent   string
+	discover func() error
+}
+
+func runCloudflareStorageChildDiscoveries(discoveries []cloudflareStorageChildDiscovery) {
+	for _, discovery := range discoveries {
+		if discovery.discover == nil {
+			continue
+		}
+		if err := discovery.discover(); err != nil {
+			log.Printf("Skipping Cloudflare storage %s discovery for %s: %v", discovery.name, discovery.parent, err)
+		}
+	}
 }
 
 func cloudflareUnsupportedJurisdictionError(err error) bool {
@@ -453,9 +471,13 @@ func (g *StorageGenerator) appendQueueResources(ctx context.Context, api *cf.API
 			)
 			setCloudflareImportID(&resource, accountID+"/"+queue.ID)
 			g.Resources = append(g.Resources, resource)
-			if err := g.appendQueueConsumerResources(ctx, api, accountID, queue); err != nil {
-				return err
-			}
+			runCloudflareStorageChildDiscoveries([]cloudflareStorageChildDiscovery{{
+				name:   "queue consumers",
+				parent: cloudflareResourceName(accountID, queue.ID),
+				discover: func() error {
+					return g.appendQueueConsumerResources(ctx, api, accountID, queue)
+				},
+			}})
 		}
 		if info == nil || !info.HasMorePages() {
 			break
@@ -465,43 +487,33 @@ func (g *StorageGenerator) appendQueueResources(ctx context.Context, api *cf.API
 	return nil
 }
 
-func (g *StorageGenerator) appendR2BucketConfigChildResources(
+func (g *StorageGenerator) appendR2BucketConfigChildResource(
 	ctx context.Context,
 	api *cf.API,
 	accountID string,
 	bucketName string,
 	jurisdiction string,
+	resourceType string,
+	pathSuffix string,
 ) error {
-	for _, config := range []struct {
-		resourceType string
-		pathSuffix   string
-	}{
-		{resourceType: "cloudflare_r2_bucket_cors", pathSuffix: "cors"},
-		{resourceType: "cloudflare_r2_bucket_lifecycle", pathSuffix: "lifecycle"},
-		{resourceType: "cloudflare_r2_bucket_lock", pathSuffix: "lock"},
-	} {
-		path := fmt.Sprintf(
-			"/accounts/%s/r2/buckets/%s/%s",
-			accountID,
-			url.PathEscape(bucketName),
-			config.pathSuffix,
-		)
-		result, found, err := cloudflareRawGetOptional(ctx, api, path, cloudflareR2JurisdictionHeaders(jurisdiction))
-		if err != nil {
-			return err
-		}
-		if !found {
-			continue
-		}
-		var rules cloudflareR2RulesResponse
-		if err := json.Unmarshal(result, &rules); err != nil {
-			return err
-		}
-		if len(rules.Rules) == 0 {
-			continue
-		}
-		g.Resources = append(g.Resources, newCloudflareR2BucketConfigResource(accountID, bucketName, jurisdiction, config.resourceType))
+	path := fmt.Sprintf(
+		"/accounts/%s/r2/buckets/%s/%s",
+		accountID,
+		url.PathEscape(bucketName),
+		pathSuffix,
+	)
+	result, found, err := cloudflareRawGetOptional(ctx, api, path, cloudflareR2JurisdictionHeaders(jurisdiction))
+	if err != nil || !found {
+		return err
 	}
+	var rules cloudflareR2RulesResponse
+	if err := json.Unmarshal(result, &rules); err != nil {
+		return err
+	}
+	if len(rules.Rules) == 0 {
+		return nil
+	}
+	g.Resources = append(g.Resources, newCloudflareR2BucketConfigResource(accountID, bucketName, jurisdiction, resourceType))
 	return nil
 }
 
@@ -596,20 +608,55 @@ func (g *StorageGenerator) appendR2BucketChildResources(
 	bucketName string,
 	jurisdiction string,
 	includeDataCatalog bool,
-) error {
-	for _, f := range []func(context.Context, *cf.API, string, string, string) error{
-		g.appendR2BucketConfigChildResources,
-		g.appendR2BucketEventNotificationResources,
-		g.appendR2CustomDomainResources,
-	} {
-		if err := f(ctx, api, accountID, bucketName, jurisdiction); err != nil {
-			return err
-		}
+) {
+	parent := cloudflareResourceName(accountID, bucketName, jurisdiction)
+	discoveries := []cloudflareStorageChildDiscovery{
+		{
+			name:   "R2 bucket CORS",
+			parent: parent,
+			discover: func() error {
+				return g.appendR2BucketConfigChildResource(ctx, api, accountID, bucketName, jurisdiction, "cloudflare_r2_bucket_cors", "cors")
+			},
+		},
+		{
+			name:   "R2 bucket lifecycle",
+			parent: parent,
+			discover: func() error {
+				return g.appendR2BucketConfigChildResource(ctx, api, accountID, bucketName, jurisdiction, "cloudflare_r2_bucket_lifecycle", "lifecycle")
+			},
+		},
+		{
+			name:   "R2 bucket lock",
+			parent: parent,
+			discover: func() error {
+				return g.appendR2BucketConfigChildResource(ctx, api, accountID, bucketName, jurisdiction, "cloudflare_r2_bucket_lock", "lock")
+			},
+		},
+		{
+			name:   "R2 bucket event notifications",
+			parent: parent,
+			discover: func() error {
+				return g.appendR2BucketEventNotificationResources(ctx, api, accountID, bucketName, jurisdiction)
+			},
+		},
+		{
+			name:   "R2 custom domains",
+			parent: parent,
+			discover: func() error {
+				return g.appendR2CustomDomainResources(ctx, api, accountID, bucketName, jurisdiction)
+			},
+		},
 	}
 	if includeDataCatalog {
-		return g.appendR2DataCatalogResource(ctx, api, accountID, bucketName)
+		discoveries = append(discoveries, cloudflareStorageChildDiscovery{
+			name:   "R2 data catalog",
+			parent: parent,
+			discover: func() error {
+				return g.appendR2DataCatalogResource(ctx, api, accountID, bucketName)
+			},
+		})
 	}
-	return nil
+	runCloudflareStorageChildDiscoveries(discoveries)
 }
 
 func (g *StorageGenerator) appendR2BucketResources(ctx context.Context, api *cf.API, accountID string) error {
@@ -638,9 +685,7 @@ func (g *StorageGenerator) appendR2BucketResources(ctx context.Context, api *cf.
 
 			includeDataCatalog := !seenDataCatalogBuckets[bucket.Name]
 			seenDataCatalogBuckets[bucket.Name] = true
-			if err := g.appendR2BucketChildResources(ctx, api, accountID, bucket.Name, jurisdiction, includeDataCatalog); err != nil {
-				return err
-			}
+			g.appendR2BucketChildResources(ctx, api, accountID, bucket.Name, jurisdiction, includeDataCatalog)
 		}
 	}
 	return nil

--- a/providers/cloudflare/storage.go
+++ b/providers/cloudflare/storage.go
@@ -13,6 +13,7 @@ import (
 	"strings"
 
 	"github.com/chenrui333/terraformer/terraformutils"
+	"github.com/chenrui333/terraformer/terraformutils/tfcompat"
 	cf "github.com/cloudflare/cloudflare-go"
 )
 
@@ -181,6 +182,16 @@ func addCloudflareStringListAttributes(attributes map[string]string, name string
 	}
 }
 
+func setCloudflarePreserveIDAfterRefresh(resource *terraformutils.Resource) {
+	if resource == nil || resource.InstanceState == nil {
+		return
+	}
+	if resource.InstanceState.Meta == nil {
+		resource.InstanceState.Meta = map[string]interface{}{}
+	}
+	resource.InstanceState.Meta[tfcompat.MetaKeyPreserveIDAfterRefresh] = true
+}
+
 func newCloudflareQueueConsumerResource(
 	accountID string,
 	queue cf.Queue,
@@ -201,7 +212,7 @@ func newCloudflareQueueConsumerResource(
 	if consumer.ScriptName != "" {
 		attributes["script_name"] = consumer.ScriptName
 	}
-	return terraformutils.NewResource(
+	resource := terraformutils.NewResource(
 		cloudflareResourceName(accountID, queue.ID, consumer.ConsumerID),
 		cloudflareResourceName(accountID, queue.Name, queue.ID, consumer.ConsumerID),
 		"cloudflare_queue_consumer",
@@ -209,7 +220,9 @@ func newCloudflareQueueConsumerResource(
 		attributes,
 		[]string{},
 		map[string]interface{}{},
-	), true
+	)
+	setCloudflarePreserveIDAfterRefresh(&resource)
+	return resource, true
 }
 
 func newCloudflareR2BucketConfigResource(
@@ -219,7 +232,7 @@ func newCloudflareR2BucketConfigResource(
 	resourceType string,
 ) terraformutils.Resource {
 	resourceName := strings.TrimPrefix(resourceType, "cloudflare_")
-	return terraformutils.NewResource(
+	resource := terraformutils.NewResource(
 		cloudflareResourceName(accountID, bucketName, jurisdiction, resourceName),
 		cloudflareResourceName(accountID, jurisdiction, bucketName, resourceName),
 		resourceType,
@@ -232,6 +245,8 @@ func newCloudflareR2BucketConfigResource(
 		[]string{},
 		map[string]interface{}{},
 	)
+	setCloudflarePreserveIDAfterRefresh(&resource)
+	return resource
 }
 
 func newCloudflareR2BucketEventNotificationResource(
@@ -274,7 +289,7 @@ func newCloudflareR2BucketEventNotificationResource(
 		return terraformutils.Resource{}, false
 	}
 	attributes["rules.#"] = strconv.Itoa(validRules)
-	return terraformutils.NewResource(
+	resource := terraformutils.NewResource(
 		cloudflareResourceName(accountID, bucketName, jurisdiction, queue.QueueID),
 		cloudflareResourceName(accountID, jurisdiction, bucketName, queue.QueueName, queue.QueueID),
 		"cloudflare_r2_bucket_event_notification",
@@ -282,7 +297,9 @@ func newCloudflareR2BucketEventNotificationResource(
 		attributes,
 		[]string{},
 		map[string]interface{}{},
-	), true
+	)
+	setCloudflarePreserveIDAfterRefresh(&resource)
+	return resource, true
 }
 
 func newCloudflareR2CustomDomainResource(
@@ -311,7 +328,7 @@ func newCloudflareR2CustomDomainResource(
 	if domain.ZoneName != "" {
 		attributes["zone_name"] = domain.ZoneName
 	}
-	return terraformutils.NewResource(
+	resource := terraformutils.NewResource(
 		cloudflareResourceName(accountID, bucketName, jurisdiction, domain.Domain),
 		cloudflareResourceName(accountID, jurisdiction, bucketName, domain.Domain),
 		"cloudflare_r2_custom_domain",
@@ -319,7 +336,9 @@ func newCloudflareR2CustomDomainResource(
 		attributes,
 		[]string{},
 		map[string]interface{}{},
-	), true
+	)
+	setCloudflarePreserveIDAfterRefresh(&resource)
+	return resource, true
 }
 
 func newCloudflareR2DataCatalogResource(

--- a/providers/cloudflare/storage.go
+++ b/providers/cloudflare/storage.go
@@ -26,6 +26,55 @@ type r2BucketListResult struct {
 	Buckets []cf.R2Bucket
 }
 
+type cloudflareQueueConsumer struct {
+	ConsumerID      string `json:"consumer_id"`
+	DeadLetterQueue string `json:"dead_letter_queue"`
+	ScriptName      string `json:"script_name"`
+	Type            string `json:"type"`
+}
+
+type cloudflareR2RulesResponse struct {
+	Rules []json.RawMessage `json:"rules"`
+}
+
+type cloudflareR2BucketEventNotificationList struct {
+	Queues []cloudflareR2BucketEventNotificationQueue `json:"queues"`
+}
+
+type cloudflareR2BucketEventNotificationQueue struct {
+	QueueID   string                                    `json:"queueId"`
+	QueueName string                                    `json:"queueName"`
+	Rules     []cloudflareR2BucketEventNotificationRule `json:"rules"`
+}
+
+type cloudflareR2BucketEventNotificationRule struct {
+	Actions     []string `json:"actions"`
+	Description string   `json:"description"`
+	Prefix      string   `json:"prefix"`
+	Suffix      string   `json:"suffix"`
+}
+
+type cloudflareR2CustomDomainList struct {
+	Domains []cloudflareR2CustomDomain `json:"domains"`
+}
+
+type cloudflareR2CustomDomain struct {
+	Ciphers  []string `json:"ciphers"`
+	Domain   string   `json:"domain"`
+	Enabled  bool     `json:"enabled"`
+	MinTLS   string   `json:"minTLS"`
+	ZoneID   string   `json:"zoneId"`
+	ZoneName string   `json:"zoneName"`
+}
+
+type cloudflareR2DataCatalog struct {
+	Bucket           string `json:"bucket"`
+	CredentialStatus string `json:"credential_status"`
+	ID               string `json:"id"`
+	Name             string `json:"name"`
+	Status           string `json:"status"`
+}
+
 func cloudflareUnsupportedJurisdictionError(err error) bool {
 	var notFoundErr *cf.NotFoundError
 	if errors.As(err, &notFoundErr) {
@@ -52,6 +101,33 @@ func cloudflareErrorIndicatesUnsupportedJurisdiction(message string, errorMessag
 		}
 	}
 	return false
+}
+
+func cloudflareR2JurisdictionHeaders(jurisdiction string) http.Header {
+	headers := http.Header{}
+	if jurisdiction != "" {
+		headers.Set("cf-r2-jurisdiction", jurisdiction)
+	}
+	return headers
+}
+
+func cloudflareRawGetOptional(
+	ctx context.Context,
+	api *cf.API,
+	path string,
+	headers http.Header,
+) (json.RawMessage, bool, error) {
+	response, err := api.Raw(ctx, http.MethodGet, path, nil, headers)
+	if err != nil {
+		if cloudflareNotFoundError(err) || cloudflareUnsupportedJurisdictionError(err) {
+			return nil, false, nil
+		}
+		return nil, false, err
+	}
+	if len(response.Result) == 0 || string(response.Result) == "null" {
+		return nil, false, nil
+	}
+	return response.Result, true, nil
 }
 
 func listR2BucketsInJurisdiction(
@@ -98,6 +174,188 @@ func listR2BucketsInJurisdiction(
 	return buckets, nil
 }
 
+func addCloudflareStringListAttributes(attributes map[string]string, name string, values []string) {
+	attributes[name+".#"] = strconv.Itoa(len(values))
+	for i, value := range values {
+		attributes[fmt.Sprintf("%s.%d", name, i)] = value
+	}
+}
+
+func newCloudflareQueueConsumerResource(
+	accountID string,
+	queue cf.Queue,
+	consumer cloudflareQueueConsumer,
+) (terraformutils.Resource, bool) {
+	if queue.ID == "" || consumer.ConsumerID == "" || consumer.Type == "" {
+		return terraformutils.Resource{}, false
+	}
+	attributes := map[string]string{
+		"account_id":  accountID,
+		"consumer_id": consumer.ConsumerID,
+		"queue_id":    queue.ID,
+		"type":        consumer.Type,
+	}
+	if consumer.DeadLetterQueue != "" {
+		attributes["dead_letter_queue"] = consumer.DeadLetterQueue
+	}
+	if consumer.ScriptName != "" {
+		attributes["script_name"] = consumer.ScriptName
+	}
+	return terraformutils.NewResource(
+		cloudflareResourceName(accountID, queue.ID, consumer.ConsumerID),
+		cloudflareResourceName(accountID, queue.Name, queue.ID, consumer.ConsumerID),
+		"cloudflare_queue_consumer",
+		"cloudflare",
+		attributes,
+		[]string{},
+		map[string]interface{}{},
+	), true
+}
+
+func newCloudflareR2BucketConfigResource(
+	accountID string,
+	bucketName string,
+	jurisdiction string,
+	resourceType string,
+) terraformutils.Resource {
+	resourceName := strings.TrimPrefix(resourceType, "cloudflare_")
+	return terraformutils.NewResource(
+		cloudflareResourceName(accountID, bucketName, jurisdiction, resourceName),
+		cloudflareResourceName(accountID, jurisdiction, bucketName, resourceName),
+		resourceType,
+		"cloudflare",
+		map[string]string{
+			"account_id":   accountID,
+			"bucket_name":  bucketName,
+			"jurisdiction": jurisdiction,
+		},
+		[]string{},
+		map[string]interface{}{},
+	)
+}
+
+func newCloudflareR2BucketEventNotificationResource(
+	accountID string,
+	bucketName string,
+	jurisdiction string,
+	queue cloudflareR2BucketEventNotificationQueue,
+) (terraformutils.Resource, bool) {
+	if queue.QueueID == "" {
+		return terraformutils.Resource{}, false
+	}
+	attributes := map[string]string{
+		"account_id":   accountID,
+		"bucket_name":  bucketName,
+		"jurisdiction": jurisdiction,
+		"queue_id":     queue.QueueID,
+	}
+	if queue.QueueName != "" {
+		attributes["queue_name"] = queue.QueueName
+	}
+	validRules := 0
+	for _, rule := range queue.Rules {
+		if len(rule.Actions) == 0 {
+			continue
+		}
+		prefix := fmt.Sprintf("rules.%d", validRules)
+		addCloudflareStringListAttributes(attributes, prefix+".actions", rule.Actions)
+		if rule.Description != "" {
+			attributes[prefix+".description"] = rule.Description
+		}
+		if rule.Prefix != "" {
+			attributes[prefix+".prefix"] = rule.Prefix
+		}
+		if rule.Suffix != "" {
+			attributes[prefix+".suffix"] = rule.Suffix
+		}
+		validRules++
+	}
+	if validRules == 0 {
+		return terraformutils.Resource{}, false
+	}
+	attributes["rules.#"] = strconv.Itoa(validRules)
+	return terraformutils.NewResource(
+		cloudflareResourceName(accountID, bucketName, jurisdiction, queue.QueueID),
+		cloudflareResourceName(accountID, jurisdiction, bucketName, queue.QueueName, queue.QueueID),
+		"cloudflare_r2_bucket_event_notification",
+		"cloudflare",
+		attributes,
+		[]string{},
+		map[string]interface{}{},
+	), true
+}
+
+func newCloudflareR2CustomDomainResource(
+	accountID string,
+	bucketName string,
+	jurisdiction string,
+	domain cloudflareR2CustomDomain,
+) (terraformutils.Resource, bool) {
+	if domain.Domain == "" || domain.ZoneID == "" {
+		return terraformutils.Resource{}, false
+	}
+	attributes := map[string]string{
+		"account_id":   accountID,
+		"bucket_name":  bucketName,
+		"domain":       domain.Domain,
+		"enabled":      strconv.FormatBool(domain.Enabled),
+		"jurisdiction": jurisdiction,
+		"zone_id":      domain.ZoneID,
+	}
+	if domain.MinTLS != "" {
+		attributes["min_tls"] = domain.MinTLS
+	}
+	if len(domain.Ciphers) > 0 {
+		addCloudflareStringListAttributes(attributes, "ciphers", domain.Ciphers)
+	}
+	if domain.ZoneName != "" {
+		attributes["zone_name"] = domain.ZoneName
+	}
+	return terraformutils.NewResource(
+		cloudflareResourceName(accountID, bucketName, jurisdiction, domain.Domain),
+		cloudflareResourceName(accountID, jurisdiction, bucketName, domain.Domain),
+		"cloudflare_r2_custom_domain",
+		"cloudflare",
+		attributes,
+		[]string{},
+		map[string]interface{}{},
+	), true
+}
+
+func newCloudflareR2DataCatalogResource(
+	accountID string,
+	bucketName string,
+	catalog cloudflareR2DataCatalog,
+) (terraformutils.Resource, bool) {
+	if catalog.Status != "active" {
+		return terraformutils.Resource{}, false
+	}
+	if catalog.Bucket != "" {
+		bucketName = catalog.Bucket
+	}
+	if bucketName == "" {
+		return terraformutils.Resource{}, false
+	}
+	resourceID := catalog.ID
+	if resourceID == "" {
+		resourceID = bucketName
+	}
+	resource := terraformutils.NewResource(
+		resourceID,
+		cloudflareResourceName(accountID, bucketName, "data_catalog"),
+		"cloudflare_r2_data_catalog",
+		"cloudflare",
+		map[string]string{
+			"account_id":  accountID,
+			"bucket_name": bucketName,
+		},
+		[]string{},
+		map[string]interface{}{},
+	)
+	setCloudflareImportID(&resource, accountID+"/"+bucketName)
+	return resource, true
+}
+
 func (g *StorageGenerator) appendWorkersKVNamespaceResources(ctx context.Context, api *cf.API, accountID string) error {
 	params := cf.ListWorkersKVNamespacesParams{ResultInfo: cf.ResultInfo{Page: 1, PerPage: cloudflarePageSize}}
 	for {
@@ -126,6 +384,37 @@ func (g *StorageGenerator) appendWorkersKVNamespaceResources(ctx context.Context
 	return nil
 }
 
+func (g *StorageGenerator) appendQueueConsumerResources(
+	ctx context.Context,
+	api *cf.API,
+	accountID string,
+	queue cf.Queue,
+) error {
+	if queue.ID == "" {
+		return nil
+	}
+	path := fmt.Sprintf(
+		"/accounts/%s/queues/%s/consumers",
+		accountID,
+		url.PathEscape(queue.ID),
+	)
+	result, found, err := cloudflareRawGetOptional(ctx, api, path, nil)
+	if err != nil || !found {
+		return err
+	}
+	var consumers []cloudflareQueueConsumer
+	if err := json.Unmarshal(result, &consumers); err != nil {
+		return err
+	}
+	for _, consumer := range consumers {
+		resource, ok := newCloudflareQueueConsumerResource(accountID, queue, consumer)
+		if ok {
+			g.Resources = append(g.Resources, resource)
+		}
+	}
+	return nil
+}
+
 func (g *StorageGenerator) appendQueueResources(ctx context.Context, api *cf.API, accountID string) error {
 	params := cf.ListQueuesParams{ResultInfo: cf.ResultInfo{Page: 1, PerPage: cloudflarePageSize}}
 	for {
@@ -145,6 +434,9 @@ func (g *StorageGenerator) appendQueueResources(ctx context.Context, api *cf.API
 			)
 			setCloudflareImportID(&resource, accountID+"/"+queue.ID)
 			g.Resources = append(g.Resources, resource)
+			if err := g.appendQueueConsumerResources(ctx, api, accountID, queue); err != nil {
+				return err
+			}
 		}
 		if info == nil || !info.HasMorePages() {
 			break
@@ -154,7 +446,155 @@ func (g *StorageGenerator) appendQueueResources(ctx context.Context, api *cf.API
 	return nil
 }
 
+func (g *StorageGenerator) appendR2BucketConfigChildResources(
+	ctx context.Context,
+	api *cf.API,
+	accountID string,
+	bucketName string,
+	jurisdiction string,
+) error {
+	for _, config := range []struct {
+		resourceType string
+		pathSuffix   string
+	}{
+		{resourceType: "cloudflare_r2_bucket_cors", pathSuffix: "cors"},
+		{resourceType: "cloudflare_r2_bucket_lifecycle", pathSuffix: "lifecycle"},
+		{resourceType: "cloudflare_r2_bucket_lock", pathSuffix: "lock"},
+	} {
+		path := fmt.Sprintf(
+			"/accounts/%s/r2/buckets/%s/%s",
+			accountID,
+			url.PathEscape(bucketName),
+			config.pathSuffix,
+		)
+		result, found, err := cloudflareRawGetOptional(ctx, api, path, cloudflareR2JurisdictionHeaders(jurisdiction))
+		if err != nil {
+			return err
+		}
+		if !found {
+			continue
+		}
+		var rules cloudflareR2RulesResponse
+		if err := json.Unmarshal(result, &rules); err != nil {
+			return err
+		}
+		if len(rules.Rules) == 0 {
+			continue
+		}
+		g.Resources = append(g.Resources, newCloudflareR2BucketConfigResource(accountID, bucketName, jurisdiction, config.resourceType))
+	}
+	return nil
+}
+
+func (g *StorageGenerator) appendR2BucketEventNotificationResources(
+	ctx context.Context,
+	api *cf.API,
+	accountID string,
+	bucketName string,
+	jurisdiction string,
+) error {
+	path := fmt.Sprintf(
+		"/accounts/%s/event_notifications/r2/%s/configuration",
+		accountID,
+		url.PathEscape(bucketName),
+	)
+	result, found, err := cloudflareRawGetOptional(ctx, api, path, cloudflareR2JurisdictionHeaders(jurisdiction))
+	if err != nil || !found {
+		return err
+	}
+	var notifications cloudflareR2BucketEventNotificationList
+	if err := json.Unmarshal(result, &notifications); err != nil {
+		return err
+	}
+	for _, queue := range notifications.Queues {
+		resource, ok := newCloudflareR2BucketEventNotificationResource(accountID, bucketName, jurisdiction, queue)
+		if ok {
+			g.Resources = append(g.Resources, resource)
+		}
+	}
+	return nil
+}
+
+func (g *StorageGenerator) appendR2CustomDomainResources(
+	ctx context.Context,
+	api *cf.API,
+	accountID string,
+	bucketName string,
+	jurisdiction string,
+) error {
+	path := fmt.Sprintf(
+		"/accounts/%s/r2/buckets/%s/domains/custom",
+		accountID,
+		url.PathEscape(bucketName),
+	)
+	result, found, err := cloudflareRawGetOptional(ctx, api, path, cloudflareR2JurisdictionHeaders(jurisdiction))
+	if err != nil || !found {
+		return err
+	}
+	var domains cloudflareR2CustomDomainList
+	if err := json.Unmarshal(result, &domains); err != nil {
+		return err
+	}
+	for _, domain := range domains.Domains {
+		resource, ok := newCloudflareR2CustomDomainResource(accountID, bucketName, jurisdiction, domain)
+		if ok {
+			g.Resources = append(g.Resources, resource)
+		}
+	}
+	return nil
+}
+
+func (g *StorageGenerator) appendR2DataCatalogResource(
+	ctx context.Context,
+	api *cf.API,
+	accountID string,
+	bucketName string,
+) error {
+	path := fmt.Sprintf(
+		"/accounts/%s/r2-catalog/%s",
+		accountID,
+		url.PathEscape(bucketName),
+	)
+	result, found, err := cloudflareRawGetOptional(ctx, api, path, nil)
+	if err != nil || !found {
+		return err
+	}
+	var catalog cloudflareR2DataCatalog
+	if err := json.Unmarshal(result, &catalog); err != nil {
+		return err
+	}
+	resource, ok := newCloudflareR2DataCatalogResource(accountID, bucketName, catalog)
+	if ok {
+		g.Resources = append(g.Resources, resource)
+	}
+	return nil
+}
+
+func (g *StorageGenerator) appendR2BucketChildResources(
+	ctx context.Context,
+	api *cf.API,
+	accountID string,
+	bucketName string,
+	jurisdiction string,
+	includeDataCatalog bool,
+) error {
+	for _, f := range []func(context.Context, *cf.API, string, string, string) error{
+		g.appendR2BucketConfigChildResources,
+		g.appendR2BucketEventNotificationResources,
+		g.appendR2CustomDomainResources,
+	} {
+		if err := f(ctx, api, accountID, bucketName, jurisdiction); err != nil {
+			return err
+		}
+	}
+	if includeDataCatalog {
+		return g.appendR2DataCatalogResource(ctx, api, accountID, bucketName)
+	}
+	return nil
+}
+
 func (g *StorageGenerator) appendR2BucketResources(ctx context.Context, api *cf.API, accountID string) error {
+	seenDataCatalogBuckets := map[string]bool{}
 	for _, jurisdiction := range r2BucketJurisdictions {
 		buckets, err := listR2BucketsInJurisdiction(ctx, api, accountID, jurisdiction)
 		if err != nil {
@@ -176,6 +616,12 @@ func (g *StorageGenerator) appendR2BucketResources(ctx context.Context, api *cf.
 			)
 			setCloudflareImportID(&resource, accountID+"/"+bucket.Name+"/"+jurisdiction)
 			g.Resources = append(g.Resources, resource)
+
+			includeDataCatalog := !seenDataCatalogBuckets[bucket.Name]
+			seenDataCatalogBuckets[bucket.Name] = true
+			if err := g.appendR2BucketChildResources(ctx, api, accountID, bucket.Name, jurisdiction, includeDataCatalog); err != nil {
+				return err
+			}
 		}
 	}
 	return nil

--- a/providers/cloudflare/storage_test.go
+++ b/providers/cloudflare/storage_test.go
@@ -5,6 +5,8 @@ package cloudflare
 import (
 	"testing"
 
+	"github.com/chenrui333/terraformer/terraformutils"
+	"github.com/chenrui333/terraformer/terraformutils/tfcompat"
 	cf "github.com/cloudflare/cloudflare-go"
 )
 
@@ -24,6 +26,7 @@ func TestNewCloudflareQueueConsumerResource(t *testing.T) {
 	if resource.InstanceInfo.Type != "cloudflare_queue_consumer" {
 		t.Fatalf("resource type = %q, want cloudflare_queue_consumer", resource.InstanceInfo.Type)
 	}
+	assertCloudflarePreservesID(t, resource)
 	attributes := resource.InstanceState.Attributes
 	for key, want := range map[string]string{
 		"account_id":        "account-id",
@@ -56,6 +59,14 @@ func TestNewCloudflareQueueConsumerResourceSkipsMalformedConsumers(t *testing.T)
 	}
 }
 
+func TestNewCloudflareR2BucketConfigResourcePreservesID(t *testing.T) {
+	resource := newCloudflareR2BucketConfigResource("account-id", "bucket-name", "eu", "cloudflare_r2_bucket_cors")
+	if resource.InstanceInfo.Type != "cloudflare_r2_bucket_cors" {
+		t.Fatalf("resource type = %q, want cloudflare_r2_bucket_cors", resource.InstanceInfo.Type)
+	}
+	assertCloudflarePreservesID(t, resource)
+}
+
 func TestNewCloudflareR2BucketEventNotificationResource(t *testing.T) {
 	resource, ok := newCloudflareR2BucketEventNotificationResource(
 		"account-id",
@@ -78,6 +89,7 @@ func TestNewCloudflareR2BucketEventNotificationResource(t *testing.T) {
 	if !ok {
 		t.Fatal("expected event notification resource")
 	}
+	assertCloudflarePreservesID(t, resource)
 	attributes := resource.InstanceState.Attributes
 	for key, want := range map[string]string{
 		"account_id":          "account-id",
@@ -129,6 +141,7 @@ func TestNewCloudflareR2CustomDomainResource(t *testing.T) {
 	if !ok {
 		t.Fatal("expected custom domain resource")
 	}
+	assertCloudflarePreservesID(t, resource)
 	attributes := resource.InstanceState.Attributes
 	for key, want := range map[string]string{
 		"account_id":   "account-id",
@@ -177,5 +190,14 @@ func TestNewCloudflareR2DataCatalogResource(t *testing.T) {
 func TestNewCloudflareR2DataCatalogResourceSkipsInactiveCatalog(t *testing.T) {
 	if _, ok := newCloudflareR2DataCatalogResource("account-id", "bucket-name", cloudflareR2DataCatalog{Status: "inactive"}); ok {
 		t.Fatal("expected inactive data catalog to be skipped")
+	}
+}
+
+func assertCloudflarePreservesID(t *testing.T, resource terraformutils.Resource) {
+	t.Helper()
+
+	preserveID, ok := resource.InstanceState.Meta[tfcompat.MetaKeyPreserveIDAfterRefresh].(bool)
+	if !ok || !preserveID {
+		t.Fatalf("preserve ID metadata = %#v, want true", resource.InstanceState.Meta[tfcompat.MetaKeyPreserveIDAfterRefresh])
 	}
 }

--- a/providers/cloudflare/storage_test.go
+++ b/providers/cloudflare/storage_test.go
@@ -1,0 +1,181 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package cloudflare
+
+import (
+	"testing"
+
+	cf "github.com/cloudflare/cloudflare-go"
+)
+
+func TestNewCloudflareQueueConsumerResource(t *testing.T) {
+	queue := cf.Queue{ID: "queue-id", Name: "orders"}
+	consumer := cloudflareQueueConsumer{
+		ConsumerID:      "consumer-id",
+		DeadLetterQueue: "orders-dlq",
+		ScriptName:      "consumer-worker",
+		Type:            "worker",
+	}
+
+	resource, ok := newCloudflareQueueConsumerResource("account-id", queue, consumer)
+	if !ok {
+		t.Fatal("expected queue consumer resource")
+	}
+	if resource.InstanceInfo.Type != "cloudflare_queue_consumer" {
+		t.Fatalf("resource type = %q, want cloudflare_queue_consumer", resource.InstanceInfo.Type)
+	}
+	attributes := resource.InstanceState.Attributes
+	for key, want := range map[string]string{
+		"account_id":        "account-id",
+		"consumer_id":       "consumer-id",
+		"dead_letter_queue": "orders-dlq",
+		"queue_id":          "queue-id",
+		"script_name":       "consumer-worker",
+		"type":              "worker",
+	} {
+		if got := attributes[key]; got != want {
+			t.Fatalf("attribute %s = %q, want %q", key, got, want)
+		}
+	}
+}
+
+func TestNewCloudflareQueueConsumerResourceSkipsMalformedConsumers(t *testing.T) {
+	queue := cf.Queue{ID: "queue-id", Name: "orders"}
+	for name, consumer := range map[string]cloudflareQueueConsumer{
+		"missing consumer id": {Type: "worker"},
+		"missing type":        {ConsumerID: "consumer-id"},
+	} {
+		t.Run(name, func(t *testing.T) {
+			if _, ok := newCloudflareQueueConsumerResource("account-id", queue, consumer); ok {
+				t.Fatal("expected malformed consumer to be skipped")
+			}
+		})
+	}
+	if _, ok := newCloudflareQueueConsumerResource("account-id", cf.Queue{}, cloudflareQueueConsumer{ConsumerID: "consumer-id", Type: "worker"}); ok {
+		t.Fatal("expected consumer without parent queue ID to be skipped")
+	}
+}
+
+func TestNewCloudflareR2BucketEventNotificationResource(t *testing.T) {
+	resource, ok := newCloudflareR2BucketEventNotificationResource(
+		"account-id",
+		"bucket-name",
+		"eu",
+		cloudflareR2BucketEventNotificationQueue{
+			QueueID:   "queue-id",
+			QueueName: "orders",
+			Rules: []cloudflareR2BucketEventNotificationRule{
+				{Description: "ignore empty actions"},
+				{
+					Actions:     []string{"PutObject", "DeleteObject"},
+					Description: "objects",
+					Prefix:      "in/",
+					Suffix:      ".json",
+				},
+			},
+		},
+	)
+	if !ok {
+		t.Fatal("expected event notification resource")
+	}
+	attributes := resource.InstanceState.Attributes
+	for key, want := range map[string]string{
+		"account_id":          "account-id",
+		"bucket_name":         "bucket-name",
+		"jurisdiction":        "eu",
+		"queue_id":            "queue-id",
+		"queue_name":          "orders",
+		"rules.#":             "1",
+		"rules.0.actions.#":   "2",
+		"rules.0.actions.0":   "PutObject",
+		"rules.0.actions.1":   "DeleteObject",
+		"rules.0.description": "objects",
+		"rules.0.prefix":      "in/",
+		"rules.0.suffix":      ".json",
+	} {
+		if got := attributes[key]; got != want {
+			t.Fatalf("attribute %s = %q, want %q", key, got, want)
+		}
+	}
+}
+
+func TestNewCloudflareR2BucketEventNotificationResourceSkipsEmptyRules(t *testing.T) {
+	queue := cloudflareR2BucketEventNotificationQueue{
+		QueueID: "queue-id",
+		Rules:   []cloudflareR2BucketEventNotificationRule{{Description: "no actions"}},
+	}
+	if _, ok := newCloudflareR2BucketEventNotificationResource("account-id", "bucket-name", "default", queue); ok {
+		t.Fatal("expected event notification without actionable rules to be skipped")
+	}
+	if _, ok := newCloudflareR2BucketEventNotificationResource("account-id", "bucket-name", "default", cloudflareR2BucketEventNotificationQueue{}); ok {
+		t.Fatal("expected event notification without queue ID to be skipped")
+	}
+}
+
+func TestNewCloudflareR2CustomDomainResource(t *testing.T) {
+	resource, ok := newCloudflareR2CustomDomainResource(
+		"account-id",
+		"bucket-name",
+		"default",
+		cloudflareR2CustomDomain{
+			Ciphers:  []string{"TLS_AES_128_GCM_SHA256"},
+			Domain:   "assets.example.com",
+			Enabled:  true,
+			MinTLS:   "1.2",
+			ZoneID:   "zone-id",
+			ZoneName: "example.com",
+		},
+	)
+	if !ok {
+		t.Fatal("expected custom domain resource")
+	}
+	attributes := resource.InstanceState.Attributes
+	for key, want := range map[string]string{
+		"account_id":   "account-id",
+		"bucket_name":  "bucket-name",
+		"ciphers.#":    "1",
+		"ciphers.0":    "TLS_AES_128_GCM_SHA256",
+		"domain":       "assets.example.com",
+		"enabled":      "true",
+		"jurisdiction": "default",
+		"min_tls":      "1.2",
+		"zone_id":      "zone-id",
+		"zone_name":    "example.com",
+	} {
+		if got := attributes[key]; got != want {
+			t.Fatalf("attribute %s = %q, want %q", key, got, want)
+		}
+	}
+}
+
+func TestNewCloudflareR2CustomDomainResourceRequiresZoneID(t *testing.T) {
+	if _, ok := newCloudflareR2CustomDomainResource("account-id", "bucket-name", "default", cloudflareR2CustomDomain{Domain: "assets.example.com"}); ok {
+		t.Fatal("expected custom domain without zone ID to be skipped")
+	}
+}
+
+func TestNewCloudflareR2DataCatalogResource(t *testing.T) {
+	resource, ok := newCloudflareR2DataCatalogResource(
+		"account-id",
+		"input-bucket",
+		cloudflareR2DataCatalog{Bucket: "catalog-bucket", ID: "catalog-id", Status: "active"},
+	)
+	if !ok {
+		t.Fatal("expected active data catalog resource")
+	}
+	if resource.InstanceState.ID != "catalog-id" {
+		t.Fatalf("state ID = %q, want catalog-id", resource.InstanceState.ID)
+	}
+	if got := resource.InstanceState.Attributes["bucket_name"]; got != "catalog-bucket" {
+		t.Fatalf("bucket_name = %q, want catalog-bucket", got)
+	}
+	if got := resource.InstanceState.Meta["import_id"]; got != "account-id/catalog-bucket" {
+		t.Fatalf("import_id = %v, want account-id/catalog-bucket", got)
+	}
+}
+
+func TestNewCloudflareR2DataCatalogResourceSkipsInactiveCatalog(t *testing.T) {
+	if _, ok := newCloudflareR2DataCatalogResource("account-id", "bucket-name", cloudflareR2DataCatalog{Status: "inactive"}); ok {
+		t.Fatal("expected inactive data catalog to be skipped")
+	}
+}

--- a/providers/cloudflare/storage_test.go
+++ b/providers/cloudflare/storage_test.go
@@ -3,12 +3,40 @@
 package cloudflare
 
 import (
+	"errors"
 	"testing"
 
 	"github.com/chenrui333/terraformer/terraformutils"
 	"github.com/chenrui333/terraformer/terraformutils/tfcompat"
 	cf "github.com/cloudflare/cloudflare-go"
 )
+
+func TestRunCloudflareStorageChildDiscoveriesContinuesAfterError(t *testing.T) {
+	calls := []string{}
+	runCloudflareStorageChildDiscoveries([]cloudflareStorageChildDiscovery{
+		{
+			name:   "fails",
+			parent: "parent",
+			discover: func() error {
+				calls = append(calls, "fails")
+				return errors.New("permission denied")
+			},
+		},
+		{
+			name:   "succeeds",
+			parent: "parent",
+			discover: func() error {
+				calls = append(calls, "succeeds")
+				return nil
+			},
+		},
+		{name: "nil discoverer", parent: "parent"},
+	})
+
+	if len(calls) != 2 || calls[0] != "fails" || calls[1] != "succeeds" {
+		t.Fatalf("discoveries called in order = %#v, want [fails succeeds]", calls)
+	}
+}
 
 func TestNewCloudflareQueueConsumerResource(t *testing.T) {
 	queue := cf.Queue{ID: "queue-id", Name: "orders"}

--- a/providers/cloudflare/unsupported_resources.json
+++ b/providers/cloudflare/unsupported_resources.json
@@ -24,6 +24,17 @@
       ]
     },
     {
+      "resource": "cloudflare_ai_search_token",
+      "service_family": "ai",
+      "reason": "AI Search tokens require Cloudflare API credential material that broad import cannot safely reconstruct.",
+      "evidence": "Terraform provider v5.19.1 marks cf_api_key as Sensitive and no_refresh, and import verification ignores cf_api_key. Terraformer cannot discover or emit a valid token resource without the required API key value.",
+      "status": "secret-required",
+      "references": [
+        "https://github.com/chenrui333/terraformer/issues/335",
+        "https://registry.terraform.io/providers/cloudflare/cloudflare/latest/docs/resources/ai_search_token"
+      ]
+    },
+    {
       "resource": "cloudflare_authenticated_origin_pulls_certificate",
       "service_family": "certificates",
       "reason": "Authenticated Origin Pull certificates require private key material that Cloudflare APIs cannot safely return.",
@@ -57,6 +68,17 @@
       ]
     },
     {
+      "resource": "cloudflare_hyperdrive_config",
+      "service_family": "storage",
+      "reason": "Hyperdrive configs require write-only origin credential material.",
+      "evidence": "Terraform provider v5.19.1 requires origin.password and documents it as Sensitive with the API never returning this write-only value. origin.access_client_secret is also Sensitive and write-only when Cloudflare Access credentials are configured.",
+      "status": "secret-required",
+      "references": [
+        "https://github.com/chenrui333/terraformer/issues/335",
+        "https://registry.terraform.io/providers/cloudflare/cloudflare/latest/docs/resources/hyperdrive_config"
+      ]
+    },
+    {
       "resource": "cloudflare_list_item",
       "service_family": "lists",
       "reason": "Standalone list-item import would duplicate Terraformer's existing inline cloudflare_list item ownership.",
@@ -79,6 +101,39 @@
       ]
     },
     {
+      "resource": "cloudflare_pipeline_sink",
+      "service_family": "platform",
+      "reason": "Pipeline sink config can contain write-only authentication material that broad import cannot reconstruct.",
+      "evidence": "Terraform provider v5.19.1 marks config.credentials.secret_access_key and config.token as Sensitive/no_refresh, and provider import verification ignores config. Terraformer cannot safely emit credential-bearing sink configuration from discovery alone.",
+      "status": "secret-required",
+      "references": [
+        "https://github.com/chenrui333/terraformer/issues/335",
+        "https://registry.terraform.io/providers/cloudflare/cloudflare/latest/docs/resources/pipeline_sink"
+      ]
+    },
+    {
+      "resource": "cloudflare_r2_bucket_sippy",
+      "service_family": "storage",
+      "reason": "R2 Sippy replication requires source or destination credential material that cannot be safely reconstructed.",
+      "evidence": "Terraform provider v5.19.1 documents cloudflare_r2_bucket_sippy as not supporting terraform import and marks source/destination secret_access_key plus GCS private_key fields as Sensitive/no_refresh.",
+      "status": "secret-required",
+      "references": [
+        "https://github.com/chenrui333/terraformer/issues/335",
+        "https://registry.terraform.io/providers/cloudflare/cloudflare/latest/docs/resources/r2_bucket_sippy"
+      ]
+    },
+    {
+      "resource": "cloudflare_r2_managed_domain",
+      "service_family": "storage",
+      "reason": "R2 managed domain provider semantics do not expose a usable broad import/read path.",
+      "evidence": "Terraform provider v5.19.1 documents cloudflare_r2_managed_domain as not supporting terraform import, and the generated resource has empty Read and Delete methods while warning that the managed domain cannot be destroyed from Terraform.",
+      "status": "not-importable",
+      "references": [
+        "https://github.com/chenrui333/terraformer/issues/335",
+        "https://registry.terraform.io/providers/cloudflare/cloudflare/latest/docs/resources/r2_managed_domain"
+      ]
+    },
+    {
       "resource": "cloudflare_snippet",
       "service_family": "snippets",
       "reason": "Snippet resources require source files and the Terraform provider does not currently support import.",
@@ -98,6 +153,39 @@
       "references": [
         "https://github.com/chenrui333/terraformer/issues/335",
         "https://registry.terraform.io/providers/cloudflare/cloudflare/latest/docs/resources/stream_download"
+      ]
+    },
+    {
+      "resource": "cloudflare_stream_key",
+      "service_family": "stream",
+      "reason": "Stream signing keys expose generated private key material that broad import should not materialize.",
+      "evidence": "Terraform provider v5.19.1 supports account-scoped import, but the jwk and pem attributes are Sensitive/no_refresh generated signing keys. Broad import would capture generated secret key material rather than reconstruct user-authored configuration.",
+      "status": "secret-required",
+      "references": [
+        "https://github.com/chenrui333/terraformer/issues/335",
+        "https://registry.terraform.io/providers/cloudflare/cloudflare/latest/docs/resources/stream_key"
+      ]
+    },
+    {
+      "resource": "cloudflare_stream_live_input",
+      "service_family": "stream",
+      "reason": "Stream live input resources expose generated streaming credentials and the provider does not support import.",
+      "evidence": "Terraform provider v5.19.1 documents cloudflare_stream_live_input as not supporting terraform import and marks generated RTMPS/SRT/WebRTC URLs, stream keys, and passphrases as Sensitive.",
+      "status": "not-importable",
+      "references": [
+        "https://github.com/chenrui333/terraformer/issues/335",
+        "https://registry.terraform.io/providers/cloudflare/cloudflare/latest/docs/resources/stream_live_input"
+      ]
+    },
+    {
+      "resource": "cloudflare_stream_webhook",
+      "service_family": "stream",
+      "reason": "Stream webhook resources expose generated verification secret material and the provider does not support import.",
+      "evidence": "Terraform provider v5.19.1 documents cloudflare_stream_webhook as not supporting terraform import and marks the generated webhook secret as Sensitive.",
+      "status": "not-importable",
+      "references": [
+        "https://github.com/chenrui333/terraformer/issues/335",
+        "https://registry.terraform.io/providers/cloudflare/cloudflare/latest/docs/resources/stream_webhook"
       ]
     },
     {


### PR DESCRIPTION
Summary:
- import Cloudflare queue consumers and safe R2 bucket child resources from existing storage inventory
- skip absent/default R2 child settings and defer managed domains or secret-backed resources in unsupported metadata
- document the new Cloudflare storage coverage

References:
- Refs #335

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds import support for Cloudflare queue consumers and R2 bucket child resources, with jurisdiction-aware, best-effort discovery that never blocks base storage imports. Preserves synthetic IDs for ID-less storage child resources across provider refresh to prevent drift (refs #335).

- New Features
  - Discover and import `cloudflare_queue_consumer` for each queue.
  - Import R2 bucket children when present: `cloudflare_r2_bucket_cors`, `cloudflare_r2_bucket_event_notification`, `cloudflare_r2_bucket_lifecycle`, `cloudflare_r2_bucket_lock`, `cloudflare_r2_custom_domain`, `cloudflare_r2_data_catalog` (active only; once per bucket across jurisdictions).
  - Jurisdiction-aware R2 discovery with safe fallbacks and best-effort error handling.
  - Skip absent/default R2 configs and ignore empty event rules.
  - Tests for consumer, event notification, custom domain, data catalog builders, and best-effort discovery behavior.
  - Docs: list new storage resources in `docs/cloudflare.md`; clarify Cloudflare unsupported categories.

- Unsupported Coverage
  - Mark secret-backed or non-importable resources in `providers/cloudflare/unsupported_resources.json`: `cloudflare_ai_search_token`, `cloudflare_hyperdrive_config`, `cloudflare_pipeline_sink`, `cloudflare_r2_bucket_sippy`, `cloudflare_r2_managed_domain`, `cloudflare_stream_key`, `cloudflare_stream_live_input`, `cloudflare_stream_webhook`.

<sup>Written for commit fa1659a3ee61bb5585f2644d49fb1cc6583a199e. Summary will update on new commits. <a href="https://cubic.dev/pr/chenrui333/terraformer/pull/463?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

