### PR TITLE
feat(cloudflare): add network edge imports

### DIFF
--- a/docs/cloudflare.md
+++ b/docs/cloudflare.md
@@ -63,6 +63,16 @@ List of supported Cloudflare services:
   * `cloudflare_magic_wan_gre_tunnel`
   * `cloudflare_magic_wan_ipsec_tunnel`
   * `cloudflare_magic_wan_static_route`
+* `network_edge`
+  * `cloudflare_address_map`
+  * `cloudflare_magic_network_monitoring_rule`
+  * `cloudflare_magic_transit_site`
+  * `cloudflare_magic_transit_site_acl`
+  * `cloudflare_magic_transit_site_lan`
+  * `cloudflare_magic_transit_site_wan`
+  * `cloudflare_regional_hostname`
+  * `cloudflare_spectrum_application`
+  * `cloudflare_web3_hostname`
 * `notifications`
   * `cloudflare_notification_policy`
   * `cloudflare_notification_policy_webhooks`

--- a/providers/cloudflare/cloudflare_provider.go
+++ b/providers/cloudflare/cloudflare_provider.go
@@ -41,6 +41,7 @@ func (p *CloudflareProvider) GetSupportedService() map[string]terraformutils.Ser
 		"load_balancing":     &LoadBalancingGenerator{},
 		"logpush":            &LogpushGenerator{},
 		"magic_wan":          &MagicWANGenerator{},
+		"network_edge":       &NetworkEdgeGenerator{},
 		"notifications":      &NotificationsGenerator{},
 		"pages":              &PagesGenerator{},
 		"ruleset":            &RulesetGenerator{},

--- a/providers/cloudflare/network_edge.go
+++ b/providers/cloudflare/network_edge.go
@@ -551,8 +551,8 @@ func (g *NetworkEdgeGenerator) appendNetworkEdgeResources(
 	accountID string,
 ) error {
 	if zonesErr != nil {
-		if accountID == "" {
-			return zonesErr
+		if accountID == "" || !cloudflareNetworkEdgeOptionalDiscoveryError(zonesErr) {
+			return fmt.Errorf("discover Cloudflare network edge zones: %w", zonesErr)
 		}
 		log.Printf("Skipping Cloudflare network edge zone discovery: %v", zonesErr)
 	} else {

--- a/providers/cloudflare/network_edge.go
+++ b/providers/cloudflare/network_edge.go
@@ -49,6 +49,16 @@ func cloudflareNetworkEdgeOptionalDiscoveryError(err error) bool {
 		return cloudflareNetworkEdgeOptionalErrorMessage(requestErr.Error(), requestErr.ErrorMessages())
 	}
 
+	var authenticationErr *cf.AuthenticationError
+	if errors.As(err, &authenticationErr) {
+		return cloudflareNetworkEdgeOptionalErrorMessage(authenticationErr.Error(), authenticationErr.ErrorMessages())
+	}
+
+	var authorizationErr *cf.AuthorizationError
+	if errors.As(err, &authorizationErr) {
+		return cloudflareNetworkEdgeOptionalErrorMessage(authorizationErr.Error(), authorizationErr.ErrorMessages())
+	}
+
 	return false
 }
 

--- a/providers/cloudflare/network_edge.go
+++ b/providers/cloudflare/network_edge.go
@@ -543,6 +543,32 @@ func (g *NetworkEdgeGenerator) appendAccountNetworkEdgeResources(ctx context.Con
 	})
 }
 
+func (g *NetworkEdgeGenerator) appendNetworkEdgeResources(
+	ctx context.Context,
+	api *cf.API,
+	zones []cf.Zone,
+	zonesErr error,
+	accountID string,
+) error {
+	if zonesErr != nil {
+		if accountID == "" {
+			return zonesErr
+		}
+		log.Printf("Skipping Cloudflare network edge zone discovery: %v", zonesErr)
+	} else {
+		for _, zone := range zones {
+			if err := g.appendZoneNetworkEdgeResources(ctx, api, zone); err != nil {
+				return err
+			}
+		}
+	}
+
+	if accountID == "" {
+		return nil
+	}
+	return g.appendAccountNetworkEdgeResources(ctx, api, accountID)
+}
+
 func (g *NetworkEdgeGenerator) InitResources() error {
 	ctx := context.Background()
 	api, err := g.initializeAPI()
@@ -550,19 +576,6 @@ func (g *NetworkEdgeGenerator) InitResources() error {
 		return err
 	}
 
-	zones, err := cloudflareZones(ctx, api)
-	if err != nil {
-		return err
-	}
-	for _, zone := range zones {
-		if err := g.appendZoneNetworkEdgeResources(ctx, api, zone); err != nil {
-			return err
-		}
-	}
-
-	accountID := g.accountID()
-	if accountID == "" {
-		return nil
-	}
-	return g.appendAccountNetworkEdgeResources(ctx, api, accountID)
+	zones, zonesErr := cloudflareZones(ctx, api)
+	return g.appendNetworkEdgeResources(ctx, api, zones, zonesErr, g.accountID())
 }

