### PR TITLE
feat(kafka): add provider skeleton and topic imports

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ A CLI tool that generates `tf`/`json` and `tfstate` files based on existing infr
         * [Yandex Cloud](/docs/yandex.md)
         * [Ionos Cloud](/docs/ionoscloud.md)
     * Infrastructure Software
+        * [Kafka](/docs/kafka.md)
         * [Kubernetes](/docs/kubernetes.md)
         * [OctopusDeploy](/docs/octopus.md)
         * [RabbitMQ](/docs/rabbitmq.md)
@@ -271,6 +272,7 @@ Links to download Terraform provider plugins:
     * Yandex provider >0.42.0 - [here](https://releases.hashicorp.com/terraform-provider-yandex/)
     * Ionoscloud provider >6.3.3 - [here](https://github.com/ionos-cloud/terraform-provider-ionoscloud/releases)
 * Infrastructure Software
+    * Kafka provider >=0.13.1 - [here](https://github.com/Mongey/terraform-provider-kafka/releases)
     * Kubernetes provider >=1.9.0 - [here](https://releases.hashicorp.com/terraform-provider-kubernetes/)
     * RabbitMQ provider >=1.1.0 - [here](https://releases.hashicorp.com/terraform-provider-rabbitmq/)
 * Network

--- a/cmd/provider_cmd_kafka.go
+++ b/cmd/provider_cmd_kafka.go
@@ -1,0 +1,53 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package cmd
+
+import (
+	"strconv"
+
+	kafka_terraforming "github.com/chenrui333/terraformer/providers/kafka"
+	"github.com/chenrui333/terraformer/terraformutils"
+	"github.com/spf13/cobra"
+)
+
+func newCmdKafkaImporter(options ImportOptions) *cobra.Command {
+	config := kafka_terraforming.ConfigFromEnv()
+	cmd := &cobra.Command{
+		Use:   "kafka",
+		Short: "Import current state to Terraform configuration from Kafka",
+		Long:  "Import current state to Terraform configuration from Kafka",
+		RunE: func(_ *cobra.Command, _ []string) error {
+			provider := newKafkaProvider()
+			err := Import(provider, options, []string{kafka_terraforming.EncodeConfig(config)})
+			if err != nil {
+				return err
+			}
+			return nil
+		},
+	}
+
+	cmd.AddCommand(listCmd(newKafkaProvider()))
+	baseProviderFlags(cmd.PersistentFlags(), &options, "topics", "topic=topic1:topic2")
+	cmd.PersistentFlags().StringSliceVar(&config.BootstrapServers, "bootstrap-servers", config.BootstrapServers, "Kafka bootstrap servers or KAFKA_BOOTSTRAP_SERVERS")
+	cmd.PersistentFlags().StringVar(&config.KafkaVersion, "kafka-version", config.KafkaVersion, "Kafka protocol version or KAFKA_VERSION")
+	cmd.PersistentFlags().BoolVar(&config.TLSEnabled, "tls-enabled", config.TLSEnabled, "Enable TLS or KAFKA_ENABLE_TLS")
+	cmd.PersistentFlags().BoolVar(&config.SkipTLSVerify, "skip-tls-verify", config.SkipTLSVerify, "Skip TLS certificate verification or KAFKA_SKIP_VERIFY")
+	cmd.PersistentFlags().StringVar(&config.SASLMechanism, "sasl-mechanism", config.SASLMechanism, "SASL mechanism or KAFKA_SASL_MECHANISM")
+	cmd.PersistentFlags().StringVar(&config.SASLUsername, "sasl-username", config.SASLUsername, "SASL username or KAFKA_SASL_USERNAME")
+	cmd.PersistentFlags().StringVar(&config.SASLAWSRegion, "sasl-aws-region", config.SASLAWSRegion, "AWS region for aws-iam SASL or KAFKA_SASL_IAM_AWS_REGION")
+	cmd.PersistentFlags().StringVar(&config.SASLAWSProfile, "sasl-aws-profile", config.SASLAWSProfile, "AWS profile for aws-iam SASL or AWS_PROFILE")
+	cmd.PersistentFlags().StringVar(&config.SASLAWSRoleARN, "sasl-aws-role-arn", config.SASLAWSRoleARN, "AWS role ARN for aws-iam SASL or AWS_ROLE_ARN")
+	cmd.PersistentFlags().StringVar(&config.SASLAWSExternalID, "sasl-aws-external-id", config.SASLAWSExternalID, "AWS external ID for aws-iam SASL")
+	cmd.PersistentFlags().StringSliceVar(&config.SASLAWSSharedConfigFiles, "sasl-aws-shared-config-files", config.SASLAWSSharedConfigFiles, "AWS shared config files for aws-iam SASL")
+	cmd.PersistentFlags().StringVar(&config.SASLTokenURL, "sasl-token-url", config.SASLTokenURL, "OAuth token URL or KAFKA_SASL_TOKEN_URL")
+	cmd.PersistentFlags().StringSliceVar(&config.SASLOAuthScopes, "sasl-oauth-scopes", config.SASLOAuthScopes, "OAuth scopes or KAFKA_SASL_OAUTH_SCOPES")
+	cmd.PersistentFlags().StringVar(&config.CACert, "ca-cert", config.CACert, "CA certificate PEM or file path, or KAFKA_CA_CERT")
+	cmd.PersistentFlags().StringVar(&config.ClientCert, "client-cert", config.ClientCert, "Client certificate PEM or file path, or KAFKA_CLIENT_CERT")
+	cmd.PersistentFlags().IntVar(&config.Timeout, "timeout", config.Timeout, "Kafka admin timeout in seconds or KAFKA_TIMEOUT")
+	cmd.PersistentFlags().Lookup("timeout").DefValue = strconv.Itoa(config.Timeout)
+	return cmd
+}
+
+func newKafkaProvider() terraformutils.ProviderGenerator {
+	return &kafka_terraforming.Provider{}
+}

--- a/cmd/provider_cmd_kafka_test.go
+++ b/cmd/provider_cmd_kafka_test.go
@@ -1,0 +1,36 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package cmd
+
+import "testing"
+
+func TestKafkaProviderCommandRegistration(t *testing.T) {
+	provider := newKafkaProvider()
+	if provider.GetName() != "kafka" {
+		t.Fatalf("provider name = %q, want kafka", provider.GetName())
+	}
+	if _, ok := provider.GetSupportedService()["topics"]; !ok {
+		t.Fatal("kafka topics service is not registered")
+	}
+
+	importers := providerImporterSubcommands()
+	foundImporter := false
+	for _, importer := range importers {
+		cmd := importer(ImportOptions{})
+		if cmd.Use == "kafka" {
+			foundImporter = true
+			if cmd.PersistentFlags().Lookup("bootstrap-servers") == nil {
+				t.Fatal("kafka command missing bootstrap-servers flag")
+			}
+			break
+		}
+	}
+	if !foundImporter {
+		t.Fatal("kafka import subcommand is not registered")
+	}
+
+	generators := providerGenerators()
+	if _, ok := generators["kafka"]; !ok {
+		t.Fatal("kafka provider generator is not registered")
+	}
+}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -45,6 +45,7 @@ func providerImporterSubcommands() []func(options ImportOptions) *cobra.Command 
 		newCmdYandexImporter,
 		newCmdIonosCloudImporter,
 		// Infrastructure Software
+		newCmdKafkaImporter,
 		newCmdKubernetesImporter,
 		newCmdOctopusDeployImporter,
 		newCmdRabbitMQImporter,
@@ -103,6 +104,7 @@ func providerGeneratorConstructors() []func() terraformutils.ProviderGenerator {
 		newVultrProvider,
 		newYandexProvider,
 		// Infrastructure Software
+		newKafkaProvider,
 		newKubernetesProvider,
 		newOctopusDeployProvider,
 		newRabbitMQProvider,

--- a/docs/kafka.md
+++ b/docs/kafka.md
@@ -33,8 +33,11 @@ Common environment variables:
 * AWS_CONTAINER_AUTHORIZATION_TOKEN_FILE
 * AWS_CONTAINER_CREDENTIALS_FULL_URI
 * AWS_SHARED_CONFIG_FILES
+* KAFKA_SASL_TOKEN_URL
 * KAFKA_SASL_OAUTH_TOKEN
 * KAFKA_SASL_OAUTH_SCOPES
+
+OAuthBearer imports can use KAFKA_SASL_TOKEN_URL with KAFKA_SASL_USERNAME, KAFKA_SASL_PASSWORD, and optional KAFKA_SASL_OAUTH_SCOPES; pre-minted bearer tokens can be supplied through KAFKA_SASL_OAUTH_TOKEN when needed.
 
 Terraformer intentionally does not write generated HCL containing SASL passwords, TLS private keys, AWS access keys, AWS secret keys, AWS session tokens, OAuth tokens, or SCRAM passwords.
 

--- a/docs/kafka.md
+++ b/docs/kafka.md
@@ -34,10 +34,9 @@ Common environment variables:
 * AWS_CONTAINER_CREDENTIALS_FULL_URI
 * AWS_SHARED_CONFIG_FILES
 * KAFKA_SASL_TOKEN_URL
-* KAFKA_SASL_OAUTH_TOKEN
 * KAFKA_SASL_OAUTH_SCOPES
 
-OAuthBearer imports can use KAFKA_SASL_TOKEN_URL with KAFKA_SASL_USERNAME, KAFKA_SASL_PASSWORD, and optional KAFKA_SASL_OAUTH_SCOPES; pre-minted bearer tokens can be supplied through KAFKA_SASL_OAUTH_TOKEN when needed.
+OAuthBearer imports use KAFKA_SASL_TOKEN_URL with KAFKA_SASL_USERNAME, KAFKA_SASL_PASSWORD, and optional KAFKA_SASL_OAUTH_SCOPES.
 
 Terraformer intentionally does not write generated HCL containing SASL passwords, TLS private keys, AWS access keys, AWS secret keys, AWS session tokens, OAuth tokens, or SCRAM passwords.
 

--- a/docs/kafka.md
+++ b/docs/kafka.md
@@ -1,0 +1,44 @@
+### Use with Kafka
+
+Example:
+
+    export KAFKA_BOOTSTRAP_SERVERS=broker1.example.com:9092,broker2.example.com:9092
+    export KAFKA_VERSION=2.7.0
+
+    terraformer import kafka --resources=topics
+    terraformer import kafka --resources=topics --filter=topic=orders:payments.events
+
+The Kafka provider also accepts bootstrap servers through the CLI:
+
+    terraformer import kafka --resources=topics --bootstrap-servers=broker1.example.com:9092,broker2.example.com:9092
+
+Authentication and TLS configuration should use environment variables where secrets are involved. Non-secret settings are also available as CLI flags.
+
+Common environment variables:
+
+* KAFKA_BOOTSTRAP_SERVERS
+* KAFKA_VERSION
+* KAFKA_ENABLE_TLS
+* KAFKA_SKIP_VERIFY
+* KAFKA_CA_CERT
+* KAFKA_CLIENT_CERT
+* KAFKA_CLIENT_KEY
+* KAFKA_CLIENT_KEY_PASSPHRASE
+* KAFKA_SASL_MECHANISM
+* KAFKA_SASL_USERNAME
+* KAFKA_SASL_PASSWORD
+* KAFKA_SASL_IAM_AWS_REGION
+* AWS_PROFILE
+* AWS_ROLE_ARN
+* AWS_CONTAINER_AUTHORIZATION_TOKEN_FILE
+* AWS_CONTAINER_CREDENTIALS_FULL_URI
+* AWS_SHARED_CONFIG_FILES
+* KAFKA_SASL_OAUTH_TOKEN
+* KAFKA_SASL_OAUTH_SCOPES
+
+Terraformer intentionally does not write generated HCL containing SASL passwords, TLS private keys, AWS access keys, AWS secret keys, AWS session tokens, OAuth tokens, or SCRAM passwords.
+
+List of supported Kafka services:
+
+* topics
+    * kafka_topic

--- a/docs/kafka.md
+++ b/docs/kafka.md
@@ -16,25 +16,32 @@ Authentication and TLS configuration should use environment variables where secr
 
 Common environment variables:
 
-* KAFKA_BOOTSTRAP_SERVERS
-* KAFKA_VERSION
-* KAFKA_ENABLE_TLS
-* KAFKA_SKIP_VERIFY
-* KAFKA_CA_CERT
-* KAFKA_CLIENT_CERT
-* KAFKA_CLIENT_KEY
-* KAFKA_CLIENT_KEY_PASSPHRASE
-* KAFKA_SASL_MECHANISM
-* KAFKA_SASL_USERNAME
-* KAFKA_SASL_PASSWORD
-* KAFKA_SASL_IAM_AWS_REGION
-* AWS_PROFILE
-* AWS_ROLE_ARN
-* AWS_CONTAINER_AUTHORIZATION_TOKEN_FILE
-* AWS_CONTAINER_CREDENTIALS_FULL_URI
-* AWS_SHARED_CONFIG_FILES
-* KAFKA_SASL_TOKEN_URL
-* KAFKA_SASL_OAUTH_SCOPES
+* KAFKA_BOOTSTRAP_SERVERS: required unless `--bootstrap-servers` is set; comma-separated Kafka broker `host:port` values.
+* KAFKA_VERSION: optional Kafka protocol version, for example `2.7.0`.
+* KAFKA_ENABLE_TLS: optional boolean; defaults to `true`.
+* KAFKA_SKIP_VERIFY: optional boolean for skipping TLS certificate verification; defaults to `false`.
+* KAFKA_CA_CERT: optional CA certificate PEM or file path.
+* KAFKA_CLIENT_CERT: optional mTLS client certificate PEM or file path; must be paired with `KAFKA_CLIENT_KEY`.
+* KAFKA_CLIENT_KEY: optional mTLS client private key PEM or file path; must be paired with `KAFKA_CLIENT_CERT`.
+* KAFKA_CLIENT_KEY_PASSPHRASE: optional passphrase for encrypted legacy PEM client keys.
+* KAFKA_SASL_MECHANISM: optional SASL mechanism, such as `plain`, `scram-sha256`, `scram-sha512`, `aws-iam`, or `oauthbearer`.
+* KAFKA_SASL_USERNAME: required for `plain`, `scram-*`, and OAuth token URL authentication.
+* KAFKA_SASL_PASSWORD: required for `plain`, `scram-*`, and OAuth token URL authentication.
+* KAFKA_SASL_IAM_AWS_REGION: required for `aws-iam` unless `AWS_REGION` or `AWS_DEFAULT_REGION` is set.
+* KAFKA_SASL_AWS_EXTERNAL_ID: optional external ID when assuming an AWS IAM role for `aws-iam`.
+* KAFKA_SASL_TOKEN_URL: required for `oauthbearer`; OAuth token endpoint URL.
+* KAFKA_SASL_OAUTH_SCOPES: optional comma-separated OAuth scopes.
+* TOKEN_URL: optional alias for `KAFKA_SASL_TOKEN_URL`.
+* AWS_PROFILE: optional AWS profile for `aws-iam`.
+* AWS_REGION: optional AWS region fallback for `aws-iam`.
+* AWS_DEFAULT_REGION: optional AWS region fallback for `aws-iam`.
+* AWS_ROLE_ARN: optional AWS role ARN for `aws-iam`.
+* AWS_ACCESS_KEY_ID: optional AWS access key ID for `aws-iam`; use environment variables rather than generated HCL.
+* AWS_SECRET_ACCESS_KEY: optional AWS secret access key for `aws-iam`; use environment variables rather than generated HCL.
+* AWS_SESSION_TOKEN: optional AWS session token for `aws-iam`; use environment variables rather than generated HCL.
+* AWS_CONTAINER_AUTHORIZATION_TOKEN_FILE: optional ECS container authorization token file path for `aws-iam`.
+* AWS_CONTAINER_CREDENTIALS_FULL_URI: optional ECS container credentials URI for `aws-iam`.
+* AWS_SHARED_CONFIG_FILES: optional comma-separated AWS shared config file paths.
 
 OAuthBearer imports use KAFKA_SASL_TOKEN_URL with KAFKA_SASL_USERNAME, KAFKA_SASL_PASSWORD, and optional KAFKA_SASL_OAUTH_SCOPES.
 

--- a/go.mod
+++ b/go.mod
@@ -233,7 +233,7 @@ require (
 	github.com/stretchr/testify v1.11.1 // indirect
 	github.com/tomnomnom/linkheader v0.0.0-20250811210735-e5fe3b51442e // indirect
 	github.com/xdg-go/pbkdf2 v1.0.0 // indirect
-	github.com/xdg-go/scram v1.2.0 // indirect
+	github.com/xdg-go/scram v1.2.0
 	github.com/xdg-go/stringprep v1.0.4 // indirect
 	github.com/youmark/pkcs8 v0.0.0-20240726163527-a2c0da244d78 // indirect
 	go.mongodb.org/mongo-driver v1.17.9 // indirect
@@ -260,6 +260,9 @@ require (
 	github.com/Azure/azure-sdk-for-go/sdk/internal v1.12.0 // indirect
 	github.com/AzureAD/microsoft-authentication-library-for-go v1.6.0 // indirect
 	github.com/PuerkitoBio/rehttp v1.4.0 // indirect
+	github.com/eapache/go-resiliency v1.7.0 // indirect
+	github.com/eapache/go-xerial-snappy v0.0.0-20230731223053-c322873962e3 // indirect
+	github.com/eapache/queue v1.1.0 // indirect
 	github.com/go-openapi/swag/cmdutils v0.26.0 // indirect
 	github.com/go-openapi/swag/conv v0.26.0 // indirect
 	github.com/go-openapi/swag/fileutils v0.26.0 // indirect
@@ -271,10 +274,17 @@ require (
 	github.com/go-openapi/swag/stringutils v0.26.0 // indirect
 	github.com/go-openapi/swag/typeutils v0.26.0 // indirect
 	github.com/go-openapi/swag/yamlutils v0.26.0 // indirect
+	github.com/jcmturner/aescts/v2 v2.0.0 // indirect
+	github.com/jcmturner/dnsutils/v2 v2.0.0 // indirect
+	github.com/jcmturner/gofork v1.7.6 // indirect
+	github.com/jcmturner/gokrb5/v8 v8.4.4 // indirect
+	github.com/jcmturner/rpc/v2 v2.0.3 // indirect
 	github.com/kylelemons/godebug v1.1.0 // indirect
 	github.com/lestrrat-go/httprc v1.0.6 // indirect
 	github.com/lestrrat-go/jwx/v2 v2.1.6 // indirect
+	github.com/pierrec/lz4/v4 v4.1.22 // indirect
 	github.com/pkg/browser v0.0.0-20240102092130-5ac0b6a4141c // indirect
+	github.com/rcrowley/go-metrics v0.0.0-20250401214520-65e299d6c5c9 // indirect
 	github.com/segmentio/asm v1.2.1 // indirect
 )
 
@@ -400,6 +410,8 @@ require (
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/storage/armstorage/v2 v2.0.0
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/synapse/armsynapse v0.8.0
 	github.com/IBM/continuous-delivery-go-sdk/v2 v2.0.8
+	github.com/IBM/sarama v1.46.1
+	github.com/aws/aws-msk-iam-sasl-signer-go v1.0.4
 	github.com/aws/aws-sdk-go-v2/service/apigatewayv2 v1.34.3
 	github.com/aws/aws-sdk-go-v2/service/appconfig v1.43.15
 	github.com/aws/aws-sdk-go-v2/service/appintegrations v1.37.9

--- a/go.sum
+++ b/go.sum
@@ -155,6 +155,8 @@ github.com/IBM/networking-go-sdk v0.53.4 h1:XDGOhavZocjVfItgcaT7/SFqB8zT2kznYuJ9
 github.com/IBM/networking-go-sdk v0.53.4/go.mod h1:TAXWyBUk3C3R7aS1m84EfKdnDcBMZMAClwLfDj/SYZc=
 github.com/IBM/platform-services-go-sdk v0.97.4 h1:UiHTDanRY+Laydss68GFLHqoOy4l7VCj0dBNFgdGlYU=
 github.com/IBM/platform-services-go-sdk v0.97.4/go.mod h1:t93mozFmKrxexnKNdx2gNOtEI9Wd62dKAVffQYm0vRM=
+github.com/IBM/sarama v1.46.1 h1:AlDkvyQm4LKktoQZxv0sbTfH3xukeH7r/UFBbUmFV9M=
+github.com/IBM/sarama v1.46.1/go.mod h1:ipyOREIx+o9rMSrrPGLZHGuT0mzecNzKd19Quq+Q8AA=
 github.com/IBM/vpc-go-sdk v0.83.2 h1:RLMha7+buktU9hrhvAMF2QRHIvxaAsuU14W6akybJqs=
 github.com/IBM/vpc-go-sdk v0.83.2/go.mod h1:85bJ/0FS7vYAifHdZvlnXypf8pQSmuf9kxReDDI5ZdY=
 github.com/Myra-Security-GmbH/myrasec-go/v2 v2.51.0 h1:HE6oTQgU3BffA1ciYHVxWptpq/6CGqaKNn2cpKnuzr8=
@@ -182,6 +184,8 @@ github.com/auth0/go-auth0 v1.40.0 h1:3uIoLXSOrL3ww83gg16tfOz0jJa32s5Rgtv5oWwEAHQ
 github.com/auth0/go-auth0 v1.40.0/go.mod h1:32sQB1uAn+99fJo6N819EniKq8h785p0ag0lMWhiTaE=
 github.com/avast/retry-go v3.0.0+incompatible h1:4SOWQ7Qs+oroOTQOYnAHqelpCO0biHSxpiH9JdtuBj0=
 github.com/avast/retry-go v3.0.0+incompatible/go.mod h1:XtSnn+n/sHqQIpZ10K1qAevBhOOCWBLXXy3hyiqqBrY=
+github.com/aws/aws-msk-iam-sasl-signer-go v1.0.4 h1:2jAwFwA0Xgcx94dUId+K24yFabsKYDtAhCgyMit6OqE=
+github.com/aws/aws-msk-iam-sasl-signer-go v1.0.4/go.mod h1:MVYeeOhILFFemC/XlYTClvBjYZrg/EPd3ts885KrNTI=
 github.com/aws/aws-sdk-go v1.34.28/go.mod h1:H7NKnBqNVzoTJpGfLrQkkD+ytBA93eiDYi/+8rV9s48=
 github.com/aws/aws-sdk-go-v2 v1.41.7 h1:DWpAJt66FmnnaRIOT/8ASTucrvuDPZASqhhLey6tLY8=
 github.com/aws/aws-sdk-go-v2 v1.41.7/go.mod h1:4LAfZOPHNVNQEckOACQx60Y8pSRjIkNZQz1w92xpMJc=
@@ -505,6 +509,12 @@ github.com/dnaeon/go-vcr v1.2.0/go.mod h1:R4UdLID7HZT3taECzJs4YgbbH6PIGXB6W/sc5O
 github.com/dunglas/httpsfv v1.1.0 h1:Jw76nAyKWKZKFrpMMcL76y35tOpYHqQPzHQiwDvpe54=
 github.com/dunglas/httpsfv v1.1.0/go.mod h1:zID2mqw9mFsnt7YC3vYQ9/cjq30q41W+1AnDwH8TiMg=
 github.com/dustin/go-humanize v1.0.0/go.mod h1:HtrtbFcZ19U5GC7JDqmcUSB87Iq5E25KnS6fMYU6eOk=
+github.com/eapache/go-resiliency v1.7.0 h1:n3NRTnBn5N0Cbi/IeOHuQn9s2UwVUH7Ga0ZWcP+9JTA=
+github.com/eapache/go-resiliency v1.7.0/go.mod h1:5yPzW0MIvSe0JDsv0v+DvcjEv2FyD6iZYSs1ZI+iQho=
+github.com/eapache/go-xerial-snappy v0.0.0-20230731223053-c322873962e3 h1:Oy0F4ALJ04o5Qqpdz8XLIpNA3WM/iSIXqxtqo7UGVws=
+github.com/eapache/go-xerial-snappy v0.0.0-20230731223053-c322873962e3/go.mod h1:YvSRo5mw33fLEx1+DlK6L2VV43tJt5Eyel9n9XBcR+0=
+github.com/eapache/queue v1.1.0 h1:YOEu7KNc61ntiQlcEeUIoDTJ2o8mQznoNvUhiigpIqc=
+github.com/eapache/queue v1.1.0/go.mod h1:6eCeP0CKFpHLu8blIFXhExK/dRa7WDZfr6jVFPTqq+I=
 github.com/elazarl/goproxy v0.0.0-20220417044921-416226498f94 h1:VIy7cdK7ufs7ctpTFkXJHm1uP3dJSnCGSPysEICB1so=
 github.com/elazarl/goproxy v0.0.0-20220417044921-416226498f94/go.mod h1:Ro8st/ElPeALwNFlcTpWmkr6IoMFfkjXAvTHpevnDsM=
 github.com/emicklei/go-restful/v3 v3.13.0 h1:C4Bl2xDndpU6nJ4bc1jXd+uTmYPVUwkD6bFY/oTyCes=
@@ -531,6 +541,8 @@ github.com/form3tech-oss/jwt-go v3.2.3+incompatible h1:7ZaBxOI7TMoYBfyA3cQHErNNy
 github.com/form3tech-oss/jwt-go v3.2.3+incompatible/go.mod h1:pbq4aXjuKjdthFRnoDwaVPLA+WlJuPGy+QneDUgJi2k=
 github.com/form3tech-oss/jwt-go v3.2.5+incompatible h1:/l4kBbb4/vGSsdtB5nUe8L7B9mImVMaBPw9L/0TBHU8=
 github.com/form3tech-oss/jwt-go v3.2.5+incompatible/go.mod h1:pbq4aXjuKjdthFRnoDwaVPLA+WlJuPGy+QneDUgJi2k=
+github.com/fortytw2/leaktest v1.3.0 h1:u8491cBMTQ8ft8aeV+adlcytMZylmA5nnwwkRZjI8vw=
+github.com/fortytw2/leaktest v1.3.0/go.mod h1:jDsjWgpAGjm2CA7WthBh/CdZYEPF31XHquHwclZch5g=
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
 github.com/fsnotify/fsnotify v1.4.9/go.mod h1:znqG4EE+3YCdAaPaxE2ZRY/06pZUdp0tY4IgpuI1SZQ=
 github.com/fsnotify/fsnotify v1.6.0 h1:n+5WquG0fcWoWp6xPWfHdbskMCQaFnG6PfBrh1Ky4HY=
@@ -712,6 +724,8 @@ github.com/googleapis/gax-go/v2 v2.22.0/go.mod h1:irWBbALSr0Sk3qlqb9SyJ1h68WjgeF
 github.com/gophercloud/gophercloud v1.14.1 h1:DTCNaTVGl8/cFu58O1JwWgis9gtISAFONqpMKNg/Vpw=
 github.com/gophercloud/gophercloud v1.14.1/go.mod h1:aAVqcocTSXh2vYFZ1JTvx4EQmfgzxRcNupUfxZbBNDM=
 github.com/gopherjs/gopherjs v0.0.0-20181017120253-0766667cb4d1/go.mod h1:wJfORRmW1u3UXTncJ5qlYoELFm8eSnnEO6hX4iZ3EWY=
+github.com/gorilla/securecookie v1.1.1/go.mod h1:ra0sb63/xPlUeL+yeDciTfxMRAA+MP+HVt/4epWDjd4=
+github.com/gorilla/sessions v1.2.1/go.mod h1:dk2InVEVJ0sfLlnXv9EAgkf6ecYs/i80K/zI+bUmuGM=
 github.com/gorilla/websocket v1.4.1/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
 github.com/gorilla/websocket v1.4.2/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
 github.com/gorilla/websocket v1.5.4-0.20250319132907-e064f32e3674 h1:JeSE6pjso5THxAzdVpqr6/geYxZytqFMBCOtn/ujyeo=
@@ -754,6 +768,7 @@ github.com/hashicorp/go-secure-stdlib/strutil v0.1.2 h1:kes8mmyCpxJsI7FTwtzRqEy9
 github.com/hashicorp/go-secure-stdlib/strutil v0.1.2/go.mod h1:Gou2R9+il93BqX25LAKCLuM+y9U2T4hlwvT1yprcna4=
 github.com/hashicorp/go-sockaddr v1.0.7 h1:G+pTkSO01HpR5qCxg7lxfsFEZaG+C0VssTy/9dbT+Fw=
 github.com/hashicorp/go-sockaddr v1.0.7/go.mod h1:FZQbEYa1pxkQ7WLpyXJ6cbjpT8q0YgQaK/JakXqGyWw=
+github.com/hashicorp/go-uuid v1.0.2/go.mod h1:6SBZvOh/SIDV7/2o3Jml5SYk/TvGqwFJ/bN7x4byOro=
 github.com/hashicorp/go-uuid v1.0.3 h1:2gKiV6YVmrJ1i2CKKa9obLvRieoRGviZFL26PcT/Co8=
 github.com/hashicorp/go-uuid v1.0.3/go.mod h1:6SBZvOh/SIDV7/2o3Jml5SYk/TvGqwFJ/bN7x4byOro=
 github.com/hashicorp/go-version v1.9.0 h1:CeOIz6k+LoN3qX9Z0tyQrPtiB1DFYRPfCIBtaXPSCnA=
@@ -808,6 +823,18 @@ github.com/ionos-cloud/sdk-go/v6 v6.3.7 h1:t773JkC/asnyVqeQ+OvN9WCRZuosSoPtJfyM8
 github.com/ionos-cloud/sdk-go/v6 v6.3.7/go.mod h1:nUGHP4kZHAZngCVr4v6C8nuargFrtvt7GrzH/hqn7c4=
 github.com/jarcoal/httpmock v1.4.1 h1:0Ju+VCFuARfFlhVXFc2HxlcQkfB+Xq12/EotHko+x2A=
 github.com/jarcoal/httpmock v1.4.1/go.mod h1:ftW1xULwo+j0R0JJkJIIi7UKigZUXCLLanykgjwBXL0=
+github.com/jcmturner/aescts/v2 v2.0.0 h1:9YKLH6ey7H4eDBXW8khjYslgyqG2xZikXP0EQFKrle8=
+github.com/jcmturner/aescts/v2 v2.0.0/go.mod h1:AiaICIRyfYg35RUkr8yESTqvSy7csK90qZ5xfvvsoNs=
+github.com/jcmturner/dnsutils/v2 v2.0.0 h1:lltnkeZGL0wILNvrNiVCR6Ro5PGU/SeBvVO/8c/iPbo=
+github.com/jcmturner/dnsutils/v2 v2.0.0/go.mod h1:b0TnjGOvI/n42bZa+hmXL+kFJZsFT7G4t3HTlQ184QM=
+github.com/jcmturner/gofork v1.7.6 h1:QH0l3hzAU1tfT3rZCnW5zXl+orbkNMMRGJfdJjHVETg=
+github.com/jcmturner/gofork v1.7.6/go.mod h1:1622LH6i/EZqLloHfE7IeZ0uEJwMSUyQ/nDd82IeqRo=
+github.com/jcmturner/goidentity/v6 v6.0.1 h1:VKnZd2oEIMorCTsFBnJWbExfNN7yZr3EhJAxwOkZg6o=
+github.com/jcmturner/goidentity/v6 v6.0.1/go.mod h1:X1YW3bgtvwAXju7V3LCIMpY0Gbxyjn/mY9zx4tFonSg=
+github.com/jcmturner/gokrb5/v8 v8.4.4 h1:x1Sv4HaTpepFkXbt2IkL29DXRf8sOfZXo8eRKh687T8=
+github.com/jcmturner/gokrb5/v8 v8.4.4/go.mod h1:1btQEpgT6k+unzCwX1KdWMEwPPkkgBtP+F6aCACiMrs=
+github.com/jcmturner/rpc/v2 v2.0.3 h1:7FXXj8Ti1IaVFpSAziCZWNzbNuZmnvw/i6CqLNdWfZY=
+github.com/jcmturner/rpc/v2 v2.0.3/go.mod h1:VUJYCIDm3PVOEHw8sgt091/20OJjskO/YJki3ELg/Hc=
 github.com/jhump/protoreflect v1.17.0 h1:qOEr613fac2lOuTgWN4tPAtLL7fUSbuJL5X5XumQh94=
 github.com/jhump/protoreflect v1.17.0/go.mod h1:h9+vUUL38jiBzck8ck+6G/aeMX8Z4QUY/NiJPwPNi+8=
 github.com/jmespath/go-jmespath v0.4.0 h1:BEgLn5cpjn8UN1mAw4NjwDrS35OdebyEtFe+9YPoQUg=
@@ -983,6 +1010,8 @@ github.com/pelletier/go-toml v1.9.5 h1:4yBQzkHv+7BHq2PQUZF3Mx0IYxG7LsP222s7Agd3v
 github.com/pelletier/go-toml v1.9.5/go.mod h1:u1nR/EPcESfeI/szUZKdtJ0xRNbUoANCkoOuaOx1Y+c=
 github.com/peterhellberg/link v1.2.0 h1:UA5pg3Gp/E0F2WdX7GERiNrPQrM1K6CVJUUWfHa4t6c=
 github.com/peterhellberg/link v1.2.0/go.mod h1:gYfAh+oJgQu2SrZHg5hROVRQe1ICoK0/HHJTcE0edxc=
+github.com/pierrec/lz4/v4 v4.1.22 h1:cKFw6uJDK+/gfw5BcDL0JL5aBsAFdsIT18eRtLj7VIU=
+github.com/pierrec/lz4/v4 v4.1.22/go.mod h1:gZWDp/Ze/IJXGXf23ltt2EXimqmTUXEy0GFuRQyBid4=
 github.com/pkg/browser v0.0.0-20240102092130-5ac0b6a4141c h1:+mdjkGKdHQG3305AYmdv1U2eRNDiU2ErMBj1gwrq8eQ=
 github.com/pkg/browser v0.0.0-20240102092130-5ac0b6a4141c/go.mod h1:7rwL4CYBLnjLxUqIJNnCWiEdr3bn6IUYi15bNlnbCCU=
 github.com/pkg/errors v0.8.0/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
@@ -994,6 +1023,8 @@ github.com/planetscale/vtprotobuf v0.6.1-0.20240319094008-0393e58bdf10/go.mod h1
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 h1:Jamvg5psRIccs7FGNTlIRMkT8wgtp5eCXdBlqhYGL6U=
 github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/rcrowley/go-metrics v0.0.0-20250401214520-65e299d6c5c9 h1:bsUq1dX0N8AOIL7EB/X911+m4EHsnWEHeJ0c+3TTBrg=
+github.com/rcrowley/go-metrics v0.0.0-20250401214520-65e299d6c5c9/go.mod h1:bCqnVzQkZxMG4s8nGwiZ5l3QUCyqpo9Y+/ZMZ9VjZe4=
 github.com/rogpeppe/go-internal v1.1.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFRclV5y23lUDJ4=
 github.com/rogpeppe/go-internal v1.2.2/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFRclV5y23lUDJ4=
 github.com/rogpeppe/go-internal v1.3.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFRclV5y23lUDJ4=
@@ -1045,6 +1076,7 @@ github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/
 github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.7.2/go.mod h1:R6va5+xMeoiuVRoj+gSkQ7d3FALtqAAGI1FQKckRals=
 github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
+github.com/stretchr/testify v1.8.1/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
 github.com/stretchr/testify v1.8.2/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
 github.com/stretchr/testify v1.8.4/go.mod h1:sz/lmYIOXD/1dqDmKjjqLyZ2RngseejIcXlSw2iwfAo=
 github.com/stretchr/testify v1.9.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
@@ -1198,6 +1230,7 @@ golang.org/x/crypto v0.0.0-20201002170205-7f63de1d35b0/go.mod h1:LzIPMQfyMNhhGPh
 golang.org/x/crypto v0.0.0-20201016220609-9e8e0b390897/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/crypto v0.0.0-20210921155107-089bfa567519/go.mod h1:GvvjBRRGRdwPK5ydBHafDWAxML/pGHZbMvKqRZ5+Abc=
 golang.org/x/crypto v0.0.0-20220829220503-c86fa9a7ed90/go.mod h1:IxCIyHEi3zRg3s0A5j5BB6A9Jmi73HwBIUl50j+osU4=
+golang.org/x/crypto v0.6.0/go.mod h1:OFC/31mSvZgRz0V1QTNCzfAI1aIRzbiufJtkMIlEp58=
 golang.org/x/crypto v0.19.0/go.mod h1:Iy9bg/ha4yyC70EfRS8jz+B6ybOBKMaSxLj6P6oBDfU=
 golang.org/x/crypto v0.50.0 h1:zO47/JPrL6vsNkINmLoo/PH1gcxpls50DNogFvB5ZGI=
 golang.org/x/crypto v0.50.0/go.mod h1:3muZ7vA7PBCE6xgPX7nkzzjiUq87kRItoJQM1Yo8S+Q=
@@ -1221,6 +1254,7 @@ golang.org/x/net v0.0.0-20190311183353-d8887717615a/go.mod h1:t9HGtf8HONx5eT2rtn
 golang.org/x/net v0.0.0-20190404232315-eb5bcb51f2a3/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
 golang.org/x/net v0.0.0-20190620200207-3b0461eec859/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/net v0.0.0-20191112182307-2180aed22343/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
+golang.org/x/net v0.0.0-20200114155413-6afb5195e5aa/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/net v0.0.0-20200202094626-16171245cfb2/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/net v0.0.0-20200520004742-59133d7f0dd7/go.mod h1:qpuaurCH72eLCgpAm/N6yyVIVM9cpaDIP3A8BGJEC5A=
 golang.org/x/net v0.0.0-20201006153459-a7d1128ccaa0/go.mod h1:sp8m0HH+o8qH0wwXwYZr8TS3Oi6o0r6Gce1SSxlDquU=
@@ -1233,6 +1267,7 @@ golang.org/x/net v0.0.0-20210610132358-84b48f89b13b/go.mod h1:9nx3DQGgdP8bBQD5qx
 golang.org/x/net v0.0.0-20211112202133-69e39bad7dc2/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
 golang.org/x/net v0.0.0-20220722155237-a158d28d115b/go.mod h1:XRhObCWvk6IyKnWLug+ECip1KBveYUHfp+8e9klMJ9c=
 golang.org/x/net v0.6.0/go.mod h1:2Tu9+aMcznHK/AK1HMvgo6xiTLG5rD5rZLDS+rp2Bjs=
+golang.org/x/net v0.7.0/go.mod h1:2Tu9+aMcznHK/AK1HMvgo6xiTLG5rD5rZLDS+rp2Bjs=
 golang.org/x/net v0.10.0/go.mod h1:0qNGK6F8kojg2nk9dLZ2mShWaEBan6FAoqfSigmmuDg=
 golang.org/x/net v0.53.0 h1:d+qAbo5L0orcWAr0a9JweQpjXF19LMXJE8Ey7hwOdUA=
 golang.org/x/net v0.53.0/go.mod h1:JvMuJH7rrdiCfbeHoo3fCQU24Lf5JJwT9W3sJFulfgs=

--- a/providers/kafka/config.go
+++ b/providers/kafka/config.go
@@ -205,6 +205,8 @@ func (c Config) newSaramaConfig() (*sarama.Config, error) {
 func (c Config) saslEnabled() bool {
 	return c.SASLMechanism == "aws-iam" ||
 		c.SASLMechanism == "oauthbearer" ||
+		c.SASLMechanism == "scram-sha256" ||
+		c.SASLMechanism == "scram-sha512" ||
 		c.SASLUsername != "" ||
 		c.SASLPassword != ""
 }

--- a/providers/kafka/config.go
+++ b/providers/kafka/config.go
@@ -50,14 +50,13 @@ type Config struct {
 	ClientCert                             string
 	Timeout                                int
 
-	ClientKey            string
-	ClientKeyPassphrase  string
-	SASLPassword         string
-	SASLAWSAccessKey     string
-	SASLAWSSecretKey     string
-	SASLAWSSessionToken  string
-	SASLAWSCredsDebug    bool
-	SASLOAuthBearerToken string
+	ClientKey           string
+	ClientKeyPassphrase string
+	SASLPassword        string
+	SASLAWSAccessKey    string
+	SASLAWSSecretKey    string
+	SASLAWSSessionToken string
+	SASLAWSCredsDebug   bool
 }
 
 func ConfigFromEnv() Config {
@@ -87,7 +86,6 @@ func ConfigFromEnv() Config {
 		SASLAWSSecretKey:                       os.Getenv("AWS_SECRET_ACCESS_KEY"),
 		SASLAWSSessionToken:                    os.Getenv("AWS_SESSION_TOKEN"),
 		SASLAWSCredsDebug:                      envBool("AWS_CREDS_DEBUG", false),
-		SASLOAuthBearerToken:                   os.Getenv("KAFKA_SASL_OAUTH_TOKEN"),
 	}
 }
 
@@ -153,9 +151,6 @@ func (c *Config) applyEnvSecrets() {
 	}
 	if !c.SASLAWSCredsDebug {
 		c.SASLAWSCredsDebug = envConfig.SASLAWSCredsDebug
-	}
-	if c.SASLOAuthBearerToken == "" {
-		c.SASLOAuthBearerToken = envConfig.SASLOAuthBearerToken
 	}
 }
 
@@ -254,11 +249,8 @@ func (c Config) configureSASL(config *sarama.Config) error {
 }
 
 func (c Config) oauthBearerTokenProvider() (sarama.AccessTokenProvider, error) {
-	if c.SASLOAuthBearerToken != "" {
-		return oauthBearerTokenProvider{token: c.SASLOAuthBearerToken}, nil
-	}
 	if c.SASLTokenURL == "" {
-		return nil, errors.New("kafka: KAFKA_SASL_OAUTH_TOKEN or KAFKA_SASL_TOKEN_URL is required for oauthbearer authentication")
+		return nil, errors.New("kafka: KAFKA_SASL_TOKEN_URL is required for oauthbearer authentication")
 	}
 	if c.SASLUsername == "" {
 		return nil, errors.New("kafka: sasl username is required for oauthbearer token URL authentication")
@@ -345,14 +337,10 @@ func (p awsIAMTokenProvider) Token() (*sarama.AccessToken, error) {
 }
 
 type oauthBearerTokenProvider struct {
-	token       string
 	tokenSource oauth2.TokenSource
 }
 
 func (p oauthBearerTokenProvider) Token() (*sarama.AccessToken, error) {
-	if p.token != "" {
-		return &sarama.AccessToken{Token: p.token}, nil
-	}
 	if p.tokenSource == nil {
 		return nil, errors.New("kafka: oauthbearer token provider is not configured")
 	}

--- a/providers/kafka/config.go
+++ b/providers/kafka/config.go
@@ -1,0 +1,438 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package kafka
+
+import (
+	"context"
+	"crypto/tls"
+	"crypto/x509"
+	"encoding/json"
+	"encoding/pem"
+	"errors"
+	"fmt"
+	"os"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/IBM/sarama"
+	"github.com/aws/aws-msk-iam-sasl-signer-go/signer"
+	"github.com/aws/aws-sdk-go-v2/credentials"
+	"github.com/aws/aws-sdk-go-v2/credentials/endpointcreds"
+	"github.com/xdg-go/scram"
+)
+
+const (
+	defaultKafkaVersion = "2.7.0"
+	defaultKafkaTimeout = 120
+)
+
+type Config struct {
+	BootstrapServers                       []string
+	KafkaVersion                           string
+	TLSEnabled                             bool
+	SkipTLSVerify                          bool
+	SASLMechanism                          string
+	SASLUsername                           string
+	SASLAWSRegion                          string
+	SASLAWSContainerAuthorizationTokenFile string
+	SASLAWSContainerCredentialsFullURI     string
+	SASLAWSRoleARN                         string
+	SASLAWSExternalID                      string
+	SASLAWSProfile                         string
+	SASLAWSSharedConfigFiles               []string
+	SASLTokenURL                           string
+	SASLOAuthScopes                        []string
+	CACert                                 string
+	ClientCert                             string
+	Timeout                                int
+
+	ClientKey            string
+	ClientKeyPassphrase  string
+	SASLPassword         string
+	SASLAWSAccessKey     string
+	SASLAWSSecretKey     string
+	SASLAWSSessionToken  string
+	SASLAWSCredsDebug    bool
+	SASLOAuthBearerToken string
+}
+
+func ConfigFromEnv() Config {
+	return Config{
+		BootstrapServers:                       splitCSV(os.Getenv("KAFKA_BOOTSTRAP_SERVERS")),
+		KafkaVersion:                           envString("KAFKA_VERSION", defaultKafkaVersion),
+		TLSEnabled:                             envBool("KAFKA_ENABLE_TLS", true),
+		SkipTLSVerify:                          envBool("KAFKA_SKIP_VERIFY", false),
+		SASLMechanism:                          envString("KAFKA_SASL_MECHANISM", "plain"),
+		SASLUsername:                           os.Getenv("KAFKA_SASL_USERNAME"),
+		SASLAWSRegion:                          firstNonEmpty(os.Getenv("KAFKA_SASL_IAM_AWS_REGION"), os.Getenv("AWS_REGION"), os.Getenv("AWS_DEFAULT_REGION")),
+		SASLAWSContainerAuthorizationTokenFile: os.Getenv("AWS_CONTAINER_AUTHORIZATION_TOKEN_FILE"),
+		SASLAWSContainerCredentialsFullURI:     os.Getenv("AWS_CONTAINER_CREDENTIALS_FULL_URI"),
+		SASLAWSRoleARN:                         os.Getenv("AWS_ROLE_ARN"),
+		SASLAWSExternalID:                      os.Getenv("KAFKA_SASL_AWS_EXTERNAL_ID"),
+		SASLAWSProfile:                         os.Getenv("AWS_PROFILE"),
+		SASLAWSSharedConfigFiles:               splitCSV(os.Getenv("AWS_SHARED_CONFIG_FILES")),
+		SASLTokenURL:                           firstNonEmpty(os.Getenv("KAFKA_SASL_TOKEN_URL"), os.Getenv("TOKEN_URL")),
+		SASLOAuthScopes:                        splitCSV(os.Getenv("KAFKA_SASL_OAUTH_SCOPES")),
+		CACert:                                 os.Getenv("KAFKA_CA_CERT"),
+		ClientCert:                             os.Getenv("KAFKA_CLIENT_CERT"),
+		Timeout:                                envInt("KAFKA_TIMEOUT", defaultKafkaTimeout),
+		ClientKey:                              os.Getenv("KAFKA_CLIENT_KEY"),
+		ClientKeyPassphrase:                    os.Getenv("KAFKA_CLIENT_KEY_PASSPHRASE"),
+		SASLPassword:                           os.Getenv("KAFKA_SASL_PASSWORD"),
+		SASLAWSAccessKey:                       os.Getenv("AWS_ACCESS_KEY_ID"),
+		SASLAWSSecretKey:                       os.Getenv("AWS_SECRET_ACCESS_KEY"),
+		SASLAWSSessionToken:                    os.Getenv("AWS_SESSION_TOKEN"),
+		SASLAWSCredsDebug:                      envBool("AWS_CREDS_DEBUG", false),
+		SASLOAuthBearerToken:                   os.Getenv("KAFKA_SASL_OAUTH_TOKEN"),
+	}
+}
+
+func EncodeConfig(config Config) string {
+	encoded, _ := json.Marshal(config)
+	return string(encoded)
+}
+
+func (c Config) MarshalJSON() ([]byte, error) {
+	return json.Marshal(map[string]interface{}{
+		"BootstrapServers":                       c.BootstrapServers,
+		"KafkaVersion":                           c.KafkaVersion,
+		"TLSEnabled":                             c.TLSEnabled,
+		"SkipTLSVerify":                          c.SkipTLSVerify,
+		"SASLMechanism":                          c.SASLMechanism,
+		"SASLUsername":                           c.SASLUsername,
+		"SASLAWSRegion":                          c.SASLAWSRegion,
+		"SASLAWSContainerAuthorizationTokenFile": c.SASLAWSContainerAuthorizationTokenFile,
+		"SASLAWSContainerCredentialsFullURI":     c.SASLAWSContainerCredentialsFullURI,
+		"SASLAWSRoleARN":                         c.SASLAWSRoleARN,
+		"SASLAWSExternalID":                      c.SASLAWSExternalID,
+		"SASLAWSProfile":                         c.SASLAWSProfile,
+		"SASLAWSSharedConfigFiles":               c.SASLAWSSharedConfigFiles,
+		"SASLTokenURL":                           c.SASLTokenURL,
+		"SASLOAuthScopes":                        c.SASLOAuthScopes,
+		"CACert":                                 c.CACert,
+		"ClientCert":                             c.ClientCert,
+		"Timeout":                                c.Timeout,
+	})
+}
+
+func configFromArgs(args []string) (Config, error) {
+	config := ConfigFromEnv()
+	if len(args) == 0 || args[0] == "" {
+		return config, nil
+	}
+	if err := json.Unmarshal([]byte(args[0]), &config); err != nil {
+		return Config{}, fmt.Errorf("kafka: decode provider config: %w", err)
+	}
+	config.applyEnvSecrets()
+	return config, nil
+}
+
+func (c *Config) applyEnvSecrets() {
+	envConfig := ConfigFromEnv()
+	if c.ClientKey == "" {
+		c.ClientKey = envConfig.ClientKey
+	}
+	if c.ClientKeyPassphrase == "" {
+		c.ClientKeyPassphrase = envConfig.ClientKeyPassphrase
+	}
+	if c.SASLPassword == "" {
+		c.SASLPassword = envConfig.SASLPassword
+	}
+	if c.SASLAWSAccessKey == "" {
+		c.SASLAWSAccessKey = envConfig.SASLAWSAccessKey
+	}
+	if c.SASLAWSSecretKey == "" {
+		c.SASLAWSSecretKey = envConfig.SASLAWSSecretKey
+	}
+	if c.SASLAWSSessionToken == "" {
+		c.SASLAWSSessionToken = envConfig.SASLAWSSessionToken
+	}
+	if !c.SASLAWSCredsDebug {
+		c.SASLAWSCredsDebug = envConfig.SASLAWSCredsDebug
+	}
+	if c.SASLOAuthBearerToken == "" {
+		c.SASLOAuthBearerToken = envConfig.SASLOAuthBearerToken
+	}
+}
+
+func (c Config) validate() error {
+	if len(c.BootstrapServers) == 0 {
+		return errors.New("kafka: bootstrap servers are required via --bootstrap-servers or KAFKA_BOOTSTRAP_SERVERS")
+	}
+	if c.KafkaVersion == "" {
+		return errors.New("kafka: kafka version is required")
+	}
+	if c.Timeout <= 0 {
+		return errors.New("kafka: timeout must be positive")
+	}
+	return nil
+}
+
+func (c Config) newSaramaConfig() (*sarama.Config, error) {
+	config := sarama.NewConfig()
+	version, err := sarama.ParseKafkaVersion(c.KafkaVersion)
+	if err != nil {
+		return nil, fmt.Errorf("kafka: parse kafka version %q: %w", c.KafkaVersion, err)
+	}
+	config.Version = version
+	config.ClientID = "terraformer-kafka"
+	config.Admin.Timeout = time.Duration(c.Timeout) * time.Second
+	config.Metadata.Full = true
+	config.Metadata.AllowAutoTopicCreation = false
+	config.Metadata.Timeout = time.Duration(c.Timeout) * time.Second
+	config.Net.ReadTimeout = time.Duration(c.Timeout) * time.Second
+	config.Net.WriteTimeout = time.Duration(c.Timeout) * time.Second
+
+	if c.saslEnabled() {
+		if err := c.configureSASL(config); err != nil {
+			return nil, err
+		}
+	}
+	if c.TLSEnabled {
+		tlsConfig, err := newTLSConfig(c.ClientCert, c.ClientKey, c.CACert, c.ClientKeyPassphrase)
+		if err != nil {
+			return nil, err
+		}
+		tlsConfig.InsecureSkipVerify = c.SkipTLSVerify
+		config.Net.TLS.Enable = true
+		config.Net.TLS.Config = tlsConfig
+	}
+	return config, nil
+}
+
+func (c Config) saslEnabled() bool {
+	return c.SASLMechanism == "aws-iam" ||
+		c.SASLMechanism == "oauthbearer" ||
+		c.SASLUsername != "" ||
+		c.SASLPassword != ""
+}
+
+func (c Config) configureSASL(config *sarama.Config) error {
+	mechanism := c.SASLMechanism
+	if mechanism == "" {
+		mechanism = "plain"
+	}
+	config.Net.SASL.Enable = true
+	config.Net.SASL.Handshake = true
+	config.Net.SASL.User = c.SASLUsername
+	config.Net.SASL.Password = c.SASLPassword
+
+	switch mechanism {
+	case "plain":
+		config.Net.SASL.Mechanism = sarama.SASLTypePlaintext
+	case "scram-sha256":
+		config.Net.SASL.Mechanism = sarama.SASLTypeSCRAMSHA256
+		config.Net.SASL.SCRAMClientGeneratorFunc = func() sarama.SCRAMClient {
+			return &xdgSCRAMClient{HashGeneratorFcn: scram.SHA256}
+		}
+	case "scram-sha512":
+		config.Net.SASL.Mechanism = sarama.SASLTypeSCRAMSHA512
+		config.Net.SASL.SCRAMClientGeneratorFunc = func() sarama.SCRAMClient {
+			return &xdgSCRAMClient{HashGeneratorFcn: scram.SHA512}
+		}
+	case "aws-iam":
+		if c.SASLAWSRegion == "" {
+			return errors.New("kafka: sasl aws region is required for aws-iam authentication")
+		}
+		config.Net.SASL.Mechanism = sarama.SASLTypeOAuth
+		config.Net.SASL.TokenProvider = awsIAMTokenProvider{config: c}
+	case "oauthbearer":
+		if c.SASLOAuthBearerToken == "" {
+			return errors.New("kafka: KAFKA_SASL_OAUTH_TOKEN is required for oauthbearer authentication")
+		}
+		config.Net.SASL.Mechanism = sarama.SASLTypeOAuth
+		config.Net.SASL.TokenProvider = oauthBearerTokenProvider{token: c.SASLOAuthBearerToken}
+	default:
+		return fmt.Errorf("kafka: unsupported sasl mechanism %q", mechanism)
+	}
+	return nil
+}
+
+type xdgSCRAMClient struct {
+	*scram.Client
+	*scram.ClientConversation
+	scram.HashGeneratorFcn
+}
+
+func (x *xdgSCRAMClient) Begin(userName, password, authzID string) error {
+	client, err := x.HashGeneratorFcn.NewClient(userName, password, authzID)
+	if err != nil {
+		return err
+	}
+	x.Client = client
+	x.ClientConversation = client.NewConversation()
+	return nil
+}
+
+func (x *xdgSCRAMClient) Step(challenge string) (string, error) {
+	return x.ClientConversation.Step(challenge)
+}
+
+func (x *xdgSCRAMClient) Done() bool {
+	return x.ClientConversation.Done()
+}
+
+type awsIAMTokenProvider struct {
+	config Config
+}
+
+func (p awsIAMTokenProvider) Token() (*sarama.AccessToken, error) {
+	signer.AwsDebugCreds = p.config.SASLAWSCredsDebug
+	var token string
+	var err error
+	switch {
+	case p.config.SASLAWSContainerAuthorizationTokenFile != "" && p.config.SASLAWSContainerCredentialsFullURI != "":
+		var authorizationToken []byte
+		authorizationToken, err = os.ReadFile(p.config.SASLAWSContainerAuthorizationTokenFile)
+		if err != nil {
+			return nil, fmt.Errorf("kafka: read AWS container authorization token file: %w", err)
+		}
+		credProvider := endpointcreds.New(p.config.SASLAWSContainerCredentialsFullURI, func(o *endpointcreds.Options) {
+			o.AuthorizationToken = string(authorizationToken)
+		})
+		token, _, err = signer.GenerateAuthTokenFromCredentialsProvider(context.TODO(), p.config.SASLAWSRegion, credProvider)
+	case p.config.SASLAWSRoleARN != "":
+		token, _, err = signer.GenerateAuthTokenFromRoleWithExternalId(context.TODO(), p.config.SASLAWSRegion, p.config.SASLAWSRoleARN, "terraformer-kafka", p.config.SASLAWSExternalID)
+	case p.config.SASLAWSProfile != "":
+		if len(p.config.SASLAWSSharedConfigFiles) > 0 {
+			token, _, err = signer.GenerateAuthTokenFromProfileWithSharedConfigFiles(context.TODO(), p.config.SASLAWSRegion, p.config.SASLAWSProfile, p.config.SASLAWSSharedConfigFiles)
+		} else {
+			token, _, err = signer.GenerateAuthTokenFromProfile(context.TODO(), p.config.SASLAWSRegion, p.config.SASLAWSProfile)
+		}
+	case p.config.SASLAWSAccessKey != "" && p.config.SASLAWSSecretKey != "":
+		token, _, err = signer.GenerateAuthTokenFromCredentialsProvider(
+			context.TODO(),
+			p.config.SASLAWSRegion,
+			credentials.NewStaticCredentialsProvider(p.config.SASLAWSAccessKey, p.config.SASLAWSSecretKey, p.config.SASLAWSSessionToken),
+		)
+	default:
+		token, _, err = signer.GenerateAuthToken(context.TODO(), p.config.SASLAWSRegion)
+	}
+	if err != nil {
+		return nil, err
+	}
+	return &sarama.AccessToken{Token: token}, nil
+}
+
+type oauthBearerTokenProvider struct {
+	token string
+}
+
+func (p oauthBearerTokenProvider) Token() (*sarama.AccessToken, error) {
+	return &sarama.AccessToken{Token: p.token}, nil
+}
+
+func newTLSConfig(clientCert, clientKey, caCert, clientKeyPassphrase string) (*tls.Config, error) {
+	tlsConfig := &tls.Config{}
+	if clientCert != "" && clientKey != "" {
+		certBytes, err := pemBytes(clientCert)
+		if err != nil {
+			return nil, err
+		}
+		keyBlock, keyBytes, err := pemBlockAndBytes(clientKey)
+		if err != nil {
+			return nil, err
+		}
+		if x509.IsEncryptedPEMBlock(keyBlock) {
+			decrypted, err := x509.DecryptPEMBlock(keyBlock, []byte(clientKeyPassphrase))
+			if err != nil {
+				return nil, err
+			}
+			keyBytes = pem.EncodeToMemory(&pem.Block{Type: keyBlock.Type, Bytes: decrypted})
+		}
+		cert, err := tls.X509KeyPair(certBytes, keyBytes)
+		if err != nil {
+			return nil, err
+		}
+		tlsConfig.Certificates = []tls.Certificate{cert}
+	}
+	if caCert == "" {
+		return tlsConfig, nil
+	}
+	caBytes, err := pemBytes(caCert)
+	if err != nil {
+		return nil, err
+	}
+	pool, err := x509.SystemCertPool()
+	if err != nil || pool == nil {
+		pool = x509.NewCertPool()
+	}
+	if !pool.AppendCertsFromPEM(caBytes) {
+		return nil, errors.New("kafka: could not add CA certificate")
+	}
+	tlsConfig.RootCAs = pool
+	return tlsConfig, nil
+}
+
+func pemBytes(input string) ([]byte, error) {
+	_, bytes, err := pemBlockAndBytes(input)
+	return bytes, err
+}
+
+func pemBlockAndBytes(input string) (*pem.Block, []byte, error) {
+	bytes := []byte(input)
+	block, _ := pem.Decode(bytes)
+	if block != nil {
+		return block, bytes, nil
+	}
+	loaded, err := os.ReadFile(input)
+	if err != nil {
+		return nil, nil, err
+	}
+	block, _ = pem.Decode(loaded)
+	if block == nil {
+		return nil, nil, errors.New("kafka: unable to decode PEM data")
+	}
+	return block, loaded, nil
+}
+
+func splitCSV(value string) []string {
+	if strings.TrimSpace(value) == "" {
+		return nil
+	}
+	parts := strings.Split(value, ",")
+	values := make([]string, 0, len(parts))
+	for _, part := range parts {
+		if trimmed := strings.TrimSpace(part); trimmed != "" {
+			values = append(values, trimmed)
+		}
+	}
+	return values
+}
+
+func envString(key, fallback string) string {
+	if value := os.Getenv(key); value != "" {
+		return value
+	}
+	return fallback
+}
+
+func envBool(key string, fallback bool) bool {
+	if value := os.Getenv(key); value != "" {
+		parsed, err := strconv.ParseBool(value)
+		if err == nil {
+			return parsed
+		}
+	}
+	return fallback
+}
+
+func envInt(key string, fallback int) int {
+	if value := os.Getenv(key); value != "" {
+		parsed, err := strconv.Atoi(value)
+		if err == nil {
+			return parsed
+		}
+	}
+	return fallback
+}
+
+func firstNonEmpty(values ...string) string {
+	for _, value := range values {
+		if value != "" {
+			return value
+		}
+	}
+	return ""
+}

--- a/providers/kafka/config.go
+++ b/providers/kafka/config.go
@@ -221,13 +221,22 @@ func (c Config) configureSASL(config *sarama.Config) error {
 
 	switch mechanism {
 	case "plain":
+		if err := c.requireSASLCredentials(mechanism); err != nil {
+			return err
+		}
 		config.Net.SASL.Mechanism = sarama.SASLTypePlaintext
 	case "scram-sha256":
+		if err := c.requireSASLCredentials(mechanism); err != nil {
+			return err
+		}
 		config.Net.SASL.Mechanism = sarama.SASLTypeSCRAMSHA256
 		config.Net.SASL.SCRAMClientGeneratorFunc = func() sarama.SCRAMClient {
 			return &xdgSCRAMClient{HashGeneratorFcn: scram.SHA256}
 		}
 	case "scram-sha512":
+		if err := c.requireSASLCredentials(mechanism); err != nil {
+			return err
+		}
 		config.Net.SASL.Mechanism = sarama.SASLTypeSCRAMSHA512
 		config.Net.SASL.SCRAMClientGeneratorFunc = func() sarama.SCRAMClient {
 			return &xdgSCRAMClient{HashGeneratorFcn: scram.SHA512}
@@ -247,6 +256,13 @@ func (c Config) configureSASL(config *sarama.Config) error {
 		config.Net.SASL.TokenProvider = tokenProvider
 	default:
 		return fmt.Errorf("kafka: unsupported sasl mechanism %q", mechanism)
+	}
+	return nil
+}
+
+func (c Config) requireSASLCredentials(mechanism string) error {
+	if c.SASLUsername == "" || c.SASLPassword == "" {
+		return fmt.Errorf("kafka: sasl username and password are required for %s authentication", mechanism)
 	}
 	return nil
 }
@@ -359,6 +375,9 @@ func (p oauthBearerTokenProvider) Token() (*sarama.AccessToken, error) {
 
 func newTLSConfig(clientCert, clientKey, caCert, clientKeyPassphrase string) (*tls.Config, error) {
 	tlsConfig := &tls.Config{}
+	if (clientCert == "") != (clientKey == "") {
+		return nil, errors.New("kafka: client certificate and client key must be provided together")
+	}
 	if clientCert != "" && clientKey != "" {
 		certBytes, err := pemBytes(clientCert)
 		if err != nil {

--- a/providers/kafka/config.go
+++ b/providers/kafka/config.go
@@ -10,6 +10,7 @@ import (
 	"encoding/pem"
 	"errors"
 	"fmt"
+	"net/http"
 	"os"
 	"strconv"
 	"strings"
@@ -20,6 +21,8 @@ import (
 	"github.com/aws/aws-sdk-go-v2/credentials"
 	"github.com/aws/aws-sdk-go-v2/credentials/endpointcreds"
 	"github.com/xdg-go/scram"
+	"golang.org/x/oauth2"
+	"golang.org/x/oauth2/clientcredentials"
 )
 
 const (
@@ -238,15 +241,41 @@ func (c Config) configureSASL(config *sarama.Config) error {
 		config.Net.SASL.Mechanism = sarama.SASLTypeOAuth
 		config.Net.SASL.TokenProvider = awsIAMTokenProvider{config: c}
 	case "oauthbearer":
-		if c.SASLOAuthBearerToken == "" {
-			return errors.New("kafka: KAFKA_SASL_OAUTH_TOKEN is required for oauthbearer authentication")
+		tokenProvider, err := c.oauthBearerTokenProvider()
+		if err != nil {
+			return err
 		}
 		config.Net.SASL.Mechanism = sarama.SASLTypeOAuth
-		config.Net.SASL.TokenProvider = oauthBearerTokenProvider{token: c.SASLOAuthBearerToken}
+		config.Net.SASL.TokenProvider = tokenProvider
 	default:
 		return fmt.Errorf("kafka: unsupported sasl mechanism %q", mechanism)
 	}
 	return nil
+}
+
+func (c Config) oauthBearerTokenProvider() (sarama.AccessTokenProvider, error) {
+	if c.SASLOAuthBearerToken != "" {
+		return oauthBearerTokenProvider{token: c.SASLOAuthBearerToken}, nil
+	}
+	if c.SASLTokenURL == "" {
+		return nil, errors.New("kafka: KAFKA_SASL_OAUTH_TOKEN or KAFKA_SASL_TOKEN_URL is required for oauthbearer authentication")
+	}
+	if c.SASLUsername == "" {
+		return nil, errors.New("kafka: sasl username is required for oauthbearer token URL authentication")
+	}
+	if c.SASLPassword == "" {
+		return nil, errors.New("kafka: KAFKA_SASL_PASSWORD is required for oauthbearer token URL authentication")
+	}
+
+	client := &http.Client{Timeout: time.Duration(c.Timeout) * time.Second}
+	ctx := context.WithValue(context.Background(), oauth2.HTTPClient, client)
+	source := (&clientcredentials.Config{
+		ClientID:     c.SASLUsername,
+		ClientSecret: c.SASLPassword,
+		TokenURL:     c.SASLTokenURL,
+		Scopes:       c.SASLOAuthScopes,
+	}).TokenSource(ctx)
+	return oauthBearerTokenProvider{tokenSource: source}, nil
 }
 
 type xdgSCRAMClient struct {
@@ -316,11 +345,25 @@ func (p awsIAMTokenProvider) Token() (*sarama.AccessToken, error) {
 }
 
 type oauthBearerTokenProvider struct {
-	token string
+	token       string
+	tokenSource oauth2.TokenSource
 }
 
 func (p oauthBearerTokenProvider) Token() (*sarama.AccessToken, error) {
-	return &sarama.AccessToken{Token: p.token}, nil
+	if p.token != "" {
+		return &sarama.AccessToken{Token: p.token}, nil
+	}
+	if p.tokenSource == nil {
+		return nil, errors.New("kafka: oauthbearer token provider is not configured")
+	}
+	token, err := p.tokenSource.Token()
+	if err != nil {
+		return nil, fmt.Errorf("kafka: fetch oauthbearer token: %w", err)
+	}
+	if token.AccessToken == "" {
+		return nil, errors.New("kafka: oauthbearer token response did not include access_token")
+	}
+	return &sarama.AccessToken{Token: token.AccessToken}, nil
 }
 
 func newTLSConfig(clientCert, clientKey, caCert, clientKeyPassphrase string) (*tls.Config, error) {

--- a/providers/kafka/config.go
+++ b/providers/kafka/config.go
@@ -50,13 +50,13 @@ type Config struct {
 	ClientCert                             string
 	Timeout                                int
 
-	ClientKey           string
-	ClientKeyPassphrase string
-	SASLPassword        string
-	SASLAWSAccessKey    string
-	SASLAWSSecretKey    string
-	SASLAWSSessionToken string
-	SASLAWSCredsDebug   bool
+	ClientKey           string `json:"-"`
+	ClientKeyPassphrase string `json:"-"`
+	SASLPassword        string `json:"-"`
+	SASLAWSAccessKey    string `json:"-"`
+	SASLAWSSecretKey    string `json:"-"`
+	SASLAWSSessionToken string `json:"-"`
+	SASLAWSCredsDebug   bool   `json:"-"`
 }
 
 func ConfigFromEnv() Config {
@@ -90,7 +90,10 @@ func ConfigFromEnv() Config {
 }
 
 func EncodeConfig(config Config) string {
-	encoded, _ := json.Marshal(config)
+	encoded, err := json.Marshal(config)
+	if err != nil {
+		return "{}"
+	}
 	return string(encoded)
 }
 
@@ -277,7 +280,7 @@ type xdgSCRAMClient struct {
 }
 
 func (x *xdgSCRAMClient) Begin(userName, password, authzID string) error {
-	client, err := x.HashGeneratorFcn.NewClient(userName, password, authzID)
+	client, err := x.NewClient(userName, password, authzID)
 	if err != nil {
 		return err
 	}
@@ -365,8 +368,8 @@ func newTLSConfig(clientCert, clientKey, caCert, clientKeyPassphrase string) (*t
 		if err != nil {
 			return nil, err
 		}
-		if x509.IsEncryptedPEMBlock(keyBlock) {
-			decrypted, err := x509.DecryptPEMBlock(keyBlock, []byte(clientKeyPassphrase))
+		if x509.IsEncryptedPEMBlock(keyBlock) { //nolint:staticcheck // Legacy encrypted PEM keys are supported for Kafka provider compatibility.
+			decrypted, err := x509.DecryptPEMBlock(keyBlock, []byte(clientKeyPassphrase)) //nolint:staticcheck // Legacy encrypted PEM keys are supported for Kafka provider compatibility.
 			if err != nil {
 				return nil, err
 			}

--- a/providers/kafka/config_test.go
+++ b/providers/kafka/config_test.go
@@ -14,27 +14,34 @@ import (
 
 func TestOAuthBearerUsesTokenURLProvider(t *testing.T) {
 	var tokenRequests int
+	handlerErrors := make(chan string, 8)
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		tokenRequests++
 		r.Body = http.MaxBytesReader(w, r.Body, 4096)
 		if r.Method != http.MethodPost {
-			t.Fatalf("method = %s, want POST", r.Method)
+			failTokenRequest(w, handlerErrors, "method = %s, want POST", r.Method)
+			return
 		}
 		if err := r.ParseForm(); err != nil {
-			t.Fatalf("ParseForm() error = %v", err)
+			failTokenRequest(w, handlerErrors, "ParseForm() error = %v", err)
+			return
 		}
 		if got := r.PostForm.Get("grant_type"); got != "client_credentials" {
-			t.Fatalf("grant_type = %q, want client_credentials", got)
+			failTokenRequest(w, handlerErrors, "grant_type = %q, want client_credentials", got)
+			return
 		}
 		if got := r.PostForm.Get("scope"); got != "read write" {
-			t.Fatalf("scope = %q, want read write", got)
+			failTokenRequest(w, handlerErrors, "scope = %q, want read write", got)
+			return
 		}
 		if user, pass, ok := r.BasicAuth(); ok {
 			if user != "client-id" || pass != "client-secret" {
-				t.Fatalf("basic auth = %q/%q, want client-id/client-secret", user, pass)
+				failTokenRequest(w, handlerErrors, "basic auth = %q/%q, want client-id/client-secret", user, pass)
+				return
 			}
 		} else if r.PostForm.Get("client_id") != "client-id" || r.PostForm.Get("client_secret") != "client-secret" {
-			t.Fatalf("client credentials not sent in basic auth or form: %v", r.PostForm)
+			failTokenRequest(w, handlerErrors, "client credentials not sent in basic auth or form: %v", r.PostForm)
+			return
 		}
 		w.Header().Set("Content-Type", "application/json")
 		fmt.Fprint(w, "{\"access_token\":\"issued-token\",\"token_type\":\"bearer\",\"expires_in\":3600}")
@@ -60,13 +67,32 @@ func TestOAuthBearerUsesTokenURLProvider(t *testing.T) {
 	}
 	token, err := saramaConfig.Net.SASL.TokenProvider.Token()
 	if err != nil {
+		assertNoTokenRequestErrors(t, handlerErrors)
 		t.Fatalf("Token() error = %v", err)
 	}
+	assertNoTokenRequestErrors(t, handlerErrors)
 	if token.Token != "issued-token" {
 		t.Fatalf("token = %q, want issued-token", token.Token)
 	}
 	if tokenRequests != 1 {
 		t.Fatalf("token requests = %d, want 1", tokenRequests)
+	}
+}
+
+func failTokenRequest(w http.ResponseWriter, errs chan<- string, format string, args ...interface{}) {
+	select {
+	case errs <- fmt.Sprintf(format, args...):
+	default:
+	}
+	http.Error(w, "invalid token request", http.StatusBadRequest)
+}
+
+func assertNoTokenRequestErrors(t *testing.T, errs <-chan string) {
+	t.Helper()
+	select {
+	case msg := <-errs:
+		t.Fatalf("token request handler error: %s", msg)
+	default:
 	}
 }
 
@@ -83,5 +109,47 @@ func TestOAuthBearerRejectsPremintedTokenOnly(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "KAFKA_SASL_TOKEN_URL") {
 		t.Fatalf("error = %q, want token URL requirement", err)
+	}
+}
+
+func TestSASLCredentialsRequiredForPlainAndSCRAM(t *testing.T) {
+	for _, mechanism := range []string{"plain", "scram-sha256", "scram-sha512"} {
+		t.Run(mechanism, func(t *testing.T) {
+			config := Config{
+				KafkaVersion:     defaultKafkaVersion,
+				Timeout:          defaultKafkaTimeout,
+				SASLMechanism:    mechanism,
+				SASLUsername:     "terraformer",
+				BootstrapServers: []string{"broker1.example.com:9092"},
+			}
+			_, err := config.newSaramaConfig()
+			if err == nil {
+				t.Fatal("expected missing sasl password error")
+			}
+			if !strings.Contains(err.Error(), "sasl username and password are required") {
+				t.Fatalf("error = %q, want sasl credential requirement", err)
+			}
+		})
+	}
+}
+
+func TestTLSRequiresClientCertAndKeyTogether(t *testing.T) {
+	for _, testCase := range []struct {
+		name       string
+		clientCert string
+		clientKey  string
+	}{
+		{name: "missing key", clientCert: "cert"},
+		{name: "missing cert", clientKey: "key"},
+	} {
+		t.Run(testCase.name, func(t *testing.T) {
+			_, err := newTLSConfig(testCase.clientCert, testCase.clientKey, "", "")
+			if err == nil {
+				t.Fatal("expected partial mTLS config error")
+			}
+			if !strings.Contains(err.Error(), "client certificate and client key must be provided together") {
+				t.Fatalf("error = %q, want client certificate and key requirement", err)
+			}
+		})
 	}
 }

--- a/providers/kafka/config_test.go
+++ b/providers/kafka/config_test.go
@@ -72,6 +72,8 @@ func TestOAuthBearerUsesTokenURLProvider(t *testing.T) {
 func TestOAuthBearerRejectsPremintedTokenOnly(t *testing.T) {
 	t.Setenv("KAFKA_SASL_MECHANISM", "oauthbearer")
 	t.Setenv("KAFKA_SASL_OAUTH_TOKEN", "preminted-token")
+	t.Setenv("KAFKA_SASL_TOKEN_URL", "")
+	t.Setenv("TOKEN_URL", "")
 
 	config := ConfigFromEnv()
 	_, err := config.newSaramaConfig()

--- a/providers/kafka/config_test.go
+++ b/providers/kafka/config_test.go
@@ -69,39 +69,16 @@ func TestOAuthBearerUsesTokenURLProvider(t *testing.T) {
 	}
 }
 
-func TestOAuthBearerStillAcceptsPremintedToken(t *testing.T) {
-	config := Config{
-		KafkaVersion:         defaultKafkaVersion,
-		Timeout:              defaultKafkaTimeout,
-		SASLMechanism:        "oauthbearer",
-		SASLOAuthBearerToken: "preminted-token",
-		BootstrapServers:     []string{"broker1.example.com:9092"},
-	}
-	saramaConfig, err := config.newSaramaConfig()
-	if err != nil {
-		t.Fatalf("newSaramaConfig() error = %v", err)
-	}
-	token, err := saramaConfig.Net.SASL.TokenProvider.Token()
-	if err != nil {
-		t.Fatalf("Token() error = %v", err)
-	}
-	if token.Token != "preminted-token" {
-		t.Fatalf("token = %q, want preminted-token", token.Token)
-	}
-}
+func TestOAuthBearerRejectsPremintedTokenOnly(t *testing.T) {
+	t.Setenv("KAFKA_SASL_MECHANISM", "oauthbearer")
+	t.Setenv("KAFKA_SASL_OAUTH_TOKEN", "preminted-token")
 
-func TestOAuthBearerRequiresTokenURLOrPremintedToken(t *testing.T) {
-	config := Config{
-		KafkaVersion:     defaultKafkaVersion,
-		Timeout:          defaultKafkaTimeout,
-		SASLMechanism:    "oauthbearer",
-		BootstrapServers: []string{"broker1.example.com:9092"},
-	}
+	config := ConfigFromEnv()
 	_, err := config.newSaramaConfig()
 	if err == nil {
 		t.Fatal("expected missing oauthbearer token configuration error")
 	}
-	if !strings.Contains(err.Error(), "KAFKA_SASL_OAUTH_TOKEN or KAFKA_SASL_TOKEN_URL") {
-		t.Fatalf("error = %q, want token URL or preminted token requirement", err)
+	if !strings.Contains(err.Error(), "KAFKA_SASL_TOKEN_URL") {
+		t.Fatalf("error = %q, want token URL requirement", err)
 	}
 }

--- a/providers/kafka/config_test.go
+++ b/providers/kafka/config_test.go
@@ -1,0 +1,107 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package kafka
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/IBM/sarama"
+)
+
+func TestOAuthBearerUsesTokenURLProvider(t *testing.T) {
+	var tokenRequests int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		tokenRequests++
+		if r.Method != http.MethodPost {
+			t.Fatalf("method = %s, want POST", r.Method)
+		}
+		if err := r.ParseForm(); err != nil {
+			t.Fatalf("ParseForm() error = %v", err)
+		}
+		if got := r.PostForm.Get("grant_type"); got != "client_credentials" {
+			t.Fatalf("grant_type = %q, want client_credentials", got)
+		}
+		if got := r.PostForm.Get("scope"); got != "read write" {
+			t.Fatalf("scope = %q, want read write", got)
+		}
+		if user, pass, ok := r.BasicAuth(); ok {
+			if user != "client-id" || pass != "client-secret" {
+				t.Fatalf("basic auth = %q/%q, want client-id/client-secret", user, pass)
+			}
+		} else if r.PostForm.Get("client_id") != "client-id" || r.PostForm.Get("client_secret") != "client-secret" {
+			t.Fatalf("client credentials not sent in basic auth or form: %v", r.PostForm)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprint(w, "{\"access_token\":\"issued-token\",\"token_type\":\"bearer\",\"expires_in\":3600}")
+	}))
+	defer server.Close()
+
+	config := Config{
+		KafkaVersion:     defaultKafkaVersion,
+		Timeout:          defaultKafkaTimeout,
+		SASLMechanism:    "oauthbearer",
+		SASLUsername:     "client-id",
+		SASLPassword:     "client-secret",
+		SASLTokenURL:     server.URL,
+		SASLOAuthScopes:  []string{"read", "write"},
+		BootstrapServers: []string{"broker1.example.com:9092"},
+	}
+	saramaConfig, err := config.newSaramaConfig()
+	if err != nil {
+		t.Fatalf("newSaramaConfig() error = %v", err)
+	}
+	if saramaConfig.Net.SASL.Mechanism != sarama.SASLTypeOAuth {
+		t.Fatalf("SASL mechanism = %q, want %q", saramaConfig.Net.SASL.Mechanism, sarama.SASLTypeOAuth)
+	}
+	token, err := saramaConfig.Net.SASL.TokenProvider.Token()
+	if err != nil {
+		t.Fatalf("Token() error = %v", err)
+	}
+	if token.Token != "issued-token" {
+		t.Fatalf("token = %q, want issued-token", token.Token)
+	}
+	if tokenRequests != 1 {
+		t.Fatalf("token requests = %d, want 1", tokenRequests)
+	}
+}
+
+func TestOAuthBearerStillAcceptsPremintedToken(t *testing.T) {
+	config := Config{
+		KafkaVersion:         defaultKafkaVersion,
+		Timeout:              defaultKafkaTimeout,
+		SASLMechanism:        "oauthbearer",
+		SASLOAuthBearerToken: "preminted-token",
+		BootstrapServers:     []string{"broker1.example.com:9092"},
+	}
+	saramaConfig, err := config.newSaramaConfig()
+	if err != nil {
+		t.Fatalf("newSaramaConfig() error = %v", err)
+	}
+	token, err := saramaConfig.Net.SASL.TokenProvider.Token()
+	if err != nil {
+		t.Fatalf("Token() error = %v", err)
+	}
+	if token.Token != "preminted-token" {
+		t.Fatalf("token = %q, want preminted-token", token.Token)
+	}
+}
+
+func TestOAuthBearerRequiresTokenURLOrPremintedToken(t *testing.T) {
+	config := Config{
+		KafkaVersion:     defaultKafkaVersion,
+		Timeout:          defaultKafkaTimeout,
+		SASLMechanism:    "oauthbearer",
+		BootstrapServers: []string{"broker1.example.com:9092"},
+	}
+	_, err := config.newSaramaConfig()
+	if err == nil {
+		t.Fatal("expected missing oauthbearer token configuration error")
+	}
+	if !strings.Contains(err.Error(), "KAFKA_SASL_OAUTH_TOKEN or KAFKA_SASL_TOKEN_URL") {
+		t.Fatalf("error = %q, want token URL or preminted token requirement", err)
+	}
+}

--- a/providers/kafka/config_test.go
+++ b/providers/kafka/config_test.go
@@ -133,6 +133,26 @@ func TestSASLCredentialsRequiredForPlainAndSCRAM(t *testing.T) {
 	}
 }
 
+func TestSCRAMMechanismsEnableSASLWithoutCredentials(t *testing.T) {
+	for _, mechanism := range []string{"scram-sha256", "scram-sha512"} {
+		t.Run(mechanism, func(t *testing.T) {
+			config := Config{
+				KafkaVersion:     defaultKafkaVersion,
+				Timeout:          defaultKafkaTimeout,
+				SASLMechanism:    mechanism,
+				BootstrapServers: []string{"broker1.example.com:9092"},
+			}
+			_, err := config.newSaramaConfig()
+			if err == nil {
+				t.Fatal("expected missing sasl credentials error")
+			}
+			if !strings.Contains(err.Error(), "sasl username and password are required") {
+				t.Fatalf("error = %q, want sasl credential requirement", err)
+			}
+		})
+	}
+}
+
 func TestTLSRequiresClientCertAndKeyTogether(t *testing.T) {
 	for _, testCase := range []struct {
 		name       string

--- a/providers/kafka/config_test.go
+++ b/providers/kafka/config_test.go
@@ -16,6 +16,7 @@ func TestOAuthBearerUsesTokenURLProvider(t *testing.T) {
 	var tokenRequests int
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		tokenRequests++
+		r.Body = http.MaxBytesReader(w, r.Body, 4096)
 		if r.Method != http.MethodPost {
 			t.Fatalf("method = %s, want POST", r.Method)
 		}

--- a/providers/kafka/kafka_provider.go
+++ b/providers/kafka/kafka_provider.go
@@ -40,9 +40,6 @@ func (p *Provider) GetBasicConfig() cty.Value {
 
 func (p *Provider) GetProviderData(_ ...string) map[string]interface{} {
 	providerConfig := p.safeConfigMap()
-	if len(providerConfig) == 0 {
-		return map[string]interface{}{}
-	}
 	return map[string]interface{}{
 		"provider": map[string]interface{}{
 			"kafka": providerConfig,

--- a/providers/kafka/kafka_provider.go
+++ b/providers/kafka/kafka_provider.go
@@ -31,7 +31,7 @@ func (p *Provider) GetName() string {
 }
 
 func (p *Provider) GetConfig() cty.Value {
-	return cty.ObjectVal(p.safeConfigCTY())
+	return cty.ObjectVal(p.configCTY())
 }
 
 func (p *Provider) GetBasicConfig() cty.Value {
@@ -167,6 +167,32 @@ func (p *Provider) safeConfigCTY() map[string]cty.Value {
 	}
 	if p.config.Timeout != 0 {
 		config["timeout"] = cty.NumberIntVal(int64(p.config.Timeout))
+	}
+	return config
+}
+
+func (p *Provider) configCTY() map[string]cty.Value {
+	config := p.safeConfigCTY()
+	if p.config.SASLPassword != "" {
+		config["sasl_password"] = cty.StringVal(p.config.SASLPassword)
+	}
+	if p.config.ClientKey != "" {
+		config["client_key"] = cty.StringVal(p.config.ClientKey)
+	}
+	if p.config.ClientKeyPassphrase != "" {
+		config["client_key_passphrase"] = cty.StringVal(p.config.ClientKeyPassphrase)
+	}
+	if p.config.SASLAWSAccessKey != "" {
+		config["sasl_aws_access_key"] = cty.StringVal(p.config.SASLAWSAccessKey)
+	}
+	if p.config.SASLAWSSecretKey != "" {
+		config["sasl_aws_secret_key"] = cty.StringVal(p.config.SASLAWSSecretKey)
+	}
+	if p.config.SASLAWSSessionToken != "" {
+		config["sasl_aws_token"] = cty.StringVal(p.config.SASLAWSSessionToken)
+	}
+	if p.config.SASLAWSCredsDebug {
+		config["sasl_aws_creds_debug"] = cty.BoolVal(p.config.SASLAWSCredsDebug)
 	}
 	return config
 }

--- a/providers/kafka/kafka_provider.go
+++ b/providers/kafka/kafka_provider.go
@@ -1,0 +1,186 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package kafka
+
+import (
+	"errors"
+
+	"github.com/chenrui333/terraformer/terraformutils"
+	"github.com/zclconf/go-cty/cty"
+)
+
+type Provider struct {
+	terraformutils.Provider
+	config Config
+}
+
+func (p *Provider) Init(args []string) error {
+	config, err := configFromArgs(args)
+	if err != nil {
+		return err
+	}
+	if err := config.validate(); err != nil {
+		return err
+	}
+	p.config = config
+	return nil
+}
+
+func (p *Provider) GetName() string {
+	return "kafka"
+}
+
+func (p *Provider) GetConfig() cty.Value {
+	return cty.ObjectVal(p.safeConfigCTY())
+}
+
+func (p *Provider) GetBasicConfig() cty.Value {
+	return p.GetConfig()
+}
+
+func (p *Provider) GetProviderData(_ ...string) map[string]interface{} {
+	providerConfig := p.safeConfigMap()
+	if len(providerConfig) == 0 {
+		return map[string]interface{}{}
+	}
+	return map[string]interface{}{
+		"provider": map[string]interface{}{
+			"kafka": providerConfig,
+		},
+	}
+}
+
+func (p *Provider) InitService(serviceName string, verbose bool) error {
+	if !terraformutils.SelectProviderService(&p.Provider, p.GetSupportedService(), serviceName, verbose, p.GetName()) {
+		return errors.New(p.GetName() + ": " + serviceName + " not supported service")
+	}
+	p.Service.SetArgs(map[string]interface{}{
+		"config": p.config,
+	})
+	return nil
+}
+
+func (p *Provider) GetSupportedService() map[string]terraformutils.ServiceGenerator {
+	return map[string]terraformutils.ServiceGenerator{
+		"topics": &TopicGenerator{},
+	}
+}
+
+func (Provider) GetResourceConnections() map[string]map[string][]string {
+	return map[string]map[string][]string{}
+}
+
+func (p *Provider) safeConfigMap() map[string]interface{} {
+	config := map[string]interface{}{
+		"bootstrap_servers": p.config.BootstrapServers,
+		"kafka_version":     p.config.KafkaVersion,
+		"tls_enabled":       p.config.TLSEnabled,
+		"skip_tls_verify":   p.config.SkipTLSVerify,
+	}
+	if p.config.SASLMechanism != "" {
+		config["sasl_mechanism"] = p.config.SASLMechanism
+	}
+	if p.config.SASLUsername != "" {
+		config["sasl_username"] = p.config.SASLUsername
+	}
+	if p.config.SASLAWSRegion != "" {
+		config["sasl_aws_region"] = p.config.SASLAWSRegion
+	}
+	if p.config.SASLAWSContainerAuthorizationTokenFile != "" {
+		config["sasl_aws_container_authorization_token_file"] = p.config.SASLAWSContainerAuthorizationTokenFile
+	}
+	if p.config.SASLAWSContainerCredentialsFullURI != "" {
+		config["sasl_aws_container_credentials_full_uri"] = p.config.SASLAWSContainerCredentialsFullURI
+	}
+	if p.config.SASLAWSRoleARN != "" {
+		config["sasl_aws_role_arn"] = p.config.SASLAWSRoleARN
+	}
+	if p.config.SASLAWSExternalID != "" {
+		config["sasl_aws_external_id"] = p.config.SASLAWSExternalID
+	}
+	if p.config.SASLAWSProfile != "" {
+		config["sasl_aws_profile"] = p.config.SASLAWSProfile
+	}
+	if len(p.config.SASLAWSSharedConfigFiles) > 0 {
+		config["sasl_aws_shared_config_files"] = p.config.SASLAWSSharedConfigFiles
+	}
+	if p.config.SASLTokenURL != "" {
+		config["sasl_token_url"] = p.config.SASLTokenURL
+	}
+	if len(p.config.SASLOAuthScopes) > 0 {
+		config["sasl_oauth_scopes"] = p.config.SASLOAuthScopes
+	}
+	if p.config.CACert != "" {
+		config["ca_cert"] = p.config.CACert
+	}
+	if p.config.ClientCert != "" {
+		config["client_cert"] = p.config.ClientCert
+	}
+	if p.config.Timeout != 0 {
+		config["timeout"] = p.config.Timeout
+	}
+	return config
+}
+
+func (p *Provider) safeConfigCTY() map[string]cty.Value {
+	config := map[string]cty.Value{
+		"bootstrap_servers": ctyStringList(p.config.BootstrapServers),
+		"kafka_version":     cty.StringVal(p.config.KafkaVersion),
+		"tls_enabled":       cty.BoolVal(p.config.TLSEnabled),
+		"skip_tls_verify":   cty.BoolVal(p.config.SkipTLSVerify),
+	}
+	if p.config.SASLMechanism != "" {
+		config["sasl_mechanism"] = cty.StringVal(p.config.SASLMechanism)
+	}
+	if p.config.SASLUsername != "" {
+		config["sasl_username"] = cty.StringVal(p.config.SASLUsername)
+	}
+	if p.config.SASLAWSRegion != "" {
+		config["sasl_aws_region"] = cty.StringVal(p.config.SASLAWSRegion)
+	}
+	if p.config.SASLAWSContainerAuthorizationTokenFile != "" {
+		config["sasl_aws_container_authorization_token_file"] = cty.StringVal(p.config.SASLAWSContainerAuthorizationTokenFile)
+	}
+	if p.config.SASLAWSContainerCredentialsFullURI != "" {
+		config["sasl_aws_container_credentials_full_uri"] = cty.StringVal(p.config.SASLAWSContainerCredentialsFullURI)
+	}
+	if p.config.SASLAWSRoleARN != "" {
+		config["sasl_aws_role_arn"] = cty.StringVal(p.config.SASLAWSRoleARN)
+	}
+	if p.config.SASLAWSExternalID != "" {
+		config["sasl_aws_external_id"] = cty.StringVal(p.config.SASLAWSExternalID)
+	}
+	if p.config.SASLAWSProfile != "" {
+		config["sasl_aws_profile"] = cty.StringVal(p.config.SASLAWSProfile)
+	}
+	if len(p.config.SASLAWSSharedConfigFiles) > 0 {
+		config["sasl_aws_shared_config_files"] = ctyStringList(p.config.SASLAWSSharedConfigFiles)
+	}
+	if p.config.SASLTokenURL != "" {
+		config["sasl_token_url"] = cty.StringVal(p.config.SASLTokenURL)
+	}
+	if len(p.config.SASLOAuthScopes) > 0 {
+		config["sasl_oauth_scopes"] = ctyStringList(p.config.SASLOAuthScopes)
+	}
+	if p.config.CACert != "" {
+		config["ca_cert"] = cty.StringVal(p.config.CACert)
+	}
+	if p.config.ClientCert != "" {
+		config["client_cert"] = cty.StringVal(p.config.ClientCert)
+	}
+	if p.config.Timeout != 0 {
+		config["timeout"] = cty.NumberIntVal(int64(p.config.Timeout))
+	}
+	return config
+}
+
+func ctyStringList(values []string) cty.Value {
+	ctyValues := make([]cty.Value, 0, len(values))
+	for _, value := range values {
+		ctyValues = append(ctyValues, cty.StringVal(value))
+	}
+	if len(ctyValues) == 0 {
+		return cty.ListValEmpty(cty.String)
+	}
+	return cty.ListVal(ctyValues)
+}

--- a/providers/kafka/kafka_provider_test.go
+++ b/providers/kafka/kafka_provider_test.go
@@ -1,0 +1,84 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package kafka
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+)
+
+func TestProviderInitRequiresBootstrapServers(t *testing.T) {
+	provider := &Provider{}
+
+	err := provider.Init([]string{EncodeConfig(Config{KafkaVersion: defaultKafkaVersion, Timeout: defaultKafkaTimeout})})
+	if err == nil {
+		t.Fatal("expected missing bootstrap servers error")
+	}
+	if !strings.Contains(err.Error(), "bootstrap servers are required") {
+		t.Fatalf("Init error = %q, want bootstrap servers requirement", err)
+	}
+}
+
+func TestProviderSafeConfigHandling(t *testing.T) {
+	config := Config{
+		BootstrapServers:     []string{"broker1.example.com:9092"},
+		KafkaVersion:         defaultKafkaVersion,
+		TLSEnabled:           true,
+		SASLMechanism:        "plain",
+		SASLUsername:         "terraformer",
+		SASLPassword:         "sasl-password",
+		ClientKey:            "tls-private-key",
+		SASLAWSAccessKey:     "aws-access-key",
+		SASLAWSSecretKey:     "aws-secret-key",
+		SASLAWSSessionToken:  "aws-session-token",
+		SASLOAuthBearerToken: "oauth-token",
+		Timeout:              defaultKafkaTimeout,
+	}
+
+	encoded := EncodeConfig(config)
+	for _, secret := range forbiddenTestSecrets() {
+		if strings.Contains(encoded, secret) {
+			t.Fatalf("encoded config contains secret %q: %s", secret, encoded)
+		}
+	}
+
+	provider := &Provider{}
+	if err := provider.Init([]string{encoded}); err != nil {
+		t.Fatalf("Init() error = %v", err)
+	}
+	rendered := fmt.Sprintf("%#v", provider.GetProviderData())
+	for _, secret := range forbiddenTestSecrets() {
+		if strings.Contains(rendered, secret) {
+			t.Fatalf("provider data contains secret %q: %s", secret, rendered)
+		}
+	}
+	if !strings.Contains(rendered, "broker1.example.com:9092") {
+		t.Fatalf("provider data missing bootstrap server: %s", rendered)
+	}
+}
+
+func TestProviderSupportedServices(t *testing.T) {
+	provider := &Provider{}
+	services := provider.GetSupportedService()
+	if _, ok := services["topics"]; !ok {
+		t.Fatalf("topics service not registered: %#v", services)
+	}
+	if err := provider.InitService("topics", false); err != nil {
+		t.Fatalf("InitService(topics) error = %v", err)
+	}
+	if provider.GetService() == nil {
+		t.Fatal("InitService(topics) did not set service")
+	}
+}
+
+func forbiddenTestSecrets() []string {
+	return []string{
+		"sasl-password",
+		"tls-private-key",
+		"aws-access-key",
+		"aws-secret-key",
+		"aws-session-token",
+		"oauth-token",
+	}
+}

--- a/providers/kafka/kafka_provider_test.go
+++ b/providers/kafka/kafka_provider_test.go
@@ -21,19 +21,20 @@ func TestProviderInitRequiresBootstrapServers(t *testing.T) {
 }
 
 func TestProviderSafeConfigHandling(t *testing.T) {
+	t.Setenv("KAFKA_SASL_OAUTH_TOKEN", "oauth-token")
+
 	config := Config{
-		BootstrapServers:     []string{"broker1.example.com:9092"},
-		KafkaVersion:         defaultKafkaVersion,
-		TLSEnabled:           true,
-		SASLMechanism:        "plain",
-		SASLUsername:         "terraformer",
-		SASLPassword:         "sasl-password",
-		ClientKey:            "tls-private-key",
-		SASLAWSAccessKey:     "aws-access-key",
-		SASLAWSSecretKey:     "aws-secret-key",
-		SASLAWSSessionToken:  "aws-session-token",
-		SASLOAuthBearerToken: "oauth-token",
-		Timeout:              defaultKafkaTimeout,
+		BootstrapServers:    []string{"broker1.example.com:9092"},
+		KafkaVersion:        defaultKafkaVersion,
+		TLSEnabled:          true,
+		SASLMechanism:       "plain",
+		SASLUsername:        "terraformer",
+		SASLPassword:        "sasl-password",
+		ClientKey:           "tls-private-key",
+		SASLAWSAccessKey:    "aws-access-key",
+		SASLAWSSecretKey:    "aws-secret-key",
+		SASLAWSSessionToken: "aws-session-token",
+		Timeout:             defaultKafkaTimeout,
 	}
 
 	encoded := EncodeConfig(config)

--- a/providers/kafka/kafka_provider_test.go
+++ b/providers/kafka/kafka_provider_test.go
@@ -6,6 +6,8 @@ import (
 	"fmt"
 	"strings"
 	"testing"
+
+	"github.com/zclconf/go-cty/cty"
 )
 
 func TestProviderInitRequiresBootstrapServers(t *testing.T) {
@@ -22,19 +24,23 @@ func TestProviderInitRequiresBootstrapServers(t *testing.T) {
 
 func TestProviderSafeConfigHandling(t *testing.T) {
 	t.Setenv("KAFKA_SASL_OAUTH_TOKEN", "oauth-token")
+	t.Setenv("KAFKA_SASL_PASSWORD", "sasl-password")
+	t.Setenv("KAFKA_CLIENT_KEY", "tls-private-key")
+	t.Setenv("KAFKA_CLIENT_KEY_PASSPHRASE", "tls-private-key-passphrase")
+	t.Setenv("AWS_ACCESS_KEY_ID", "aws-access-key")
+	t.Setenv("AWS_SECRET_ACCESS_KEY", "aws-secret-key")
+	t.Setenv("AWS_SESSION_TOKEN", "aws-session-token")
+	t.Setenv("AWS_CREDS_DEBUG", "true")
 
 	config := Config{
-		BootstrapServers:    []string{"broker1.example.com:9092"},
-		KafkaVersion:        defaultKafkaVersion,
-		TLSEnabled:          true,
-		SASLMechanism:       "plain",
-		SASLUsername:        "terraformer",
-		SASLPassword:        "sasl-password",
-		ClientKey:           "tls-private-key",
-		SASLAWSAccessKey:    "aws-access-key",
-		SASLAWSSecretKey:    "aws-secret-key",
-		SASLAWSSessionToken: "aws-session-token",
-		Timeout:             defaultKafkaTimeout,
+		BootstrapServers: []string{"broker1.example.com:9092"},
+		KafkaVersion:     defaultKafkaVersion,
+		TLSEnabled:       true,
+		SASLMechanism:    "plain",
+		SASLUsername:     "terraformer",
+		SASLPassword:     "sasl-password",
+		ClientKey:        "tls-private-key",
+		Timeout:          defaultKafkaTimeout,
 	}
 
 	encoded := EncodeConfig(config)
@@ -57,6 +63,21 @@ func TestProviderSafeConfigHandling(t *testing.T) {
 	if !strings.Contains(rendered, "broker1.example.com:9092") {
 		t.Fatalf("provider data missing bootstrap server: %s", rendered)
 	}
+
+	refreshConfig := provider.GetConfig()
+	for key, want := range map[string]string{
+		"sasl_password":         "sasl-password",
+		"client_key":            "tls-private-key",
+		"client_key_passphrase": "tls-private-key-passphrase",
+		"sasl_aws_access_key":   "aws-access-key",
+		"sasl_aws_secret_key":   "aws-secret-key",
+		"sasl_aws_token":        "aws-session-token",
+	} {
+		assertStringConfigAttr(t, refreshConfig, key, want)
+	}
+	if got := refreshConfig.GetAttr("sasl_aws_creds_debug"); !got.RawEquals(cty.BoolVal(true)) {
+		t.Fatalf("sasl_aws_creds_debug = %#v, want true", got)
+	}
 }
 
 func TestProviderSupportedServices(t *testing.T) {
@@ -77,9 +98,18 @@ func forbiddenTestSecrets() []string {
 	return []string{
 		"sasl-password",
 		"tls-private-key",
+		"tls-private-key-passphrase",
 		"aws-access-key",
 		"aws-secret-key",
 		"aws-session-token",
 		"oauth-token",
+	}
+}
+
+func assertStringConfigAttr(t *testing.T, config cty.Value, key, want string) {
+	t.Helper()
+	got := config.GetAttr(key)
+	if got.AsString() != want {
+		t.Fatalf("%s = %q, want %q", key, got.AsString(), want)
 	}
 }

--- a/providers/kafka/kafka_service.go
+++ b/providers/kafka/kafka_service.go
@@ -1,0 +1,37 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package kafka
+
+import (
+	"github.com/IBM/sarama"
+	"github.com/chenrui333/terraformer/terraformutils"
+)
+
+type adminClient interface {
+	ListTopics() (map[string]sarama.TopicDetail, error)
+	DescribeTopics(topics []string) ([]*sarama.TopicMetadata, error)
+	DescribeConfig(resource sarama.ConfigResource) ([]sarama.ConfigEntry, error)
+	Close() error
+}
+
+type adminFactory func(Config) (adminClient, error)
+
+type Service struct {
+	terraformutils.Service
+	newAdmin adminFactory
+}
+
+func defaultAdminFactory(config Config) (adminClient, error) {
+	saramaConfig, err := config.newSaramaConfig()
+	if err != nil {
+		return nil, err
+	}
+	return sarama.NewClusterAdmin(config.BootstrapServers, saramaConfig)
+}
+
+func (s *Service) admin(config Config) (adminClient, error) {
+	if s.newAdmin != nil {
+		return s.newAdmin(config)
+	}
+	return defaultAdminFactory(config)
+}

--- a/providers/kafka/kafka_service.go
+++ b/providers/kafka/kafka_service.go
@@ -8,7 +8,6 @@ import (
 )
 
 type adminClient interface {
-	ListTopics() (map[string]sarama.TopicDetail, error)
 	DescribeTopics(topics []string) ([]*sarama.TopicMetadata, error)
 	DescribeConfig(resource sarama.ConfigResource) ([]sarama.ConfigEntry, error)
 	Close() error

--- a/providers/kafka/topic.go
+++ b/providers/kafka/topic.go
@@ -70,7 +70,8 @@ func (g *TopicGenerator) ParseFilters(rawFilters []string) {
 }
 
 func (g *TopicGenerator) listTopics(admin adminClient, config Config) ([]Topic, error) {
-	metadata, err := admin.DescribeTopics(nil)
+	explicitTopics := g.explicitlyRequestedTopics()
+	metadata, err := admin.DescribeTopics(explicitTopicNames(explicitTopics))
 	if err != nil {
 		return nil, err
 	}
@@ -87,7 +88,6 @@ func (g *TopicGenerator) listTopics(admin adminClient, config Config) ([]Topic, 
 		return metadata[i].Name < metadata[j].Name
 	})
 
-	explicitTopics := g.explicitlyRequestedTopics()
 	topics := make([]Topic, 0, len(metadata))
 	for _, topicMetadata := range metadata {
 		if topicMetadata == nil {
@@ -131,6 +131,18 @@ func (g *TopicGenerator) explicitlyRequestedTopics() map[string]bool {
 		}
 	}
 	return explicitTopics
+}
+
+func explicitTopicNames(explicitTopics map[string]bool) []string {
+	if len(explicitTopics) == 0 {
+		return nil
+	}
+	names := make([]string, 0, len(explicitTopics))
+	for name := range explicitTopics {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	return names
 }
 
 func (g *TopicGenerator) topicFromMetadata(admin adminClient, metadata *sarama.TopicMetadata, providerConfig Config) (Topic, error) {

--- a/providers/kafka/topic.go
+++ b/providers/kafka/topic.go
@@ -41,7 +41,7 @@ func (g *TopicGenerator) InitResources() error {
 		}
 	}()
 
-	topics, err := g.listTopics(admin)
+	topics, err := g.listTopics(admin, config)
 	if err != nil {
 		return err
 	}
@@ -67,7 +67,7 @@ func (g *TopicGenerator) ParseFilters(rawFilters []string) {
 	}
 }
 
-func (g *TopicGenerator) listTopics(admin adminClient) ([]Topic, error) {
+func (g *TopicGenerator) listTopics(admin adminClient, config Config) ([]Topic, error) {
 	details, err := admin.ListTopics()
 	if err != nil {
 		return nil, err
@@ -83,7 +83,7 @@ func (g *TopicGenerator) listTopics(admin adminClient) ([]Topic, error) {
 
 	topics := make([]Topic, 0, len(names))
 	for _, name := range names {
-		topic, err := g.topicFromDetail(admin, name, details[name])
+		topic, err := g.topicFromDetail(admin, name, details[name], config)
 		if err != nil {
 			return nil, err
 		}
@@ -92,7 +92,7 @@ func (g *TopicGenerator) listTopics(admin adminClient) ([]Topic, error) {
 	return topics, nil
 }
 
-func (g *TopicGenerator) topicFromDetail(admin adminClient, name string, detail sarama.TopicDetail) (Topic, error) {
+func (g *TopicGenerator) topicFromDetail(admin adminClient, name string, detail sarama.TopicDetail, providerConfig Config) (Topic, error) {
 	partitions, replicationFactor, err := topicShapeFromDetail(detail)
 	if err != nil {
 		return Topic{}, fmt.Errorf("kafka topic %q: %w", name, err)
@@ -107,7 +107,7 @@ func (g *TopicGenerator) topicFromDetail(admin adminClient, name string, detail 
 			return Topic{}, err
 		}
 	}
-	config, err := topicConfig(admin, name)
+	config, err := topicConfig(admin, name, providerConfig)
 	if err != nil {
 		log.Printf("kafka: skipping topic config for %q: %v", name, err)
 		config = map[string]string{}
@@ -176,7 +176,7 @@ func topicShapeFromMetadata(name string, topics []*sarama.TopicMetadata) (int32,
 	return 0, 0, fmt.Errorf("kafka topic %q: metadata not found", name)
 }
 
-func topicConfig(admin adminClient, name string) (map[string]string, error) {
+func topicConfig(admin adminClient, name string, providerConfig Config) (map[string]string, error) {
 	entries, err := admin.DescribeConfig(sarama.ConfigResource{
 		Type: sarama.TopicResource,
 		Name: name,
@@ -186,7 +186,7 @@ func topicConfig(admin adminClient, name string) (map[string]string, error) {
 	}
 	config := map[string]string{}
 	for _, entry := range entries {
-		if entry.Sensitive || isDefaultConfig(entry) || isForbiddenConfigName(entry.Name) {
+		if entry.Sensitive || isDefaultConfig(entry) || isForbiddenConfigName(entry.Name) || isUnsupportedTopicConfigName(entry.Name, providerConfig) {
 			continue
 		}
 		config[entry.Name] = entry.Value
@@ -213,6 +213,19 @@ func isForbiddenConfigName(name string) bool {
 		"scram.password",
 	} {
 		if strings.Contains(lower, needle) {
+			return true
+		}
+	}
+	return false
+}
+
+func isUnsupportedTopicConfigName(name string, providerConfig Config) bool {
+	return strings.EqualFold(name, "segment.bytes") && isMSKServerless(providerConfig.BootstrapServers)
+}
+
+func isMSKServerless(bootstrapServers []string) bool {
+	for _, server := range bootstrapServers {
+		if strings.Contains(strings.ToLower(server), "kafka-serverless") {
 			return true
 		}
 	}

--- a/providers/kafka/topic.go
+++ b/providers/kafka/topic.go
@@ -5,6 +5,7 @@ package kafka
 import (
 	"crypto/sha256"
 	"encoding/hex"
+	"errors"
 	"fmt"
 	"log"
 	"sort"
@@ -130,6 +131,9 @@ func (g *TopicGenerator) topicFromDetail(admin adminClient, name string, detail 
 	}
 	config, err := topicConfig(admin, name, providerConfig)
 	if err != nil {
+		if !isSkippableTopicConfigError(err) {
+			return Topic{}, fmt.Errorf("kafka topic %q: describe config: %w", name, err)
+		}
 		log.Printf("kafka: skipping topic config for %q: %v", name, err)
 		config = map[string]string{}
 	}
@@ -236,6 +240,18 @@ func safeReplicationFactor(value int) (int16, error) {
 	}
 	converted := int16(value) //nolint:gosec // value is bounds checked above.
 	return converted, nil
+}
+
+func isSkippableTopicConfigError(err error) bool {
+	if errors.Is(err, sarama.ErrTopicAuthorizationFailed) ||
+		errors.Is(err, sarama.ErrClusterAuthorizationFailed) ||
+		errors.Is(err, sarama.ErrUnsupportedVersion) {
+		return true
+	}
+	lower := strings.ToLower(err.Error())
+	return strings.Contains(lower, "authorization failed") ||
+		strings.Contains(lower, "not authorized") ||
+		strings.Contains(lower, "unsupported version")
 }
 
 func topicConfig(admin adminClient, name string, providerConfig Config) (map[string]string, error) {

--- a/providers/kafka/topic.go
+++ b/providers/kafka/topic.go
@@ -1,0 +1,275 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package kafka
+
+import (
+	"crypto/sha1" //nolint:gosec // deterministic resource-name suffix, not security-sensitive.
+	"encoding/hex"
+	"fmt"
+	"log"
+	"sort"
+	"strconv"
+	"strings"
+	"unicode"
+
+	"github.com/IBM/sarama"
+	"github.com/chenrui333/terraformer/terraformutils"
+)
+
+type TopicGenerator struct {
+	Service
+}
+
+type Topic struct {
+	Name              string
+	Partitions        int32
+	ReplicationFactor int16
+	Config            map[string]string
+}
+
+var TopicAllowEmptyValues = []string{}
+
+func (g *TopicGenerator) InitResources() error {
+	config := g.Args["config"].(Config)
+	admin, err := g.admin(config)
+	if err != nil {
+		return err
+	}
+	defer func() {
+		if closeErr := admin.Close(); closeErr != nil {
+			log.Printf("kafka: close admin client: %v", closeErr)
+		}
+	}()
+
+	topics, err := g.listTopics(admin)
+	if err != nil {
+		return err
+	}
+	g.Resources = g.createResources(topics)
+	return nil
+}
+
+func (g *TopicGenerator) ParseFilter(rawFilter string) []terraformutils.ResourceFilter {
+	normalized := rawFilter
+	for _, prefix := range []string{"kafka_topic=", "topics="} {
+		if strings.HasPrefix(rawFilter, prefix) {
+			normalized = "topic=" + strings.TrimPrefix(rawFilter, prefix)
+			break
+		}
+	}
+	return g.Service.ParseFilter(normalized)
+}
+
+func (g *TopicGenerator) ParseFilters(rawFilters []string) {
+	g.Filter = []terraformutils.ResourceFilter{}
+	for _, rawFilter := range rawFilters {
+		g.Filter = append(g.Filter, g.ParseFilter(rawFilter)...)
+	}
+}
+
+func (g *TopicGenerator) listTopics(admin adminClient) ([]Topic, error) {
+	details, err := admin.ListTopics()
+	if err != nil {
+		return nil, err
+	}
+	if len(details) == 0 {
+		return nil, nil
+	}
+	names := make([]string, 0, len(details))
+	for name := range details {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+
+	topics := make([]Topic, 0, len(names))
+	for _, name := range names {
+		topic, err := g.topicFromDetail(admin, name, details[name])
+		if err != nil {
+			return nil, err
+		}
+		topics = append(topics, topic)
+	}
+	return topics, nil
+}
+
+func (g *TopicGenerator) topicFromDetail(admin adminClient, name string, detail sarama.TopicDetail) (Topic, error) {
+	partitions, replicationFactor, err := topicShapeFromDetail(detail)
+	if err != nil {
+		return Topic{}, fmt.Errorf("kafka topic %q: %w", name, err)
+	}
+	if partitions == 0 || replicationFactor == 0 {
+		metadata, err := admin.DescribeTopics([]string{name})
+		if err != nil {
+			return Topic{}, fmt.Errorf("kafka topic %q: describe metadata: %w", name, err)
+		}
+		partitions, replicationFactor, err = topicShapeFromMetadata(name, metadata)
+		if err != nil {
+			return Topic{}, err
+		}
+	}
+	config, err := topicConfig(admin, name)
+	if err != nil {
+		log.Printf("kafka: skipping topic config for %q: %v", name, err)
+		config = map[string]string{}
+	}
+	return Topic{
+		Name:              name,
+		Partitions:        partitions,
+		ReplicationFactor: replicationFactor,
+		Config:            config,
+	}, nil
+}
+
+func topicShapeFromDetail(detail sarama.TopicDetail) (int32, int16, error) {
+	partitions := detail.NumPartitions
+	replicationFactor := detail.ReplicationFactor
+	if partitions <= 0 && len(detail.ReplicaAssignment) > 0 {
+		partitions = int32(len(detail.ReplicaAssignment))
+	}
+	if replicationFactor <= 0 && len(detail.ReplicaAssignment) > 0 {
+		for _, replicas := range detail.ReplicaAssignment {
+			if len(replicas) == 0 {
+				continue
+			}
+			if replicationFactor == 0 || replicationFactor == -1 {
+				replicationFactor = int16(len(replicas))
+				continue
+			}
+			if replicationFactor != int16(len(replicas)) {
+				return 0, 0, fmt.Errorf("inconsistent replication factor %d != %d", replicationFactor, len(replicas))
+			}
+		}
+	}
+	if partitions < 0 {
+		partitions = 0
+	}
+	if replicationFactor < 0 {
+		replicationFactor = 0
+	}
+	return partitions, replicationFactor, nil
+}
+
+func topicShapeFromMetadata(name string, topics []*sarama.TopicMetadata) (int32, int16, error) {
+	for _, metadata := range topics {
+		if metadata == nil || metadata.Name != name {
+			continue
+		}
+		partitions := int32(len(metadata.Partitions))
+		var replicationFactor int16
+		for _, partition := range metadata.Partitions {
+			if partition == nil || len(partition.Replicas) == 0 {
+				continue
+			}
+			if replicationFactor == 0 {
+				replicationFactor = int16(len(partition.Replicas))
+				continue
+			}
+			if replicationFactor != int16(len(partition.Replicas)) {
+				return 0, 0, fmt.Errorf("kafka topic %q: inconsistent replication factor %d != %d", name, replicationFactor, len(partition.Replicas))
+			}
+		}
+		if partitions == 0 || replicationFactor == 0 {
+			return 0, 0, fmt.Errorf("kafka topic %q: could not determine partitions and replication factor", name)
+		}
+		return partitions, replicationFactor, nil
+	}
+	return 0, 0, fmt.Errorf("kafka topic %q: metadata not found", name)
+}
+
+func topicConfig(admin adminClient, name string) (map[string]string, error) {
+	entries, err := admin.DescribeConfig(sarama.ConfigResource{
+		Type: sarama.TopicResource,
+		Name: name,
+	})
+	if err != nil {
+		return nil, err
+	}
+	config := map[string]string{}
+	for _, entry := range entries {
+		if entry.Sensitive || isDefaultConfig(entry) || isForbiddenConfigName(entry.Name) {
+			continue
+		}
+		config[entry.Name] = entry.Value
+	}
+	return config, nil
+}
+
+func isDefaultConfig(entry sarama.ConfigEntry) bool {
+	return entry.Default ||
+		entry.Source == sarama.SourceDefault ||
+		entry.Source == sarama.SourceStaticBroker ||
+		entry.Source == sarama.SourceDynamicDefaultBroker
+}
+
+func isForbiddenConfigName(name string) bool {
+	lower := strings.ToLower(name)
+	for _, needle := range []string{
+		"password",
+		"private.key",
+		"access.key",
+		"secret.key",
+		"session.token",
+		"oauth.token",
+		"scram.password",
+	} {
+		if strings.Contains(lower, needle) {
+			return true
+		}
+	}
+	return false
+}
+
+func (g TopicGenerator) createResources(topics []Topic) []terraformutils.Resource {
+	resources := make([]terraformutils.Resource, 0, len(topics))
+	for _, topic := range topics {
+		attributes := map[string]string{
+			"name":               topic.Name,
+			"partitions":         strconv.Itoa(int(topic.Partitions)),
+			"replication_factor": strconv.Itoa(int(topic.ReplicationFactor)),
+		}
+		additionalFields := map[string]interface{}{}
+		if len(topic.Config) > 0 {
+			attributes["config.%"] = strconv.Itoa(len(topic.Config))
+			config := map[string]interface{}{}
+			for key, value := range topic.Config {
+				attributes["config."+key] = value
+				config[key] = value
+			}
+			additionalFields["config"] = config
+		}
+		resources = append(resources, terraformutils.NewResource(
+			topic.Name,
+			kafkaTopicResourceName(topic.Name),
+			"kafka_topic",
+			"kafka",
+			attributes,
+			TopicAllowEmptyValues,
+			additionalFields,
+		))
+	}
+	return resources
+}
+
+func kafkaTopicResourceName(topicName string) string {
+	hash := sha1.Sum([]byte(topicName))
+	return "topic_" + normalizeTopicResourceName(topicName) + "_" + hex.EncodeToString(hash[:4])
+}
+
+func normalizeTopicResourceName(topicName string) string {
+	var builder strings.Builder
+	for _, r := range topicName {
+		switch {
+		case r >= 'a' && r <= 'z', r >= 'A' && r <= 'Z', r >= '0' && r <= '9', r == '_', r == '-':
+			builder.WriteRune(r)
+		case unicode.IsSpace(r):
+			builder.WriteByte('_')
+		default:
+			builder.WriteString(fmt.Sprintf("_x%04X_", r))
+		}
+	}
+	name := strings.Trim(builder.String(), "_")
+	if name == "" {
+		return "topic"
+	}
+	return name
+}

--- a/providers/kafka/topic.go
+++ b/providers/kafka/topic.go
@@ -100,6 +100,13 @@ func (g *TopicGenerator) listTopics(admin adminClient, config Config) ([]Topic, 
 		if isInternalTopic(name) && !explicitTopics[name] {
 			continue
 		}
+		if topicMetadata.Err != sarama.ErrNoError {
+			if isSkippableTopicMetadataError(topicMetadata.Err) {
+				log.Printf("kafka: skipping topic metadata for %q: %v", name, topicMetadata.Err)
+				continue
+			}
+			return nil, fmt.Errorf("kafka topic %q: describe metadata: %w", name, topicMetadata.Err)
+		}
 		topic, err := g.topicFromMetadata(admin, topicMetadata, config)
 		if err != nil {
 			return nil, err
@@ -295,6 +302,15 @@ func isSkippableTopicConfigError(err error) bool {
 	return strings.Contains(lower, "authorization failed") ||
 		strings.Contains(lower, "not authorized") ||
 		strings.Contains(lower, "unsupported version")
+}
+
+func isSkippableTopicMetadataError(err error) bool {
+	if errors.Is(err, sarama.ErrTopicAuthorizationFailed) {
+		return true
+	}
+	lower := strings.ToLower(err.Error())
+	return strings.Contains(lower, "topic authorization failed") ||
+		strings.Contains(lower, "not authorized")
 }
 
 func topicConfig(admin adminClient, name string, providerConfig Config) (map[string]string, error) {

--- a/providers/kafka/topic.go
+++ b/providers/kafka/topic.go
@@ -26,7 +26,6 @@ type Topic struct {
 	Partitions        int32
 	ReplicationFactor int16
 	Config            map[string]string
-	ConfigUnavailable bool
 }
 
 var TopicAllowEmptyValues = []string{}
@@ -155,21 +154,18 @@ func (g *TopicGenerator) topicFromMetadata(admin adminClient, metadata *sarama.T
 		return Topic{}, err
 	}
 	config, err := topicConfig(admin, name, providerConfig)
-	configUnavailable := false
 	if err != nil {
 		if !isSkippableTopicConfigError(err) {
 			return Topic{}, fmt.Errorf("kafka topic %q: describe config: %w", name, err)
 		}
 		log.Printf("kafka: skipping topic config for %q: %v", name, err)
 		config = map[string]string{}
-		configUnavailable = true
 	}
 	return Topic{
 		Name:              name,
 		Partitions:        partitions,
 		ReplicationFactor: replicationFactor,
 		Config:            config,
-		ConfigUnavailable: configUnavailable,
 	}, nil
 }
 
@@ -189,21 +185,18 @@ func (g *TopicGenerator) topicFromDetail(admin adminClient, name string, detail 
 		}
 	}
 	config, err := topicConfig(admin, name, providerConfig)
-	configUnavailable := false
 	if err != nil {
 		if !isSkippableTopicConfigError(err) {
 			return Topic{}, fmt.Errorf("kafka topic %q: describe config: %w", name, err)
 		}
 		log.Printf("kafka: skipping topic config for %q: %v", name, err)
 		config = map[string]string{}
-		configUnavailable = true
 	}
 	return Topic{
 		Name:              name,
 		Partitions:        partitions,
 		ReplicationFactor: replicationFactor,
 		Config:            config,
-		ConfigUnavailable: configUnavailable,
 	}, nil
 }
 
@@ -389,11 +382,10 @@ func (g TopicGenerator) createResources(topics []Topic) []terraformutils.Resourc
 			"partitions":         strconv.Itoa(int(topic.Partitions)),
 			"replication_factor": strconv.Itoa(int(topic.ReplicationFactor)),
 		}
-		additionalFields := map[string]interface{}{}
-		if topic.ConfigUnavailable {
-			additionalFields["name"] = topic.Name
-			additionalFields["partitions"] = int(topic.Partitions)
-			additionalFields["replication_factor"] = int(topic.ReplicationFactor)
+		additionalFields := map[string]interface{}{
+			"name":               topic.Name,
+			"partitions":         int(topic.Partitions),
+			"replication_factor": int(topic.ReplicationFactor),
 		}
 		if len(topic.Config) > 0 {
 			attributes["config.%"] = strconv.Itoa(len(topic.Config))

--- a/providers/kafka/topic.go
+++ b/providers/kafka/topic.go
@@ -3,7 +3,7 @@
 package kafka
 
 import (
-	"crypto/sha1" //nolint:gosec // deterministic resource-name suffix, not security-sensitive.
+	"crypto/sha256"
 	"encoding/hex"
 	"fmt"
 	"log"
@@ -124,7 +124,11 @@ func topicShapeFromDetail(detail sarama.TopicDetail) (int32, int16, error) {
 	partitions := detail.NumPartitions
 	replicationFactor := detail.ReplicationFactor
 	if partitions <= 0 && len(detail.ReplicaAssignment) > 0 {
-		partitions = int32(len(detail.ReplicaAssignment))
+		converted, err := safePartitionCount(len(detail.ReplicaAssignment))
+		if err != nil {
+			return 0, 0, err
+		}
+		partitions = converted
 	}
 	if replicationFactor <= 0 && len(detail.ReplicaAssignment) > 0 {
 		for _, replicas := range detail.ReplicaAssignment {
@@ -132,10 +136,18 @@ func topicShapeFromDetail(detail sarama.TopicDetail) (int32, int16, error) {
 				continue
 			}
 			if replicationFactor == 0 || replicationFactor == -1 {
-				replicationFactor = int16(len(replicas))
+				converted, err := safeReplicationFactor(len(replicas))
+				if err != nil {
+					return 0, 0, err
+				}
+				replicationFactor = converted
 				continue
 			}
-			if replicationFactor != int16(len(replicas)) {
+			converted, err := safeReplicationFactor(len(replicas))
+			if err != nil {
+				return 0, 0, err
+			}
+			if replicationFactor != converted {
 				return 0, 0, fmt.Errorf("inconsistent replication factor %d != %d", replicationFactor, len(replicas))
 			}
 		}
@@ -154,17 +166,28 @@ func topicShapeFromMetadata(name string, topics []*sarama.TopicMetadata) (int32,
 		if metadata == nil || metadata.Name != name {
 			continue
 		}
-		partitions := int32(len(metadata.Partitions))
+		partitions, err := safePartitionCount(len(metadata.Partitions))
+		if err != nil {
+			return 0, 0, fmt.Errorf("kafka topic %q: %w", name, err)
+		}
 		var replicationFactor int16
 		for _, partition := range metadata.Partitions {
 			if partition == nil || len(partition.Replicas) == 0 {
 				continue
 			}
 			if replicationFactor == 0 {
-				replicationFactor = int16(len(partition.Replicas))
+				converted, err := safeReplicationFactor(len(partition.Replicas))
+				if err != nil {
+					return 0, 0, fmt.Errorf("kafka topic %q: %w", name, err)
+				}
+				replicationFactor = converted
 				continue
 			}
-			if replicationFactor != int16(len(partition.Replicas)) {
+			converted, err := safeReplicationFactor(len(partition.Replicas))
+			if err != nil {
+				return 0, 0, fmt.Errorf("kafka topic %q: %w", name, err)
+			}
+			if replicationFactor != converted {
 				return 0, 0, fmt.Errorf("kafka topic %q: inconsistent replication factor %d != %d", name, replicationFactor, len(partition.Replicas))
 			}
 		}
@@ -174,6 +197,24 @@ func topicShapeFromMetadata(name string, topics []*sarama.TopicMetadata) (int32,
 		return partitions, replicationFactor, nil
 	}
 	return 0, 0, fmt.Errorf("kafka topic %q: metadata not found", name)
+}
+
+func safePartitionCount(value int) (int32, error) {
+	const maxInt32 = 2147483647
+	if value > maxInt32 {
+		return 0, fmt.Errorf("partition count %d exceeds int32 max", value)
+	}
+	converted := int32(value) //nolint:gosec // value is bounds checked above.
+	return converted, nil
+}
+
+func safeReplicationFactor(value int) (int16, error) {
+	const maxInt16 = 32767
+	if value > maxInt16 {
+		return 0, fmt.Errorf("replication factor %d exceeds int16 max", value)
+	}
+	converted := int16(value) //nolint:gosec // value is bounds checked above.
+	return converted, nil
 }
 
 func topicConfig(admin adminClient, name string, providerConfig Config) (map[string]string, error) {
@@ -264,7 +305,7 @@ func (g TopicGenerator) createResources(topics []Topic) []terraformutils.Resourc
 }
 
 func kafkaTopicResourceName(topicName string) string {
-	hash := sha1.Sum([]byte(topicName))
+	hash := sha256.Sum256([]byte(topicName))
 	return "topic_" + normalizeTopicResourceName(topicName) + "_" + hex.EncodeToString(hash[:4])
 }
 
@@ -277,7 +318,7 @@ func normalizeTopicResourceName(topicName string) string {
 		case unicode.IsSpace(r):
 			builder.WriteByte('_')
 		default:
-			builder.WriteString(fmt.Sprintf("_x%04X_", r))
+			fmt.Fprintf(&builder, "_x%04X_", r)
 		}
 	}
 	name := strings.Trim(builder.String(), "_")

--- a/providers/kafka/topic.go
+++ b/providers/kafka/topic.go
@@ -83,6 +83,9 @@ func (g *TopicGenerator) listTopics(admin adminClient, config Config) ([]Topic, 
 
 	topics := make([]Topic, 0, len(names))
 	for _, name := range names {
+		if isInternalTopic(name) && !g.isExplicitlyRequestedTopic(name) {
+			continue
+		}
 		topic, err := g.topicFromDetail(admin, name, details[name], config)
 		if err != nil {
 			return nil, err
@@ -90,6 +93,24 @@ func (g *TopicGenerator) listTopics(admin adminClient, config Config) ([]Topic, 
 		topics = append(topics, topic)
 	}
 	return topics, nil
+}
+
+func isInternalTopic(name string) bool {
+	return strings.HasPrefix(name, "__")
+}
+
+func (g *TopicGenerator) isExplicitlyRequestedTopic(name string) bool {
+	for _, filter := range g.Filter {
+		if filter.FieldPath != "id" || !filter.IsApplicable("topic") {
+			continue
+		}
+		for _, value := range filter.AcceptableValues {
+			if value == name {
+				return true
+			}
+		}
+	}
+	return false
 }
 
 func (g *TopicGenerator) topicFromDetail(admin adminClient, name string, detail sarama.TopicDetail, providerConfig Config) (Topic, error) {

--- a/providers/kafka/topic.go
+++ b/providers/kafka/topic.go
@@ -26,6 +26,7 @@ type Topic struct {
 	Partitions        int32
 	ReplicationFactor int16
 	Config            map[string]string
+	ConfigUnavailable bool
 }
 
 var TopicAllowEmptyValues = []string{}
@@ -135,18 +136,21 @@ func (g *TopicGenerator) topicFromMetadata(admin adminClient, metadata *sarama.T
 		return Topic{}, err
 	}
 	config, err := topicConfig(admin, name, providerConfig)
+	configUnavailable := false
 	if err != nil {
 		if !isSkippableTopicConfigError(err) {
 			return Topic{}, fmt.Errorf("kafka topic %q: describe config: %w", name, err)
 		}
 		log.Printf("kafka: skipping topic config for %q: %v", name, err)
 		config = map[string]string{}
+		configUnavailable = true
 	}
 	return Topic{
 		Name:              name,
 		Partitions:        partitions,
 		ReplicationFactor: replicationFactor,
 		Config:            config,
+		ConfigUnavailable: configUnavailable,
 	}, nil
 }
 
@@ -166,18 +170,21 @@ func (g *TopicGenerator) topicFromDetail(admin adminClient, name string, detail 
 		}
 	}
 	config, err := topicConfig(admin, name, providerConfig)
+	configUnavailable := false
 	if err != nil {
 		if !isSkippableTopicConfigError(err) {
 			return Topic{}, fmt.Errorf("kafka topic %q: describe config: %w", name, err)
 		}
 		log.Printf("kafka: skipping topic config for %q: %v", name, err)
 		config = map[string]string{}
+		configUnavailable = true
 	}
 	return Topic{
 		Name:              name,
 		Partitions:        partitions,
 		ReplicationFactor: replicationFactor,
 		Config:            config,
+		ConfigUnavailable: configUnavailable,
 	}, nil
 }
 
@@ -355,6 +362,11 @@ func (g TopicGenerator) createResources(topics []Topic) []terraformutils.Resourc
 			"replication_factor": strconv.Itoa(int(topic.ReplicationFactor)),
 		}
 		additionalFields := map[string]interface{}{}
+		if topic.ConfigUnavailable {
+			additionalFields["name"] = topic.Name
+			additionalFields["partitions"] = int(topic.Partitions)
+			additionalFields["replication_factor"] = int(topic.ReplicationFactor)
+		}
 		if len(topic.Config) > 0 {
 			attributes["config.%"] = strconv.Itoa(len(topic.Config))
 			config := map[string]interface{}{}

--- a/providers/kafka/topic.go
+++ b/providers/kafka/topic.go
@@ -69,25 +69,37 @@ func (g *TopicGenerator) ParseFilters(rawFilters []string) {
 }
 
 func (g *TopicGenerator) listTopics(admin adminClient, config Config) ([]Topic, error) {
-	details, err := admin.ListTopics()
+	metadata, err := admin.DescribeTopics(nil)
 	if err != nil {
 		return nil, err
 	}
-	if len(details) == 0 {
+	if len(metadata) == 0 {
 		return nil, nil
 	}
-	names := make([]string, 0, len(details))
-	for name := range details {
-		names = append(names, name)
-	}
-	sort.Strings(names)
+	sort.Slice(metadata, func(i, j int) bool {
+		if metadata[i] == nil {
+			return false
+		}
+		if metadata[j] == nil {
+			return true
+		}
+		return metadata[i].Name < metadata[j].Name
+	})
 
-	topics := make([]Topic, 0, len(names))
-	for _, name := range names {
-		if isInternalTopic(name) && !g.isExplicitlyRequestedTopic(name) {
+	explicitTopics := g.explicitlyRequestedTopics()
+	topics := make([]Topic, 0, len(metadata))
+	for _, topicMetadata := range metadata {
+		if topicMetadata == nil {
 			continue
 		}
-		topic, err := g.topicFromDetail(admin, name, details[name], config)
+		name := topicMetadata.Name
+		if len(explicitTopics) > 0 && !explicitTopics[name] {
+			continue
+		}
+		if isInternalTopic(name) && !explicitTopics[name] {
+			continue
+		}
+		topic, err := g.topicFromMetadata(admin, topicMetadata, config)
 		if err != nil {
 			return nil, err
 		}
@@ -100,18 +112,42 @@ func isInternalTopic(name string) bool {
 	return strings.HasPrefix(name, "__")
 }
 
-func (g *TopicGenerator) isExplicitlyRequestedTopic(name string) bool {
+func (g *TopicGenerator) explicitlyRequestedTopics() map[string]bool {
+	explicitTopics := map[string]bool{}
 	for _, filter := range g.Filter {
 		if filter.FieldPath != "id" || !filter.IsApplicable("topic") {
 			continue
 		}
 		for _, value := range filter.AcceptableValues {
-			if value == name {
-				return true
-			}
+			explicitTopics[value] = true
 		}
 	}
-	return false
+	return explicitTopics
+}
+
+func (g *TopicGenerator) topicFromMetadata(admin adminClient, metadata *sarama.TopicMetadata, providerConfig Config) (Topic, error) {
+	name := metadata.Name
+	if metadata.Err != sarama.ErrNoError {
+		return Topic{}, fmt.Errorf("kafka topic %q: describe metadata: %w", name, metadata.Err)
+	}
+	partitions, replicationFactor, err := topicShapeFromMetadata(name, []*sarama.TopicMetadata{metadata})
+	if err != nil {
+		return Topic{}, err
+	}
+	config, err := topicConfig(admin, name, providerConfig)
+	if err != nil {
+		if !isSkippableTopicConfigError(err) {
+			return Topic{}, fmt.Errorf("kafka topic %q: describe config: %w", name, err)
+		}
+		log.Printf("kafka: skipping topic config for %q: %v", name, err)
+		config = map[string]string{}
+	}
+	return Topic{
+		Name:              name,
+		Partitions:        partitions,
+		ReplicationFactor: replicationFactor,
+		Config:            config,
+	}, nil
 }
 
 func (g *TopicGenerator) topicFromDetail(admin adminClient, name string, detail sarama.TopicDetail, providerConfig Config) (Topic, error) {

--- a/providers/kafka/topic_test.go
+++ b/providers/kafka/topic_test.go
@@ -1,0 +1,196 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package kafka
+
+import (
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/IBM/sarama"
+)
+
+type mockAdmin struct {
+	topics          map[string]sarama.TopicDetail
+	metadata        map[string]*sarama.TopicMetadata
+	configs         map[string][]sarama.ConfigEntry
+	describeConfigs []sarama.ConfigResource
+	closed          bool
+}
+
+func (m *mockAdmin) ListTopics() (map[string]sarama.TopicDetail, error) {
+	return m.topics, nil
+}
+
+func (m *mockAdmin) DescribeTopics(names []string) ([]*sarama.TopicMetadata, error) {
+	metadata := make([]*sarama.TopicMetadata, 0, len(names))
+	for _, name := range names {
+		if topicMetadata := m.metadata[name]; topicMetadata != nil {
+			metadata = append(metadata, topicMetadata)
+		}
+	}
+	return metadata, nil
+}
+
+func (m *mockAdmin) DescribeConfig(resource sarama.ConfigResource) ([]sarama.ConfigEntry, error) {
+	m.describeConfigs = append(m.describeConfigs, resource)
+	return m.configs[resource.Name], nil
+}
+
+func (m *mockAdmin) Close() error {
+	m.closed = true
+	return nil
+}
+
+func TestTopicInitResourcesConstructsResources(t *testing.T) {
+	admin := &mockAdmin{
+		topics: map[string]sarama.TopicDetail{
+			"payments.events": {
+				NumPartitions:     12,
+				ReplicationFactor: 3,
+			},
+		},
+		configs: map[string][]sarama.ConfigEntry{
+			"payments.events": {
+				{Name: "retention.ms", Value: "604800000", Source: sarama.SourceTopic},
+				{Name: "cleanup.policy", Value: "delete", Source: sarama.SourceDefault, Default: true},
+				{Name: "sasl.password", Value: "secret", Source: sarama.SourceTopic},
+			},
+		},
+	}
+	generator := &TopicGenerator{}
+	generator.SetArgs(map[string]interface{}{
+		"config": Config{BootstrapServers: []string{"broker1.example.com:9092"}},
+	})
+	generator.newAdmin = func(Config) (adminClient, error) { return admin, nil }
+
+	if err := generator.InitResources(); err != nil {
+		t.Fatalf("InitResources() error = %v", err)
+	}
+	if !admin.closed {
+		t.Fatal("admin client was not closed")
+	}
+	if len(generator.Resources) != 1 {
+		t.Fatalf("resources len = %d, want 1", len(generator.Resources))
+	}
+
+	resource := generator.Resources[0]
+	if resource.InstanceState.ID != "payments.events" {
+		t.Fatalf("resource ID = %q, want topic name", resource.InstanceState.ID)
+	}
+	if resource.InstanceInfo.Type != "kafka_topic" {
+		t.Fatalf("resource type = %q, want kafka_topic", resource.InstanceInfo.Type)
+	}
+	if got := resource.InstanceState.Attributes["name"]; got != "payments.events" {
+		t.Fatalf("name = %q, want payments.events", got)
+	}
+	if got := resource.InstanceState.Attributes["partitions"]; got != "12" {
+		t.Fatalf("partitions = %q, want 12", got)
+	}
+	if got := resource.InstanceState.Attributes["replication_factor"]; got != "3" {
+		t.Fatalf("replication_factor = %q, want 3", got)
+	}
+	if got := resource.InstanceState.Attributes["config.retention.ms"]; got != "604800000" {
+		t.Fatalf("config.retention.ms = %q, want 604800000", got)
+	}
+	if _, ok := resource.InstanceState.Attributes["config.sasl.password"]; ok {
+		t.Fatal("secret-looking topic config was exported")
+	}
+	if _, ok := resource.InstanceState.Attributes["config.cleanup.policy"]; ok {
+		t.Fatal("default topic config was exported")
+	}
+	if resource.ResourceName == "tfer--topic_payments.events" {
+		t.Fatalf("resource name was not normalized for punctuation: %q", resource.ResourceName)
+	}
+}
+
+func TestTopicInitResourcesEmptyList(t *testing.T) {
+	admin := &mockAdmin{topics: map[string]sarama.TopicDetail{}}
+	generator := &TopicGenerator{}
+	generator.SetArgs(map[string]interface{}{
+		"config": Config{BootstrapServers: []string{"broker1.example.com:9092"}},
+	})
+	generator.newAdmin = func(Config) (adminClient, error) { return admin, nil }
+
+	if err := generator.InitResources(); err != nil {
+		t.Fatalf("InitResources() error = %v", err)
+	}
+	if len(generator.Resources) != 0 {
+		t.Fatalf("resources len = %d, want 0", len(generator.Resources))
+	}
+}
+
+func TestTopicFallsBackToMetadataShape(t *testing.T) {
+	admin := &mockAdmin{
+		topics: map[string]sarama.TopicDetail{
+			"orders": {
+				NumPartitions:     -1,
+				ReplicationFactor: -1,
+			},
+		},
+		metadata: map[string]*sarama.TopicMetadata{
+			"orders": {
+				Name: "orders",
+				Partitions: []*sarama.PartitionMetadata{
+					{ID: 0, Replicas: []int32{1, 2}},
+					{ID: 1, Replicas: []int32{2, 3}},
+				},
+			},
+		},
+		configs: map[string][]sarama.ConfigEntry{"orders": nil},
+	}
+	generator := &TopicGenerator{}
+	topic, err := generator.topicFromDetail(admin, "orders", admin.topics["orders"])
+	if err != nil {
+		t.Fatalf("topicFromDetail() error = %v", err)
+	}
+	if topic.Partitions != 2 {
+		t.Fatalf("partitions = %d, want 2", topic.Partitions)
+	}
+	if topic.ReplicationFactor != 2 {
+		t.Fatalf("replication factor = %d, want 2", topic.ReplicationFactor)
+	}
+}
+
+func TestTopicIDFilterAliases(t *testing.T) {
+	generator := &TopicGenerator{}
+	generator.ParseFilters([]string{"topics=orders:payments.events"})
+	wantValues := []string{"orders", "payments.events"}
+	if len(generator.Filter) != 1 {
+		t.Fatalf("filter len = %d, want 1", len(generator.Filter))
+	}
+	if generator.Filter[0].ServiceName != "topic" {
+		t.Fatalf("filter service = %q, want topic", generator.Filter[0].ServiceName)
+	}
+	if generator.Filter[0].FieldPath != "id" {
+		t.Fatalf("filter field = %q, want id", generator.Filter[0].FieldPath)
+	}
+	if !reflect.DeepEqual(generator.Filter[0].AcceptableValues, wantValues) {
+		t.Fatalf("filter values = %#v, want %#v", generator.Filter[0].AcceptableValues, wantValues)
+	}
+
+	generator.Resources = generator.createResources([]Topic{
+		{Name: "orders", Partitions: 3, ReplicationFactor: 2},
+		{Name: "audit", Partitions: 1, ReplicationFactor: 1},
+	})
+	generator.InitialCleanup()
+	if len(generator.Resources) != 1 {
+		t.Fatalf("filtered resources len = %d, want 1", len(generator.Resources))
+	}
+	if generator.Resources[0].InstanceState.ID != "orders" {
+		t.Fatalf("remaining resource ID = %q, want orders", generator.Resources[0].InstanceState.ID)
+	}
+}
+
+func TestKafkaTopicResourceNameIsStableForPunctuation(t *testing.T) {
+	first := kafkaTopicResourceName("a.b_c-d/slash")
+	second := kafkaTopicResourceName("a.b_c-d/slash")
+	if first != second {
+		t.Fatalf("resource names are not stable: %q != %q", first, second)
+	}
+	for _, disallowed := range []string{".", "/"} {
+		if strings.Contains(first, disallowed) {
+			t.Fatalf("resource name = %q contains %q", first, disallowed)
+		}
+	}
+}

--- a/providers/kafka/topic_test.go
+++ b/providers/kafka/topic_test.go
@@ -3,6 +3,7 @@
 package kafka
 
 import (
+	"errors"
 	"reflect"
 	"strings"
 	"testing"
@@ -14,6 +15,7 @@ type mockAdmin struct {
 	topics          map[string]sarama.TopicDetail
 	metadata        map[string]*sarama.TopicMetadata
 	configs         map[string][]sarama.ConfigEntry
+	configErrors    map[string]error
 	describeConfigs []sarama.ConfigResource
 	closed          bool
 }
@@ -34,6 +36,9 @@ func (m *mockAdmin) DescribeTopics(names []string) ([]*sarama.TopicMetadata, err
 
 func (m *mockAdmin) DescribeConfig(resource sarama.ConfigResource) ([]sarama.ConfigEntry, error) {
 	m.describeConfigs = append(m.describeConfigs, resource)
+	if err := m.configErrors[resource.Name]; err != nil {
+		return nil, err
+	}
 	return m.configs[resource.Name], nil
 }
 
@@ -223,6 +228,58 @@ func TestTopicFallsBackToMetadataShape(t *testing.T) {
 	}
 	if topic.ReplicationFactor != 2 {
 		t.Fatalf("replication factor = %d, want 2", topic.ReplicationFactor)
+	}
+}
+
+func TestTopicConfigAuthorizationErrorIsSkippable(t *testing.T) {
+	admin := &mockAdmin{
+		topics: map[string]sarama.TopicDetail{
+			"orders": {
+				NumPartitions:     3,
+				ReplicationFactor: 2,
+			},
+		},
+		configErrors: map[string]error{"orders": sarama.ErrTopicAuthorizationFailed},
+	}
+	generator := &TopicGenerator{}
+	generator.SetArgs(map[string]interface{}{
+		"config": Config{BootstrapServers: []string{"broker1.example.com:9092"}},
+	})
+	generator.newAdmin = func(Config) (adminClient, error) { return admin, nil }
+
+	if err := generator.InitResources(); err != nil {
+		t.Fatalf("InitResources() error = %v", err)
+	}
+	if len(generator.Resources) != 1 {
+		t.Fatalf("resources len = %d, want 1", len(generator.Resources))
+	}
+	if _, ok := generator.Resources[0].InstanceState.Attributes["config.%"]; ok {
+		t.Fatal("topic config was exported after authorization failure")
+	}
+}
+
+func TestTopicConfigUnexpectedErrorFailsImport(t *testing.T) {
+	admin := &mockAdmin{
+		topics: map[string]sarama.TopicDetail{
+			"orders": {
+				NumPartitions:     3,
+				ReplicationFactor: 2,
+			},
+		},
+		configErrors: map[string]error{"orders": errors.New("broker connection reset")},
+	}
+	generator := &TopicGenerator{}
+	generator.SetArgs(map[string]interface{}{
+		"config": Config{BootstrapServers: []string{"broker1.example.com:9092"}},
+	})
+	generator.newAdmin = func(Config) (adminClient, error) { return admin, nil }
+
+	err := generator.InitResources()
+	if err == nil {
+		t.Fatal("expected unexpected topic config error")
+	}
+	if !strings.Contains(err.Error(), "describe config") {
+		t.Fatalf("error = %q, want describe config context", err)
 	}
 }
 

--- a/providers/kafka/topic_test.go
+++ b/providers/kafka/topic_test.go
@@ -140,7 +140,9 @@ func TestTopicFallsBackToMetadataShape(t *testing.T) {
 		configs: map[string][]sarama.ConfigEntry{"orders": nil},
 	}
 	generator := &TopicGenerator{}
-	topic, err := generator.topicFromDetail(admin, "orders", admin.topics["orders"])
+	topic, err := generator.topicFromDetail(admin, "orders", admin.topics["orders"], Config{
+		BootstrapServers: []string{"broker1.example.com:9092"},
+	})
 	if err != nil {
 		t.Fatalf("topicFromDetail() error = %v", err)
 	}
@@ -192,5 +194,47 @@ func TestKafkaTopicResourceNameIsStableForPunctuation(t *testing.T) {
 		if strings.Contains(first, disallowed) {
 			t.Fatalf("resource name = %q contains %q", first, disallowed)
 		}
+	}
+}
+
+func TestTopicConfigSkipsMSKServerlessSegmentBytes(t *testing.T) {
+	admin := &mockAdmin{
+		configs: map[string][]sarama.ConfigEntry{
+			"orders": {
+				{Name: "segment.bytes", Value: "104857600", Source: sarama.SourceTopic},
+				{Name: "retention.ms", Value: "604800000", Source: sarama.SourceTopic},
+			},
+		},
+	}
+	config, err := topicConfig(admin, "orders", Config{
+		BootstrapServers: []string{"boot-abcd.c1.kafka-serverless.us-east-1.amazonaws.com:9098"},
+	})
+	if err != nil {
+		t.Fatalf("topicConfig() error = %v", err)
+	}
+	if _, ok := config["segment.bytes"]; ok {
+		t.Fatal("MSK Serverless segment.bytes config was exported")
+	}
+	if got := config["retention.ms"]; got != "604800000" {
+		t.Fatalf("retention.ms = %q, want 604800000", got)
+	}
+}
+
+func TestTopicConfigKeepsSegmentBytesOutsideMSKServerless(t *testing.T) {
+	admin := &mockAdmin{
+		configs: map[string][]sarama.ConfigEntry{
+			"orders": {
+				{Name: "segment.bytes", Value: "104857600", Source: sarama.SourceTopic},
+			},
+		},
+	}
+	config, err := topicConfig(admin, "orders", Config{
+		BootstrapServers: []string{"broker1.example.com:9092"},
+	})
+	if err != nil {
+		t.Fatalf("topicConfig() error = %v", err)
+	}
+	if got := config["segment.bytes"]; got != "104857600" {
+		t.Fatalf("segment.bytes = %q, want 104857600", got)
 	}
 }

--- a/providers/kafka/topic_test.go
+++ b/providers/kafka/topic_test.go
@@ -335,6 +335,9 @@ func TestTopicInitResourcesIncludesExplicitInternalTopicFilter(t *testing.T) {
 	if err := generator.InitResources(); err != nil {
 		t.Fatalf("InitResources() error = %v", err)
 	}
+	if !reflect.DeepEqual(admin.describeTopics, [][]string{{"__consumer_offsets"}}) {
+		t.Fatalf("DescribeTopics calls = %#v, want only __consumer_offsets", admin.describeTopics)
+	}
 	generator.InitialCleanup()
 	if len(generator.Resources) != 1 {
 		t.Fatalf("resources len = %d, want 1", len(generator.Resources))
@@ -368,6 +371,9 @@ func TestTopicInitResourcesAppliesIDFilterBeforeConfigDescribe(t *testing.T) {
 
 	if err := generator.InitResources(); err != nil {
 		t.Fatalf("InitResources() error = %v", err)
+	}
+	if !reflect.DeepEqual(admin.describeTopics, [][]string{{"orders"}}) {
+		t.Fatalf("DescribeTopics calls = %#v, want only orders", admin.describeTopics)
 	}
 	if len(generator.Resources) != 1 {
 		t.Fatalf("resources len = %d, want 1", len(generator.Resources))

--- a/providers/kafka/topic_test.go
+++ b/providers/kafka/topic_test.go
@@ -5,11 +5,14 @@ package kafka
 import (
 	"errors"
 	"reflect"
+	"regexp"
 	"sort"
 	"strings"
 	"testing"
 
 	"github.com/IBM/sarama"
+	"github.com/chenrui333/terraformer/terraformutils"
+	"github.com/zclconf/go-cty/cty"
 )
 
 type mockAdmin struct {
@@ -397,6 +400,52 @@ func TestTopicConfigAuthorizationErrorIsSkippable(t *testing.T) {
 	}
 	if _, ok := generator.Resources[0].InstanceState.Attributes["config.%"]; ok {
 		t.Fatal("topic config was exported after authorization failure")
+	}
+	for key, want := range map[string]interface{}{
+		"name":               "orders",
+		"partitions":         3,
+		"replication_factor": 2,
+	} {
+		if got := generator.Resources[0].AdditionalFields[key]; got != want {
+			t.Fatalf("AdditionalFields[%q] = %#v, want %#v", key, got, want)
+		}
+	}
+}
+
+func TestTopicConfigAuthorizationPreservesRequiredFieldsAfterImportFallback(t *testing.T) {
+	resource := TopicGenerator{}.createResources([]Topic{{
+		Name:              "orders",
+		Partitions:        3,
+		ReplicationFactor: 2,
+		ConfigUnavailable: true,
+	}})[0]
+
+	resource.InstanceState.Attributes = map[string]string{"id": "orders"}
+	parser := terraformutils.NewFlatmapParser(
+		resource.InstanceState.Attributes,
+		[]*regexp.Regexp{regexp.MustCompile("^id$")},
+		nil,
+	)
+	if err := resource.ParseTFstate(parser, cty.Object(map[string]cty.Type{
+		"id":                 cty.String,
+		"name":               cty.String,
+		"partitions":         cty.Number,
+		"replication_factor": cty.Number,
+	})); err != nil {
+		t.Fatalf("ParseTFstate() error = %v", err)
+	}
+
+	for key, want := range map[string]interface{}{
+		"name":               "orders",
+		"partitions":         3,
+		"replication_factor": 2,
+	} {
+		if got := resource.Item[key]; got != want {
+			t.Fatalf("Item[%q] = %#v, want %#v", key, got, want)
+		}
+	}
+	if _, ok := resource.Item["id"]; ok {
+		t.Fatal("id attribute was not filtered from generated config item")
 	}
 }
 

--- a/providers/kafka/topic_test.go
+++ b/providers/kafka/topic_test.go
@@ -456,12 +456,11 @@ func TestTopicConfigAuthorizationErrorIsSkippable(t *testing.T) {
 	}
 }
 
-func TestTopicConfigAuthorizationPreservesRequiredFieldsAfterImportFallback(t *testing.T) {
+func TestTopicPreservesRequiredFieldsAfterImportFallback(t *testing.T) {
 	resource := TopicGenerator{}.createResources([]Topic{{
 		Name:              "orders",
 		Partitions:        3,
 		ReplicationFactor: 2,
-		ConfigUnavailable: true,
 	}})[0]
 
 	resource.InstanceState.Attributes = map[string]string{"id": "orders"}

--- a/providers/kafka/topic_test.go
+++ b/providers/kafka/topic_test.go
@@ -5,6 +5,7 @@ package kafka
 import (
 	"errors"
 	"reflect"
+	"sort"
 	"strings"
 	"testing"
 
@@ -16,22 +17,83 @@ type mockAdmin struct {
 	metadata        map[string]*sarama.TopicMetadata
 	configs         map[string][]sarama.ConfigEntry
 	configErrors    map[string]error
+	describeTopics  [][]string
 	describeConfigs []sarama.ConfigResource
 	closed          bool
 }
 
-func (m *mockAdmin) ListTopics() (map[string]sarama.TopicDetail, error) {
-	return m.topics, nil
-}
-
 func (m *mockAdmin) DescribeTopics(names []string) ([]*sarama.TopicMetadata, error) {
+	m.describeTopics = append(m.describeTopics, append([]string(nil), names...))
+	if len(names) == 0 {
+		names = m.topicNames()
+	}
 	metadata := make([]*sarama.TopicMetadata, 0, len(names))
 	for _, name := range names {
 		if topicMetadata := m.metadata[name]; topicMetadata != nil {
 			metadata = append(metadata, topicMetadata)
+			continue
+		}
+		if detail, ok := m.topics[name]; ok {
+			topicMetadata, err := topicMetadataFromDetail(name, detail)
+			if err != nil {
+				return nil, err
+			}
+			metadata = append(metadata, topicMetadata)
 		}
 	}
 	return metadata, nil
+}
+
+func (m *mockAdmin) topicNames() []string {
+	seen := map[string]struct{}{}
+	names := make([]string, 0, len(m.topics)+len(m.metadata))
+	for name := range m.topics {
+		seen[name] = struct{}{}
+		names = append(names, name)
+	}
+	for name := range m.metadata {
+		if _, ok := seen[name]; ok {
+			continue
+		}
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	return names
+}
+
+func topicMetadataFromDetail(name string, detail sarama.TopicDetail) (*sarama.TopicMetadata, error) {
+	partitions, replicationFactor, err := topicShapeFromDetail(detail)
+	if err != nil {
+		return nil, err
+	}
+	partitionMetadata := []*sarama.PartitionMetadata{}
+	if len(detail.ReplicaAssignment) > 0 {
+		partitionIDs := make([]int32, 0, len(detail.ReplicaAssignment))
+		for partitionID := range detail.ReplicaAssignment {
+			partitionIDs = append(partitionIDs, partitionID)
+		}
+		sort.Slice(partitionIDs, func(i, j int) bool {
+			return partitionIDs[i] < partitionIDs[j]
+		})
+		for _, partitionID := range partitionIDs {
+			partitionMetadata = append(partitionMetadata, &sarama.PartitionMetadata{
+				ID:       partitionID,
+				Replicas: detail.ReplicaAssignment[partitionID],
+			})
+		}
+		return &sarama.TopicMetadata{Name: name, Partitions: partitionMetadata}, nil
+	}
+	for partitionID := int32(0); partitionID < partitions; partitionID++ {
+		replicas := []int32{}
+		for replicaID := int16(0); replicaID < replicationFactor; replicaID++ {
+			replicas = append(replicas, int32(replicaID)+1)
+		}
+		partitionMetadata = append(partitionMetadata, &sarama.PartitionMetadata{
+			ID:       partitionID,
+			Replicas: replicas,
+		})
+	}
+	return &sarama.TopicMetadata{Name: name, Partitions: partitionMetadata}, nil
 }
 
 func (m *mockAdmin) DescribeConfig(resource sarama.ConfigResource) ([]sarama.ConfigEntry, error) {
@@ -125,6 +187,49 @@ func TestTopicInitResourcesEmptyList(t *testing.T) {
 	}
 }
 
+func TestTopicInitResourcesDoesNotRequireConfigsForMetadataListing(t *testing.T) {
+	admin := &mockAdmin{
+		metadata: map[string]*sarama.TopicMetadata{
+			"orders": {
+				Name: "orders",
+				Partitions: []*sarama.PartitionMetadata{
+					{ID: 0, Replicas: []int32{1, 2}},
+					{ID: 1, Replicas: []int32{1, 2}},
+				},
+			},
+		},
+		configErrors: map[string]error{"orders": sarama.ErrTopicAuthorizationFailed},
+	}
+	generator := &TopicGenerator{}
+	generator.SetArgs(map[string]interface{}{
+		"config": Config{BootstrapServers: []string{"broker1.example.com:9092"}},
+	})
+	generator.newAdmin = func(Config) (adminClient, error) { return admin, nil }
+
+	if err := generator.InitResources(); err != nil {
+		t.Fatalf("InitResources() error = %v", err)
+	}
+	if len(admin.describeTopics) != 1 || admin.describeTopics[0] != nil {
+		t.Fatalf("DescribeTopics calls = %#v, want one all-topic metadata call", admin.describeTopics)
+	}
+	if len(generator.Resources) != 1 {
+		t.Fatalf("resources len = %d, want 1", len(generator.Resources))
+	}
+	resource := generator.Resources[0]
+	if resource.InstanceState.ID != "orders" {
+		t.Fatalf("resource ID = %q, want orders", resource.InstanceState.ID)
+	}
+	if got := resource.InstanceState.Attributes["partitions"]; got != "2" {
+		t.Fatalf("partitions = %q, want 2", got)
+	}
+	if got := resource.InstanceState.Attributes["replication_factor"]; got != "2" {
+		t.Fatalf("replication_factor = %q, want 2", got)
+	}
+	if _, ok := resource.InstanceState.Attributes["config.%"]; ok {
+		t.Fatal("topic config was exported after authorization failure")
+	}
+}
+
 func TestTopicInitResourcesSkipsInternalTopicsByDefault(t *testing.T) {
 	admin := &mockAdmin{
 		topics: map[string]sarama.TopicDetail{
@@ -140,6 +245,7 @@ func TestTopicInitResourcesSkipsInternalTopicsByDefault(t *testing.T) {
 		configs: map[string][]sarama.ConfigEntry{
 			"orders": nil,
 		},
+		configErrors: map[string]error{"__consumer_offsets": errors.New("internal topic config should not be described")},
 	}
 	generator := &TopicGenerator{}
 	generator.SetArgs(map[string]interface{}{
@@ -194,6 +300,42 @@ func TestTopicInitResourcesIncludesExplicitInternalTopicFilter(t *testing.T) {
 	}
 	if generator.Resources[0].InstanceState.ID != "__consumer_offsets" {
 		t.Fatalf("resource ID = %q, want __consumer_offsets", generator.Resources[0].InstanceState.ID)
+	}
+}
+
+func TestTopicInitResourcesAppliesIDFilterBeforeConfigDescribe(t *testing.T) {
+	admin := &mockAdmin{
+		topics: map[string]sarama.TopicDetail{
+			"orders": {
+				NumPartitions:     3,
+				ReplicationFactor: 2,
+			},
+			"payments": {
+				NumPartitions:     6,
+				ReplicationFactor: 3,
+			},
+		},
+		configs:      map[string][]sarama.ConfigEntry{"orders": nil},
+		configErrors: map[string]error{"payments": errors.New("unfiltered topic config should not be described")},
+	}
+	generator := &TopicGenerator{}
+	generator.SetArgs(map[string]interface{}{
+		"config": Config{BootstrapServers: []string{"broker1.example.com:9092"}},
+	})
+	generator.ParseFilters([]string{"topics=orders"})
+	generator.newAdmin = func(Config) (adminClient, error) { return admin, nil }
+
+	if err := generator.InitResources(); err != nil {
+		t.Fatalf("InitResources() error = %v", err)
+	}
+	if len(generator.Resources) != 1 {
+		t.Fatalf("resources len = %d, want 1", len(generator.Resources))
+	}
+	if generator.Resources[0].InstanceState.ID != "orders" {
+		t.Fatalf("resource ID = %q, want orders", generator.Resources[0].InstanceState.ID)
+	}
+	if len(admin.describeConfigs) != 1 || admin.describeConfigs[0].Name != "orders" {
+		t.Fatalf("DescribeConfig calls = %#v, want only orders", admin.describeConfigs)
 	}
 }
 

--- a/providers/kafka/topic_test.go
+++ b/providers/kafka/topic_test.go
@@ -120,6 +120,78 @@ func TestTopicInitResourcesEmptyList(t *testing.T) {
 	}
 }
 
+func TestTopicInitResourcesSkipsInternalTopicsByDefault(t *testing.T) {
+	admin := &mockAdmin{
+		topics: map[string]sarama.TopicDetail{
+			"orders": {
+				NumPartitions:     3,
+				ReplicationFactor: 2,
+			},
+			"__consumer_offsets": {
+				NumPartitions:     50,
+				ReplicationFactor: 3,
+			},
+		},
+		configs: map[string][]sarama.ConfigEntry{
+			"orders": nil,
+		},
+	}
+	generator := &TopicGenerator{}
+	generator.SetArgs(map[string]interface{}{
+		"config": Config{BootstrapServers: []string{"broker1.example.com:9092"}},
+	})
+	generator.newAdmin = func(Config) (adminClient, error) { return admin, nil }
+
+	if err := generator.InitResources(); err != nil {
+		t.Fatalf("InitResources() error = %v", err)
+	}
+	if len(generator.Resources) != 1 {
+		t.Fatalf("resources len = %d, want 1", len(generator.Resources))
+	}
+	if generator.Resources[0].InstanceState.ID != "orders" {
+		t.Fatalf("resource ID = %q, want orders", generator.Resources[0].InstanceState.ID)
+	}
+	if len(admin.describeConfigs) != 1 || admin.describeConfigs[0].Name != "orders" {
+		t.Fatalf("DescribeConfig calls = %#v, want only orders", admin.describeConfigs)
+	}
+}
+
+func TestTopicInitResourcesIncludesExplicitInternalTopicFilter(t *testing.T) {
+	admin := &mockAdmin{
+		topics: map[string]sarama.TopicDetail{
+			"orders": {
+				NumPartitions:     3,
+				ReplicationFactor: 2,
+			},
+			"__consumer_offsets": {
+				NumPartitions:     50,
+				ReplicationFactor: 3,
+			},
+		},
+		configs: map[string][]sarama.ConfigEntry{
+			"orders":             nil,
+			"__consumer_offsets": nil,
+		},
+	}
+	generator := &TopicGenerator{}
+	generator.SetArgs(map[string]interface{}{
+		"config": Config{BootstrapServers: []string{"broker1.example.com:9092"}},
+	})
+	generator.ParseFilters([]string{"topics=__consumer_offsets"})
+	generator.newAdmin = func(Config) (adminClient, error) { return admin, nil }
+
+	if err := generator.InitResources(); err != nil {
+		t.Fatalf("InitResources() error = %v", err)
+	}
+	generator.InitialCleanup()
+	if len(generator.Resources) != 1 {
+		t.Fatalf("resources len = %d, want 1", len(generator.Resources))
+	}
+	if generator.Resources[0].InstanceState.ID != "__consumer_offsets" {
+		t.Fatalf("resource ID = %q, want __consumer_offsets", generator.Resources[0].InstanceState.ID)
+	}
+}
+
 func TestTopicFallsBackToMetadataShape(t *testing.T) {
 	admin := &mockAdmin{
 		topics: map[string]sarama.TopicDetail{

--- a/providers/kafka/topic_test.go
+++ b/providers/kafka/topic_test.go
@@ -233,6 +233,44 @@ func TestTopicInitResourcesDoesNotRequireConfigsForMetadataListing(t *testing.T)
 	}
 }
 
+func TestTopicInitResourcesSkipsUnauthorizedMetadataEntries(t *testing.T) {
+	admin := &mockAdmin{
+		metadata: map[string]*sarama.TopicMetadata{
+			"orders": {
+				Name: "orders",
+				Partitions: []*sarama.PartitionMetadata{
+					{ID: 0, Replicas: []int32{1, 2}},
+					{ID: 1, Replicas: []int32{1, 2}},
+				},
+			},
+			"private": {
+				Name: "private",
+				Err:  sarama.ErrTopicAuthorizationFailed,
+			},
+		},
+		configs:      map[string][]sarama.ConfigEntry{"orders": nil},
+		configErrors: map[string]error{"private": errors.New("unauthorized topic config should not be described")},
+	}
+	generator := &TopicGenerator{}
+	generator.SetArgs(map[string]interface{}{
+		"config": Config{BootstrapServers: []string{"broker1.example.com:9092"}},
+	})
+	generator.newAdmin = func(Config) (adminClient, error) { return admin, nil }
+
+	if err := generator.InitResources(); err != nil {
+		t.Fatalf("InitResources() error = %v", err)
+	}
+	if len(generator.Resources) != 1 {
+		t.Fatalf("resources len = %d, want 1", len(generator.Resources))
+	}
+	if generator.Resources[0].InstanceState.ID != "orders" {
+		t.Fatalf("resource ID = %q, want orders", generator.Resources[0].InstanceState.ID)
+	}
+	if len(admin.describeConfigs) != 1 || admin.describeConfigs[0].Name != "orders" {
+		t.Fatalf("DescribeConfig calls = %#v, want only orders", admin.describeConfigs)
+	}
+}
+
 func TestTopicInitResourcesSkipsInternalTopicsByDefault(t *testing.T) {
 	admin := &mockAdmin{
 		topics: map[string]sarama.TopicDetail{

--- a/terraformutils/provider_source.go
+++ b/terraformutils/provider_source.go
@@ -24,6 +24,7 @@ var providerSources = map[string]string{
 	"honeycombio":   "honeycombio/honeycombio",
 	"ibm":           "IBM-Cloud/ibm",
 	"ionoscloud":    "ionos-cloud/ionoscloud",
+	"kafka":         "Mongey/kafka",
 	"keycloak":      "keycloak/keycloak",
 	"launchdarkly":  "launchdarkly/launchdarkly",
 	"linode":        "linode/linode",

--- a/terraformutils/provider_source_test.go
+++ b/terraformutils/provider_source_test.go
@@ -31,6 +31,7 @@ func TestProviderSource(t *testing.T) {
 		"honeycombio":                 "honeycombio/honeycombio",
 		"ibm":                         "IBM-Cloud/ibm",
 		"ionoscloud":                  "ionos-cloud/ionoscloud",
+		"kafka":                       "Mongey/kafka",
 		"keycloak":                    "keycloak/keycloak",
 		"kubernetes":                  "hashicorp/kubernetes",
 		"launchdarkly":                "launchdarkly/launchdarkly",


### PR DESCRIPTION
## Summary

Add initial Terraformer provider support for Kafka using the upstream `Mongey/kafka` Terraform provider.

This PR adds:

- Kafka provider skeleton
- provider command wiring
- provider source mapping for `Mongey/kafka`
- `kafka_topic` import support
- docs for Kafka provider usage
- provider/source/topic tests

## Implementation

- Discovers Kafka topics through Kafka admin APIs.
- Seeds topic import IDs using topic names.
- Seeds required topic fields for Terraform provider refresh, including partitions, replication factor, and non-default config where available.
- Keeps auth/secrets out of generated HCL.

## Security

Terraformer must not export or synthesize:

- SASL passwords
- SCRAM passwords
- TLS private keys
- AWS access keys
- AWS secret keys
- AWS session tokens
- OAuth tokens

Provider authentication should rely on environment variables, profiles, or existing provider config paths.

## Follow-ups

- `kafka_acl` import support
- `kafka_quota` importer audit
- `kafka_user_scram_credential` secret/write-only audit and unsupported metadata if needed

## Validation

- `go test ./providers/kafka/...`
- `go test ./terraformutils/...`
- `go test ./cmd/...`
- `git diff --check`

Ref: Kafka provider support tracking issue draft

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a `kafka` provider with `kafka_topic` imports using `Mongey/kafka`, covering topic discovery, safe config export, and always preserving topic shape (name, partitions, replication factor) when configs can’t be read or during TF state fallback. Skips unauthorized topic metadata, lists only filtered topics directly, applies filters before describing configs, and never writes secrets to HCL.

- **New Features**
  - New `kafka` provider and import subcommand; provider source mapped to `Mongey/kafka`.
  - Topic discovery via admin APIs; imports partitions, replication factor, and non-default config.
  - Skips internal topics (`__*`) unless explicitly filtered; skips topics with metadata authorization errors.
  - Describes configs only for filtered/selected topics and queries filtered topics directly; on config access denied/unsupported, imports topic shape and omits config; keeps required topic shape even on state fallback.
  - Auth via CLI/env: TLS, SASL (PLAIN/SCRAM/`aws-iam`), OAuth bearer via token URL. MSK Serverless: skip unsupported configs (e.g., `segment.bytes`). Added docs (`docs/kafka.md`) and tests.

- **Dependencies**
  - Add `github.com/IBM/sarama`, `github.com/aws/aws-msk-iam-sasl-signer-go`, and related Kafka/AWS/OAuth deps; make `github.com/xdg-go/scram` a direct dependency.

<sup>Written for commit 95fca5b7f6ce366d98ab72925d52335b291dd5f3. Summary will update on new commits. <a href="https://cubic.dev/pr/chenrui333/terraformer/pull/466?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added Kafka provider for importing Kafka topics into Terraform configurations
  * Supports multiple authentication methods: TLS, SASL (plain, SCRAM, AWS MSK IAM), and OAuth bearer tokens

* **Documentation**
  * Added Kafka provider usage guide with configuration examples and supported services

* **Chores**
  * Updated dependencies to support Kafka integration

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/chenrui333/terraformer/pull/466?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->