### PR TITLE
feat(cloudflare): add security and API Shield imports

### DIFF
--- a/docs/cloudflare.md
+++ b/docs/cloudflare.md
@@ -73,6 +73,13 @@ List of supported Cloudflare services:
   * `cloudflare_pages_project`
 * `ruleset`
   * `cloudflare_ruleset`
+* `security`
+  * `cloudflare_api_shield`
+  * `cloudflare_api_shield_operation`
+  * `cloudflare_page_shield_policy`
+  * `cloudflare_schema_validation_schemas`
+  * `cloudflare_vulnerability_scanner_credential_set`
+  * `cloudflare_vulnerability_scanner_target_environment`
 * `storage`
   * `cloudflare_d1_database`
   * `cloudflare_queue`

--- a/providers/cloudflare/cloudflare_provider.go
+++ b/providers/cloudflare/cloudflare_provider.go
@@ -44,6 +44,7 @@ func (p *CloudflareProvider) GetSupportedService() map[string]terraformutils.Ser
 		"notifications":      &NotificationsGenerator{},
 		"pages":              &PagesGenerator{},
 		"ruleset":            &RulesetGenerator{},
+		"security":           &SecurityGenerator{},
 		"storage":            &StorageGenerator{},
 		"turnstile":          &TurnstileGenerator{},
 		"tunnel":             &TunnelGenerator{},

