### PR TITLE
feat(cloudflare): add Workers imports

### DIFF
--- a/docs/cloudflare.md
+++ b/docs/cloudflare.md
@@ -145,6 +145,7 @@ List of supported Cloudflare services:
 * `web_analytics`
   * `cloudflare_web_analytics_site`
 * `workers`
+  * `cloudflare_worker`
   * `cloudflare_workers_cron_trigger`
   * `cloudflare_workers_custom_domain`
   * `cloudflare_workers_for_platforms_dispatch_namespace`

--- a/providers/cloudflare/unsupported_resources.json
+++ b/providers/cloudflare/unsupported_resources.json
@@ -390,6 +390,28 @@
       ]
     },
     {
+      "resource": "cloudflare_snippet_rules",
+      "service_family": "snippets",
+      "reason": "Snippet rules are zone-level rule-list ownership without a Terraform provider import path.",
+      "evidence": "Terraform provider v5.19.1 documents cloudflare_snippet_rules as not supporting terraform import, and the generated resource has an empty Read method with no ResourceWithImportState implementation. Broad import cannot safely seed the authoritative rules list.",
+      "status": "not-importable",
+      "references": [
+        "https://github.com/chenrui333/terraformer/issues/335",
+        "https://registry.terraform.io/providers/cloudflare/cloudflare/latest/docs/resources/snippet_rules"
+      ]
+    },
+    {
+      "resource": "cloudflare_snippets",
+      "service_family": "snippets",
+      "reason": "Deprecated snippets resources are non-functional in the Terraform provider.",
+      "evidence": "Terraform provider v5.19.1 marks cloudflare_snippets as deprecated in favor of cloudflare_snippet, documents no terraform import support, and the generated resource returns a non-functional resource error for create, read, update, and delete.",
+      "status": "not-importable",
+      "references": [
+        "https://github.com/chenrui333/terraformer/issues/335",
+        "https://registry.terraform.io/providers/cloudflare/cloudflare/latest/docs/resources/snippets"
+      ]
+    },
+    {
       "resource": "cloudflare_sso_connector",
       "service_family": "identity",
       "reason": "SSO connector resources include identity-provider verification workflow state that broad settings import should not claim.",
@@ -492,7 +514,7 @@
       "resource": "cloudflare_worker_version",
       "service_family": "workers",
       "reason": "Worker version resources couple runtime version state to code modules, assets, and bindings that broad discovery cannot safely reconstruct.",
-      "evidence": "The Terraform provider resource includes modules, main_module, assets, bindings, migrations, and sensitive asset or binding values. Terraformer currently imports Workers routes, custom domains, cron triggers, and dispatch namespaces, but not script body or version ownership.",
+      "evidence": "The Terraform provider resource includes modules, main_module, assets, bindings, migrations, and sensitive asset or binding values. Terraformer imports Worker metadata, routes, custom domains, cron triggers, and dispatch namespaces, but not script body or version ownership.",
       "status": "deferred",
       "references": [
         "https://github.com/chenrui333/terraformer/issues/335",
@@ -525,11 +547,23 @@
       "resource": "cloudflare_workers_script",
       "service_family": "workers",
       "reason": "Worker scripts can include source code, assets, modules, and sensitive binding material that should not be reconstructed blindly.",
-      "evidence": "The Terraform provider resource accepts content/content_file, assets, bindings, migrations, and sensitive asset or binding fields. Terraformer currently imports Workers routes, custom domains, cron triggers, and dispatch namespaces, but not script body ownership.",
+      "evidence": "The Terraform provider resource accepts content/content_file, assets, bindings, migrations, and sensitive asset or binding fields. Terraformer imports Worker metadata, routes, custom domains, cron triggers, and dispatch namespaces, but not script body ownership.",
       "status": "deferred",
       "references": [
         "https://github.com/chenrui333/terraformer/issues/335",
         "https://registry.terraform.io/providers/cloudflare/cloudflare/latest/docs/resources/workers_script"
+      ]
+    },
+    {
+      "resource": "cloudflare_workers_script_subdomain",
+      "service_family": "workers",
+      "reason": "Workers script subdomain ownership is redundant with cloudflare_worker subdomain settings.",
+      "evidence": "Terraform provider v5.19.1 documents cloudflare_workers_script_subdomain as redundant with cloudflare_worker and says it should not be used together with the worker resource. Terraformer imports cloudflare_worker for durable Worker metadata, so also importing script subdomain resources would create duplicate ownership.",
+      "status": "deferred",
+      "references": [
+        "https://github.com/chenrui333/terraformer/issues/335",
+        "https://registry.terraform.io/providers/cloudflare/cloudflare/latest/docs/resources/workers_script_subdomain",
+        "https://registry.terraform.io/providers/cloudflare/cloudflare/latest/docs/resources/worker"
       ]
     },
     {

--- a/providers/cloudflare/workers.go
+++ b/providers/cloudflare/workers.go
@@ -5,6 +5,7 @@ package cloudflare
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
 	"strconv"
@@ -15,6 +16,20 @@ import (
 
 type WorkersGenerator struct {
 	CloudflareService
+}
+
+type cloudflareWorker struct {
+	ID   string `json:"id"`
+	Name string `json:"name"`
+}
+
+var cloudflareWorkerComputedKeys = []string{
+	"^created_on$",
+	"^deployed_on$",
+	"^id$",
+	"^references$",
+	"^references\\..*$",
+	"^updated_on$",
 }
 
 func (g *WorkersGenerator) InitResources() error {
@@ -49,6 +64,9 @@ func (g *WorkersGenerator) InitResources() error {
 		return nil
 	}
 	account := cf.AccountIdentifier(accountID)
+	if err := g.appendWorkerResources(ctx, api, accountID); err != nil {
+		return err
+	}
 	if err := g.appendWorkerCustomDomainResources(ctx, api, accountID); err != nil {
 		return err
 	}
@@ -85,6 +103,32 @@ func listWorkerRoutes(ctx context.Context, api *cf.API, zoneID string) ([]cf.Wor
 		}
 	}
 	return routes, nil
+}
+
+func listWorkers(ctx context.Context, api *cf.API, accountID string) ([]cloudflareWorker, error) {
+	var workers []cloudflareWorker
+	page, cursor := 1, ""
+	for {
+		response, err := api.Raw(
+			ctx,
+			http.MethodGet,
+			fmt.Sprintf("/accounts/%s/workers/workers?%s", accountID, cloudflarePaginationQuery(page, cursor)),
+			nil,
+			nil,
+		)
+		if err != nil {
+			return nil, err
+		}
+		var pageWorkers []cloudflareWorker
+		if err := json.Unmarshal(response.Result, &pageWorkers); err != nil {
+			return nil, err
+		}
+		workers = append(workers, pageWorkers...)
+		if !cloudflareAdvancePagination(response.ResultInfo, &page, &cursor) {
+			break
+		}
+	}
+	return workers, nil
 }
 
 func listWorkerCustomDomains(ctx context.Context, api *cf.API, accountID string) ([]cf.WorkersDomain, error) {
@@ -201,6 +245,53 @@ func workerCronTriggerAttributes(
 		attributes[fmt.Sprintf("schedules.%d.cron", index)] = schedule.Cron
 	}
 	return attributes
+}
+
+func cloudflareWorkersOptionalDiscoveryError(err error) bool {
+	if cloudflareNotFoundError(err) || cloudflareForbiddenError(err) {
+		return true
+	}
+	var authorizationErr *cf.AuthorizationError
+	return errors.As(err, &authorizationErr)
+}
+
+func cloudflareWorkerResource(accountID string, worker cloudflareWorker) (terraformutils.Resource, bool) {
+	if accountID == "" || worker.ID == "" || worker.Name == "" {
+		return terraformutils.Resource{}, false
+	}
+	resource := terraformutils.NewResource(
+		worker.ID,
+		cloudflareResourceName(accountID, worker.Name, worker.ID),
+		"cloudflare_worker",
+		"cloudflare",
+		map[string]string{
+			"account_id": accountID,
+			"name":       worker.Name,
+		},
+		[]string{},
+		map[string]interface{}{},
+	)
+	setCloudflareImportID(&resource, accountID+"/"+worker.ID)
+	resource.IgnoreKeys = append(resource.IgnoreKeys, cloudflareWorkerComputedKeys...)
+	return resource, true
+}
+
+func (g *WorkersGenerator) appendWorkerResources(ctx context.Context, api *cf.API, accountID string) error {
+	workers, err := listWorkers(ctx, api, accountID)
+	if err != nil {
+		if cloudflareWorkersOptionalDiscoveryError(err) {
+			return nil
+		}
+		return fmt.Errorf("list Workers for account %q: %w", accountID, err)
+	}
+	for _, worker := range workers {
+		resource, ok := cloudflareWorkerResource(accountID, worker)
+		if !ok {
+			continue
+		}
+		g.Resources = append(g.Resources, resource)
+	}
+	return nil
 }
 
 func (g *WorkersGenerator) appendWorkerCustomDomainResources(ctx context.Context, api *cf.API, accountID string) error {

--- a/providers/cloudflare/workers.go
+++ b/providers/cloudflare/workers.go
@@ -124,11 +124,29 @@ func listWorkers(ctx context.Context, api *cf.API, accountID string) ([]cloudfla
 			return nil, err
 		}
 		workers = append(workers, pageWorkers...)
-		if !cloudflareAdvancePagination(response.ResultInfo, &page, &cursor) {
+		if !cloudflareAdvanceWorkersPagination(response.ResultInfo, &page, &cursor, len(pageWorkers)) {
 			break
 		}
 	}
 	return workers, nil
+}
+
+func cloudflareAdvanceWorkersPagination(info *cf.ResultInfo, page *int, cursor *string, itemCount int) bool {
+	if cloudflareAdvancePagination(info, page, cursor) {
+		return true
+	}
+	if *cursor != "" {
+		return false
+	}
+	pageSize := cloudflarePageSize
+	if info != nil && info.PerPage > 0 {
+		pageSize = info.PerPage
+	}
+	if itemCount < pageSize {
+		return false
+	}
+	*page++
+	return true
 }
 
 func listWorkerCustomDomains(ctx context.Context, api *cf.API, accountID string) ([]cf.WorkersDomain, error) {

--- a/providers/cloudflare/workers_test.go
+++ b/providers/cloudflare/workers_test.go
@@ -1,0 +1,211 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package cloudflare
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"testing"
+
+	"github.com/chenrui333/terraformer/terraformutils"
+	cf "github.com/cloudflare/cloudflare-go"
+)
+
+func TestCloudflareWorkerResource(t *testing.T) {
+	resource, ok := cloudflareWorkerResource("account-123", cloudflareWorker{
+		ID:   "worker-456",
+		Name: "api-worker",
+	})
+	if !ok {
+		t.Fatal("expected Worker resource")
+	}
+	if resource.InstanceInfo.Type != "cloudflare_worker" {
+		t.Fatalf("resource type = %q, want cloudflare_worker", resource.InstanceInfo.Type)
+	}
+	if resource.InstanceState.ID != "worker-456" {
+		t.Fatalf("resource ID = %q, want worker-456", resource.InstanceState.ID)
+	}
+	if got := resource.InstanceState.Attributes["account_id"]; got != "account-123" {
+		t.Fatalf("account_id = %q, want account-123", got)
+	}
+	if got := resource.InstanceState.Attributes["name"]; got != "api-worker" {
+		t.Fatalf("name = %q, want api-worker", got)
+	}
+	if got, want := resource.ResourceName, terraformutils.TfSanitize(cloudflareResourceName("account-123", "api-worker", "worker-456")); got != want {
+		t.Fatalf("resource name = %q, want %q", got, want)
+	}
+	if got := resource.InstanceState.Meta["import_id"]; got != "account-123/worker-456" {
+		t.Fatalf("import_id = %q, want account-123/worker-456", got)
+	}
+	for _, key := range cloudflareWorkerComputedKeys {
+		if !cloudflareResourceIgnoresKey(resource, key) {
+			t.Fatalf("Worker resource should ignore computed key %q", key)
+		}
+	}
+}
+
+func TestCloudflareWorkerResourceSkipsMalformedWorkers(t *testing.T) {
+	for name, worker := range map[string]cloudflareWorker{
+		"missing id":   {Name: "api-worker"},
+		"missing name": {ID: "worker-456"},
+	} {
+		t.Run(name, func(t *testing.T) {
+			if _, ok := cloudflareWorkerResource("account-123", worker); ok {
+				t.Fatal("expected malformed Worker to be skipped")
+			}
+		})
+	}
+	if _, ok := cloudflareWorkerResource("", cloudflareWorker{ID: "worker-456", Name: "api-worker"}); ok {
+		t.Fatal("expected Worker without account ID to be skipped")
+	}
+}
+
+func TestListWorkersPaginates(t *testing.T) {
+	api := newCloudflareWorkersTestAPI(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/accounts/account-123/workers/workers" {
+			t.Fatalf("path = %q, want /accounts/account-123/workers/workers", r.URL.Path)
+		}
+		switch r.URL.Query().Get("cursor") {
+		case "":
+			if got := r.URL.Query().Get("page"); got != "1" {
+				t.Fatalf("page query = %q, want 1", got)
+			}
+			writeCloudflareWorkersTestResponse(t, w, []cloudflareWorker{{ID: "worker-1", Name: "api"}}, map[string]interface{}{
+				"cursors": map[string]string{"after": "cursor-2"},
+			})
+		case "cursor-2":
+			writeCloudflareWorkersTestResponse(t, w, []cloudflareWorker{{ID: "worker-2", Name: "jobs"}}, map[string]interface{}{
+				"cursors": map[string]string{},
+			})
+		default:
+			t.Fatalf("cursor query = %q, want empty or cursor-2", r.URL.Query().Get("cursor"))
+		}
+	}))
+
+	workers, err := listWorkers(context.Background(), api, "account-123")
+	if err != nil {
+		t.Fatalf("listWorkers() error = %v", err)
+	}
+	if len(workers) != 2 {
+		t.Fatalf("worker count = %d, want 2", len(workers))
+	}
+	if workers[0].ID != "worker-1" || workers[1].ID != "worker-2" {
+		t.Fatalf("workers = %#v, want worker-1 and worker-2", workers)
+	}
+}
+
+func TestAppendWorkerResourcesHandlesEmptyAndMalformedResponses(t *testing.T) {
+	api := newCloudflareWorkersTestAPI(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		writeCloudflareWorkersTestResponse(t, w, []cloudflareWorker{
+			{ID: "worker-1", Name: "api"},
+			{ID: "worker-2"},
+			{Name: "missing-id"},
+		}, nil)
+	}))
+	generator := &WorkersGenerator{}
+	if err := generator.appendWorkerResources(context.Background(), api, "account-123"); err != nil {
+		t.Fatalf("appendWorkerResources() error = %v", err)
+	}
+	if len(generator.Resources) != 1 {
+		t.Fatalf("resource count = %d, want 1", len(generator.Resources))
+	}
+	if got := generator.Resources[0].InstanceInfo.Type; got != "cloudflare_worker" {
+		t.Fatalf("resource type = %q, want cloudflare_worker", got)
+	}
+
+	emptyAPI := newCloudflareWorkersTestAPI(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		writeCloudflareWorkersTestResponse(t, w, []cloudflareWorker{}, nil)
+	}))
+	generator = &WorkersGenerator{}
+	if err := generator.appendWorkerResources(context.Background(), emptyAPI, "account-123"); err != nil {
+		t.Fatalf("appendWorkerResources() empty response error = %v", err)
+	}
+	if len(generator.Resources) != 0 {
+		t.Fatalf("empty response resource count = %d, want 0", len(generator.Resources))
+	}
+}
+
+func TestCloudflareWorkersOptionalDiscoveryError(t *testing.T) {
+	notFoundErr := cf.NewNotFoundError(&cf.Error{ErrorMessages: []string{"not found"}})
+	if !cloudflareWorkersOptionalDiscoveryError(&notFoundErr) {
+		t.Fatal("not found errors should be optional for Workers discovery")
+	}
+	authenticationErr := cf.NewAuthenticationError(&cf.Error{ErrorMessages: []string{"forbidden"}})
+	if !cloudflareWorkersOptionalDiscoveryError(&authenticationErr) {
+		t.Fatal("authentication errors should be optional for Workers discovery")
+	}
+	authorizationErr := cf.NewAuthorizationError(&cf.Error{ErrorMessages: []string{"missing permission"}})
+	if !cloudflareWorkersOptionalDiscoveryError(&authorizationErr) {
+		t.Fatal("authorization errors should be optional for Workers discovery")
+	}
+	if cloudflareWorkersOptionalDiscoveryError(errors.New("temporary Cloudflare failure")) {
+		t.Fatal("generic errors should not be optional for Workers discovery")
+	}
+}
+
+func TestWorkersUnsupportedResourcesMetadata(t *testing.T) {
+	data, err := os.ReadFile("unsupported_resources.json")
+	if err != nil {
+		t.Fatalf("read unsupported resources: %v", err)
+	}
+	var metadata cloudflareUnsupportedResourcesFile
+	if err := json.Unmarshal(data, &metadata); err != nil {
+		t.Fatalf("decode unsupported resources: %v", err)
+	}
+	seen := map[string]bool{}
+	for _, resource := range metadata.Resources {
+		seen[resource.Resource] = true
+	}
+	for _, resource := range []string{
+		"cloudflare_snippet",
+		"cloudflare_snippet_rules",
+		"cloudflare_snippets",
+		"cloudflare_worker_version",
+		"cloudflare_workers_deployment",
+		"cloudflare_workers_script",
+		"cloudflare_workers_script_subdomain",
+		"cloudflare_workflow",
+	} {
+		if !seen[resource] {
+			t.Fatalf("unsupported metadata is missing %s", resource)
+		}
+	}
+}
+
+func newCloudflareWorkersTestAPI(t *testing.T, handler http.Handler) *cf.API {
+	t.Helper()
+
+	server := httptest.NewServer(handler)
+	t.Cleanup(server.Close)
+
+	api, err := cf.NewWithAPIToken(
+		"test-token",
+		cf.BaseURL(server.URL),
+		cf.UsingRateLimit(100000),
+		cf.UsingRetryPolicy(0, 0, 0),
+	)
+	if err != nil {
+		t.Fatalf("create Cloudflare test API: %v", err)
+	}
+	return api
+}
+
+func writeCloudflareWorkersTestResponse(t *testing.T, w http.ResponseWriter, result interface{}, resultInfo interface{}) {
+	t.Helper()
+	w.Header().Set("Content-Type", "application/json")
+
+	payload := map[string]interface{}{
+		"success": true,
+		"result":  result,
+	}
+	if resultInfo != nil {
+		payload["result_info"] = resultInfo
+	}
+	if err := json.NewEncoder(w).Encode(payload); err != nil {
+		t.Fatalf("encode test response: %v", err)
+	}
+}

