### PR TITLE
ci: label Kafka provider changes

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -212,6 +212,13 @@ provider/keycloak:
           - "docs/keycloak.md"
           - "cmd/provider_cmd_keycloak.go"
 
+provider/kafka:
+  - changed-files:
+      - any-glob-to-any-file:
+          - "providers/kafka/**"
+          - "docs/kafka.md"
+          - "cmd/provider_cmd_kafka.go"
+
 provider/kubernetes:
   - changed-files:
       - any-glob-to-any-file:


### PR DESCRIPTION
Summary:
- Add the Kafka provider path mapping to the pull request labeler.

References:
- Follow-up to #466


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add Kafka provider paths to the PR labeler so changes are auto-labeled `provider/kafka`. Covers providers/kafka/**, docs/kafka.md, and cmd/provider_cmd_kafka.go.

<sup>Written for commit 2a1f46eba4d8f9227ceab9bbb20ffc21e4ae31a5. Summary will update on new commits. <a href="https://cubic.dev/pr/chenrui333/terraformer/pull/478?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