--- a/providers/cloudflare/security.go
+++ b/providers/cloudflare/security.go
@@ -1,0 +1,429 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package cloudflare
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"log"
+	"net/http"
+	"strings"
+
+	"github.com/chenrui333/terraformer/terraformutils"
+	cf "github.com/cloudflare/cloudflare-go"
+)
+
+type SecurityGenerator struct {
+	CloudflareService
+}
+
+type cloudflareSecurityRawResource map[string]interface{}
+
+type cloudflareSecurityDiscovery struct {
+	name     string
+	scope    string
+	discover func() error
+}
+
+func cloudflareSecurityString(resource cloudflareSecurityRawResource, keys ...string) string {
+	for _, key := range keys {
+		value, ok := resource[key].(string)
+		if ok && value != "" {
+			return value
+		}
+	}
+	return ""
+}
+
+func cloudflareSecurityOptionalDiscoveryError(err error) bool {
+	var notFoundErr *cf.NotFoundError
+	if errors.As(err, &notFoundErr) {
+		return cloudflareSecurityOptionalErrorMessage(notFoundErr.Error(), notFoundErr.ErrorMessages())
+	}
+
+	var requestErr *cf.RequestError
+	if errors.As(err, &requestErr) {
+		return cloudflareSecurityOptionalErrorMessage(requestErr.Error(), requestErr.ErrorMessages())
+	}
+
+	return false
+}
+
+func cloudflareSecurityOptionalErrorMessage(message string, errorMessages []string) bool {
+	messages := append([]string{message}, errorMessages...)
+	for _, msg := range messages {
+		normalized := strings.ToLower(msg)
+		for _, marker := range []string{
+			"access denied",
+			"feature is not available",
+			"missing permission",
+			"not authorized",
+			"not configured",
+			"not enabled",
+			"not entitled",
+			"permission denied",
+			"requires a paid plan",
+			"upgrade your plan",
+		} {
+			if strings.Contains(normalized, marker) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func runCloudflareSecurityDiscoveries(discoveries []cloudflareSecurityDiscovery) error {
+	for _, discovery := range discoveries {
+		if discovery.discover == nil {
+			continue
+		}
+		if err := discovery.discover(); err != nil {
+			if cloudflareSecurityOptionalDiscoveryError(err) {
+				log.Printf("Skipping Cloudflare security %s discovery for %s: %v", discovery.name, discovery.scope, err)
+				continue
+			}
+			return fmt.Errorf("discover Cloudflare security %s for %s: %w", discovery.name, discovery.scope, err)
+		}
+	}
+	return nil
+}
+
+func cloudflareSecurityPagedPath(path string, page int, cursor string) string {
+	separator := "?"
+	if strings.Contains(path, "?") {
+		separator = "&"
+	}
+	return fmt.Sprintf("%s%s%s", path, separator, cloudflarePaginationQuery(page, cursor))
+}
+
+func listCloudflareSecurityResources(ctx context.Context, api *cf.API, path string) ([]cloudflareSecurityRawResource, error) {
+	var resources []cloudflareSecurityRawResource
+	page, cursor := 1, ""
+	for {
+		response, err := api.Raw(
+			ctx,
+			http.MethodGet,
+			cloudflareSecurityPagedPath(path, page, cursor),
+			nil,
+			nil,
+		)
+		if err != nil {
+			return nil, err
+		}
+		if len(response.Result) == 0 || string(response.Result) == "null" {
+			return resources, nil
+		}
+
+		var pageResources []cloudflareSecurityRawResource
+		if err := json.Unmarshal(response.Result, &pageResources); err != nil {
+			return nil, err
+		}
+		resources = append(resources, pageResources...)
+		if !cloudflareAdvancePagination(response.ResultInfo, &page, &cursor) {
+			break
+		}
+	}
+	return resources, nil
+}
+
+func getCloudflareSecurityResource(ctx context.Context, api *cf.API, path string) (cloudflareSecurityRawResource, bool, error) {
+	response, err := api.Raw(ctx, http.MethodGet, path, nil, nil)
+	if err != nil {
+		return nil, false, err
+	}
+	if len(response.Result) == 0 || string(response.Result) == "null" {
+		return nil, false, nil
+	}
+	var resource cloudflareSecurityRawResource
+	if err := json.Unmarshal(response.Result, &resource); err != nil {
+		return nil, false, err
+	}
+	return resource, len(resource) > 0, nil
+}
+
+func cloudflareZoneSecurityResource(
+	zone cf.Zone,
+	id string,
+	resourceType string,
+	resourceNamePrefix string,
+	nameParts ...string,
+) (terraformutils.Resource, bool) {
+	if zone.ID == "" || id == "" {
+		return terraformutils.Resource{}, false
+	}
+	parts := append([]string{zone.Name, resourceNamePrefix}, nameParts...)
+	parts = append(parts, id)
+	resource := terraformutils.NewResource(
+		id,
+		cloudflareResourceName(parts...),
+		resourceType,
+		"cloudflare",
+		map[string]string{"zone_id": zone.ID},
+		[]string{},
+		map[string]interface{}{},
+	)
+	setCloudflareImportID(&resource, zone.ID+"/"+id)
+	return resource, true
+}
+
+func cloudflareZoneSecuritySingletonResource(
+	zone cf.Zone,
+	resourceType string,
+	resourceNamePrefix string,
+) (terraformutils.Resource, bool) {
+	if zone.ID == "" {
+		return terraformutils.Resource{}, false
+	}
+	resource := terraformutils.NewResource(
+		zone.ID,
+		cloudflareResourceName(zone.Name, resourceNamePrefix),
+		resourceType,
+		"cloudflare",
+		map[string]string{"zone_id": zone.ID},
+		[]string{},
+		map[string]interface{}{},
+	)
+	setCloudflareImportID(&resource, zone.ID)
+	return resource, true
+}
+
+func cloudflareAccountSecurityResource(
+	accountID string,
+	id string,
+	resourceType string,
+	resourceNamePrefix string,
+	nameParts ...string,
+) (terraformutils.Resource, bool) {
+	if accountID == "" || id == "" {
+		return terraformutils.Resource{}, false
+	}
+	parts := append([]string{accountID, resourceNamePrefix}, nameParts...)
+	parts = append(parts, id)
+	resource := terraformutils.NewResource(
+		id,
+		cloudflareResourceName(parts...),
+		resourceType,
+		"cloudflare",
+		map[string]string{"account_id": accountID},
+		[]string{},
+		map[string]interface{}{},
+	)
+	setCloudflareImportID(&resource, accountID+"/"+id)
+	return resource, true
+}
+
+func apiShieldConfigImportable(config cloudflareSecurityRawResource) bool {
+	characteristics, ok := config["auth_id_characteristics"].([]interface{})
+	return ok && len(characteristics) > 0
+}
+
+func (g *SecurityGenerator) appendAPIShieldResource(ctx context.Context, api *cf.API, zone cf.Zone) error {
+	config, exists, err := getCloudflareSecurityResource(ctx, api, fmt.Sprintf("/zones/%s/api_gateway/configuration", zone.ID))
+	if err != nil {
+		return err
+	}
+	if !exists || !apiShieldConfigImportable(config) {
+		return nil
+	}
+	resource, ok := cloudflareZoneSecuritySingletonResource(zone, "cloudflare_api_shield", "api_shield")
+	if ok {
+		g.Resources = append(g.Resources, resource)
+	}
+	return nil
+}
+
+func (g *SecurityGenerator) appendAPIShieldOperationResources(ctx context.Context, api *cf.API, zone cf.Zone) error {
+	operations, err := listCloudflareSecurityResources(ctx, api, fmt.Sprintf("/zones/%s/api_gateway/operations", zone.ID))
+	if err != nil {
+		return err
+	}
+	for _, operation := range operations {
+		id := cloudflareSecurityString(operation, "operation_id", "id")
+		resource, ok := cloudflareZoneSecurityResource(
+			zone,
+			id,
+			"cloudflare_api_shield_operation",
+			"api_shield_operation",
+			cloudflareSecurityString(operation, "host"),
+			cloudflareSecurityString(operation, "method"),
+			cloudflareSecurityString(operation, "endpoint"),
+		)
+		if ok {
+			g.Resources = append(g.Resources, resource)
+		}
+	}
+	return nil
+}
+
+func (g *SecurityGenerator) appendSchemaValidationSchemaResources(ctx context.Context, api *cf.API, zone cf.Zone) error {
+	schemas, err := listCloudflareSecurityResources(ctx, api, fmt.Sprintf("/zones/%s/schema_validation/schemas", zone.ID))
+	if err != nil {
+		return err
+	}
+	for _, schema := range schemas {
+		id := cloudflareSecurityString(schema, "schema_id", "id")
+		resource, ok := cloudflareZoneSecurityResource(
+			zone,
+			id,
+			"cloudflare_schema_validation_schemas",
+			"schema_validation_schema",
+			cloudflareSecurityString(schema, "name"),
+			cloudflareSecurityString(schema, "kind"),
+		)
+		if ok {
+			g.Resources = append(g.Resources, resource)
+		}
+	}
+	return nil
+}
+
+func (g *SecurityGenerator) appendPageShieldPolicyResources(ctx context.Context, api *cf.API, zone cf.Zone) error {
+	policies, err := listCloudflareSecurityResources(ctx, api, fmt.Sprintf("/zones/%s/page_shield/policies", zone.ID))
+	if err != nil {
+		return err
+	}
+	for _, policy := range policies {
+		id := cloudflareSecurityString(policy, "id")
+		resource, ok := cloudflareZoneSecurityResource(
+			zone,
+			id,
+			"cloudflare_page_shield_policy",
+			"page_shield_policy",
+			cloudflareSecurityString(policy, "description"),
+			cloudflareSecurityString(policy, "action"),
+		)
+		if ok {
+			g.Resources = append(g.Resources, resource)
+		}
+	}
+	return nil
+}
+
+func (g *SecurityGenerator) appendVulnerabilityScannerCredentialSetResources(
+	ctx context.Context,
+	api *cf.API,
+	accountID string,
+) error {
+	credentialSets, err := listCloudflareSecurityResources(ctx, api, fmt.Sprintf("/accounts/%s/vuln_scanner/credential_sets", accountID))
+	if err != nil {
+		return err
+	}
+	for _, credentialSet := range credentialSets {
+		id := cloudflareSecurityString(credentialSet, "id")
+		resource, ok := cloudflareAccountSecurityResource(
+			accountID,
+			id,
+			"cloudflare_vulnerability_scanner_credential_set",
+			"vulnerability_scanner_credential_set",
+			cloudflareSecurityString(credentialSet, "name"),
+		)
+		if ok {
+			g.Resources = append(g.Resources, resource)
+		}
+	}
+	return nil
+}
+
+func (g *SecurityGenerator) appendVulnerabilityScannerTargetEnvironmentResources(
+	ctx context.Context,
+	api *cf.API,
+	accountID string,
+) error {
+	targetEnvironments, err := listCloudflareSecurityResources(ctx, api, fmt.Sprintf("/accounts/%s/vuln_scanner/target_environments", accountID))
+	if err != nil {
+		return err
+	}
+	for _, targetEnvironment := range targetEnvironments {
+		id := cloudflareSecurityString(targetEnvironment, "id")
+		resource, ok := cloudflareAccountSecurityResource(
+			accountID,
+			id,
+			"cloudflare_vulnerability_scanner_target_environment",
+			"vulnerability_scanner_target_environment",
+			cloudflareSecurityString(targetEnvironment, "name"),
+		)
+		if ok {
+			g.Resources = append(g.Resources, resource)
+		}
+	}
+	return nil
+}
+
+func (g *SecurityGenerator) appendZoneSecurityResources(ctx context.Context, api *cf.API, zone cf.Zone) error {
+	return runCloudflareSecurityDiscoveries([]cloudflareSecurityDiscovery{
+		{
+			name:  "API Shield configuration",
+			scope: zone.ID,
+			discover: func() error {
+				return g.appendAPIShieldResource(ctx, api, zone)
+			},
+		},
+		{
+			name:  "API Shield operations",
+			scope: zone.ID,
+			discover: func() error {
+				return g.appendAPIShieldOperationResources(ctx, api, zone)
+			},
+		},
+		{
+			name:  "schema validation schemas",
+			scope: zone.ID,
+			discover: func() error {
+				return g.appendSchemaValidationSchemaResources(ctx, api, zone)
+			},
+		},
+		{
+			name:  "Page Shield policies",
+			scope: zone.ID,
+			discover: func() error {
+				return g.appendPageShieldPolicyResources(ctx, api, zone)
+			},
+		},
+	})
+}
+
+func (g *SecurityGenerator) appendAccountSecurityResources(ctx context.Context, api *cf.API, accountID string) error {
+	return runCloudflareSecurityDiscoveries([]cloudflareSecurityDiscovery{
+		{
+			name:  "vulnerability scanner credential sets",
+			scope: accountID,
+			discover: func() error {
+				return g.appendVulnerabilityScannerCredentialSetResources(ctx, api, accountID)
+			},
+		},
+		{
+			name:  "vulnerability scanner target environments",
+			scope: accountID,
+			discover: func() error {
+				return g.appendVulnerabilityScannerTargetEnvironmentResources(ctx, api, accountID)
+			},
+		},
+	})
+}
+
+func (g *SecurityGenerator) InitResources() error {
+	ctx := context.Background()
+	api, err := g.initializeAPI()
+	if err != nil {
+		return err
+	}
+
+	zones, err := cloudflareZones(ctx, api)
+	if err != nil {
+		return err
+	}
+	for _, zone := range zones {
+		if err := g.appendZoneSecurityResources(ctx, api, zone); err != nil {
+			return err
+		}
+	}
+
+	accountID := g.accountID()
+	if accountID == "" {
+		return nil
+	}
+	return g.appendAccountSecurityResources(ctx, api, accountID)
+}

--- a/providers/cloudflare/security_test.go
+++ b/providers/cloudflare/security_test.go
@@ -1,0 +1,399 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package cloudflare
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"reflect"
+	"strings"
+	"testing"
+
+	cf "github.com/cloudflare/cloudflare-go"
+)
+
+func TestCloudflareZoneSecurityResourceUsesCompositeImportID(t *testing.T) {
+	resource, ok := cloudflareZoneSecurityResource(
+		cf.Zone{ID: "zone-123", Name: "example.com"},
+		"operation-456",
+		"cloudflare_api_shield_operation",
+		"api_shield_operation",
+		"api.example.com",
+		"GET",
+	)
+	if !ok {
+		t.Fatal("expected zone security resource")
+	}
+	if resource.InstanceInfo.Type != "cloudflare_api_shield_operation" {
+		t.Fatalf("resource type = %q, want cloudflare_api_shield_operation", resource.InstanceInfo.Type)
+	}
+	if resource.InstanceState.ID != "operation-456" {
+		t.Fatalf("resource ID = %q, want operation-456", resource.InstanceState.ID)
+	}
+	if got := resource.InstanceState.Attributes["zone_id"]; got != "zone-123" {
+		t.Fatalf("zone_id = %q, want zone-123", got)
+	}
+	if got := resource.InstanceState.Meta["import_id"]; got != "zone-123/operation-456" {
+		t.Fatalf("import_id = %q, want zone-123/operation-456", got)
+	}
+}
+
+func TestCloudflareZoneSecuritySingletonResourceUsesZoneImportID(t *testing.T) {
+	resource, ok := cloudflareZoneSecuritySingletonResource(
+		cf.Zone{ID: "zone-123", Name: "example.com"},
+		"cloudflare_api_shield",
+		"api_shield",
+	)
+	if !ok {
+		t.Fatal("expected zone security singleton resource")
+	}
+	if resource.InstanceState.ID != "zone-123" {
+		t.Fatalf("resource ID = %q, want zone-123", resource.InstanceState.ID)
+	}
+	if got := resource.InstanceState.Meta["import_id"]; got != "zone-123" {
+		t.Fatalf("import_id = %q, want zone-123", got)
+	}
+}
+
+func TestCloudflareAccountSecurityResourceUsesCompositeImportID(t *testing.T) {
+	resource, ok := cloudflareAccountSecurityResource(
+		"account-123",
+		"target-456",
+		"cloudflare_vulnerability_scanner_target_environment",
+		"vulnerability_scanner_target_environment",
+		"production",
+	)
+	if !ok {
+		t.Fatal("expected account security resource")
+	}
+	if resource.InstanceInfo.Type != "cloudflare_vulnerability_scanner_target_environment" {
+		t.Fatalf("resource type = %q, want cloudflare_vulnerability_scanner_target_environment", resource.InstanceInfo.Type)
+	}
+	if got := resource.InstanceState.Attributes["account_id"]; got != "account-123" {
+		t.Fatalf("account_id = %q, want account-123", got)
+	}
+	if got := resource.InstanceState.Meta["import_id"]; got != "account-123/target-456" {
+		t.Fatalf("import_id = %q, want account-123/target-456", got)
+	}
+}
+
+func TestCloudflareSecurityResourceConstructorsSkipMissingIDs(t *testing.T) {
+	if _, ok := cloudflareZoneSecurityResource(cf.Zone{ID: "zone-123"}, "", "cloudflare_api_shield_operation", "api_shield_operation"); ok {
+		t.Fatal("expected zone resource without resource ID to be skipped")
+	}
+	if _, ok := cloudflareZoneSecurityResource(cf.Zone{}, "operation-123", "cloudflare_api_shield_operation", "api_shield_operation"); ok {
+		t.Fatal("expected zone resource without zone ID to be skipped")
+	}
+	if _, ok := cloudflareAccountSecurityResource("", "credential-set-123", "cloudflare_vulnerability_scanner_credential_set", "credential_set"); ok {
+		t.Fatal("expected account resource without account ID to be skipped")
+	}
+	if _, ok := cloudflareAccountSecurityResource("account-123", "", "cloudflare_vulnerability_scanner_credential_set", "credential_set"); ok {
+		t.Fatal("expected account resource without resource ID to be skipped")
+	}
+}
+
+func TestListCloudflareSecurityResourcesPaginates(t *testing.T) {
+	api := newCloudflareSecurityTestAPI(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/zones/zone-123/api_gateway/operations" {
+			t.Fatalf("path = %q, want /zones/zone-123/api_gateway/operations", r.URL.Path)
+		}
+		switch r.URL.Query().Get("page") {
+		case "1":
+			writeCloudflareSecurityTestResponse(t, w, []map[string]string{{"operation_id": "operation-1"}}, map[string]int{
+				"page":        1,
+				"per_page":    cloudflarePageSize,
+				"total_pages": 2,
+			})
+		case "2":
+			writeCloudflareSecurityTestResponse(t, w, []map[string]string{{"operation_id": "operation-2"}}, map[string]int{
+				"page":        2,
+				"per_page":    cloudflarePageSize,
+				"total_pages": 2,
+			})
+		default:
+			t.Fatalf("page query = %q, want 1 or 2", r.URL.Query().Get("page"))
+		}
+	}))
+
+	resources, err := listCloudflareSecurityResources(context.Background(), api, "/zones/zone-123/api_gateway/operations")
+	if err != nil {
+		t.Fatalf("listCloudflareSecurityResources() error = %v", err)
+	}
+	got := []string{
+		cloudflareSecurityString(resources[0], "operation_id"),
+		cloudflareSecurityString(resources[1], "operation_id"),
+	}
+	if want := []string{"operation-1", "operation-2"}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("operation IDs = %#v, want %#v", got, want)
+	}
+}
+
+func TestListCloudflareSecurityResourcesHandlesEmptyResponse(t *testing.T) {
+	api := newCloudflareSecurityTestAPI(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		writeCloudflareSecurityTestResponse(t, w, []map[string]string{}, map[string]int{
+			"page":        1,
+			"per_page":    cloudflarePageSize,
+			"total_pages": 1,
+		})
+	}))
+
+	resources, err := listCloudflareSecurityResources(context.Background(), api, "/zones/zone-123/page_shield/policies")
+	if err != nil {
+		t.Fatalf("listCloudflareSecurityResources() error = %v", err)
+	}
+	if len(resources) != 0 {
+		t.Fatalf("resources = %#v, want empty", resources)
+	}
+}
+
+func TestAPIShieldConfigImportable(t *testing.T) {
+	tests := []struct {
+		name   string
+		config cloudflareSecurityRawResource
+		want   bool
+	}{
+		{name: "configured", config: cloudflareSecurityRawResource{"auth_id_characteristics": []interface{}{map[string]interface{}{"name": "authorization", "type": "header"}}}, want: true},
+		{name: "default empty", config: cloudflareSecurityRawResource{"auth_id_characteristics": []interface{}{}}, want: false},
+		{name: "missing characteristics", config: cloudflareSecurityRawResource{}, want: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := apiShieldConfigImportable(tt.config); got != tt.want {
+				t.Fatalf("apiShieldConfigImportable() = %t, want %t", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestAppendAPIShieldResourceSkipsDefaultConfig(t *testing.T) {
+	api := newCloudflareSecurityTestAPI(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/zones/zone-123/api_gateway/configuration" {
+			t.Fatalf("path = %q, want /zones/zone-123/api_gateway/configuration", r.URL.Path)
+		}
+		writeCloudflareSecurityTestResponse(t, w, map[string]interface{}{
+			"auth_id_characteristics": []interface{}{},
+		}, nil)
+	}))
+	g := &SecurityGenerator{}
+
+	if err := g.appendAPIShieldResource(context.Background(), api, cf.Zone{ID: "zone-123", Name: "example.com"}); err != nil {
+		t.Fatalf("appendAPIShieldResource() error = %v", err)
+	}
+	if len(g.Resources) != 0 {
+		t.Fatalf("resources = %#v, want empty", g.Resources)
+	}
+}
+
+func TestAppendAPIShieldResourceCreatesConfiguredSingleton(t *testing.T) {
+	api := newCloudflareSecurityTestAPI(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		writeCloudflareSecurityTestResponse(t, w, map[string]interface{}{
+			"auth_id_characteristics": []map[string]string{{"name": "authorization", "type": "header"}},
+		}, nil)
+	}))
+	g := &SecurityGenerator{}
+
+	if err := g.appendAPIShieldResource(context.Background(), api, cf.Zone{ID: "zone-123", Name: "example.com"}); err != nil {
+		t.Fatalf("appendAPIShieldResource() error = %v", err)
+	}
+	if len(g.Resources) != 1 {
+		t.Fatalf("resource count = %d, want 1", len(g.Resources))
+	}
+	resource := g.Resources[0]
+	if resource.InstanceInfo.Type != "cloudflare_api_shield" {
+		t.Fatalf("resource type = %q, want cloudflare_api_shield", resource.InstanceInfo.Type)
+	}
+	if got := resource.InstanceState.Meta["import_id"]; got != "zone-123" {
+		t.Fatalf("import_id = %q, want zone-123", got)
+	}
+}
+
+func TestAppendAPIShieldOperationResources(t *testing.T) {
+	api := newCloudflareSecurityTestAPI(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		writeCloudflareSecurityTestResponse(t, w, []map[string]string{
+			{
+				"endpoint":     "/api/users/{var1}",
+				"host":         "api.example.com",
+				"method":       "GET",
+				"operation_id": "operation-123",
+			},
+		}, nil)
+	}))
+	g := &SecurityGenerator{}
+
+	if err := g.appendAPIShieldOperationResources(context.Background(), api, cf.Zone{ID: "zone-123", Name: "example.com"}); err != nil {
+		t.Fatalf("appendAPIShieldOperationResources() error = %v", err)
+	}
+	if len(g.Resources) != 1 {
+		t.Fatalf("resource count = %d, want 1", len(g.Resources))
+	}
+	resource := g.Resources[0]
+	if resource.InstanceInfo.Type != "cloudflare_api_shield_operation" {
+		t.Fatalf("resource type = %q, want cloudflare_api_shield_operation", resource.InstanceInfo.Type)
+	}
+	if got := resource.InstanceState.Meta["import_id"]; got != "zone-123/operation-123" {
+		t.Fatalf("import_id = %q, want zone-123/operation-123", got)
+	}
+}
+
+func TestRunCloudflareSecurityDiscoveriesSkipsOptionalErrors(t *testing.T) {
+	calls := []string{}
+	err := runCloudflareSecurityDiscoveries([]cloudflareSecurityDiscovery{
+		{
+			name:  "Page Shield policies",
+			scope: "zone-123",
+			discover: func() error {
+				calls = append(calls, "optional")
+				return testCloudflareRequestError("access denied: missing permission Page Shield Read")
+			},
+		},
+		{
+			name:  "API Shield operations",
+			scope: "zone-123",
+			discover: func() error {
+				calls = append(calls, "next")
+				return nil
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("runCloudflareSecurityDiscoveries() error = %v, want nil", err)
+	}
+	if want := []string{"optional", "next"}; !reflect.DeepEqual(calls, want) {
+		t.Fatalf("calls = %#v, want %#v", calls, want)
+	}
+}
+
+func TestRunCloudflareSecurityDiscoveriesPropagatesUnexpectedErrors(t *testing.T) {
+	expectedErr := errors.New("json decode failed")
+	err := runCloudflareSecurityDiscoveries([]cloudflareSecurityDiscovery{
+		{
+			name:  "schema validation schemas",
+			scope: "zone-123",
+			discover: func() error {
+				return expectedErr
+			},
+		},
+	})
+
+	if !errors.Is(err, expectedErr) {
+		t.Fatalf("runCloudflareSecurityDiscoveries() error = %v, want wrapped %v", err, expectedErr)
+	}
+	for _, expected := range []string{"schema validation schemas", "zone-123"} {
+		if !strings.Contains(err.Error(), expected) {
+			t.Fatalf("runCloudflareSecurityDiscoveries() error = %q, want to contain %q", err, expected)
+		}
+	}
+}
+
+func TestCloudflareSecurityOptionalDiscoveryError(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{name: "generic not found propagates", err: testCloudflareNotFoundError("not found"), want: false},
+		{name: "feature unavailable is optional", err: testCloudflareNotFoundError("feature is not available for this zone"), want: true},
+		{name: "access denied is optional", err: testCloudflareRequestError("access denied: missing permission Domain Page Shield Read"), want: true},
+		{name: "forbidden is optional", err: testCloudflareRequestError("forbidden: API Gateway is not enabled on this zone"), want: true},
+		{name: "server error propagates", err: testCloudflareRequestError("internal server error"), want: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := cloudflareSecurityOptionalDiscoveryError(tt.err); got != tt.want {
+				t.Fatalf("cloudflareSecurityOptionalDiscoveryError() = %t, want %t", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestCloudflareProviderIncludesSecurityService(t *testing.T) {
+	services := (&CloudflareProvider{}).GetSupportedService()
+	if _, ok := services["security"]; !ok {
+		t.Fatal("security service is not registered")
+	}
+}
+
+func TestCloudflareSecurityUnsupportedMetadataCoversDeferredResources(t *testing.T) {
+	data, err := os.ReadFile("unsupported_resources.json")
+	if err != nil {
+		t.Fatalf("read unsupported resources: %v", err)
+	}
+	var metadata cloudflareUnsupportedResourcesFile
+	if err := json.Unmarshal(data, &metadata); err != nil {
+		t.Fatalf("decode unsupported resources: %v", err)
+	}
+
+	seen := map[string]bool{}
+	for _, resource := range metadata.Resources {
+		seen[resource.Resource] = true
+	}
+	for _, resource := range []string{
+		"cloudflare_api_shield_discovery_operation",
+		"cloudflare_api_shield_operation_schema_validation_settings",
+		"cloudflare_api_shield_schema",
+		"cloudflare_api_shield_schema_validation_settings",
+		"cloudflare_bot_management",
+		"cloudflare_content_scanning",
+		"cloudflare_content_scanning_expression",
+		"cloudflare_schema_validation_operation_settings",
+		"cloudflare_schema_validation_settings",
+	} {
+		if !seen[resource] {
+			t.Fatalf("unsupported metadata is missing %s", resource)
+		}
+	}
+}
+
+func newCloudflareSecurityTestAPI(t *testing.T, handler http.Handler) *cf.API {
+	t.Helper()
+
+	server := httptest.NewServer(handler)
+	t.Cleanup(server.Close)
+
+	api, err := cf.NewWithAPIToken(
+		"test-token",
+		cf.BaseURL(server.URL),
+		cf.UsingRateLimit(100000),
+		cf.UsingRetryPolicy(0, 0, 0),
+	)
+	if err != nil {
+		t.Fatalf("create Cloudflare test API: %v", err)
+	}
+	return api
+}
+
+func writeCloudflareSecurityTestResponse(t *testing.T, w http.ResponseWriter, result interface{}, resultInfo interface{}) {
+	t.Helper()
+	w.Header().Set("Content-Type", "application/json")
+
+	payload := map[string]interface{}{
+		"success": true,
+		"result":  result,
+	}
+	if resultInfo != nil {
+		payload["result_info"] = resultInfo
+	}
+	if err := json.NewEncoder(w).Encode(payload); err != nil {
+		t.Fatalf("encode test response: %v", err)
+	}
+}
+
+func ExampleSecurityGenerator_resources() {
+	resources := []string{
+		"cloudflare_api_shield",
+		"cloudflare_api_shield_operation",
+		"cloudflare_page_shield_policy",
+		"cloudflare_schema_validation_schemas",
+		"cloudflare_vulnerability_scanner_credential_set",
+		"cloudflare_vulnerability_scanner_target_environment",
+	}
+	fmt.Println(strings.Join(resources, ", "))
+	// Output: cloudflare_api_shield, cloudflare_api_shield_operation, cloudflare_page_shield_policy, cloudflare_schema_validation_schemas, cloudflare_vulnerability_scanner_credential_set, cloudflare_vulnerability_scanner_target_environment
+}

--- a/providers/cloudflare/unsupported_resources.json
+++ b/providers/cloudflare/unsupported_resources.json
@@ -35,6 +35,53 @@
       ]
     },
     {
+      "resource": "cloudflare_api_shield_discovery_operation",
+      "service_family": "api_shield",
+      "reason": "API Shield discovery operation resources are review workflow state and the Terraform provider does not support import.",
+      "evidence": "Terraform provider v5.19.1 documents cloudflare_api_shield_discovery_operation as not supporting terraform import. The resource marks discovered operations as review or ignored rather than owning durable endpoint configuration.",
+      "status": "not-importable",
+      "references": [
+        "https://github.com/chenrui333/terraformer/issues/335",
+        "https://registry.terraform.io/providers/cloudflare/cloudflare/latest/docs/resources/api_shield_discovery_operation"
+      ]
+    },
+    {
+      "resource": "cloudflare_api_shield_operation_schema_validation_settings",
+      "service_family": "api_shield",
+      "reason": "Deprecated API Shield operation schema-validation settings should not be added as new Terraformer coverage ahead of the replacement resource's import contract.",
+      "evidence": "Terraform provider v5.19.1 marks cloudflare_api_shield_operation_schema_validation_settings as deprecated and directs users to cloudflare_schema_validation_operation_settings, whose provider docs state that terraform import is not currently supported.",
+      "status": "deferred",
+      "references": [
+        "https://github.com/chenrui333/terraformer/issues/335",
+        "https://registry.terraform.io/providers/cloudflare/cloudflare/latest/docs/resources/api_shield_operation_schema_validation_settings",
+        "https://registry.terraform.io/providers/cloudflare/cloudflare/latest/docs/resources/schema_validation_operation_settings"
+      ]
+    },
+    {
+      "resource": "cloudflare_api_shield_schema",
+      "service_family": "api_shield",
+      "reason": "Deprecated API Shield schemas require uploaded schema source and the Terraform provider does not expose a current import contract for this legacy resource.",
+      "evidence": "Terraform provider v5.19.1 marks cloudflare_api_shield_schema as deprecated in favor of cloudflare_schema_validation_schemas and does not implement ResourceWithImportState for the legacy resource. Terraformer imports the replacement schema_validation_schemas resource instead.",
+      "status": "not-importable",
+      "references": [
+        "https://github.com/chenrui333/terraformer/issues/335",
+        "https://registry.terraform.io/providers/cloudflare/cloudflare/latest/docs/resources/api_shield_schema",
+        "https://registry.terraform.io/providers/cloudflare/cloudflare/latest/docs/resources/schema_validation_schemas"
+      ]
+    },
+    {
+      "resource": "cloudflare_api_shield_schema_validation_settings",
+      "service_family": "api_shield",
+      "reason": "Deprecated API Shield schema-validation settings should not be added as new Terraformer coverage ahead of the replacement resource's import contract.",
+      "evidence": "Terraform provider v5.19.1 marks cloudflare_api_shield_schema_validation_settings as deprecated and directs users to cloudflare_schema_validation_settings, whose provider docs state that terraform import is not currently supported.",
+      "status": "deferred",
+      "references": [
+        "https://github.com/chenrui333/terraformer/issues/335",
+        "https://registry.terraform.io/providers/cloudflare/cloudflare/latest/docs/resources/api_shield_schema_validation_settings",
+        "https://registry.terraform.io/providers/cloudflare/cloudflare/latest/docs/resources/schema_validation_settings"
+      ]
+    },
+    {
       "resource": "cloudflare_authenticated_origin_pulls_certificate",
       "service_family": "certificates",
       "reason": "Authenticated Origin Pull certificates require private key material that Cloudflare APIs cannot safely return.",
@@ -43,6 +90,17 @@
       "references": [
         "https://github.com/chenrui333/terraformer/issues/335",
         "https://registry.terraform.io/providers/cloudflare/cloudflare/latest/docs/resources/authenticated_origin_pulls_certificate"
+      ]
+    },
+    {
+      "resource": "cloudflare_bot_management",
+      "service_family": "bot_management",
+      "reason": "Bot Management is a plan-gated zone singleton with many optional/default fields that need a dedicated explicit-ownership design.",
+      "evidence": "Terraform provider v5.19.1 supports zone_id import, but the resource owns Bot Fight Mode, Super Bot Fight Mode, AI bot, content bot, robots.txt, and model-update settings whose availability and API response shape vary by zone plan. The provider preserves existing state for fields missing from API responses, so broad import can confuse defaults, stale zone configuration, and explicit user intent.",
+      "status": "deferred",
+      "references": [
+        "https://github.com/chenrui333/terraformer/issues/335",
+        "https://registry.terraform.io/providers/cloudflare/cloudflare/latest/docs/resources/bot_management"
       ]
     },
     {
@@ -65,6 +123,28 @@
       "references": [
         "https://github.com/chenrui333/terraformer/issues/335",
         "https://registry.terraform.io/providers/cloudflare/cloudflare/latest/docs/resources/cloudforce_one_request_message"
+      ]
+    },
+    {
+      "resource": "cloudflare_content_scanning",
+      "service_family": "content_scanning",
+      "reason": "Content Scanning status is a zone singleton setting whose Terraform provider resource does not support import.",
+      "evidence": "Terraform provider v5.19.1 documents cloudflare_content_scanning as not supporting terraform import. The resource has a no-op delete path and toggles zone-level status, so broad import needs an explicit settings/default ownership design before Terraformer emits it.",
+      "status": "not-importable",
+      "references": [
+        "https://github.com/chenrui333/terraformer/issues/335",
+        "https://registry.terraform.io/providers/cloudflare/cloudflare/latest/docs/resources/content_scanning"
+      ]
+    },
+    {
+      "resource": "cloudflare_content_scanning_expression",
+      "service_family": "content_scanning",
+      "reason": "Content Scanning expression resources do not expose a provider import/read path.",
+      "evidence": "Terraform provider v5.19.1 documents cloudflare_content_scanning_expression as not supporting terraform import, and the generated resource has an empty Read method while owning payload expressions through a create/delete API.",
+      "status": "not-importable",
+      "references": [
+        "https://github.com/chenrui333/terraformer/issues/335",
+        "https://registry.terraform.io/providers/cloudflare/cloudflare/latest/docs/resources/content_scanning_expression"
       ]
     },
     {
@@ -131,6 +211,28 @@
       "references": [
         "https://github.com/chenrui333/terraformer/issues/335",
         "https://registry.terraform.io/providers/cloudflare/cloudflare/latest/docs/resources/r2_managed_domain"
+      ]
+    },
+    {
+      "resource": "cloudflare_schema_validation_operation_settings",
+      "service_family": "schema_validation",
+      "reason": "Schema validation operation settings do not currently have a Terraform provider import contract.",
+      "evidence": "Terraform provider v5.19.1 documents cloudflare_schema_validation_operation_settings as not supporting terraform import. Although the API lists per-operation mitigation settings, Terraformer cannot seed this resource through provider import until the provider exposes ResourceWithImportState.",
+      "status": "not-importable",
+      "references": [
+        "https://github.com/chenrui333/terraformer/issues/335",
+        "https://registry.terraform.io/providers/cloudflare/cloudflare/latest/docs/resources/schema_validation_operation_settings"
+      ]
+    },
+    {
+      "resource": "cloudflare_schema_validation_settings",
+      "service_family": "schema_validation",
+      "reason": "Schema validation zone settings do not currently have a Terraform provider import contract.",
+      "evidence": "Terraform provider v5.19.1 documents cloudflare_schema_validation_settings as not supporting terraform import. The resource owns zone-level mitigation defaults and overrides, so Terraformer should not emit it until provider import support and default-handling are explicit.",
+      "status": "not-importable",
+      "references": [
+        "https://github.com/chenrui333/terraformer/issues/335",
+        "https://registry.terraform.io/providers/cloudflare/cloudflare/latest/docs/resources/schema_validation_settings"
       ]
     },
     {


### PR DESCRIPTION
## Summary

Add Terraformer import support for high-confidence Cloudflare Security / API Shield / Page Shield / Content Scanning resources.

## Resources

- `cloudflare_api_shield`
- `cloudflare_api_shield_operation`
- `cloudflare_page_shield_policy`
- `cloudflare_schema_validation_schemas`
- `cloudflare_vulnerability_scanner_credential_set`
- `cloudflare_vulnerability_scanner_target_environment`

## Implementation Notes

- Uses provider-compatible import IDs.
- Exhausts pagination where applicable.
- Seeds required fields for provider refresh.
- Keeps optional or permission-sensitive lookups best-effort where appropriate.
- Does not import plan-gated/default-ambiguous, runtime, Cloudflare-managed, or secret-required resources.

## Deferred / Unsupported

- `cloudflare_api_shield_discovery_operation`: discovery review workflow state; provider import is not supported.
- `cloudflare_api_shield_operation_schema_validation_settings`: deprecated alias; replacement resource lacks provider import support.
- `cloudflare_api_shield_schema`: deprecated legacy schema resource without current import support.
- `cloudflare_api_shield_schema_validation_settings`: deprecated alias; replacement resource lacks provider import support.
- `cloudflare_bot_management`: plan-gated/default-ambiguous zone singleton requiring dedicated ownership design.
- `cloudflare_content_scanning`: zone singleton setting without provider import support.
- `cloudflare_content_scanning_expression`: no provider import/read path.
- `cloudflare_schema_validation_operation_settings`: provider import is not supported.
- `cloudflare_schema_validation_settings`: provider import is not supported.

## Scope

This PR is intentionally limited to Security / API Shield / Page Shield / Content Scanning.

Not included:

- storage/R2/queues/Hyperdrive
- Zero Trust Gateway
- zone/account settings
- Workers script/version/deployment/body resources
- Workers KV individual key/value records
- media/platform long-tail resources
- network edge resources

## Validation

- `go test ./providers/cloudflare/...`
- `go test ./cmd/...`
- `go test ./providers -run 'TestUnsupportedResourcesMetadata|TestUnsupportedResourceStatusesAreDocumented' -count=1`
- `jq . providers/cloudflare/unsupported_resources.json`
- `git diff --check`

Ref: #335


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds Terraformer import support for Cloudflare Security (API Shield, Page Shield, Schema Validation, Vulnerability Scanner). Registers a new `security` service and updates docs.

- New Features
  - Added `security` generator to the `cloudflare` provider.
  - Import support for `cloudflare_api_shield`, `cloudflare_api_shield_operation`, `cloudflare_page_shield_policy`, `cloudflare_schema_validation_schemas`, `cloudflare_vulnerability_scanner_credential_set`, `cloudflare_vulnerability_scanner_target_environment`.
  - Uses provider-compatible import IDs, exhausts pagination, seeds required fields, and treats permission/plan-gated endpoints as best-effort.
  - Documented deferred or not-importable resources in `unsupported_resources.json`.

<sup>Written for commit cac871c37ef8797bc7a8f977ad195f2c43de7241. Summary will update on new commits. <a href="https://cubic.dev/pr/chenrui333/terraformer/pull/469?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