--- a/providers/cloudflare/network_edge.go
+++ b/providers/cloudflare/network_edge.go
@@ -1,0 +1,559 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package cloudflare
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"log"
+	"net/http"
+	"strings"
+
+	"github.com/chenrui333/terraformer/terraformutils"
+	cf "github.com/cloudflare/cloudflare-go"
+)
+
+type NetworkEdgeGenerator struct {
+	CloudflareService
+}
+
+type cloudflareNetworkEdgeRawResource map[string]interface{}
+
+type cloudflareNetworkEdgeDiscovery struct {
+	name      string
+	scope     string
+	resources *[]terraformutils.Resource
+	discover  func() error
+}
+
+func cloudflareNetworkEdgeString(resource cloudflareNetworkEdgeRawResource, keys ...string) string {
+	for _, key := range keys {
+		value, ok := resource[key].(string)
+		if ok && value != "" {
+			return value
+		}
+	}
+	return ""
+}
+
+func cloudflareNetworkEdgeOptionalDiscoveryError(err error) bool {
+	var notFoundErr *cf.NotFoundError
+	if errors.As(err, &notFoundErr) {
+		return cloudflareNetworkEdgeOptionalErrorMessage(notFoundErr.Error(), notFoundErr.ErrorMessages())
+	}
+
+	var requestErr *cf.RequestError
+	if errors.As(err, &requestErr) {
+		return cloudflareNetworkEdgeOptionalErrorMessage(requestErr.Error(), requestErr.ErrorMessages())
+	}
+
+	return false
+}
+
+func cloudflareNetworkEdgeOptionalErrorMessage(message string, errorMessages []string) bool {
+	messages := append([]string{message}, errorMessages...)
+	for _, msg := range messages {
+		normalized := strings.ToLower(msg)
+		for _, marker := range []string{
+			"access denied",
+			"feature is not available",
+			"missing permission",
+			"not authorized",
+			"not configured",
+			"not enabled",
+			"not entitled",
+			"not found",
+			"permission denied",
+			"requires a paid plan",
+			"upgrade your plan",
+		} {
+			if strings.Contains(normalized, marker) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func runCloudflareNetworkEdgeDiscoveries(discoveries []cloudflareNetworkEdgeDiscovery) error {
+	for _, discovery := range discoveries {
+		if discovery.discover == nil {
+			continue
+		}
+		resourceCount := 0
+		if discovery.resources != nil {
+			resourceCount = len(*discovery.resources)
+		}
+		if err := discovery.discover(); err != nil {
+			if discovery.resources != nil && resourceCount <= len(*discovery.resources) {
+				*discovery.resources = (*discovery.resources)[:resourceCount]
+			}
+			if cloudflareNetworkEdgeOptionalDiscoveryError(err) {
+				log.Printf("Skipping Cloudflare network edge %s discovery for %s: %v", discovery.name, discovery.scope, err)
+				continue
+			}
+			return fmt.Errorf("discover Cloudflare network edge %s for %s: %w", discovery.name, discovery.scope, err)
+		}
+	}
+	return nil
+}
+
+func cloudflareNetworkEdgePagedPath(path string, page int, cursor string) string {
+	separator := "?"
+	if strings.Contains(path, "?") {
+		separator = "&"
+	}
+	return fmt.Sprintf("%s%s%s", path, separator, cloudflarePaginationQuery(page, cursor))
+}
+
+func listCloudflareNetworkEdgeResources(
+	ctx context.Context,
+	api *cf.API,
+	path string,
+) ([]cloudflareNetworkEdgeRawResource, error) {
+	var resources []cloudflareNetworkEdgeRawResource
+	page, cursor := 1, ""
+	for {
+		response, err := api.Raw(ctx, http.MethodGet, cloudflareNetworkEdgePagedPath(path, page, cursor), nil, nil)
+		if err != nil {
+			return nil, err
+		}
+		if len(response.Result) == 0 || string(response.Result) == "null" {
+			return resources, nil
+		}
+
+		var pageResources []cloudflareNetworkEdgeRawResource
+		if err := json.Unmarshal(response.Result, &pageResources); err != nil {
+			return nil, err
+		}
+		resources = append(resources, pageResources...)
+		if !cloudflareAdvancePagination(response.ResultInfo, &page, &cursor) {
+			break
+		}
+	}
+	return resources, nil
+}
+
+func cloudflareZoneNetworkEdgeResource(
+	zone cf.Zone,
+	id string,
+	resourceType string,
+	resourceNamePrefix string,
+	nameParts ...string,
+) (terraformutils.Resource, bool) {
+	if zone.ID == "" || id == "" {
+		return terraformutils.Resource{}, false
+	}
+	parts := append([]string{zone.Name, resourceNamePrefix}, nameParts...)
+	parts = append(parts, id)
+	resource := terraformutils.NewResource(
+		id,
+		cloudflareResourceName(parts...),
+		resourceType,
+		"cloudflare",
+		map[string]string{"zone_id": zone.ID},
+		[]string{},
+		map[string]interface{}{},
+	)
+	setCloudflareImportID(&resource, zone.ID+"/"+id)
+	return resource, true
+}
+
+func cloudflareRegionalHostnameResource(zone cf.Zone, hostname string) (terraformutils.Resource, bool) {
+	if zone.ID == "" || hostname == "" {
+		return terraformutils.Resource{}, false
+	}
+	resource := terraformutils.NewResource(
+		hostname,
+		cloudflareResourceName(zone.Name, "regional_hostname", hostname),
+		"cloudflare_regional_hostname",
+		"cloudflare",
+		map[string]string{"zone_id": zone.ID},
+		[]string{},
+		map[string]interface{}{},
+	)
+	setCloudflareImportID(&resource, zone.ID+"/"+hostname)
+	setCloudflarePreserveIDAfterRefresh(&resource)
+	return resource, true
+}
+
+func cloudflareAccountNetworkEdgeResource(
+	accountID string,
+	id string,
+	resourceType string,
+	resourceNamePrefix string,
+	nameParts ...string,
+) (terraformutils.Resource, bool) {
+	if accountID == "" || id == "" {
+		return terraformutils.Resource{}, false
+	}
+	parts := append([]string{accountID, resourceNamePrefix}, nameParts...)
+	parts = append(parts, id)
+	resource := terraformutils.NewResource(
+		id,
+		cloudflareResourceName(parts...),
+		resourceType,
+		"cloudflare",
+		map[string]string{"account_id": accountID},
+		[]string{},
+		map[string]interface{}{},
+	)
+	setCloudflareImportID(&resource, accountID+"/"+id)
+	return resource, true
+}
+
+func cloudflareMagicTransitSiteChildResource(
+	accountID string,
+	siteID string,
+	id string,
+	resourceType string,
+	resourceNamePrefix string,
+	nameParts ...string,
+) (terraformutils.Resource, bool) {
+	if accountID == "" || siteID == "" || id == "" {
+		return terraformutils.Resource{}, false
+	}
+	parts := append([]string{accountID, resourceNamePrefix, siteID}, nameParts...)
+	parts = append(parts, id)
+	resource := terraformutils.NewResource(
+		id,
+		cloudflareResourceName(parts...),
+		resourceType,
+		"cloudflare",
+		map[string]string{
+			"account_id": accountID,
+			"site_id":    siteID,
+		},
+		[]string{},
+		map[string]interface{}{},
+	)
+	setCloudflareImportID(&resource, accountID+"/"+siteID+"/"+id)
+	return resource, true
+}
+
+func cloudflareAddressMapImportable(addressMap cloudflareNetworkEdgeRawResource) bool {
+	for _, key := range []string{"can_delete", "can_modify_ips"} {
+		if value, ok := addressMap[key].(bool); ok && !value {
+			return false
+		}
+	}
+	return true
+}
+
+func (g *NetworkEdgeGenerator) appendSpectrumApplicationResources(ctx context.Context, api *cf.API, zone cf.Zone) error {
+	applications, err := listCloudflareNetworkEdgeResources(ctx, api, fmt.Sprintf("/zones/%s/spectrum/apps", zone.ID))
+	if err != nil {
+		return err
+	}
+	for _, application := range applications {
+		id := cloudflareNetworkEdgeString(application, "id")
+		dnsName := ""
+		if dns, ok := application["dns"].(map[string]interface{}); ok {
+			dnsName = cloudflareNetworkEdgeString(cloudflareNetworkEdgeRawResource(dns), "name")
+		}
+		resource, ok := cloudflareZoneNetworkEdgeResource(
+			zone,
+			id,
+			"cloudflare_spectrum_application",
+			"spectrum_application",
+			dnsName,
+			cloudflareNetworkEdgeString(application, "protocol"),
+		)
+		if ok {
+			g.Resources = append(g.Resources, resource)
+		}
+	}
+	return nil
+}
+
+func (g *NetworkEdgeGenerator) appendRegionalHostnameResources(ctx context.Context, api *cf.API, zone cf.Zone) error {
+	hostnames, err := listCloudflareNetworkEdgeResources(ctx, api, fmt.Sprintf("/zones/%s/addressing/regional_hostnames", zone.ID))
+	if err != nil {
+		return err
+	}
+	for _, hostname := range hostnames {
+		resource, ok := cloudflareRegionalHostnameResource(zone, cloudflareNetworkEdgeString(hostname, "hostname"))
+		if ok {
+			g.Resources = append(g.Resources, resource)
+		}
+	}
+	return nil
+}
+
+func (g *NetworkEdgeGenerator) appendWeb3HostnameResources(ctx context.Context, api *cf.API, zone cf.Zone) error {
+	hostnames, err := listCloudflareNetworkEdgeResources(ctx, api, fmt.Sprintf("/zones/%s/web3/hostnames", zone.ID))
+	if err != nil {
+		return err
+	}
+	for _, hostname := range hostnames {
+		id := cloudflareNetworkEdgeString(hostname, "id")
+		resource, ok := cloudflareZoneNetworkEdgeResource(
+			zone,
+			id,
+			"cloudflare_web3_hostname",
+			"web3_hostname",
+			cloudflareNetworkEdgeString(hostname, "name"),
+		)
+		if ok {
+			g.Resources = append(g.Resources, resource)
+		}
+	}
+	return nil
+}
+
+func (g *NetworkEdgeGenerator) appendAddressMapResources(ctx context.Context, api *cf.API, accountID string) error {
+	addressMaps, err := listCloudflareNetworkEdgeResources(ctx, api, fmt.Sprintf("/accounts/%s/addressing/address_maps", accountID))
+	if err != nil {
+		return err
+	}
+	for _, addressMap := range addressMaps {
+		if !cloudflareAddressMapImportable(addressMap) {
+			continue
+		}
+		resource, ok := cloudflareAccountNetworkEdgeResource(
+			accountID,
+			cloudflareNetworkEdgeString(addressMap, "id"),
+			"cloudflare_address_map",
+			"address_map",
+			cloudflareNetworkEdgeString(addressMap, "description", "default_sni"),
+		)
+		if ok {
+			g.Resources = append(g.Resources, resource)
+		}
+	}
+	return nil
+}
+
+func (g *NetworkEdgeGenerator) appendMagicNetworkMonitoringRuleResources(ctx context.Context, api *cf.API, accountID string) error {
+	rules, err := listCloudflareNetworkEdgeResources(ctx, api, fmt.Sprintf("/accounts/%s/mnm/rules", accountID))
+	if err != nil {
+		return err
+	}
+	for _, rule := range rules {
+		resource, ok := cloudflareAccountNetworkEdgeResource(
+			accountID,
+			cloudflareNetworkEdgeString(rule, "id"),
+			"cloudflare_magic_network_monitoring_rule",
+			"magic_network_monitoring_rule",
+			cloudflareNetworkEdgeString(rule, "name"),
+		)
+		if ok {
+			g.Resources = append(g.Resources, resource)
+		}
+	}
+	return nil
+}
+
+func (g *NetworkEdgeGenerator) appendMagicTransitSiteACLResources(
+	ctx context.Context,
+	api *cf.API,
+	accountID string,
+	siteID string,
+) error {
+	acls, err := listCloudflareNetworkEdgeResources(ctx, api, fmt.Sprintf("/accounts/%s/magic/sites/%s/acls", accountID, siteID))
+	if err != nil {
+		return err
+	}
+	for _, acl := range acls {
+		resource, ok := cloudflareMagicTransitSiteChildResource(
+			accountID,
+			siteID,
+			cloudflareNetworkEdgeString(acl, "id"),
+			"cloudflare_magic_transit_site_acl",
+			"magic_transit_site_acl",
+			cloudflareNetworkEdgeString(acl, "name"),
+		)
+		if ok {
+			g.Resources = append(g.Resources, resource)
+		}
+	}
+	return nil
+}
+
+func (g *NetworkEdgeGenerator) appendMagicTransitSiteLANResources(
+	ctx context.Context,
+	api *cf.API,
+	accountID string,
+	siteID string,
+) error {
+	lans, err := listCloudflareNetworkEdgeResources(ctx, api, fmt.Sprintf("/accounts/%s/magic/sites/%s/lans", accountID, siteID))
+	if err != nil {
+		return err
+	}
+	for _, lan := range lans {
+		resource, ok := cloudflareMagicTransitSiteChildResource(
+			accountID,
+			siteID,
+			cloudflareNetworkEdgeString(lan, "id"),
+			"cloudflare_magic_transit_site_lan",
+			"magic_transit_site_lan",
+			cloudflareNetworkEdgeString(lan, "name"),
+		)
+		if ok {
+			g.Resources = append(g.Resources, resource)
+		}
+	}
+	return nil
+}
+
+func (g *NetworkEdgeGenerator) appendMagicTransitSiteWANResources(
+	ctx context.Context,
+	api *cf.API,
+	accountID string,
+	siteID string,
+) error {
+	wans, err := listCloudflareNetworkEdgeResources(ctx, api, fmt.Sprintf("/accounts/%s/magic/sites/%s/wans", accountID, siteID))
+	if err != nil {
+		return err
+	}
+	for _, wan := range wans {
+		resource, ok := cloudflareMagicTransitSiteChildResource(
+			accountID,
+			siteID,
+			cloudflareNetworkEdgeString(wan, "id"),
+			"cloudflare_magic_transit_site_wan",
+			"magic_transit_site_wan",
+			cloudflareNetworkEdgeString(wan, "name"),
+		)
+		if ok {
+			g.Resources = append(g.Resources, resource)
+		}
+	}
+	return nil
+}
+
+func (g *NetworkEdgeGenerator) appendMagicTransitSiteResources(ctx context.Context, api *cf.API, accountID string) error {
+	sites, err := listCloudflareNetworkEdgeResources(ctx, api, fmt.Sprintf("/accounts/%s/magic/sites", accountID))
+	if err != nil {
+		return err
+	}
+	for _, site := range sites {
+		siteID := cloudflareNetworkEdgeString(site, "id")
+		resource, ok := cloudflareAccountNetworkEdgeResource(
+			accountID,
+			siteID,
+			"cloudflare_magic_transit_site",
+			"magic_transit_site",
+			cloudflareNetworkEdgeString(site, "name"),
+		)
+		if ok {
+			g.Resources = append(g.Resources, resource)
+		}
+		if siteID == "" {
+			continue
+		}
+		if err := runCloudflareNetworkEdgeDiscoveries([]cloudflareNetworkEdgeDiscovery{
+			{
+				name:      "Magic Transit site ACLs",
+				scope:     siteID,
+				resources: &g.Resources,
+				discover: func() error {
+					return g.appendMagicTransitSiteACLResources(ctx, api, accountID, siteID)
+				},
+			},
+			{
+				name:      "Magic Transit site LANs",
+				scope:     siteID,
+				resources: &g.Resources,
+				discover: func() error {
+					return g.appendMagicTransitSiteLANResources(ctx, api, accountID, siteID)
+				},
+			},
+			{
+				name:      "Magic Transit site WANs",
+				scope:     siteID,
+				resources: &g.Resources,
+				discover: func() error {
+					return g.appendMagicTransitSiteWANResources(ctx, api, accountID, siteID)
+				},
+			},
+		}); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (g *NetworkEdgeGenerator) appendZoneNetworkEdgeResources(ctx context.Context, api *cf.API, zone cf.Zone) error {
+	return runCloudflareNetworkEdgeDiscoveries([]cloudflareNetworkEdgeDiscovery{
+		{
+			name:      "Spectrum applications",
+			scope:     zone.ID,
+			resources: &g.Resources,
+			discover: func() error {
+				return g.appendSpectrumApplicationResources(ctx, api, zone)
+			},
+		},
+		{
+			name:      "regional hostnames",
+			scope:     zone.ID,
+			resources: &g.Resources,
+			discover: func() error {
+				return g.appendRegionalHostnameResources(ctx, api, zone)
+			},
+		},
+		{
+			name:      "Web3 hostnames",
+			scope:     zone.ID,
+			resources: &g.Resources,
+			discover: func() error {
+				return g.appendWeb3HostnameResources(ctx, api, zone)
+			},
+		},
+	})
+}
+
+func (g *NetworkEdgeGenerator) appendAccountNetworkEdgeResources(ctx context.Context, api *cf.API, accountID string) error {
+	return runCloudflareNetworkEdgeDiscoveries([]cloudflareNetworkEdgeDiscovery{
+		{
+			name:      "address maps",
+			scope:     accountID,
+			resources: &g.Resources,
+			discover: func() error {
+				return g.appendAddressMapResources(ctx, api, accountID)
+			},
+		},
+		{
+			name:      "Magic Network Monitoring rules",
+			scope:     accountID,
+			resources: &g.Resources,
+			discover: func() error {
+				return g.appendMagicNetworkMonitoringRuleResources(ctx, api, accountID)
+			},
+		},
+		{
+			name:      "Magic Transit sites",
+			scope:     accountID,
+			resources: &g.Resources,
+			discover: func() error {
+				return g.appendMagicTransitSiteResources(ctx, api, accountID)
+			},
+		},
+	})
+}
+
+func (g *NetworkEdgeGenerator) InitResources() error {
+	ctx := context.Background()
+	api, err := g.initializeAPI()
+	if err != nil {
+		return err
+	}
+
+	zones, err := cloudflareZones(ctx, api)
+	if err != nil {
+		return err
+	}
+	for _, zone := range zones {
+		if err := g.appendZoneNetworkEdgeResources(ctx, api, zone); err != nil {
+			return err
+		}
+	}
+
+	accountID := g.accountID()
+	if accountID == "" {
+		return nil
+	}
+	return g.appendAccountNetworkEdgeResources(ctx, api, accountID)
+}

--- a/providers/cloudflare/network_edge.go
+++ b/providers/cloudflare/network_edge.go
@@ -179,7 +179,10 @@ func cloudflareRegionalHostnameResource(zone cf.Zone, hostname string) (terrafor
 		cloudflareResourceName(zone.Name, "regional_hostname", hostname),
 		"cloudflare_regional_hostname",
 		"cloudflare",
-		map[string]string{"zone_id": zone.ID},
+		map[string]string{
+			"hostname": hostname,
+			"zone_id":  zone.ID,
+		},
 		[]string{},
 		map[string]interface{}{},
 	)

--- a/providers/cloudflare/network_edge.go
+++ b/providers/cloudflare/network_edge.go
@@ -76,6 +76,7 @@ func cloudflareNetworkEdgeOptionalErrorMessage(message string, errorMessages []s
 			"not entitled",
 			"permission denied",
 			"requires a paid plan",
+			"unauthorized",
 			"upgrade your plan",
 		} {
 			if strings.Contains(normalized, marker) {

--- a/providers/cloudflare/network_edge_test.go
+++ b/providers/cloudflare/network_edge_test.go
@@ -194,7 +194,7 @@ func TestRunCloudflareNetworkEdgeDiscoveriesContinuesAfterOptionalError(t *testi
 	}
 }
 
-func TestAppendNetworkEdgeResourcesContinuesToAccountResourcesAfterZoneListingError(t *testing.T) {
+func TestAppendNetworkEdgeResourcesContinuesToAccountResourcesAfterOptionalZoneListingError(t *testing.T) {
 	api := newCloudflareNetworkEdgeTestAPI(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch r.URL.Path {
 		case "/accounts/account-123/addressing/address_maps":
@@ -208,8 +208,9 @@ func TestAppendNetworkEdgeResourcesContinuesToAccountResourcesAfterZoneListingEr
 		}
 	}))
 	g := &NetworkEdgeGenerator{}
+	zoneErr := cf.NewAuthorizationError(&cf.Error{ErrorMessages: []string{"missing permission"}})
 
-	err := g.appendNetworkEdgeResources(context.Background(), api, nil, errors.New("zone read denied"), "account-123")
+	err := g.appendNetworkEdgeResources(context.Background(), api, nil, &zoneErr, "account-123")
 	if err != nil {
 		t.Fatalf("appendNetworkEdgeResources() error = %v, want nil", err)
 	}
@@ -224,10 +225,20 @@ func TestAppendNetworkEdgeResourcesContinuesToAccountResourcesAfterZoneListingEr
 	}
 }
 
+func TestAppendNetworkEdgeResourcesReturnsNonOptionalZoneListingErrorWithAccountID(t *testing.T) {
+	g := &NetworkEdgeGenerator{}
+	zoneErr := errors.New("temporary Cloudflare failure")
+	err := g.appendNetworkEdgeResources(context.Background(), nil, nil, zoneErr, "account-123")
+	if !errors.Is(err, zoneErr) {
+		t.Fatalf("appendNetworkEdgeResources() error = %v, want wrapped zone error", err)
+	}
+}
+
 func TestAppendNetworkEdgeResourcesReturnsZoneListingErrorWithoutAccountID(t *testing.T) {
 	g := &NetworkEdgeGenerator{}
-	err := g.appendNetworkEdgeResources(context.Background(), nil, nil, errors.New("zone read denied"), "")
-	if err == nil {
+	zoneErr := errors.New("zone read denied")
+	err := g.appendNetworkEdgeResources(context.Background(), nil, nil, zoneErr, "")
+	if !errors.Is(err, zoneErr) {
 		t.Fatal("expected zone listing error without account ID")
 	}
 }

--- a/providers/cloudflare/network_edge_test.go
+++ b/providers/cloudflare/network_edge_test.go
@@ -1,0 +1,290 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package cloudflare
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"testing"
+
+	"github.com/chenrui333/terraformer/terraformutils"
+	"github.com/chenrui333/terraformer/terraformutils/tfcompat"
+	cf "github.com/cloudflare/cloudflare-go"
+)
+
+func TestCloudflareZoneNetworkEdgeResourceUsesCompositeImportID(t *testing.T) {
+	resource, ok := cloudflareZoneNetworkEdgeResource(
+		cf.Zone{ID: "zone-123", Name: "example.com"},
+		"app-456",
+		"cloudflare_spectrum_application",
+		"spectrum_application",
+		"ssh.example.com",
+		"tcp/22",
+	)
+	if !ok {
+		t.Fatal("expected zone network edge resource")
+	}
+	if resource.InstanceInfo.Type != "cloudflare_spectrum_application" {
+		t.Fatalf("resource type = %q, want cloudflare_spectrum_application", resource.InstanceInfo.Type)
+	}
+	if resource.InstanceState.ID != "app-456" {
+		t.Fatalf("resource ID = %q, want app-456", resource.InstanceState.ID)
+	}
+	if got := resource.InstanceState.Attributes["zone_id"]; got != "zone-123" {
+		t.Fatalf("zone_id = %q, want zone-123", got)
+	}
+	if got := resource.InstanceState.Meta["import_id"]; got != "zone-123/app-456" {
+		t.Fatalf("import_id = %q, want zone-123/app-456", got)
+	}
+}
+
+func TestCloudflareRegionalHostnameResourcePreservesID(t *testing.T) {
+	resource, ok := cloudflareRegionalHostnameResource(
+		cf.Zone{ID: "zone-123", Name: "example.com"},
+		"eu.example.com",
+	)
+	if !ok {
+		t.Fatal("expected regional hostname resource")
+	}
+	if resource.InstanceInfo.Type != "cloudflare_regional_hostname" {
+		t.Fatalf("resource type = %q, want cloudflare_regional_hostname", resource.InstanceInfo.Type)
+	}
+	if got := resource.InstanceState.Meta["import_id"]; got != "zone-123/eu.example.com" {
+		t.Fatalf("import_id = %q, want zone-123/eu.example.com", got)
+	}
+	preserveID, ok := resource.InstanceState.Meta[tfcompat.MetaKeyPreserveIDAfterRefresh].(bool)
+	if !ok || !preserveID {
+		t.Fatalf("preserve ID metadata = %#v, want true", resource.InstanceState.Meta[tfcompat.MetaKeyPreserveIDAfterRefresh])
+	}
+}
+
+func TestCloudflareAccountNetworkEdgeResourceUsesCompositeImportID(t *testing.T) {
+	resource, ok := cloudflareAccountNetworkEdgeResource(
+		"account-123",
+		"map-456",
+		"cloudflare_address_map",
+		"address_map",
+		"production",
+	)
+	if !ok {
+		t.Fatal("expected account network edge resource")
+	}
+	if resource.InstanceInfo.Type != "cloudflare_address_map" {
+		t.Fatalf("resource type = %q, want cloudflare_address_map", resource.InstanceInfo.Type)
+	}
+	if got := resource.InstanceState.Attributes["account_id"]; got != "account-123" {
+		t.Fatalf("account_id = %q, want account-123", got)
+	}
+	if got := resource.InstanceState.Meta["import_id"]; got != "account-123/map-456" {
+		t.Fatalf("import_id = %q, want account-123/map-456", got)
+	}
+}
+
+func TestCloudflareMagicTransitSiteChildResourceUsesCompositeImportID(t *testing.T) {
+	resource, ok := cloudflareMagicTransitSiteChildResource(
+		"account-123",
+		"site-456",
+		"lan-789",
+		"cloudflare_magic_transit_site_lan",
+		"magic_transit_site_lan",
+		"office",
+	)
+	if !ok {
+		t.Fatal("expected Magic Transit site child resource")
+	}
+	if got := resource.InstanceState.Attributes["account_id"]; got != "account-123" {
+		t.Fatalf("account_id = %q, want account-123", got)
+	}
+	if got := resource.InstanceState.Attributes["site_id"]; got != "site-456" {
+		t.Fatalf("site_id = %q, want site-456", got)
+	}
+	if got := resource.InstanceState.Meta["import_id"]; got != "account-123/site-456/lan-789" {
+		t.Fatalf("import_id = %q, want account-123/site-456/lan-789", got)
+	}
+}
+
+func TestCloudflareNetworkEdgeResourceConstructorsSkipMissingIDs(t *testing.T) {
+	if _, ok := cloudflareZoneNetworkEdgeResource(cf.Zone{ID: "zone-123"}, "", "cloudflare_spectrum_application", "spectrum_application"); ok {
+		t.Fatal("expected zone resource without resource ID to be skipped")
+	}
+	if _, ok := cloudflareRegionalHostnameResource(cf.Zone{ID: "zone-123"}, ""); ok {
+		t.Fatal("expected regional hostname without hostname to be skipped")
+	}
+	if _, ok := cloudflareAccountNetworkEdgeResource("", "map-123", "cloudflare_address_map", "address_map"); ok {
+		t.Fatal("expected account resource without account ID to be skipped")
+	}
+	if _, ok := cloudflareMagicTransitSiteChildResource("account-123", "", "lan-123", "cloudflare_magic_transit_site_lan", "lan"); ok {
+		t.Fatal("expected site child resource without site ID to be skipped")
+	}
+}
+
+func TestCloudflareAddressMapImportableSkipsManagedMaps(t *testing.T) {
+	tests := []struct {
+		name       string
+		addressMap cloudflareNetworkEdgeRawResource
+		want       bool
+	}{
+		{name: "modifiable", addressMap: cloudflareNetworkEdgeRawResource{"can_delete": true, "can_modify_ips": true}, want: true},
+		{name: "cannot delete", addressMap: cloudflareNetworkEdgeRawResource{"can_delete": false, "can_modify_ips": true}, want: false},
+		{name: "cannot modify IPs", addressMap: cloudflareNetworkEdgeRawResource{"can_delete": true, "can_modify_ips": false}, want: false},
+		{name: "missing flags", addressMap: cloudflareNetworkEdgeRawResource{}, want: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := cloudflareAddressMapImportable(tt.addressMap); got != tt.want {
+				t.Fatalf("cloudflareAddressMapImportable() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestRunCloudflareNetworkEdgeDiscoveriesRollsBackFailedDiscovery(t *testing.T) {
+	resources := []terraformutils.Resource{}
+	err := runCloudflareNetworkEdgeDiscoveries([]cloudflareNetworkEdgeDiscovery{
+		{
+			name:      "fails",
+			scope:     "account-123",
+			resources: &resources,
+			discover: func() error {
+				resources = append(resources, terraformutils.NewResource("partial", "partial", "cloudflare_address_map", "cloudflare", nil, nil, nil))
+				return errors.New("unexpected response")
+			},
+		},
+	})
+	if err == nil {
+		t.Fatal("expected non-optional discovery error")
+	}
+	if len(resources) != 0 {
+		t.Fatalf("resources after failed discovery = %#v, want none", resources)
+	}
+}
+
+func TestRunCloudflareNetworkEdgeDiscoveriesContinuesAfterOptionalError(t *testing.T) {
+	resources := []terraformutils.Resource{}
+	err := runCloudflareNetworkEdgeDiscoveries([]cloudflareNetworkEdgeDiscovery{
+		{
+			name:      "permission gated",
+			scope:     "account-123",
+			resources: &resources,
+			discover: func() error {
+				resources = append(resources, terraformutils.NewResource("partial", "partial", "cloudflare_address_map", "cloudflare", nil, nil, nil))
+				requestErr := cf.NewRequestError(&cf.Error{ErrorMessages: []string{"access denied"}})
+				return &requestErr
+			},
+		},
+		{
+			name:      "succeeds",
+			scope:     "account-123",
+			resources: &resources,
+			discover: func() error {
+				resources = append(resources, terraformutils.NewResource("complete", "complete", "cloudflare_address_map", "cloudflare", nil, nil, nil))
+				return nil
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("runCloudflareNetworkEdgeDiscoveries() error = %v, want nil", err)
+	}
+	if len(resources) != 1 || resources[0].InstanceState.ID != "complete" {
+		t.Fatalf("resources after optional discovery rollback = %#v, want only complete", resources)
+	}
+}
+
+func TestListCloudflareNetworkEdgeResourcesPaginates(t *testing.T) {
+	api := newCloudflareNetworkEdgeTestAPI(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/accounts/account-123/addressing/address_maps" {
+			t.Fatalf("path = %q, want /accounts/account-123/addressing/address_maps", r.URL.Path)
+		}
+		switch r.URL.Query().Get("cursor") {
+		case "":
+			if got := r.URL.Query().Get("page"); got != "1" {
+				t.Fatalf("page query = %q, want 1", got)
+			}
+			writeCloudflareNetworkEdgeTestResponse(t, w, []map[string]string{{"id": "map-1"}}, map[string]interface{}{
+				"cursors": map[string]string{"after": "cursor-2"},
+			})
+		case "cursor-2":
+			writeCloudflareNetworkEdgeTestResponse(t, w, []map[string]string{{"id": "map-2"}}, map[string]interface{}{
+				"cursors": map[string]string{},
+			})
+		default:
+			t.Fatalf("cursor query = %q, want empty or cursor-2", r.URL.Query().Get("cursor"))
+		}
+	}))
+
+	resources, err := listCloudflareNetworkEdgeResources(context.Background(), api, "/accounts/account-123/addressing/address_maps")
+	if err != nil {
+		t.Fatalf("listCloudflareNetworkEdgeResources() error = %v", err)
+	}
+	if len(resources) != 2 {
+		t.Fatalf("resource count = %d, want 2", len(resources))
+	}
+	if got := cloudflareNetworkEdgeString(resources[0], "id"); got != "map-1" {
+		t.Fatalf("first id = %q, want map-1", got)
+	}
+	if got := cloudflareNetworkEdgeString(resources[1], "id"); got != "map-2" {
+		t.Fatalf("second id = %q, want map-2", got)
+	}
+}
+
+func TestNetworkEdgeUnsupportedResourcesMetadata(t *testing.T) {
+	data, err := os.ReadFile("unsupported_resources.json")
+	if err != nil {
+		t.Fatalf("read unsupported resources: %v", err)
+	}
+	var metadata cloudflareUnsupportedResourcesFile
+	if err := json.Unmarshal(data, &metadata); err != nil {
+		t.Fatalf("decode unsupported resources: %v", err)
+	}
+	seen := map[string]bool{}
+	for _, resource := range metadata.Resources {
+		seen[resource.Resource] = true
+	}
+	for _, resource := range []string{
+		"cloudflare_byo_ip_prefix",
+		"cloudflare_magic_network_monitoring_configuration",
+		"cloudflare_magic_transit_connector",
+	} {
+		if !seen[resource] {
+			t.Fatalf("unsupported metadata is missing %s", resource)
+		}
+	}
+}
+
+func newCloudflareNetworkEdgeTestAPI(t *testing.T, handler http.Handler) *cf.API {
+	t.Helper()
+
+	server := httptest.NewServer(handler)
+	t.Cleanup(server.Close)
+
+	api, err := cf.NewWithAPIToken(
+		"test-token",
+		cf.BaseURL(server.URL),
+		cf.UsingRateLimit(100000),
+		cf.UsingRetryPolicy(0, 0, 0),
+	)
+	if err != nil {
+		t.Fatalf("create Cloudflare test API: %v", err)
+	}
+	return api
+}
+
+func writeCloudflareNetworkEdgeTestResponse(t *testing.T, w http.ResponseWriter, result interface{}, resultInfo interface{}) {
+	t.Helper()
+	w.Header().Set("Content-Type", "application/json")
+
+	payload := map[string]interface{}{
+		"success": true,
+		"result":  result,
+	}
+	if resultInfo != nil {
+		payload["result_info"] = resultInfo
+	}
+	if err := json.NewEncoder(w).Encode(payload); err != nil {
+		t.Fatalf("encode test response: %v", err)
+	}
+}

--- a/providers/cloudflare/network_edge_test.go
+++ b/providers/cloudflare/network_edge_test.go
@@ -194,6 +194,44 @@ func TestRunCloudflareNetworkEdgeDiscoveriesContinuesAfterOptionalError(t *testi
 	}
 }
 
+func TestAppendNetworkEdgeResourcesContinuesToAccountResourcesAfterZoneListingError(t *testing.T) {
+	api := newCloudflareNetworkEdgeTestAPI(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/accounts/account-123/addressing/address_maps":
+			writeCloudflareNetworkEdgeTestResponse(t, w, []map[string]string{
+				{"id": "map-123", "description": "production"},
+			}, nil)
+		case "/accounts/account-123/mnm/rules", "/accounts/account-123/magic/sites":
+			writeCloudflareNetworkEdgeTestResponse(t, w, []map[string]string{}, nil)
+		default:
+			t.Fatalf("unexpected account discovery path %q", r.URL.Path)
+		}
+	}))
+	g := &NetworkEdgeGenerator{}
+
+	err := g.appendNetworkEdgeResources(context.Background(), api, nil, errors.New("zone read denied"), "account-123")
+	if err != nil {
+		t.Fatalf("appendNetworkEdgeResources() error = %v, want nil", err)
+	}
+	if len(g.Resources) != 1 {
+		t.Fatalf("resource count = %d, want 1", len(g.Resources))
+	}
+	if got := g.Resources[0].InstanceInfo.Type; got != "cloudflare_address_map" {
+		t.Fatalf("resource type = %q, want cloudflare_address_map", got)
+	}
+	if got := g.Resources[0].InstanceState.Meta["import_id"]; got != "account-123/map-123" {
+		t.Fatalf("import_id = %q, want account-123/map-123", got)
+	}
+}
+
+func TestAppendNetworkEdgeResourcesReturnsZoneListingErrorWithoutAccountID(t *testing.T) {
+	g := &NetworkEdgeGenerator{}
+	err := g.appendNetworkEdgeResources(context.Background(), nil, nil, errors.New("zone read denied"), "")
+	if err == nil {
+		t.Fatal("expected zone listing error without account ID")
+	}
+}
+
 func TestCloudflareNetworkEdgeOptionalErrorMessageDoesNotHideGenericNotFound(t *testing.T) {
 	if cloudflareNetworkEdgeOptionalErrorMessage("not found", nil) {
 		t.Fatal("generic not found should not be treated as optional")

--- a/providers/cloudflare/network_edge_test.go
+++ b/providers/cloudflare/network_edge_test.go
@@ -203,6 +203,18 @@ func TestCloudflareNetworkEdgeOptionalErrorMessageDoesNotHideGenericNotFound(t *
 	}
 }
 
+func TestCloudflareNetworkEdgeOptionalDiscoveryErrorHandlesAuthErrors(t *testing.T) {
+	authenticationErr := cf.NewAuthenticationError(&cf.Error{ErrorMessages: []string{"not authorized"}})
+	if !cloudflareNetworkEdgeOptionalDiscoveryError(&authenticationErr) {
+		t.Fatal("authentication errors should be treated as optional when they match optional markers")
+	}
+
+	authorizationErr := cf.NewAuthorizationError(&cf.Error{ErrorMessages: []string{"missing permission"}})
+	if !cloudflareNetworkEdgeOptionalDiscoveryError(&authorizationErr) {
+		t.Fatal("authorization errors should be treated as optional when they match optional markers")
+	}
+}
+
 func TestListCloudflareNetworkEdgeResourcesPaginates(t *testing.T) {
 	api := newCloudflareNetworkEdgeTestAPI(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path != "/accounts/account-123/addressing/address_maps" {

--- a/providers/cloudflare/network_edge_test.go
+++ b/providers/cloudflare/network_edge_test.go
@@ -214,7 +214,7 @@ func TestAppendNetworkEdgeResourcesContinuesToAccountResourcesAfterOptionalZoneL
 		}
 	}))
 	g := &NetworkEdgeGenerator{}
-	zoneErr := cf.NewAuthorizationError(&cf.Error{ErrorMessages: []string{"missing permission"}})
+	zoneErr := cf.NewAuthorizationError(&cf.Error{ErrorMessages: []string{"Unauthorized to access requested resource"}})
 
 	err := g.appendNetworkEdgeResources(context.Background(), api, nil, &zoneErr, "account-123")
 	if err != nil {
@@ -255,6 +255,9 @@ func TestCloudflareNetworkEdgeOptionalErrorMessageDoesNotHideGenericNotFound(t *
 	}
 	if !cloudflareNetworkEdgeOptionalErrorMessage("", []string{"feature is not available on this plan"}) {
 		t.Fatal("feature-gated errors should be treated as optional")
+	}
+	if !cloudflareNetworkEdgeOptionalErrorMessage("", []string{"Unauthorized to access requested resource"}) {
+		t.Fatal("unauthorized permission errors should be treated as optional")
 	}
 }
 

--- a/providers/cloudflare/network_edge_test.go
+++ b/providers/cloudflare/network_edge_test.go
@@ -53,6 +53,12 @@ func TestCloudflareRegionalHostnameResourcePreservesID(t *testing.T) {
 	if resource.InstanceInfo.Type != "cloudflare_regional_hostname" {
 		t.Fatalf("resource type = %q, want cloudflare_regional_hostname", resource.InstanceInfo.Type)
 	}
+	if got := resource.InstanceState.Attributes["zone_id"]; got != "zone-123" {
+		t.Fatalf("zone_id = %q, want zone-123", got)
+	}
+	if got := resource.InstanceState.Attributes["hostname"]; got != "eu.example.com" {
+		t.Fatalf("hostname = %q, want eu.example.com", got)
+	}
 	if got := resource.InstanceState.Meta["import_id"]; got != "zone-123/eu.example.com" {
 		t.Fatalf("import_id = %q, want zone-123/eu.example.com", got)
 	}

--- a/providers/cloudflare/unsupported_resources.json
+++ b/providers/cloudflare/unsupported_resources.json
@@ -104,6 +104,17 @@
       ]
     },
     {
+      "resource": "cloudflare_byo_ip_prefix",
+      "service_family": "network_edge",
+      "reason": "BYOIP prefixes are onboarding and validation lifecycle resources rather than safe broad-import inventory.",
+      "evidence": "Terraform provider v5.19.1 requires ASN and CIDR and optionally an LOA document or delegated LOA creation, while read state exposes approval, ownership, IRR, RPKI validation states, and an ownership validation token. Broad import would turn prefix onboarding and validation workflow state into Terraform-owned configuration.",
+      "status": "request-style",
+      "references": [
+        "https://github.com/chenrui333/terraformer/issues/335",
+        "https://registry.terraform.io/providers/cloudflare/cloudflare/latest/docs/resources/byo_ip_prefix"
+      ]
+    },
+    {
       "resource": "cloudflare_cloudforce_one_request",
       "service_family": "cloudforce_one",
       "reason": "Cloudforce One requests represent submitted analysis work rather than stable infrastructure inventory.",
@@ -178,6 +189,28 @@
       "references": [
         "https://github.com/chenrui333/terraformer/issues/335",
         "https://registry.terraform.io/providers/cloudflare/cloudflare/latest/docs/resources/logpush_ownership_challenge"
+      ]
+    },
+    {
+      "resource": "cloudflare_magic_network_monitoring_configuration",
+      "service_family": "network_edge",
+      "reason": "Magic Network Monitoring account configuration does not expose a provider import contract.",
+      "evidence": "Terraform provider v5.19.1 implements read/create/update/delete for cloudflare_magic_network_monitoring_configuration but does not implement ResourceWithImportState or document terraform import. The resource owns account-level router and WARP-device monitoring configuration, so Terraformer cannot safely seed it through provider import.",
+      "status": "not-importable",
+      "references": [
+        "https://github.com/chenrui333/terraformer/issues/335",
+        "https://registry.terraform.io/providers/cloudflare/cloudflare/latest/docs/resources/magic_network_monitoring_configuration"
+      ]
+    },
+    {
+      "resource": "cloudflare_magic_transit_connector",
+      "service_family": "network_edge",
+      "reason": "Magic Transit connectors can require generated or write-only license material that broad import cannot reconstruct.",
+      "evidence": "Terraform provider v5.19.1 marks license_key as Sensitive and documents it is only returned on creation, while device.provision_license is a write-only creation field. Provider import verification ignores these fields, so Terraformer cannot emit a complete connector resource from discovery alone.",
+      "status": "secret-required",
+      "references": [
+        "https://github.com/chenrui333/terraformer/issues/335",
+        "https://registry.terraform.io/providers/cloudflare/cloudflare/latest/docs/resources/magic_transit_connector"
       ]
     },
     {


### PR DESCRIPTION
## Summary

Add Terraformer import support for high-confidence Cloudflare network edge resources.

## Resources

- `cloudflare_address_map`
- `cloudflare_magic_network_monitoring_rule`
- `cloudflare_magic_transit_site`
- `cloudflare_magic_transit_site_acl`
- `cloudflare_magic_transit_site_lan`
- `cloudflare_magic_transit_site_wan`
- `cloudflare_regional_hostname`
- `cloudflare_spectrum_application`
- `cloudflare_web3_hostname`

## Implementation Notes

- Uses provider-compatible import IDs.
- Exhausts pagination where applicable.
- Seeds required fields for provider refresh.
- Keeps optional or permission-sensitive lookups best-effort where appropriate.
- Does not import Cloudflare-managed, request-style, runtime, or secret-required resources.

## Deferred / Unsupported

- `cloudflare_byo_ip_prefix`: BYOIP prefix onboarding/validation lifecycle state is request-style and includes LOA/ownership validation workflow state.
- `cloudflare_magic_network_monitoring_configuration`: provider read/write exists but the resource has no import contract.
- `cloudflare_magic_transit_connector`: connector license keys are generated/creation-only and provisioning fields are write-only.

## Scope

This PR is intentionally limited to network edge resources.

Not included:

- storage/R2/queues/Hyperdrive
- Zero Trust Gateway
- zone/account settings
- Workers script/version/deployment/body resources
- Workers KV individual key/value records
- API Shield/bot/page shield resources
- media/platform long-tail resources
- billing/subscription resources

## Validation

- `go test ./providers/cloudflare/...`
- `go test ./cmd/...`
- `go test ./providers -run 'TestUnsupportedResourcesMetadata|TestUnsupportedResourceStatusesAreDocumented' -count=1`
- `jq . providers/cloudflare/unsupported_resources.json`
- `git diff --check`

Ref: #335

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds Terraformer import support for Cloudflare Network Edge. Imports Spectrum apps, Magic Transit sites (ACL/LAN/WAN), MNM rules, address maps, and regional/Web3 hostnames.

- **New Features**
  - Import support for: `cloudflare_spectrum_application`, `cloudflare_magic_transit_site`, `cloudflare_magic_transit_site_acl`, `cloudflare_magic_transit_site_lan`, `cloudflare_magic_transit_site_wan`, `cloudflare_magic_network_monitoring_rule`, `cloudflare_address_map`, `cloudflare_regional_hostname`, `cloudflare_web3_hostname`.
  - Uses provider-compatible import IDs, exhausts pagination, seeds required fields; treats auth/permission-gated lookups as optional with safe rollback; decouples account discovery from zone listing so account resources import even when zone reads are gated.
  - Registers `network_edge`; updates docs and tests; updates `unsupported_resources.json` to exclude `cloudflare_byo_ip_prefix`, `cloudflare_magic_network_monitoring_configuration`, and `cloudflare_magic_transit_connector`.

- **Bug Fixes**
  - Recognizes unauthorized responses as optional in network edge discovery; still propagates non-optional zone errors and proceeds with account-level imports when zone reads are gated.
  - Seeds `cloudflare_regional_hostname` state so provider refresh preserves hostname and ID.

<sup>Written for commit 4ffbb888ca7513cb111e434a09d298f57119884b. Summary will update on new commits. <a href="https://cubic.dev/pr/chenrui333/terraformer/pull/471?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

