### PR TITLE
feat(cloudflare): add DNS and zone settings imports

### DIFF
--- a/docs/cloudflare.md
+++ b/docs/cloudflare.md
@@ -107,10 +107,10 @@ List of supported Cloudflare services:
   * `cloudflare_zone_setting`
 
   Account-scoped settings and DNS transfer resources require `CLOUDFLARE_ACCOUNT_ID`.
-  Zone singleton settings are imported only when Terraformer can see durable, non-default
+  Zone singleton settings are imported only when Terraformer can see durable, explicit
   user-owned configuration. Cloudflare defaults are skipped so generated Terraform does not
   claim ownership of unset account or zone settings. Generic zone settings use a conservative
-  allowlist and import only known non-default values.
+  allowlist and require Cloudflare modification metadata before import.
 * `storage`
   * `cloudflare_d1_database`
   * `cloudflare_queue`

--- a/docs/cloudflare.md
+++ b/docs/cloudflare.md
@@ -104,11 +104,13 @@ List of supported Cloudflare services:
   * `cloudflare_zone_cache_variants`
   * `cloudflare_zone_dnssec`
   * `cloudflare_zone_hold`
+  * `cloudflare_zone_setting`
 
   Account-scoped settings and DNS transfer resources require `CLOUDFLARE_ACCOUNT_ID`.
   Zone singleton settings are imported only when Terraformer can see durable, non-default
   user-owned configuration. Cloudflare defaults are skipped so generated Terraform does not
-  claim ownership of unset account or zone settings.
+  claim ownership of unset account or zone settings. Generic zone settings use a conservative
+  allowlist and import only known non-default values.
 * `storage`
   * `cloudflare_d1_database`
   * `cloudflare_queue`

--- a/providers/cloudflare/settings.go
+++ b/providers/cloudflare/settings.go
@@ -73,6 +73,13 @@ type cloudflareZoneDNSSECSetting struct {
 	DNSSECUseNsec3    *bool  `json:"dnssec_use_nsec3"`
 }
 
