### PR TITLE
feat(cloudflare): add DNSSEC settings imports

### DIFF
--- a/docs/cloudflare.md
+++ b/docs/cloudflare.md
@@ -102,6 +102,7 @@ List of supported Cloudflare services:
   * `cloudflare_waiting_room_settings`
   * `cloudflare_zone_cache_reserve`
   * `cloudflare_zone_cache_variants`
+  * `cloudflare_zone_dnssec`
   * `cloudflare_zone_hold`
 
   Account-scoped settings and DNS transfer resources require `CLOUDFLARE_ACCOUNT_ID`.

--- a/providers/cloudflare/settings.go
+++ b/providers/cloudflare/settings.go
@@ -745,18 +745,24 @@ func cloudflareZoneCacheVariantsConfigured(value cf.ZoneCacheVariantsValues) boo
 }
 
 func cloudflareZoneDNSSECShouldImport(setting cloudflareZoneDNSSECSetting) bool {
+	desiredStatus := cloudflareZoneDNSSECDesiredStatus(setting.Status)
+	if desiredStatus == "active" || strings.EqualFold(setting.Status, "pending-disabled") {
+		return true
+	}
+	if setting.Status != "" && desiredStatus == "" {
+		return false
+	}
 	if cloudflareBoolPointerValue(setting.DNSSECMultiSigner) ||
 		cloudflareBoolPointerValue(setting.DNSSECPresigned) ||
 		cloudflareBoolPointerValue(setting.DNSSECUseNsec3) {
 		return true
 	}
-	return strings.ToLower(setting.Status) == "active"
+	return false
 }
 
 func cloudflareZoneDNSSECAttributes(setting cloudflareZoneDNSSECSetting) map[string]string {
 	attributes := map[string]string{}
-	status := strings.ToLower(setting.Status)
-	if cloudflareZoneDNSSECStatusConfigurable(status) {
+	if status := cloudflareZoneDNSSECDesiredStatus(setting.Status); status != "" {
 		attributes["status"] = status
 	}
 	cloudflareSetBoolPointerAttribute(attributes, "dnssec_multi_signer", setting.DNSSECMultiSigner)
@@ -772,21 +778,19 @@ func cloudflareZoneDNSSECResource(zone cf.Zone, setting cloudflareZoneDNSSECSett
 		"zone_dnssec",
 		cloudflareZoneDNSSECAttributes(setting),
 	)
-	resource.IgnoreKeys = append(resource.IgnoreKeys, cloudflareZoneDNSSECIgnoreKeys(setting)...)
+	resource.IgnoreKeys = append(resource.IgnoreKeys, cloudflareZoneDNSSECComputedKeys...)
 	return resource
 }
 
-func cloudflareZoneDNSSECIgnoreKeys(setting cloudflareZoneDNSSECSetting) []string {
-	ignoreKeys := append([]string{}, cloudflareZoneDNSSECComputedKeys...)
-	if !cloudflareZoneDNSSECStatusConfigurable(setting.Status) {
-		ignoreKeys = append(ignoreKeys, "^status$")
+func cloudflareZoneDNSSECDesiredStatus(status string) string {
+	switch strings.ToLower(status) {
+	case "active", "pending":
+		return "active"
+	case "disabled", "pending-disabled":
+		return "disabled"
+	default:
+		return ""
 	}
-	return ignoreKeys
-}
-
-func cloudflareZoneDNSSECStatusConfigurable(status string) bool {
-	status = strings.ToLower(status)
-	return status == "active" || status == "disabled"
 }
 
 func cloudflareSetBoolPointerAttribute(attributes map[string]string, key string, value *bool) {

--- a/providers/cloudflare/settings.go
+++ b/providers/cloudflare/settings.go
@@ -66,6 +66,26 @@ type cloudflareManagedTransformHeader struct {
 	Enabled bool   `json:"enabled"`
 }
 
+type cloudflareZoneDNSSECSetting struct {
+	Status            string `json:"status"`
+	DNSSECMultiSigner *bool  `json:"dnssec_multi_signer"`
+	DNSSECPresigned   *bool  `json:"dnssec_presigned"`
+	DNSSECUseNsec3    *bool  `json:"dnssec_use_nsec3"`
+}
+
+var cloudflareZoneDNSSECComputedKeys = []string{
+	"^algorithm$",
+	"^digest$",
+	"^digest_algorithm$",
+	"^digest_type$",
+	"^ds$",
+	"^flags$",
+	"^key_tag$",
+	"^key_type$",
+	"^modified_on$",
+	"^public_key$",
+}
+
 func (g *SettingsGenerator) InitResources() error {
 	ctx := context.Background()
 	api, err := g.initializeAPI()
@@ -124,6 +144,7 @@ func (g *SettingsGenerator) appendZoneSettingsResources(ctx context.Context, api
 		g.appendWaitingRoomSettingsResource,
 		g.appendZoneCacheReserveResource,
 		g.appendZoneCacheVariantsResource,
+		g.appendZoneDNSSECResource,
 		g.appendZoneHoldResource,
 		g.appendDNSZoneTransfersIncomingResource,
 		g.appendDNSZoneTransfersOutgoingResource,
@@ -487,6 +508,21 @@ func (g *SettingsGenerator) appendZoneCacheVariantsResource(ctx context.Context,
 	return nil
 }
 
+func (g *SettingsGenerator) appendZoneDNSSECResource(ctx context.Context, api *cf.API, zone cf.Zone) error {
+	setting := cloudflareZoneDNSSECSetting{}
+	if err := cloudflareReadRawSetting(ctx, api, fmt.Sprintf("/zones/%s/dnssec", zone.ID), &setting); err != nil {
+		if cloudflareOptionalSettingsMissing(err) {
+			return nil
+		}
+		return fmt.Errorf("get Zone DNSSEC setting for zone %q: %w", zone.ID, err)
+	}
+	if !cloudflareZoneDNSSECShouldImport(setting) {
+		return nil
+	}
+	g.Resources = append(g.Resources, cloudflareZoneDNSSECResource(zone, setting))
+	return nil
+}
+
 func (g *SettingsGenerator) appendZoneHoldResource(ctx context.Context, api *cf.API, zone cf.Zone) error {
 	setting, err := api.GetZoneHold(ctx, cf.ZoneIdentifier(zone.ID), cf.GetZoneHoldParams{})
 	if err != nil {
@@ -706,6 +742,53 @@ func cloudflareZoneCacheVariantsConfigured(value cf.ZoneCacheVariantsValues) boo
 		len(value.Tif) > 0 ||
 		len(value.Tiff) > 0 ||
 		len(value.Webp) > 0
+}
+
+func cloudflareZoneDNSSECShouldImport(setting cloudflareZoneDNSSECSetting) bool {
+	status := strings.ToLower(setting.Status)
+	if status == "active" {
+		return true
+	}
+	if status != "" && status != "disabled" {
+		return false
+	}
+	return cloudflareBoolPointerValue(setting.DNSSECMultiSigner) ||
+		cloudflareBoolPointerValue(setting.DNSSECPresigned) ||
+		cloudflareBoolPointerValue(setting.DNSSECUseNsec3)
+}
+
+func cloudflareZoneDNSSECAttributes(setting cloudflareZoneDNSSECSetting) map[string]string {
+	attributes := map[string]string{}
+	status := strings.ToLower(setting.Status)
+	if status == "active" || status == "disabled" {
+		attributes["status"] = status
+	}
+	cloudflareSetBoolPointerAttribute(attributes, "dnssec_multi_signer", setting.DNSSECMultiSigner)
+	cloudflareSetBoolPointerAttribute(attributes, "dnssec_presigned", setting.DNSSECPresigned)
+	cloudflareSetBoolPointerAttribute(attributes, "dnssec_use_nsec3", setting.DNSSECUseNsec3)
+	return attributes
+}
+
+func cloudflareZoneDNSSECResource(zone cf.Zone, setting cloudflareZoneDNSSECSetting) terraformutils.Resource {
+	resource := cloudflareZoneSingletonSettingResourceWithAttributes(
+		zone,
+		"cloudflare_zone_dnssec",
+		"zone_dnssec",
+		cloudflareZoneDNSSECAttributes(setting),
+	)
+	resource.IgnoreKeys = append(resource.IgnoreKeys, cloudflareZoneDNSSECComputedKeys...)
+	return resource
+}
+
+func cloudflareSetBoolPointerAttribute(attributes map[string]string, key string, value *bool) {
+	if value == nil {
+		return
+	}
+	attributes[key] = strconv.FormatBool(*value)
+}
+
+func cloudflareBoolPointerValue(value *bool) bool {
+	return value != nil && *value
 }
 
 func cloudflareZoneHoldConfigured(setting cf.ZoneHold) bool {

--- a/providers/cloudflare/settings.go
+++ b/providers/cloudflare/settings.go
@@ -756,7 +756,7 @@ func cloudflareZoneDNSSECShouldImport(setting cloudflareZoneDNSSECSetting) bool 
 func cloudflareZoneDNSSECAttributes(setting cloudflareZoneDNSSECSetting) map[string]string {
 	attributes := map[string]string{}
 	status := strings.ToLower(setting.Status)
-	if status == "active" || status == "disabled" {
+	if cloudflareZoneDNSSECStatusConfigurable(status) {
 		attributes["status"] = status
 	}
 	cloudflareSetBoolPointerAttribute(attributes, "dnssec_multi_signer", setting.DNSSECMultiSigner)
@@ -772,8 +772,21 @@ func cloudflareZoneDNSSECResource(zone cf.Zone, setting cloudflareZoneDNSSECSett
 		"zone_dnssec",
 		cloudflareZoneDNSSECAttributes(setting),
 	)
-	resource.IgnoreKeys = append(resource.IgnoreKeys, cloudflareZoneDNSSECComputedKeys...)
+	resource.IgnoreKeys = append(resource.IgnoreKeys, cloudflareZoneDNSSECIgnoreKeys(setting)...)
 	return resource
+}
+
+func cloudflareZoneDNSSECIgnoreKeys(setting cloudflareZoneDNSSECSetting) []string {
+	ignoreKeys := append([]string{}, cloudflareZoneDNSSECComputedKeys...)
+	if !cloudflareZoneDNSSECStatusConfigurable(setting.Status) {
+		ignoreKeys = append(ignoreKeys, "^status$")
+	}
+	return ignoreKeys
+}
+
+func cloudflareZoneDNSSECStatusConfigurable(status string) bool {
+	status = strings.ToLower(status)
+	return status == "active" || status == "disabled"
 }
 
 func cloudflareSetBoolPointerAttribute(attributes map[string]string, key string, value *bool) {

--- a/providers/cloudflare/settings.go
+++ b/providers/cloudflare/settings.go
@@ -745,16 +745,12 @@ func cloudflareZoneCacheVariantsConfigured(value cf.ZoneCacheVariantsValues) boo
 }
 
 func cloudflareZoneDNSSECShouldImport(setting cloudflareZoneDNSSECSetting) bool {
-	status := strings.ToLower(setting.Status)
-	if status == "active" {
+	if cloudflareBoolPointerValue(setting.DNSSECMultiSigner) ||
+		cloudflareBoolPointerValue(setting.DNSSECPresigned) ||
+		cloudflareBoolPointerValue(setting.DNSSECUseNsec3) {
 		return true
 	}
-	if status != "" && status != "disabled" {
-		return false
-	}
-	return cloudflareBoolPointerValue(setting.DNSSECMultiSigner) ||
-		cloudflareBoolPointerValue(setting.DNSSECPresigned) ||
-		cloudflareBoolPointerValue(setting.DNSSECUseNsec3)
+	return strings.ToLower(setting.Status) == "active"
 }
 
 func cloudflareZoneDNSSECAttributes(setting cloudflareZoneDNSSECSetting) map[string]string {

--- a/providers/cloudflare/settings.go
+++ b/providers/cloudflare/settings.go
@@ -772,14 +772,23 @@ func cloudflareZoneDNSSECAttributes(setting cloudflareZoneDNSSECSetting) map[str
 }
 
 func cloudflareZoneDNSSECResource(zone cf.Zone, setting cloudflareZoneDNSSECSetting) terraformutils.Resource {
-	resource := cloudflareZoneSingletonSettingResourceWithAttributes(
+	resource := cloudflareZoneSingletonSettingResourceWithAttributesAndAdditionalFields(
 		zone,
 		"cloudflare_zone_dnssec",
 		"zone_dnssec",
 		cloudflareZoneDNSSECAttributes(setting),
+		cloudflareZoneDNSSECAdditionalFields(setting),
 	)
 	resource.IgnoreKeys = append(resource.IgnoreKeys, cloudflareZoneDNSSECComputedKeys...)
 	return resource
+}
+
+func cloudflareZoneDNSSECAdditionalFields(setting cloudflareZoneDNSSECSetting) map[string]interface{} {
+	additionalFields := map[string]interface{}{}
+	if status := cloudflareZoneDNSSECDesiredStatus(setting.Status); status != "" {
+		additionalFields["status"] = status
+	}
+	return additionalFields
 }
 
 func cloudflareZoneDNSSECDesiredStatus(status string) string {

--- a/providers/cloudflare/settings_test.go
+++ b/providers/cloudflare/settings_test.go
@@ -334,16 +334,12 @@ func TestCloudflareZoneDNSSECResource(t *testing.T) {
 		t.Fatal("nil dnssec_use_nsec3 should not be seeded")
 	}
 	for _, key := range cloudflareZoneDNSSECComputedKeys {
-		found := false
-		for _, ignoreKey := range resource.IgnoreKeys {
-			if ignoreKey == key {
-				found = true
-				break
-			}
-		}
-		if !found {
+		if !cloudflareResourceIgnoresKey(resource, key) {
 			t.Fatalf("DNSSEC resource should ignore computed key %q", key)
 		}
+	}
+	if cloudflareResourceIgnoresKey(resource, "^status$") {
+		t.Fatal("configurable DNSSEC status should not be ignored")
 	}
 
 	transitionalResource := cloudflareZoneDNSSECResource(zone, cloudflareZoneDNSSECSetting{
@@ -356,6 +352,18 @@ func TestCloudflareZoneDNSSECResource(t *testing.T) {
 	if got := transitionalResource.InstanceState.Attributes["dnssec_use_nsec3"]; got != "true" {
 		t.Fatalf("dnssec_use_nsec3 = %q, want true", got)
 	}
+	if !cloudflareResourceIgnoresKey(transitionalResource, "^status$") {
+		t.Fatal("transitional DNSSEC status should be ignored after provider refresh")
+	}
+}
+
+func cloudflareResourceIgnoresKey(resource terraformutils.Resource, key string) bool {
+	for _, ignoreKey := range resource.IgnoreKeys {
+		if ignoreKey == key {
+			return true
+		}
+	}
+	return false
 }
 
 func TestCloudflareZoneHoldAttributes(t *testing.T) {

--- a/providers/cloudflare/settings_test.go
+++ b/providers/cloudflare/settings_test.go
@@ -361,6 +361,22 @@ func TestCloudflareZoneDNSSECResource(t *testing.T) {
 	if cloudflareResourceIgnoresKey(transitionalResource, "^status$") {
 		t.Fatal("transitional DNSSEC desired status should not be ignored")
 	}
+	if got := transitionalResource.AdditionalFields["status"]; got != "active" {
+		t.Fatalf("transitional DNSSEC AdditionalFields status = %#v, want active", got)
+	}
+
+	transitionalResource.InstanceState.Attributes["status"] = "pending"
+	parser := terraformutils.NewFlatmapParser(transitionalResource.InstanceState.Attributes, nil, nil)
+	impliedType := cty.Object(map[string]cty.Type{
+		"status":  cty.String,
+		"zone_id": cty.String,
+	})
+	if err := transitionalResource.ParseTFstate(parser, impliedType); err != nil {
+		t.Fatalf("ParseTFstate() error = %v", err)
+	}
+	if got := transitionalResource.Item["status"]; got != "active" {
+		t.Fatalf("parsed transitional DNSSEC status = %q, want active", got)
+	}
 
 	disablingResource := cloudflareZoneDNSSECResource(zone, cloudflareZoneDNSSECSetting{Status: "pending-disabled"})
 	if got := disablingResource.InstanceState.Attributes["status"]; got != "disabled" {

--- a/providers/cloudflare/settings_test.go
+++ b/providers/cloudflare/settings_test.go
@@ -103,6 +103,9 @@ func TestCloudflareSettingsDefaultImportPolicy(t *testing.T) {
 	if cloudflareZoneDNSSECShouldImport(cloudflareZoneDNSSECSetting{Status: "pending"}) {
 		t.Fatal("unsupported DNSSEC status should be skipped")
 	}
+	if !cloudflareZoneDNSSECShouldImport(cloudflareZoneDNSSECSetting{Status: "pending", DNSSECMultiSigner: &trueValue}) {
+		t.Fatal("explicit DNSSEC options should be imported for transitional statuses")
+	}
 	if !cloudflareZoneDNSSECShouldImport(cloudflareZoneDNSSECSetting{Status: "disabled", DNSSECMultiSigner: &trueValue}) {
 		t.Fatal("explicit DNSSEC options should be imported")
 	}
@@ -341,6 +344,17 @@ func TestCloudflareZoneDNSSECResource(t *testing.T) {
 		if !found {
 			t.Fatalf("DNSSEC resource should ignore computed key %q", key)
 		}
+	}
+
+	transitionalResource := cloudflareZoneDNSSECResource(zone, cloudflareZoneDNSSECSetting{
+		Status:         "pending",
+		DNSSECUseNsec3: &trueValue,
+	})
+	if _, ok := transitionalResource.InstanceState.Attributes["status"]; ok {
+		t.Fatal("transitional DNSSEC status should not be seeded")
+	}
+	if got := transitionalResource.InstanceState.Attributes["dnssec_use_nsec3"]; got != "true" {
+		t.Fatalf("dnssec_use_nsec3 = %q, want true", got)
 	}
 }
 

--- a/providers/cloudflare/settings_test.go
+++ b/providers/cloudflare/settings_test.go
@@ -100,11 +100,17 @@ func TestCloudflareSettingsDefaultImportPolicy(t *testing.T) {
 	if cloudflareZoneDNSSECShouldImport(cloudflareZoneDNSSECSetting{Status: "disabled"}) {
 		t.Fatal("disabled DNSSEC without explicit options should be skipped")
 	}
-	if cloudflareZoneDNSSECShouldImport(cloudflareZoneDNSSECSetting{Status: "pending"}) {
-		t.Fatal("unsupported DNSSEC status should be skipped")
+	if !cloudflareZoneDNSSECShouldImport(cloudflareZoneDNSSECSetting{Status: "pending"}) {
+		t.Fatal("pending DNSSEC should be imported")
 	}
 	if !cloudflareZoneDNSSECShouldImport(cloudflareZoneDNSSECSetting{Status: "pending", DNSSECMultiSigner: &trueValue}) {
 		t.Fatal("explicit DNSSEC options should be imported for transitional statuses")
+	}
+	if !cloudflareZoneDNSSECShouldImport(cloudflareZoneDNSSECSetting{Status: "pending-disabled"}) {
+		t.Fatal("pending-disabled DNSSEC should be imported")
+	}
+	if cloudflareZoneDNSSECShouldImport(cloudflareZoneDNSSECSetting{Status: "unknown", DNSSECMultiSigner: &trueValue}) {
+		t.Fatal("unknown DNSSEC status should be skipped")
 	}
 	if !cloudflareZoneDNSSECShouldImport(cloudflareZoneDNSSECSetting{Status: "disabled", DNSSECMultiSigner: &trueValue}) {
 		t.Fatal("explicit DNSSEC options should be imported")
@@ -346,14 +352,19 @@ func TestCloudflareZoneDNSSECResource(t *testing.T) {
 		Status:         "pending",
 		DNSSECUseNsec3: &trueValue,
 	})
-	if _, ok := transitionalResource.InstanceState.Attributes["status"]; ok {
-		t.Fatal("transitional DNSSEC status should not be seeded")
+	if got := transitionalResource.InstanceState.Attributes["status"]; got != "active" {
+		t.Fatalf("transitional DNSSEC status = %q, want active", got)
 	}
 	if got := transitionalResource.InstanceState.Attributes["dnssec_use_nsec3"]; got != "true" {
 		t.Fatalf("dnssec_use_nsec3 = %q, want true", got)
 	}
-	if !cloudflareResourceIgnoresKey(transitionalResource, "^status$") {
-		t.Fatal("transitional DNSSEC status should be ignored after provider refresh")
+	if cloudflareResourceIgnoresKey(transitionalResource, "^status$") {
+		t.Fatal("transitional DNSSEC desired status should not be ignored")
+	}
+
+	disablingResource := cloudflareZoneDNSSECResource(zone, cloudflareZoneDNSSECSetting{Status: "pending-disabled"})
+	if got := disablingResource.InstanceState.Attributes["status"]; got != "disabled" {
+		t.Fatalf("pending-disabled DNSSEC status = %q, want disabled", got)
 	}
 }
 

--- a/providers/cloudflare/settings_test.go
+++ b/providers/cloudflare/settings_test.go
@@ -49,6 +49,8 @@ func TestAppendZoneSingletonSettingResource(t *testing.T) {
 }
 
 func TestCloudflareSettingsDefaultImportPolicy(t *testing.T) {
+	trueValue := true
+
 	if !cloudflareSettingIsOn("on") {
 		t.Fatal("cloudflareSettingIsOn(on) = false, want true")
 	}
@@ -91,6 +93,18 @@ func TestCloudflareSettingsDefaultImportPolicy(t *testing.T) {
 	}
 	if cloudflareZoneCacheVariantsConfigured(cf.ZoneCacheVariantsValues{}) {
 		t.Fatal("empty cache variants should be skipped")
+	}
+	if !cloudflareZoneDNSSECShouldImport(cloudflareZoneDNSSECSetting{Status: "active"}) {
+		t.Fatal("active DNSSEC should be imported")
+	}
+	if cloudflareZoneDNSSECShouldImport(cloudflareZoneDNSSECSetting{Status: "disabled"}) {
+		t.Fatal("disabled DNSSEC without explicit options should be skipped")
+	}
+	if cloudflareZoneDNSSECShouldImport(cloudflareZoneDNSSECSetting{Status: "pending"}) {
+		t.Fatal("unsupported DNSSEC status should be skipped")
+	}
+	if !cloudflareZoneDNSSECShouldImport(cloudflareZoneDNSSECSetting{Status: "disabled", DNSSECMultiSigner: &trueValue}) {
+		t.Fatal("explicit DNSSEC options should be imported")
 	}
 }
 
@@ -282,6 +296,51 @@ func TestCloudflareZoneHoldConfigured(t *testing.T) {
 				t.Fatalf("cloudflareZoneHoldConfigured() = %t, want %t", got, tt.want)
 			}
 		})
+	}
+}
+
+func TestCloudflareZoneDNSSECResource(t *testing.T) {
+	trueValue := true
+	falseValue := false
+	zone := cf.Zone{ID: "zone-123", Name: "example.com"}
+	resource := cloudflareZoneDNSSECResource(zone, cloudflareZoneDNSSECSetting{
+		Status:            "ACTIVE",
+		DNSSECMultiSigner: &trueValue,
+		DNSSECPresigned:   &falseValue,
+	})
+
+	if resource.InstanceInfo.Type != "cloudflare_zone_dnssec" {
+		t.Fatalf("resource type = %q, want cloudflare_zone_dnssec", resource.InstanceInfo.Type)
+	}
+	if got, want := resource.ResourceName, terraformutils.TfSanitize(cloudflareResourceName("example.com", "zone_dnssec")); got != want {
+		t.Fatalf("resource name = %q, want %s", got, want)
+	}
+	if got := resource.InstanceState.Attributes["zone_id"]; got != "zone-123" {
+		t.Fatalf("zone_id = %q, want zone-123", got)
+	}
+	if got := resource.InstanceState.Attributes["status"]; got != "active" {
+		t.Fatalf("status = %q, want active", got)
+	}
+	if got := resource.InstanceState.Attributes["dnssec_multi_signer"]; got != "true" {
+		t.Fatalf("dnssec_multi_signer = %q, want true", got)
+	}
+	if got := resource.InstanceState.Attributes["dnssec_presigned"]; got != "false" {
+		t.Fatalf("dnssec_presigned = %q, want false", got)
+	}
+	if _, ok := resource.InstanceState.Attributes["dnssec_use_nsec3"]; ok {
+		t.Fatal("nil dnssec_use_nsec3 should not be seeded")
+	}
+	for _, key := range cloudflareZoneDNSSECComputedKeys {
+		found := false
+		for _, ignoreKey := range resource.IgnoreKeys {
+			if ignoreKey == key {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Fatalf("DNSSEC resource should ignore computed key %q", key)
+		}
 	}
 }
 

--- a/providers/cloudflare/unsupported_resources.json
+++ b/providers/cloudflare/unsupported_resources.json
@@ -654,17 +654,6 @@
       ]
     },
     {
-      "resource": "cloudflare_zone_dnssec",
-      "service_family": "dns",
-      "reason": "Zone DNSSEC is a zone singleton with desired settings mixed with Cloudflare-generated DNSSEC metadata.",
-      "evidence": "The Terraform provider resource requires zone_id and optional desired DNSSEC settings, while read state includes generated DS/public-key fields, digest values, key tags, and modified timestamps. Import needs scoped handling to avoid treating Cloudflare-generated key material as user-authored configuration.",
-      "status": "deferred",
-      "references": [
-        "https://github.com/chenrui333/terraformer/issues/335",
-        "https://registry.terraform.io/providers/cloudflare/cloudflare/latest/docs/resources/zone_dnssec"
-      ]
-    },
-    {
       "resource": "cloudflare_zone_setting",
       "service_family": "zone_settings",
       "reason": "Generic zone setting imports need per-setting review for plan availability, value shape, and default-versus-explicit ownership.",


### PR DESCRIPTION
## Summary

Add follow-up Cloudflare settings import support for zone DNSSEC.

## Notes

- Imports cloudflare_zone_dnssec only for active DNSSEC or explicit DNSSEC options.
- Keeps disabled/default DNSSEC out of generated configuration.
- Suppresses Cloudflare-generated DNSSEC key and DS metadata from generated HCL.
- Removes the stale deferred metadata entry now that scoped DNSSEC import handling exists.

References:
- #335

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds DNSSEC settings import for Cloudflare zones, generating `cloudflare_zone_dnssec` with only user-configurable fields. Maps transitional statuses to stable values, preserves the mapped status to avoid drift, and ignores Cloudflare-generated DS/key metadata.

- **New Features**
  - Import when status is active, pending, or pending-disabled, or when any of `dnssec_multi_signer`, `dnssec_presigned`, or `dnssec_use_nsec3` is set.
  - Preserve explicit `dnssec_*` options even if status is pending/disabled.
  - Map `pending`→`active` and `pending-disabled`→`disabled` in HCL and state; skip disabled/default DNSSEC with no options.
  - Document `cloudflare_zone_dnssec` and remove its deferred entry from `unsupported_resources.json` (addresses #335).

<sup>Written for commit 05ac359ce3325c6fe625b3d19b68f8776928fc87. Summary will update on new commits. <a href="https://cubic.dev/pr/chenrui333/terraformer/pull/472?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