--- a/providers/cloudflare/workers_test.go
+++ b/providers/cloudflare/workers_test.go
@@ -148,7 +148,7 @@ func TestListWorkersPaginatesPageOnlyResultInfo(t *testing.T) {
 }
 
 func TestAppendWorkerResourcesHandlesEmptyAndMalformedResponses(t *testing.T) {
-	api := newCloudflareWorkersTestAPI(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	api := newCloudflareWorkersTestAPI(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		writeCloudflareWorkersTestResponse(t, w, []cloudflareWorker{
 			{ID: "worker-1", Name: "api"},
 			{ID: "worker-2"},
@@ -166,7 +166,7 @@ func TestAppendWorkerResourcesHandlesEmptyAndMalformedResponses(t *testing.T) {
 		t.Fatalf("resource type = %q, want cloudflare_worker", got)
 	}
 
-	emptyAPI := newCloudflareWorkersTestAPI(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	emptyAPI := newCloudflareWorkersTestAPI(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		writeCloudflareWorkersTestResponse(t, w, []cloudflareWorker{}, nil)
 	}))
 	generator = &WorkersGenerator{}

--- a/providers/cloudflare/workers_test.go
+++ b/providers/cloudflare/workers_test.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -95,6 +96,42 @@ func TestListWorkersPaginates(t *testing.T) {
 	}
 	if workers[0].ID != "worker-1" || workers[1].ID != "worker-2" {
 		t.Fatalf("workers = %#v, want worker-1 and worker-2", workers)
+	}
+}
+
+func TestListWorkersPaginatesPageOnlyResultInfo(t *testing.T) {
+	api := newCloudflareWorkersTestAPI(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/accounts/account-123/workers/workers" {
+			t.Fatalf("path = %q, want /accounts/account-123/workers/workers", r.URL.Path)
+		}
+		if got := r.URL.Query().Get("cursor"); got != "" {
+			t.Fatalf("cursor query = %q, want empty", got)
+		}
+		switch r.URL.Query().Get("page") {
+		case "1":
+			writeCloudflareWorkersTestResponse(t, w, cloudflareWorkersForTest(cloudflarePageSize), map[string]interface{}{
+				"page":     1,
+				"per_page": cloudflarePageSize,
+			})
+		case "2":
+			writeCloudflareWorkersTestResponse(t, w, []cloudflareWorker{{ID: "worker-last", Name: "last"}}, map[string]interface{}{
+				"page":     2,
+				"per_page": cloudflarePageSize,
+			})
+		default:
+			t.Fatalf("page query = %q, want 1 or 2", r.URL.Query().Get("page"))
+		}
+	}))
+
+	workers, err := listWorkers(context.Background(), api, "account-123")
+	if err != nil {
+		t.Fatalf("listWorkers() error = %v", err)
+	}
+	if len(workers) != cloudflarePageSize+1 {
+		t.Fatalf("worker count = %d, want %d", len(workers), cloudflarePageSize+1)
+	}
+	if workers[cloudflarePageSize].ID != "worker-last" {
+		t.Fatalf("last worker = %#v, want worker-last", workers[cloudflarePageSize])
 	}
 }
 