+type cloudflareZoneSetting struct {
+	ID         string          `json:"id"`
+	Editable   bool            `json:"editable"`
+	ModifiedOn string          `json:"modified_on"`
+	Value      json.RawMessage `json:"value"`
+}
+
 var cloudflareZoneDNSSECComputedKeys = []string{
 	"^algorithm$",
 	"^digest$",
@@ -551,17 +558,14 @@ func (g *SettingsGenerator) appendZoneDNSSECResource(ctx context.Context, api *c
 }
 
 func (g *SettingsGenerator) appendZoneSettingResources(ctx context.Context, api *cf.API, zone cf.Zone) error {
-	response, err := api.ZoneSettings(ctx, zone.ID)
-	if err != nil {
+	settings := []cloudflareZoneSetting{}
+	if err := cloudflareReadRawSetting(ctx, api, fmt.Sprintf("/zones/%s/settings", zone.ID), &settings); err != nil {
 		if cloudflareOptionalSettingsMissing(err) {
 			return nil
 		}
 		return fmt.Errorf("list zone settings for zone %q: %w", zone.ID, err)
 	}
-	if response == nil {
-		return nil
-	}
-	for _, setting := range response.Result {
+	for _, setting := range settings {
 		if !cloudflareZoneSettingShouldImport(setting) {
 			continue
 		}
@@ -849,7 +853,7 @@ func cloudflareZoneDNSSECDesiredStatus(status string) string {
 	}
 }
 
-func cloudflareZoneSettingShouldImport(setting cf.ZoneSetting) bool {
+func cloudflareZoneSettingShouldImport(setting cloudflareZoneSetting) bool {
 	defaultValue, ok := cloudflareZoneSettingDefaultValues[setting.ID]
 	if !ok {
 		return false
@@ -857,12 +861,23 @@ func cloudflareZoneSettingShouldImport(setting cf.ZoneSetting) bool {
 	if !setting.Editable {
 		return false
 	}
-	value, ok := setting.Value.(string)
+	value, ok := cloudflareZoneSettingStringValue(setting)
 	return ok && !strings.EqualFold(value, defaultValue)
 }
 
-func cloudflareZoneSettingResource(zone cf.Zone, setting cf.ZoneSetting) terraformutils.Resource {
-	value, _ := setting.Value.(string)
+func cloudflareZoneSettingStringValue(setting cloudflareZoneSetting) (string, bool) {
+	if len(setting.Value) == 0 || string(setting.Value) == "null" {
+		return "", false
+	}
+	var value string
+	if err := json.Unmarshal(setting.Value, &value); err != nil {
+		return "", false
+	}
+	return value, true
+}
+
+func cloudflareZoneSettingResource(zone cf.Zone, setting cloudflareZoneSetting) terraformutils.Resource {
+	value, _ := cloudflareZoneSettingStringValue(setting)
 	resource := terraformutils.NewResource(
 		setting.ID,
 		cloudflareResourceName(zone.Name, zone.ID, "zone_setting", setting.ID),

--- a/providers/cloudflare/settings.go
+++ b/providers/cloudflare/settings.go
@@ -94,9 +94,9 @@ var cloudflareZoneDNSSECComputedKeys = []string{
 }
 
 var cloudflareZoneSettingDefaultValues = map[string]string{
-	"always_online":       "off",
+	"always_online":       "on",
 	"always_use_https":    "off",
-	"brotli":              "on",
+	"brotli":              "off",
 	"browser_check":       "on",
 	"cache_level":         "aggressive",
 	"email_obfuscation":   "on",
@@ -106,8 +106,8 @@ var cloudflareZoneSettingDefaultValues = map[string]string{
 	"rocket_loader":       "off",
 	"security_level":      "medium",
 	"server_side_exclude": "on",
-	"tls_1_3":             "on",
-	"websockets":          "on",
+	"tls_1_3":             "off",
+	"websockets":          "off",
 }
 
 var cloudflareZoneSettingIgnoredKeys = []string{

--- a/providers/cloudflare/settings.go
+++ b/providers/cloudflare/settings.go
@@ -93,21 +93,21 @@ var cloudflareZoneDNSSECComputedKeys = []string{
 	"^public_key$",
 }
 
-var cloudflareZoneSettingDefaultValues = map[string]string{
-	"always_online":       "on",
-	"always_use_https":    "off",
-	"brotli":              "off",
-	"browser_check":       "on",
-	"cache_level":         "aggressive",
-	"email_obfuscation":   "on",
-	"hotlink_protection":  "off",
-	"ip_geolocation":      "on",
-	"min_tls_version":     "1.0",
-	"rocket_loader":       "off",
-	"security_level":      "medium",
-	"server_side_exclude": "on",
-	"tls_1_3":             "off",
-	"websockets":          "off",
+var cloudflareZoneSettingImportAllowlist = map[string]struct{}{
+	"always_online":       {},
+	"always_use_https":    {},
+	"brotli":              {},
+	"browser_check":       {},
+	"cache_level":         {},
+	"email_obfuscation":   {},
+	"hotlink_protection":  {},
+	"ip_geolocation":      {},
+	"min_tls_version":     {},
+	"rocket_loader":       {},
+	"security_level":      {},
+	"server_side_exclude": {},
+	"tls_1_3":             {},
+	"websockets":          {},
 }
 
 var cloudflareZoneSettingIgnoredKeys = []string{
@@ -854,15 +854,17 @@ func cloudflareZoneDNSSECDesiredStatus(status string) string {
 }
 
 func cloudflareZoneSettingShouldImport(setting cloudflareZoneSetting) bool {
-	defaultValue, ok := cloudflareZoneSettingDefaultValues[setting.ID]
-	if !ok {
+	if _, ok := cloudflareZoneSettingImportAllowlist[setting.ID]; !ok {
 		return false
 	}
 	if !setting.Editable {
 		return false
 	}
-	value, ok := cloudflareZoneSettingStringValue(setting)
-	return ok && !strings.EqualFold(value, defaultValue)
+	if setting.ModifiedOn == "" {
+		return false
+	}
+	_, ok := cloudflareZoneSettingStringValue(setting)
+	return ok
 }
 
 func cloudflareZoneSettingStringValue(setting cloudflareZoneSetting) (string, bool) {

--- a/providers/cloudflare/settings.go
+++ b/providers/cloudflare/settings.go
@@ -86,6 +86,32 @@ var cloudflareZoneDNSSECComputedKeys = []string{
 	"^public_key$",
 }
 
+var cloudflareZoneSettingDefaultValues = map[string]string{
+	"always_online":       "off",
+	"always_use_https":    "off",
+	"brotli":              "on",
+	"browser_check":       "on",
+	"cache_level":         "aggressive",
+	"email_obfuscation":   "on",
+	"hotlink_protection":  "off",
+	"ip_geolocation":      "on",
+	"min_tls_version":     "1.0",
+	"rocket_loader":       "off",
+	"security_level":      "medium",
+	"server_side_exclude": "on",
+	"tls_1_3":             "on",
+	"websockets":          "on",
+}
+
+var cloudflareZoneSettingIgnoredKeys = []string{
+	"^id$",
+	"^editable$",
+	"^enabled$",
+	"^modified_on$",
+	"^time_remaining$",
+	"^value$",
+}
+
 func (g *SettingsGenerator) InitResources() error {
 	ctx := context.Background()
 	api, err := g.initializeAPI()
@@ -145,6 +171,7 @@ func (g *SettingsGenerator) appendZoneSettingsResources(ctx context.Context, api
 		g.appendZoneCacheReserveResource,
 		g.appendZoneCacheVariantsResource,
 		g.appendZoneDNSSECResource,
+		g.appendZoneSettingResources,
 		g.appendZoneHoldResource,
 		g.appendDNSZoneTransfersIncomingResource,
 		g.appendDNSZoneTransfersOutgoingResource,
@@ -523,6 +550,26 @@ func (g *SettingsGenerator) appendZoneDNSSECResource(ctx context.Context, api *c
 	return nil
 }
 
+func (g *SettingsGenerator) appendZoneSettingResources(ctx context.Context, api *cf.API, zone cf.Zone) error {
+	response, err := api.ZoneSettings(ctx, zone.ID)
+	if err != nil {
+		if cloudflareOptionalSettingsMissing(err) {
+			return nil
+		}
+		return fmt.Errorf("list zone settings for zone %q: %w", zone.ID, err)
+	}
+	if response == nil {
+		return nil
+	}
+	for _, setting := range response.Result {
+		if !cloudflareZoneSettingShouldImport(setting) {
+			continue
+		}
+		g.Resources = append(g.Resources, cloudflareZoneSettingResource(zone, setting))
+	}
+	return nil
+}
+
 func (g *SettingsGenerator) appendZoneHoldResource(ctx context.Context, api *cf.API, zone cf.Zone) error {
 	setting, err := api.GetZoneHold(ctx, cf.ZoneIdentifier(zone.ID), cf.GetZoneHoldParams{})
 	if err != nil {
@@ -800,6 +847,38 @@ func cloudflareZoneDNSSECDesiredStatus(status string) string {
 	default:
 		return ""
 	}
+}
+
+func cloudflareZoneSettingShouldImport(setting cf.ZoneSetting) bool {
+	defaultValue, ok := cloudflareZoneSettingDefaultValues[setting.ID]
+	if !ok {
+		return false
+	}
+	if !setting.Editable {
+		return false
+	}
+	value, ok := setting.Value.(string)
+	return ok && !strings.EqualFold(value, defaultValue)
+}
+
+func cloudflareZoneSettingResource(zone cf.Zone, setting cf.ZoneSetting) terraformutils.Resource {
+	value, _ := setting.Value.(string)
+	resource := terraformutils.NewResource(
+		setting.ID,
+		cloudflareResourceName(zone.Name, zone.ID, "zone_setting", setting.ID),
+		"cloudflare_zone_setting",
+		"cloudflare",
+		map[string]string{
+			"setting_id": setting.ID,
+			"value":      value,
+			"zone_id":    zone.ID,
+		},
+		[]string{},
+		map[string]interface{}{"value": value},
+	)
+	setCloudflareImportID(&resource, zone.ID+"/"+setting.ID)
+	resource.IgnoreKeys = append(resource.IgnoreKeys, cloudflareZoneSettingIgnoredKeys...)
+	return resource
 }
 
 func cloudflareSetBoolPointerAttribute(attributes map[string]string, key string, value *bool) {

--- a/providers/cloudflare/settings_test.go
+++ b/providers/cloudflare/settings_test.go
@@ -404,14 +404,14 @@ func TestCloudflareZoneSettingShouldImport(t *testing.T) {
 			want: true,
 		},
 		{
-			name: "supported but default effective state",
+			name: "supported modified default value",
 			setting: cloudflareZoneSetting{
 				ID:         "always_use_https",
 				Editable:   true,
 				ModifiedOn: "2026-05-17T12:00:00Z",
 				Value:      json.RawMessage(`"off"`),
 			},
-			want: false,
+			want: true,
 		},
 		{
 			name: "supported non default without modified timestamp",
@@ -420,7 +420,7 @@ func TestCloudflareZoneSettingShouldImport(t *testing.T) {
 				Editable: true,
 				Value:    json.RawMessage(`"on"`),
 			},
-			want: true,
+			want: false,
 		},
 		{
 			name: "supported but not editable",
@@ -444,7 +444,7 @@ func TestCloudflareZoneSettingShouldImport(t *testing.T) {
 		{
 			name: "non string value",
 			setting: cloudflareZoneSetting{
-				ID:         "browser_cache_ttl",
+				ID:         "always_use_https",
 				Editable:   true,
 				ModifiedOn: "2026-05-17T12:00:00Z",
 				Value:      json.RawMessage(`14400`),
@@ -460,36 +460,63 @@ func TestCloudflareZoneSettingShouldImport(t *testing.T) {
 	}
 }
 
-func TestCloudflareZoneSettingDocumentedDefaults(t *testing.T) {
+func TestCloudflareZoneSettingSkipsUnmodifiedDefaultResponses(t *testing.T) {
 	for _, tt := range []struct {
-		settingID       string
-		defaultValue    string
-		nonDefaultValue string
+		settingID    string
+		defaultValue string
 	}{
-		{settingID: "always_online", defaultValue: "on", nonDefaultValue: "off"},
-		{settingID: "brotli", defaultValue: "off", nonDefaultValue: "on"},
-		{settingID: "tls_1_3", defaultValue: "off", nonDefaultValue: "on"},
-		{settingID: "websockets", defaultValue: "off", nonDefaultValue: "on"},
+		{settingID: "always_online", defaultValue: "off"},
+		{settingID: "brotli", defaultValue: "off"},
+		{settingID: "tls_1_3", defaultValue: "on"},
+		{settingID: "websockets", defaultValue: "on"},
 	} {
 		t.Run(tt.settingID, func(t *testing.T) {
-			defaultSetting := cloudflareZoneSetting{
+			setting := cloudflareZoneSetting{
 				ID:       tt.settingID,
 				Editable: true,
 				Value:    cloudflareZoneSettingTestStringValue(tt.defaultValue),
 			}
-			if cloudflareZoneSettingShouldImport(defaultSetting) {
-				t.Fatalf("%s default value %q should not import", tt.settingID, tt.defaultValue)
-			}
-
-			nonDefaultSetting := cloudflareZoneSetting{
-				ID:       tt.settingID,
-				Editable: true,
-				Value:    cloudflareZoneSettingTestStringValue(tt.nonDefaultValue),
-			}
-			if !cloudflareZoneSettingShouldImport(nonDefaultSetting) {
-				t.Fatalf("%s non-default value %q should import", tt.settingID, tt.nonDefaultValue)
+			if cloudflareZoneSettingShouldImport(setting) {
+				t.Fatalf("%s unmodified default value %q should not import", tt.settingID, tt.defaultValue)
 			}
 		})
+	}
+}
+
+func TestCloudflareZoneSettingImportsModifiedAllowlistedValues(t *testing.T) {
+	for _, tt := range []struct {
+		settingID string
+		value     string
+	}{
+		{settingID: "always_online", value: "on"},
+		{settingID: "brotli", value: "on"},
+		{settingID: "tls_1_3", value: "off"},
+		{settingID: "websockets", value: "off"},
+	} {
+		t.Run(tt.settingID, func(t *testing.T) {
+			setting := cloudflareZoneSetting{
+				ID:         tt.settingID,
+				Editable:   true,
+				ModifiedOn: "2026-05-17T12:00:00Z",
+				Value:      cloudflareZoneSettingTestStringValue(tt.value),
+			}
+			if !cloudflareZoneSettingShouldImport(setting) {
+				t.Fatalf("%s modified value %q should import", tt.settingID, tt.value)
+			}
+		})
+	}
+}
+
+func TestCloudflareZoneSettingRawNullModifiedOnSkipsDefaultResponses(t *testing.T) {
+	response := []byte("[{\"id\":\"always_online\",\"editable\":true,\"modified_on\":null,\"value\":\"off\"},{\"id\":\"tls_1_3\",\"editable\":true,\"modified_on\":null,\"value\":\"on\"},{\"id\":\"websockets\",\"editable\":true,\"modified_on\":null,\"value\":\"on\"}]")
+	var settings []cloudflareZoneSetting
+	if err := json.Unmarshal(response, &settings); err != nil {
+		t.Fatalf("unmarshal zone settings response = %v", err)
+	}
+	for _, setting := range settings {
+		if cloudflareZoneSettingShouldImport(setting) {
+			t.Fatalf("%s with null modified_on should not import", setting.ID)
+		}
 	}
 }
 
@@ -554,7 +581,7 @@ func TestCloudflareZoneSettingResource(t *testing.T) {
 }
 
 func TestCloudflareZoneSettingRawResponseIgnoresBooleanTimeRemaining(t *testing.T) {
-	response := []byte("[{\"id\":\"development_mode\",\"editable\":true,\"modified_on\":\"2026-05-17T12:00:00Z\",\"value\":\"off\",\"time_remaining\":false},{\"id\":\"always_use_https\",\"editable\":true,\"value\":\"on\",\"time_remaining\":0}]")
+	response := []byte("[{\"id\":\"development_mode\",\"editable\":true,\"modified_on\":\"2026-05-17T12:00:00Z\",\"value\":\"off\",\"time_remaining\":false},{\"id\":\"always_use_https\",\"editable\":true,\"modified_on\":\"2026-05-17T12:00:00Z\",\"value\":\"on\",\"time_remaining\":0}]")
 	var settings []cloudflareZoneSetting
 	if err := json.Unmarshal(response, &settings); err != nil {
 		t.Fatalf("unmarshal zone settings response = %v", err)

--- a/providers/cloudflare/settings_test.go
+++ b/providers/cloudflare/settings_test.go
@@ -3,6 +3,7 @@
 package cloudflare
 
 import (
+	"encoding/json"
 	"errors"
 	"regexp"
 	"strings"
@@ -388,65 +389,65 @@ func TestCloudflareZoneDNSSECResource(t *testing.T) {
 func TestCloudflareZoneSettingShouldImport(t *testing.T) {
 	for _, tt := range []struct {
 		name    string
-		setting cf.ZoneSetting
+		setting cloudflareZoneSetting
 		want    bool
 	}{
-		{name: "empty", setting: cf.ZoneSetting{}, want: false},
+		{name: "empty", setting: cloudflareZoneSetting{}, want: false},
 		{
 			name: "supported modified editable string",
-			setting: cf.ZoneSetting{
+			setting: cloudflareZoneSetting{
 				ID:         "always_use_https",
 				Editable:   true,
 				ModifiedOn: "2026-05-17T12:00:00Z",
-				Value:      "on",
+				Value:      json.RawMessage(`"on"`),
 			},
 			want: true,
 		},
 		{
 			name: "supported but default effective state",
-			setting: cf.ZoneSetting{
+			setting: cloudflareZoneSetting{
 				ID:         "always_use_https",
 				Editable:   true,
 				ModifiedOn: "2026-05-17T12:00:00Z",
-				Value:      "off",
+				Value:      json.RawMessage(`"off"`),
 			},
 			want: false,
 		},
 		{
 			name: "supported non default without modified timestamp",
-			setting: cf.ZoneSetting{
+			setting: cloudflareZoneSetting{
 				ID:       "always_use_https",
 				Editable: true,
-				Value:    "on",
+				Value:    json.RawMessage(`"on"`),
 			},
 			want: true,
 		},
 		{
 			name: "supported but not editable",
-			setting: cf.ZoneSetting{
+			setting: cloudflareZoneSetting{
 				ID:         "always_use_https",
 				ModifiedOn: "2026-05-17T12:00:00Z",
-				Value:      "on",
+				Value:      json.RawMessage(`"on"`),
 			},
 			want: false,
 		},
 		{
 			name: "unsupported setting",
-			setting: cf.ZoneSetting{
+			setting: cloudflareZoneSetting{
 				ID:         "development_mode",
 				Editable:   true,
 				ModifiedOn: "2026-05-17T12:00:00Z",
-				Value:      "on",
+				Value:      json.RawMessage(`"on"`),
 			},
 			want: false,
 		},
 		{
 			name: "non string value",
-			setting: cf.ZoneSetting{
+			setting: cloudflareZoneSetting{
 				ID:         "browser_cache_ttl",
 				Editable:   true,
 				ModifiedOn: "2026-05-17T12:00:00Z",
-				Value:      14400,
+				Value:      json.RawMessage(`14400`),
 			},
 			want: false,
 		},
@@ -461,11 +462,11 @@ func TestCloudflareZoneSettingShouldImport(t *testing.T) {
 
 func TestCloudflareZoneSettingResource(t *testing.T) {
 	zone := cf.Zone{ID: "zone-123", Name: "example.com"}
-	resource := cloudflareZoneSettingResource(zone, cf.ZoneSetting{
+	resource := cloudflareZoneSettingResource(zone, cloudflareZoneSetting{
 		ID:         "always_use_https",
 		Editable:   true,
 		ModifiedOn: "2026-05-17T12:00:00Z",
-		Value:      "on",
+		Value:      json.RawMessage(`"on"`),
 	})
 
 	if resource.InstanceInfo.Type != "cloudflare_zone_setting" {
@@ -516,6 +517,23 @@ func TestCloudflareZoneSettingResource(t *testing.T) {
 	}
 	if _, ok := resource.Item["editable"]; ok {
 		t.Fatal("computed editable field should be ignored")
+	}
+}
+
+func TestCloudflareZoneSettingRawResponseIgnoresBooleanTimeRemaining(t *testing.T) {
+	response := []byte("[{\"id\":\"development_mode\",\"editable\":true,\"modified_on\":\"2026-05-17T12:00:00Z\",\"value\":\"off\",\"time_remaining\":false},{\"id\":\"always_use_https\",\"editable\":true,\"value\":\"on\",\"time_remaining\":0}]")
+	var settings []cloudflareZoneSetting
+	if err := json.Unmarshal(response, &settings); err != nil {
+		t.Fatalf("unmarshal zone settings response = %v", err)
+	}
+	if len(settings) != 2 {
+		t.Fatalf("settings length = %d, want 2", len(settings))
+	}
+	if cloudflareZoneSettingShouldImport(settings[0]) {
+		t.Fatal("development_mode should remain outside the zone setting allowlist")
+	}
+	if !cloudflareZoneSettingShouldImport(settings[1]) {
+		t.Fatal("always_use_https non-default value should import")
 	}
 }
 

--- a/providers/cloudflare/settings_test.go
+++ b/providers/cloudflare/settings_test.go
@@ -4,6 +4,7 @@ package cloudflare
 
 import (
 	"errors"
+	"regexp"
 	"strings"
 	"testing"
 	"time"
@@ -384,6 +385,140 @@ func TestCloudflareZoneDNSSECResource(t *testing.T) {
 	}
 }
 
+func TestCloudflareZoneSettingShouldImport(t *testing.T) {
+	for _, tt := range []struct {
+		name    string
+		setting cf.ZoneSetting
+		want    bool
+	}{
+		{name: "empty", setting: cf.ZoneSetting{}, want: false},
+		{
+			name: "supported modified editable string",
+			setting: cf.ZoneSetting{
+				ID:         "always_use_https",
+				Editable:   true,
+				ModifiedOn: "2026-05-17T12:00:00Z",
+				Value:      "on",
+			},
+			want: true,
+		},
+		{
+			name: "supported but default effective state",
+			setting: cf.ZoneSetting{
+				ID:         "always_use_https",
+				Editable:   true,
+				ModifiedOn: "2026-05-17T12:00:00Z",
+				Value:      "off",
+			},
+			want: false,
+		},
+		{
+			name: "supported non default without modified timestamp",
+			setting: cf.ZoneSetting{
+				ID:       "always_use_https",
+				Editable: true,
+				Value:    "on",
+			},
+			want: true,
+		},
+		{
+			name: "supported but not editable",
+			setting: cf.ZoneSetting{
+				ID:         "always_use_https",
+				ModifiedOn: "2026-05-17T12:00:00Z",
+				Value:      "on",
+			},
+			want: false,
+		},
+		{
+			name: "unsupported setting",
+			setting: cf.ZoneSetting{
+				ID:         "development_mode",
+				Editable:   true,
+				ModifiedOn: "2026-05-17T12:00:00Z",
+				Value:      "on",
+			},
+			want: false,
+		},
+		{
+			name: "non string value",
+			setting: cf.ZoneSetting{
+				ID:         "browser_cache_ttl",
+				Editable:   true,
+				ModifiedOn: "2026-05-17T12:00:00Z",
+				Value:      14400,
+			},
+			want: false,
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := cloudflareZoneSettingShouldImport(tt.setting); got != tt.want {
+				t.Fatalf("cloudflareZoneSettingShouldImport() = %t, want %t", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestCloudflareZoneSettingResource(t *testing.T) {
+	zone := cf.Zone{ID: "zone-123", Name: "example.com"}
+	resource := cloudflareZoneSettingResource(zone, cf.ZoneSetting{
+		ID:         "always_use_https",
+		Editable:   true,
+		ModifiedOn: "2026-05-17T12:00:00Z",
+		Value:      "on",
+	})
+
+	if resource.InstanceInfo.Type != "cloudflare_zone_setting" {
+		t.Fatalf("resource type = %q, want cloudflare_zone_setting", resource.InstanceInfo.Type)
+	}
+	if got, want := resource.ResourceName, terraformutils.TfSanitize(cloudflareResourceName("example.com", "zone-123", "zone_setting", "always_use_https")); got != want {
+		t.Fatalf("resource name = %q, want %s", got, want)
+	}
+	if got := resource.InstanceState.ID; got != "always_use_https" {
+		t.Fatalf("resource ID = %q, want always_use_https", got)
+	}
+	if got := resource.InstanceState.Attributes["zone_id"]; got != "zone-123" {
+		t.Fatalf("zone_id = %q, want zone-123", got)
+	}
+	if got := resource.InstanceState.Attributes["setting_id"]; got != "always_use_https" {
+		t.Fatalf("setting_id = %q, want always_use_https", got)
+	}
+	if got := resource.InstanceState.Attributes["value"]; got != "on" {
+		t.Fatalf("value = %q, want on", got)
+	}
+	if got := resource.InstanceState.Meta["import_id"]; got != "zone-123/always_use_https" {
+		t.Fatalf("import_id = %v, want zone-123/always_use_https", got)
+	}
+	if got := resource.AdditionalFields["value"]; got != "on" {
+		t.Fatalf("AdditionalFields value = %#v, want on", got)
+	}
+	for _, key := range cloudflareZoneSettingIgnoredKeys {
+		if !cloudflareResourceIgnoresKey(resource, key) {
+			t.Fatalf("zone setting resource should ignore key %q", key)
+		}
+	}
+
+	resource.InstanceState.Attributes["editable"] = "true"
+	resource.InstanceState.Attributes["modified_on"] = "2026-05-17T12:00:00Z"
+	parser := terraformutils.NewFlatmapParser(resource.InstanceState.Attributes, cloudflareResourceIgnoreRegexps(resource), nil)
+	impliedType := cty.Object(map[string]cty.Type{
+		"editable":    cty.Bool,
+		"modified_on": cty.String,
+		"setting_id":  cty.String,
+		"value":       cty.DynamicPseudoType,
+		"zone_id":     cty.String,
+	})
+	if err := resource.ParseTFstate(parser, impliedType); err != nil {
+		t.Fatalf("ParseTFstate() error = %v", err)
+	}
+	if got := resource.Item["value"]; got != "on" {
+		t.Fatalf("parsed value = %#v, want on", got)
+	}
+	if _, ok := resource.Item["editable"]; ok {
+		t.Fatal("computed editable field should be ignored")
+	}
+}
+
 func cloudflareResourceIgnoresKey(resource terraformutils.Resource, key string) bool {
 	for _, ignoreKey := range resource.IgnoreKeys {
 		if ignoreKey == key {
@@ -391,6 +526,14 @@ func cloudflareResourceIgnoresKey(resource terraformutils.Resource, key string) 
 		}
 	}
 	return false
+}
+
+func cloudflareResourceIgnoreRegexps(resource terraformutils.Resource) []*regexp.Regexp {
+	regexps := make([]*regexp.Regexp, 0, len(resource.IgnoreKeys))
+	for _, ignoreKey := range resource.IgnoreKeys {
+		regexps = append(regexps, regexp.MustCompile(ignoreKey))
+	}
+	return regexps
 }
 
 func TestCloudflareZoneHoldAttributes(t *testing.T) {

--- a/providers/cloudflare/settings_test.go
+++ b/providers/cloudflare/settings_test.go
@@ -460,6 +460,39 @@ func TestCloudflareZoneSettingShouldImport(t *testing.T) {
 	}
 }
 
+func TestCloudflareZoneSettingDocumentedDefaults(t *testing.T) {
+	for _, tt := range []struct {
+		settingID       string
+		defaultValue    string
+		nonDefaultValue string
+	}{
+		{settingID: "always_online", defaultValue: "on", nonDefaultValue: "off"},
+		{settingID: "brotli", defaultValue: "off", nonDefaultValue: "on"},
+		{settingID: "tls_1_3", defaultValue: "off", nonDefaultValue: "on"},
+		{settingID: "websockets", defaultValue: "off", nonDefaultValue: "on"},
+	} {
+		t.Run(tt.settingID, func(t *testing.T) {
+			defaultSetting := cloudflareZoneSetting{
+				ID:       tt.settingID,
+				Editable: true,
+				Value:    cloudflareZoneSettingTestStringValue(tt.defaultValue),
+			}
+			if cloudflareZoneSettingShouldImport(defaultSetting) {
+				t.Fatalf("%s default value %q should not import", tt.settingID, tt.defaultValue)
+			}
+
+			nonDefaultSetting := cloudflareZoneSetting{
+				ID:       tt.settingID,
+				Editable: true,
+				Value:    cloudflareZoneSettingTestStringValue(tt.nonDefaultValue),
+			}
+			if !cloudflareZoneSettingShouldImport(nonDefaultSetting) {
+				t.Fatalf("%s non-default value %q should import", tt.settingID, tt.nonDefaultValue)
+			}
+		})
+	}
+}
+
 func TestCloudflareZoneSettingResource(t *testing.T) {
 	zone := cf.Zone{ID: "zone-123", Name: "example.com"}
 	resource := cloudflareZoneSettingResource(zone, cloudflareZoneSetting{
@@ -535,6 +568,10 @@ func TestCloudflareZoneSettingRawResponseIgnoresBooleanTimeRemaining(t *testing.
 	if !cloudflareZoneSettingShouldImport(settings[1]) {
 		t.Fatal("always_use_https non-default value should import")
 	}
+}
+
+func cloudflareZoneSettingTestStringValue(value string) json.RawMessage {
+	return json.RawMessage(`"` + value + `"`)
 }
 
 func cloudflareResourceIgnoresKey(resource terraformutils.Resource, key string) bool {

--- a/providers/cloudflare/unsupported_resources.json
+++ b/providers/cloudflare/unsupported_resources.json
@@ -15,8 +15,8 @@
     {
       "resource": "cloudflare_account_dns_settings",
       "service_family": "dns",
-      "reason": "Account DNS defaults are singleton settings that need scoped follow-up before broad import.",
-      "evidence": "Issue #335 tracks account and zone DNS settings as a dedicated PR bucket. Terraformer currently imports Cloudflare DNS records and zones, while this resource owns account-level DNS defaults whose API state can include inherited defaults versus explicit account configuration.",
+      "reason": "Account DNS defaults remain deferred because the provider has no import path and API reads return effective defaults without explicit ownership markers.",
+      "evidence": "Cloudflare provider v5.19.1 documents that cloudflare_account_dns_settings does not support terraform import. Its read path returns the full account DNS defaults object, including zone_defaults, but the response does not distinguish inherited/default values from settings explicitly owned by the account.",
       "status": "deferred",
       "references": [
         "https://github.com/chenrui333/terraformer/issues/335",
@@ -645,23 +645,12 @@
     {
       "resource": "cloudflare_zone_dns_settings",
       "service_family": "dns",
-      "reason": "Zone DNS settings are zone-scoped singleton settings that need explicit ownership and default-handling review.",
-      "evidence": "Issue #335 tracks DNS settings as follow-up work. This resource owns a full zone DNS settings object, including nameserver, SOA, multi-provider, secondary DNS, and internal DNS options that may reflect API defaults rather than explicit Terraform intent.",
+      "reason": "Zone DNS settings remain deferred because the provider has no import path and API reads return effective zone settings without explicit ownership markers.",
+      "evidence": "Cloudflare provider v5.19.1 documents that cloudflare_zone_dns_settings does not support terraform import. Its read path returns the full zone DNS settings object, including nameserver, SOA, multi-provider, secondary DNS, and internal DNS options, but does not distinguish inherited/default values from zone-authored configuration.",
       "status": "deferred",
       "references": [
         "https://github.com/chenrui333/terraformer/issues/335",
         "https://registry.terraform.io/providers/cloudflare/cloudflare/latest/docs/resources/zone_dns_settings"
-      ]
-    },
-    {
-      "resource": "cloudflare_zone_setting",
-      "service_family": "zone_settings",
-      "reason": "Generic zone setting imports need per-setting review for plan availability, value shape, and default-versus-explicit ownership.",
-      "evidence": "The Terraform provider exposes many setting_id values with different value types and plan-level availability. Issue #335 lists zone settings as a dedicated follow-up bucket rather than a safe broad parity import.",
-      "status": "deferred",
-      "references": [
-        "https://github.com/chenrui333/terraformer/issues/335",
-        "https://registry.terraform.io/providers/cloudflare/cloudflare/latest/docs/resources/zone_setting"
       ]
     },
     {


### PR DESCRIPTION
## Summary

Add Terraformer import support for safe Cloudflare DNS and zone settings follow-up resources.

## Resources

Adds scoped import support for:

- cloudflare_zone_setting

## Implementation Notes

- Imports only durable configured or non-default state.
- Avoids claiming Cloudflare defaults as Terraform-owned configuration.
- Uses provider-compatible import IDs.
- Seeds required fields for provider refresh.
- Keeps ambiguous or plan-gated settings deferred.
- Limits generic zone settings to editable, string-valued settings from a conservative known-default allowlist.

## Deferred / Unsupported

Retained and tightened deferred metadata for:

- cloudflare_account_dns_settings: provider v5.19.1 has no import path and API reads return effective account defaults without explicit ownership markers.
- cloudflare_zone_dns_settings: provider v5.19.1 has no import path and API reads return effective zone settings without explicit ownership markers.

Removed deferred metadata for:

- cloudflare_zone_setting: implemented with a conservative per-setting allowlist and non-default import gate.

## Scope

This PR is intentionally limited to DNS settings / zone settings follow-up.

Not included:

- DNSSEC, already implemented in PR #472
- settings resources already implemented in PR #465
- storage/R2/queues/Hyperdrive
- Zero Trust Gateway
- API Shield / Page Shield / security resources
- Workers script/version/deployment/body resources
- media/platform long-tail resources
- network edge resources

## Validation

- go test ./providers/cloudflare/...
- go test ./cmd/...
- go test ./providers -run 'TestUnsupportedResourcesMetadata|TestUnsupportedResourceStatusesAreDocumented' -count=1
- jq . providers/cloudflare/unsupported_resources.json
- git diff --check

Ref: #335

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds import support for Cloudflare zone settings via `cloudflare_zone_setting`, limited to allowlisted, editable settings that include Cloudflare modification metadata and string values. Keeps defaults and unmodified settings out of state, advancing #335.

- New Features
  - Scoped import for `cloudflare_zone_setting` using `{zone_id}/{setting_id}`.
  - Conservative allowlist; imports only string-valued, editable settings with `modified_on`.
  - Seeds required fields, ignores computed ones (e.g., `time_remaining`, `enabled`), and tolerates mixed API response shapes.
  - Docs updated; `cloudflare_account_dns_settings` and `cloudflare_zone_dns_settings` remain deferred (no import path; ownership unclear).

- Bug Fixes
  - Require modification metadata (`modified_on`) and correct default gates to avoid claiming unedited defaults.

<sup>Written for commit 4b335ea33ca3849d0c8ecca066f77b0f6b686fbe. Summary will update on new commits. <a href="https://cubic.dev/pr/chenrui333/terraformer/pull/476?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

