### PR TITLE
feat(cloudflare): add storage queue and Hyperdrive imports

### DIFF
--- a/providers/cloudflare/storage.go
+++ b/providers/cloudflare/storage.go
@@ -83,6 +83,12 @@ type cloudflareStorageChildDiscovery struct {
 	discover func() error
 }
 
+type cloudflareStorageFamilyDiscovery struct {
+	name     string
+	account  string
+	discover func() error
+}
+
 func runCloudflareStorageChildDiscoveries(discoveries []cloudflareStorageChildDiscovery) {
 	for _, discovery := range discoveries {
 		if discovery.discover == nil {
@@ -92,6 +98,28 @@ func runCloudflareStorageChildDiscoveries(discoveries []cloudflareStorageChildDi
 			log.Printf("Skipping Cloudflare storage %s discovery for %s: %v", discovery.name, discovery.parent, err)
 		}
 	}
+}
+
+func runCloudflareStorageFamilyDiscoveries(discoveries []cloudflareStorageFamilyDiscovery) error {
+	successes := 0
+	var firstErr error
+	for _, discovery := range discoveries {
+		if discovery.discover == nil {
+			continue
+		}
+		if err := discovery.discover(); err != nil {
+			if firstErr == nil {
+				firstErr = err
+			}
+			log.Printf("Skipping Cloudflare storage %s discovery for %s: %v", discovery.name, discovery.account, err)
+			continue
+		}
+		successes++
+	}
+	if successes == 0 && firstErr != nil {
+		return firstErr
+	}
+	return nil
 }
 
 func cloudflareUnsupportedJurisdictionError(err error) bool {
@@ -729,15 +757,34 @@ func (g *StorageGenerator) InitResources() error {
 	if err != nil {
 		return err
 	}
-	for _, f := range []func(context.Context, *cf.API, string) error{
-		g.appendWorkersKVNamespaceResources,
-		g.appendQueueResources,
-		g.appendR2BucketResources,
-		g.appendD1DatabaseResources,
-	} {
-		if err := f(ctx, api, account.Identifier); err != nil {
-			return err
-		}
-	}
-	return nil
+	return runCloudflareStorageFamilyDiscoveries([]cloudflareStorageFamilyDiscovery{
+		{
+			name:    "Workers KV namespaces",
+			account: account.Identifier,
+			discover: func() error {
+				return g.appendWorkersKVNamespaceResources(ctx, api, account.Identifier)
+			},
+		},
+		{
+			name:    "queues",
+			account: account.Identifier,
+			discover: func() error {
+				return g.appendQueueResources(ctx, api, account.Identifier)
+			},
+		},
+		{
+			name:    "R2 buckets",
+			account: account.Identifier,
+			discover: func() error {
+				return g.appendR2BucketResources(ctx, api, account.Identifier)
+			},
+		},
+		{
+			name:    "D1 databases",
+			account: account.Identifier,
+			discover: func() error {
+				return g.appendD1DatabaseResources(ctx, api, account.Identifier)
+			},
+		},
+	})
 }

--- a/providers/cloudflare/storage.go
+++ b/providers/cloudflare/storage.go
@@ -84,9 +84,10 @@ type cloudflareStorageChildDiscovery struct {
 }
 
 type cloudflareStorageFamilyDiscovery struct {
-	name     string
-	account  string
-	discover func() error
+	name      string
+	account   string
+	resources *[]terraformutils.Resource
+	discover  func() error
 }
 
 func runCloudflareStorageChildDiscoveries(discoveries []cloudflareStorageChildDiscovery) {
@@ -107,7 +108,14 @@ func runCloudflareStorageFamilyDiscoveries(discoveries []cloudflareStorageFamily
 		if discovery.discover == nil {
 			continue
 		}
+		resourceCount := 0
+		if discovery.resources != nil {
+			resourceCount = len(*discovery.resources)
+		}
 		if err := discovery.discover(); err != nil {
+			if discovery.resources != nil && resourceCount <= len(*discovery.resources) {
+				*discovery.resources = (*discovery.resources)[:resourceCount]
+			}
 			if firstErr == nil {
 				firstErr = err
 			}
@@ -759,29 +767,33 @@ func (g *StorageGenerator) InitResources() error {
 	}
 	return runCloudflareStorageFamilyDiscoveries([]cloudflareStorageFamilyDiscovery{
 		{
-			name:    "Workers KV namespaces",
-			account: account.Identifier,
+			name:      "Workers KV namespaces",
+			account:   account.Identifier,
+			resources: &g.Resources,
 			discover: func() error {
 				return g.appendWorkersKVNamespaceResources(ctx, api, account.Identifier)
 			},
 		},
 		{
-			name:    "queues",
-			account: account.Identifier,
+			name:      "queues",
+			account:   account.Identifier,
+			resources: &g.Resources,
 			discover: func() error {
 				return g.appendQueueResources(ctx, api, account.Identifier)
 			},
 		},
 		{
-			name:    "R2 buckets",
-			account: account.Identifier,
+			name:      "R2 buckets",
+			account:   account.Identifier,
+			resources: &g.Resources,
 			discover: func() error {
 				return g.appendR2BucketResources(ctx, api, account.Identifier)
 			},
 		},
 		{
-			name:    "D1 databases",
-			account: account.Identifier,
+			name:      "D1 databases",
+			account:   account.Identifier,
+			resources: &g.Resources,
 			discover: func() error {
 				return g.appendD1DatabaseResources(ctx, api, account.Identifier)
 			},

--- a/providers/cloudflare/storage_test.go
+++ b/providers/cloudflare/storage_test.go
@@ -40,20 +40,25 @@ func TestRunCloudflareStorageChildDiscoveriesContinuesAfterError(t *testing.T) {
 
 func TestRunCloudflareStorageFamilyDiscoveriesContinuesAfterError(t *testing.T) {
 	calls := []string{}
+	resources := []terraformutils.Resource{}
 	err := runCloudflareStorageFamilyDiscoveries([]cloudflareStorageFamilyDiscovery{
 		{
-			name:    "queues",
-			account: "account-id",
+			name:      "queues",
+			account:   "account-id",
+			resources: &resources,
 			discover: func() error {
 				calls = append(calls, "queues")
+				resources = append(resources, terraformutils.NewResource("partial-queue", "partial_queue", "cloudflare_queue", "cloudflare", nil, nil, nil))
 				return errors.New("permission denied")
 			},
 		},
 		{
-			name:    "R2 buckets",
-			account: "account-id",
+			name:      "R2 buckets",
+			account:   "account-id",
+			resources: &resources,
 			discover: func() error {
 				calls = append(calls, "r2")
+				resources = append(resources, terraformutils.NewResource("complete-r2", "complete_r2", "cloudflare_r2_bucket", "cloudflare", nil, nil, nil))
 				return nil
 			},
 		},
@@ -65,28 +70,39 @@ func TestRunCloudflareStorageFamilyDiscoveriesContinuesAfterError(t *testing.T) 
 	if len(calls) != 2 || calls[0] != "queues" || calls[1] != "r2" {
 		t.Fatalf("discoveries called in order = %#v, want [queues r2]", calls)
 	}
+	if len(resources) != 1 || resources[0].InstanceState.ID != "complete-r2" {
+		t.Fatalf("resources after rollback = %#v, want only complete-r2", resources)
+	}
 }
 
 func TestRunCloudflareStorageFamilyDiscoveriesReturnsErrorWhenAllFail(t *testing.T) {
 	wantErr := errors.New("permission denied")
+	resources := []terraformutils.Resource{}
 	err := runCloudflareStorageFamilyDiscoveries([]cloudflareStorageFamilyDiscovery{
 		{
-			name:    "queues",
-			account: "account-id",
+			name:      "queues",
+			account:   "account-id",
+			resources: &resources,
 			discover: func() error {
+				resources = append(resources, terraformutils.NewResource("partial-queue", "partial_queue", "cloudflare_queue", "cloudflare", nil, nil, nil))
 				return wantErr
 			},
 		},
 		{
-			name:    "R2 buckets",
-			account: "account-id",
+			name:      "R2 buckets",
+			account:   "account-id",
+			resources: &resources,
 			discover: func() error {
+				resources = append(resources, terraformutils.NewResource("partial-r2", "partial_r2", "cloudflare_r2_bucket", "cloudflare", nil, nil, nil))
 				return errors.New("forbidden")
 			},
 		},
 	})
 	if !errors.Is(err, wantErr) {
 		t.Fatalf("runCloudflareStorageFamilyDiscoveries() error = %v, want %v", err, wantErr)
+	}
+	if len(resources) != 0 {
+		t.Fatalf("resources after all failed discoveries = %#v, want none", resources)
 	}
 }
 

--- a/providers/cloudflare/storage_test.go
+++ b/providers/cloudflare/storage_test.go
@@ -38,6 +38,58 @@ func TestRunCloudflareStorageChildDiscoveriesContinuesAfterError(t *testing.T) {
 	}
 }
 
+func TestRunCloudflareStorageFamilyDiscoveriesContinuesAfterError(t *testing.T) {
+	calls := []string{}
+	err := runCloudflareStorageFamilyDiscoveries([]cloudflareStorageFamilyDiscovery{
+		{
+			name:    "queues",
+			account: "account-id",
+			discover: func() error {
+				calls = append(calls, "queues")
+				return errors.New("permission denied")
+			},
+		},
+		{
+			name:    "R2 buckets",
+			account: "account-id",
+			discover: func() error {
+				calls = append(calls, "r2")
+				return nil
+			},
+		},
+		{name: "nil discoverer", account: "account-id"},
+	})
+	if err != nil {
+		t.Fatalf("runCloudflareStorageFamilyDiscoveries() error = %v, want nil", err)
+	}
+	if len(calls) != 2 || calls[0] != "queues" || calls[1] != "r2" {
+		t.Fatalf("discoveries called in order = %#v, want [queues r2]", calls)
+	}
+}
+
+func TestRunCloudflareStorageFamilyDiscoveriesReturnsErrorWhenAllFail(t *testing.T) {
+	wantErr := errors.New("permission denied")
+	err := runCloudflareStorageFamilyDiscoveries([]cloudflareStorageFamilyDiscovery{
+		{
+			name:    "queues",
+			account: "account-id",
+			discover: func() error {
+				return wantErr
+			},
+		},
+		{
+			name:    "R2 buckets",
+			account: "account-id",
+			discover: func() error {
+				return errors.New("forbidden")
+			},
+		},
+	})
+	if !errors.Is(err, wantErr) {
+		t.Fatalf("runCloudflareStorageFamilyDiscoveries() error = %v, want %v", err, wantErr)
+	}
+}
+
 func TestNewCloudflareQueueConsumerResource(t *testing.T) {
 	queue := cf.Queue{ID: "queue-id", Name: "orders"}
 	consumer := cloudflareQueueConsumer{

--- a/providers/cloudflare/unsupported_resources.json
+++ b/providers/cloudflare/unsupported_resources.json
@@ -71,7 +71,7 @@
       "resource": "cloudflare_hyperdrive_config",
       "service_family": "storage",
       "reason": "Hyperdrive configs require write-only origin credential material.",
-      "evidence": "Terraform provider v5.19.1 requires origin.password and documents it as Sensitive with the API never returning this write-only value. origin.access_client_secret is also Sensitive and write-only when Cloudflare Access credentials are configured.",
+      "evidence": "Terraform provider v5.19.1 requires origin.password and documents it as Sensitive with the API never returning this write-only value. The provider read path can only preserve write-only origin.password and origin.access_client_secret from prior state, which broad Terraformer discovery does not have.",
       "status": "secret-required",
       "references": [
         "https://github.com/chenrui333/terraformer/issues/335",


### PR DESCRIPTION
## Summary

Add Terraformer import support for high-confidence Cloudflare storage, queue, and Hyperdrive resources.

## Resources

No new resource types were added. Current `origin/main` already includes the high-confidence storage and queue resources from prior Cloudflare storage work:

- `cloudflare_d1_database`
- `cloudflare_queue`
- `cloudflare_queue_consumer`
- `cloudflare_r2_bucket`
- `cloudflare_r2_bucket_cors`
- `cloudflare_r2_bucket_event_notification`
- `cloudflare_r2_bucket_lifecycle`
- `cloudflare_r2_bucket_lock`
- `cloudflare_r2_custom_domain`
- `cloudflare_r2_data_catalog`
- `cloudflare_workers_kv_namespace`

This PR hardens those storage imports by keeping independent storage-family discovery best-effort when one family endpoint is unavailable while still surfacing an error when every storage family fails.

## Implementation Notes

- Uses provider-compatible import IDs.
- Exhausts pagination where applicable.
- Seeds required fields for provider refresh.
- Keeps optional or permission-sensitive lookups best-effort where appropriate.
- Does not import high-cardinality content records or resources requiring unrecoverable secret/source material.

## Deferred / Unsupported

Updated `cloudflare_hyperdrive_config` evidence: Hyperdrive remains unsupported because provider v5.19.1 requires write-only `origin.password`; the provider read path can only preserve `origin.password` and `origin.access_client_secret` from prior state, which broad Terraformer discovery does not have.

Existing storage deferred/unsupported decisions remain in force:

- `cloudflare_hyperdrive_config`: write-only origin credentials.
- `cloudflare_r2_bucket_sippy`: source/destination secret material and no provider import support.
- `cloudflare_r2_managed_domain`: no usable provider import/read path.
- `cloudflare_workers_kv`: high-cardinality KV content records.

## Scope

This PR is intentionally limited to storage/queues/Hyperdrive.

Not included:

- Zero Trust Gateway resources
- zone/account settings resources
- Workers script/version/deployment/body resources
- Workers KV individual key/value records
- API Shield/bot/page shield resources
- media/platform long-tail resources
- network edge resources

## Validation

- `go test ./providers/cloudflare/...`
- `go test ./cmd/...`
- `go test ./providers -run 'TestUnsupportedResourcesMetadata|TestUnsupportedResourceStatusesAreDocumented' -count=1`
- `jq . providers/cloudflare/unsupported_resources.json`
- `git diff --check`

Ref: #335

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hardened Cloudflare storage and queue imports with resilient per-family discovery. Adds rollback of partial resources on failure; Hyperdrive remains unsupported with clarified read-path limits.

- **Refactors**
  - Added `runCloudflareStorageFamilyDiscoveries` and updated `StorageGenerator.InitResources()` to discover `cloudflare_workers_kv_namespace`, `cloudflare_queue`, `cloudflare_r2_bucket`, and `cloudflare_d1_database` independently.
  - On failure, discard resources added by the failed family and continue; return an error only if all families fail.
  - Added tests for rollback-on-failure, partial success, and all-fail cases.
  - Updated `unsupported_resources.json` for `cloudflare_hyperdrive_config` to clarify provider read-path limitations with write-only secrets.

<sup>Written for commit 79af81b897c60b8df074bc78f1d7a0856b9f782b. Summary will update on new commits. <a href="https://cubic.dev/pr/chenrui333/terraformer/pull/468?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