@@ -208,4 +245,15 @@ func writeCloudflareWorkersTestResponse(t *testing.T, w http.ResponseWriter, res
 	if err := json.NewEncoder(w).Encode(payload); err != nil {
 		t.Fatalf("encode test response: %v", err)
 	}
+}
+
+func cloudflareWorkersForTest(count int) []cloudflareWorker {
+	workers := make([]cloudflareWorker, count)
+	for i := range workers {
+		workers[i] = cloudflareWorker{
+			ID:   fmt.Sprintf("worker-%d", i),
+			Name: fmt.Sprintf("worker-%d", i),
+		}
+	}
+	return workers
 }

--- a/providers/cloudflare/workers_test.go
+++ b/providers/cloudflare/workers_test.go
@@ -68,12 +68,16 @@ func TestCloudflareWorkerResourceSkipsMalformedWorkers(t *testing.T) {
 func TestListWorkersPaginates(t *testing.T) {
 	api := newCloudflareWorkersTestAPI(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path != "/accounts/account-123/workers/workers" {
-			t.Fatalf("path = %q, want /accounts/account-123/workers/workers", r.URL.Path)
+			t.Errorf("path = %q, want /accounts/account-123/workers/workers", r.URL.Path)
+			http.Error(w, "unexpected path", http.StatusInternalServerError)
+			return
 		}
 		switch r.URL.Query().Get("cursor") {
 		case "":
 			if got := r.URL.Query().Get("page"); got != "1" {
-				t.Fatalf("page query = %q, want 1", got)
+				t.Errorf("page query = %q, want 1", got)
+				http.Error(w, "unexpected page", http.StatusInternalServerError)
+				return
 			}
 			writeCloudflareWorkersTestResponse(t, w, []cloudflareWorker{{ID: "worker-1", Name: "api"}}, map[string]interface{}{
 				"cursors": map[string]string{"after": "cursor-2"},
@@ -83,7 +87,9 @@ func TestListWorkersPaginates(t *testing.T) {
 				"cursors": map[string]string{},
 			})
 		default:
-			t.Fatalf("cursor query = %q, want empty or cursor-2", r.URL.Query().Get("cursor"))
+			t.Errorf("cursor query = %q, want empty or cursor-2", r.URL.Query().Get("cursor"))
+			http.Error(w, "unexpected cursor", http.StatusInternalServerError)
+			return
 		}
 	}))
 
@@ -102,10 +108,14 @@ func TestListWorkersPaginates(t *testing.T) {
 func TestListWorkersPaginatesPageOnlyResultInfo(t *testing.T) {
 	api := newCloudflareWorkersTestAPI(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path != "/accounts/account-123/workers/workers" {
-			t.Fatalf("path = %q, want /accounts/account-123/workers/workers", r.URL.Path)
+			t.Errorf("path = %q, want /accounts/account-123/workers/workers", r.URL.Path)
+			http.Error(w, "unexpected path", http.StatusInternalServerError)
+			return
 		}
 		if got := r.URL.Query().Get("cursor"); got != "" {
-			t.Fatalf("cursor query = %q, want empty", got)
+			t.Errorf("cursor query = %q, want empty", got)
+			http.Error(w, "unexpected cursor", http.StatusInternalServerError)
+			return
 		}
 		switch r.URL.Query().Get("page") {
 		case "1":
@@ -119,7 +129,9 @@ func TestListWorkersPaginatesPageOnlyResultInfo(t *testing.T) {
 				"per_page": cloudflarePageSize,
 			})
 		default:
-			t.Fatalf("page query = %q, want 1 or 2", r.URL.Query().Get("page"))
+			t.Errorf("page query = %q, want 1 or 2", r.URL.Query().Get("page"))
+			http.Error(w, "unexpected page", http.StatusInternalServerError)
+			return
 		}
 	}))
 
