### PR TITLE
docs: update provider maintenance guidance for Kafka

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -15,6 +15,15 @@
 - Keep Renovate changes small and auditable: adjust `renovate.json`, validate it, and let Renovate regenerate dependency PRs from `main`.
 - For large Go dependency backlogs, prefer grouped provider-family updates over broad manual all-at-once bumps.
 
+## Provider Maintenance Guidance
+
+- For provider-support work, read `CLAUDE.md` in addition to this file; it contains the detailed Terraformer provider-maintenance rules.
+- New external providers should land the full Terraformer surface together: CLI command, provider and service registration, provider-source mapping, docs, README/provider list when applicable, and tests.
+- Use upstream service or provider API clients for discovery, then seed provider-compatible state for refresh. Do not use Terraform provider refresh/import as the inventory discovery mechanism.
+- Keep generated HCL secret-free. Prefer environment variables, profiles, or existing provider config paths for authentication, and keep refresh-time auth config separate from generated provider data.
+- Apply filters before broad, expensive, or permission-sensitive reads. Skip system, internal, default, or provider-managed resources unless explicitly filtered and verified as safely user-owned.
+- Preserve required identity and shape fields through refresh/import fallback. Defer resources with unrecoverable write-only fields, importer mismatches, or unreadable required config into unsupported metadata with evidence.
+
 ## Validation
 
 Use the narrowest validation that matches the change, and broaden it when touching shared behavior or dependencies.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -36,6 +36,19 @@ Use this skill for provider-focused work in `chenrui333/terraformer`: feature ga
    - Generated Terraform addresses remain unique when display names, joined name segments, or child names collide.
 5. Prefer high-confidence additions. If a resource cannot be reconstructed accurately, document the gap or skip it rather than emitting misleading config. Docs-only corrections are valid when docs drift from already-supported behavior.
 
+## New External Provider Skeletons
+
+When adding a new non-HashiCorp or external provider, land the whole Terraformer surface together:
+
+- CLI command wiring, provider registration, service registration, provider-source mapping, docs, README/provider list when applicable, and tests for command/service/source wiring.
+- Use service or provider API clients for discovery, then seed provider-compatible state for Terraform provider refresh. Do not rely on Terraform provider refresh/import as the inventory discovery mechanism.
+- Keep generated provider HCL secret-free. Separate refresh-time provider config from generated provider data: `GetConfig` may need auth fields that the provider requires to refresh, but `GetProviderData` must omit passwords, private keys, access keys, session tokens, OAuth tokens, and similar secret material.
+- Prefer environment variables, profiles, or existing provider config paths for authentication instead of synthesizing credentials into generated configuration.
+- Apply typed ID filters before broad, expensive, or permission-sensitive list/describe calls when the upstream API supports scoped reads.
+- Skip system, internal, default, or provider-managed resources by default unless they are explicitly filtered and provider read confirms they are safely user-owned.
+- Partial import is acceptable only when required identity and shape fields are still preserved through refresh/import fallback and the unread fields are optional. If provider refresh cannot recover required fields, defer or mark the resource unsupported.
+- Treat cloud-managed variants and provider quirks as evidence-backed filters with tests; skip read-only or unsupported config entries that the Terraform provider intentionally cannot manage.
+
 ## Provider Read/Reconstruction Safety
 
 A Terraformer resource is safe to add only when both conditions are true:


### PR DESCRIPTION
## Summary

Update repo-local provider maintenance guidance with durable lessons from the Kafka provider skeleton and topic import work.

## Notes

- Documents new-provider wiring and discovery patterns.
- Reinforces secret-free generated HCL and environment/profile-based auth.
- Captures Kafka-specific import safety lessons such as internal topic skips and optional config-read failures.
- No provider behavior changes.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updates `CLAUDE.md` and `AGENTS.md` with clear, repo-wide guidance for adding and maintaining external providers, based on the Kafka provider and topic import work. Covers the full provider skeleton (CLI/service registration, provider-source mapping, docs/tests), API-client discovery (not provider refresh/import), secret-free generated HCL with env/profile auth and separate refresh-time config, typed ID filters and system/default skips, and strict import/refresh safety; no behavior changes.

<sup>Written for commit 49407d4fde35f8a0d55e2fc204876884ab4890bd. Summary will update on new commits. <a href="https://cubic.dev/pr/chenrui333/terraformer/pull/479?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