@@ -243,7 +255,7 @@ func writeCloudflareWorkersTestResponse(t *testing.T, w http.ResponseWriter, res
 		payload["result_info"] = resultInfo
 	}
 	if err := json.NewEncoder(w).Encode(payload); err != nil {
-		t.Fatalf("encode test response: %v", err)
+		t.Errorf("encode test response: %v", err)
 	}
 }
 


### PR DESCRIPTION
## Summary

Add Terraformer import support for high-confidence Cloudflare Workers/Scripts/Snippets/Workflows resources.

## Resources

Implemented:

- `cloudflare_worker`

## Implementation Notes

- Uses provider-compatible import IDs.
- Exhausts pagination where applicable.
- Seeds required fields for provider refresh.
- Keeps optional or permission-sensitive lookups best-effort where appropriate.
- Does not import source/body-heavy, runtime, deployment/version, Cloudflare-managed, or secret-required resources unless refreshable HCL can be safely reconstructed.

## Deferred / Unsupported

Added:

- `cloudflare_snippet_rules`: provider docs state no import support, and generated provider resource has no read/import path.
- `cloudflare_snippets`: deprecated non-functional provider resource.
- `cloudflare_workers_script_subdomain`: duplicate ownership with `cloudflare_worker` subdomain settings.

Updated:

- `cloudflare_worker_version`: still deferred because code modules, assets, migrations, and sensitive binding values are not safe to reconstruct broadly.
- `cloudflare_workers_script`: still deferred because script source, assets, modules, migrations, and sensitive bindings are source/body-heavy.

## Scope

This PR is intentionally limited to Workers/Scripts/Snippets/Workflows.

Not included:

- zone/account settings
- storage/R2/queues/Hyperdrive
- Zero Trust Gateway
- API Shield / Page Shield / security resources
- media/platform long-tail resources outside Workers
- network edge resources

## Validation

- `go test ./providers/cloudflare/...`
- `go test ./cmd/...`
- `go test ./providers -run 'TestUnsupportedResourcesMetadata|TestUnsupportedResourceStatusesAreDocumented' -count=1`
- `jq . providers/cloudflare/unsupported_resources.json`
- `git diff --check`

Ref: #335

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add Terraformer import support for Cloudflare Workers via `cloudflare_worker`, enabling safe, refreshable imports with robust pagination. Scope stays within Workers/Scripts/Snippets/Workflows to align with #335.

- **New Features**
  - Import `cloudflare_worker` using provider-compatible IDs; paginate across cursors and continue by page when cursors stop.
  - Seed only required fields (`account_id`, `name`) and ignore computed keys for stable plans.
  - Treat not found/forbidden/authorization errors as optional during discovery.
  - Updated docs and unit tests; handlers avoid fatal assertions and satisfy lint checks.

- **Deferred/Unsupported**
  - Not-importable: `cloudflare_snippet_rules`, `cloudflare_snippets`.
  - Deferred: `cloudflare_workers_script`, `cloudflare_worker_version`, `cloudflare_workers_script_subdomain` (source/sensitive or duplicate ownership).

<sup>Written for commit 2cf4cc2016573f94ba323ebe67baadce092dc923. Summary will update on new commits. <a href="https://cubic.dev/pr/chenrui333/terraformer/pull/480?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

