### PR TITLE
docs(kafka): document quota and SCRAM import limitations

### DIFF
--- a/docs/kafka.md
+++ b/docs/kafka.md
@@ -51,3 +51,5 @@ List of supported Kafka services:
 
 * topics
     * kafka_topic
+
+Unsupported Kafka resources with evidence-backed import limitations are tracked in [unsupported_resources.json](../providers/kafka/unsupported_resources.json). Terraformer does not emit `kafka_quota` because Mongey/kafka v0.13.1 documents an import form but does not expose a resource importer, and it does not emit `kafka_user_scram_credential` because refresh cannot recover the required password material that Terraformer must not export or synthesize.

--- a/docs/unsupported-resources.md
+++ b/docs/unsupported-resources.md
@@ -110,6 +110,7 @@ This inventory is an informational coverage snapshot. The source of truth is the
 | ibm | no | no | not present yet |
 | ionoscloud | no | no | not present yet |
 | keycloak | no | no | not present yet |
+| kafka | yes | yes | metadata present; provider-specific assertions |
 | kubernetes | yes | yes | metadata present; provider-specific assertions |
 | launchdarkly | yes | no | metadata present |
 | linode | no | no | not present yet |

--- a/providers/kafka/unsupported_resources.json
+++ b/providers/kafka/unsupported_resources.json
@@ -1,0 +1,32 @@
+{
+  "version": 1,
+  "resources": [
+    {
+      "resource": "kafka_quota",
+      "service_family": "quotas",
+      "reason": "Quota imports are not safe until the upstream provider exposes a real importer with a verified ID shape.",
+      "evidence": "Mongey/kafka v0.13.1 documents terraform import as entity_type:entity_name, but kafkaQuotaResource does not define a ResourceImporter. The source ID shape is entity_name|entity_type or entity-default|entity_type, and quotaRead expects entity_type and entity_name to already be seeded in state.",
+      "status": "not-importable",
+      "references": [
+        "https://github.com/chenrui333/terraformer/issues/481",
+        "https://github.com/Mongey/terraform-provider-kafka/blob/v0.13.1/docs/resources/quota.md",
+        "https://github.com/Mongey/terraform-provider-kafka/blob/v0.13.1/kafka/resource_kafka_quota.go",
+        "https://github.com/Mongey/terraform-provider-kafka/blob/v0.13.1/kafka/kafka_quotas.go"
+      ]
+    },
+    {
+      "resource": "kafka_user_scram_credential",
+      "service_family": "scram_credentials",
+      "reason": "SCRAM credential configuration requires password material that Kafka describe APIs and provider refresh cannot return.",
+      "evidence": "Mongey/kafka v0.13.1 accepts two-part username|scram_mechanism imports and legacy three-part imports, but the docs note that the password must be provided because it cannot be read from Kafka. The resource CustomizeDiff requires password or password_wo for configuration, while userScramCredentialRead only restores username, scram_mechanism, and scram_iterations; Sarama DescribeUserScramCredentials responses expose mechanism and iterations but no password.",
+      "status": "secret-required",
+      "references": [
+        "https://github.com/chenrui333/terraformer/issues/481",
+        "https://github.com/Mongey/terraform-provider-kafka/blob/v0.13.1/docs/resources/user_scram_credential.md",
+        "https://github.com/Mongey/terraform-provider-kafka/blob/v0.13.1/kafka/resource_kafka_user_scram_credential.go",
+        "https://github.com/Mongey/terraform-provider-kafka/blob/v0.13.1/kafka/kafka_user_scram_credentials.go",
+        "https://github.com/IBM/sarama/blob/v1.46.1/describe_user_scram_credentials_response.go"
+      ]
+    }
+  ]
+}

--- a/providers/kafka/unsupported_resources_test.go
+++ b/providers/kafka/unsupported_resources_test.go
@@ -1,0 +1,84 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package kafka
+
+import (
+	"encoding/json"
+	"os"
+	"sort"
+	"testing"
+)
+
+const kafkaUnsupportedIssue = "https://github.com/chenrui333/terraformer/issues/481"
+
+type kafkaUnsupportedResourcesFile struct {
+	Version   int                                `json:"version"`
+	Resources []kafkaUnsupportedResourceMetadata `json:"resources"`
+}
+
+type kafkaUnsupportedResourceMetadata struct {
+	Resource      string   `json:"resource"`
+	ServiceFamily string   `json:"service_family"`
+	Reason        string   `json:"reason"`
+	Evidence      string   `json:"evidence"`
+	Status        string   `json:"status"`
+	References    []string `json:"references"`
+}
+
+func TestKafkaUnsupportedResourcesMetadata(t *testing.T) {
+	data, err := os.ReadFile("unsupported_resources.json")
+	if err != nil {
+		t.Fatalf("read unsupported resources: %v", err)
+	}
+
+	var metadata kafkaUnsupportedResourcesFile
+	if err := json.Unmarshal(data, &metadata); err != nil {
+		t.Fatalf("decode unsupported resources: %v", err)
+	}
+	if metadata.Version != 1 {
+		t.Fatalf("unsupported resources version = %d, want 1", metadata.Version)
+	}
+
+	wantStatuses := map[string]string{
+		"kafka_quota":                 "not-importable",
+		"kafka_user_scram_credential": "secret-required",
+	}
+	seen := map[string]string{}
+	resources := make([]string, 0, len(metadata.Resources))
+	for _, resource := range metadata.Resources {
+		if resource.Resource == "" || resource.ServiceFamily == "" || resource.Reason == "" || resource.Evidence == "" {
+			t.Fatalf("unsupported resource entry is missing required metadata: %+v", resource)
+		}
+		if len(resource.References) == 0 {
+			t.Fatalf("unsupported resource %q is missing references", resource.Resource)
+		}
+		if !hasReference(resource.References, kafkaUnsupportedIssue) {
+			t.Fatalf("unsupported resource %q is missing issue #481 reference", resource.Resource)
+		}
+		if _, exists := seen[resource.Resource]; exists {
+			t.Fatalf("duplicate unsupported resource entry: %s", resource.Resource)
+		}
+		seen[resource.Resource] = resource.Status
+		resources = append(resources, resource.Resource)
+	}
+	if !sort.StringsAreSorted(resources) {
+		t.Fatalf("unsupported resources are not sorted by resource: %v", resources)
+	}
+
+	for resource, wantStatus := range wantStatuses {
+		if status, ok := seen[resource]; !ok {
+			t.Fatalf("%s unsupported metadata entry was not found", resource)
+		} else if status != wantStatus {
+			t.Fatalf("%s status = %q, want %s", resource, status, wantStatus)
+		}
+	}
+}
+
+func hasReference(references []string, expected string) bool {
+	for _, reference := range references {
+		if reference == expected {
+			return true
+		}
+	}
+	return false
+}


### PR DESCRIPTION
## Summary

Audit Kafka quota and SCRAM credential importability for Terraformer Kafka provider support.

## Findings

- `kafka_quota`: deferred from implementation because Mongey/kafka v0.13.1 documents an import form but the resource source does not expose a ResourceImporter, and its internal ID shape differs from the docs.
- `kafka_user_scram_credential`: deferred from implementation because provider refresh can restore username, mechanism, and iterations, but generated configuration still requires password material that Kafka cannot return and Terraformer must not synthesize.

## Security

Terraformer must not export or synthesize SCRAM passwords or other authentication secrets.

## Metadata

Added `providers/kafka/unsupported_resources.json` entries for:

- `kafka_quota`
- `kafka_user_scram_credential`

## Scope

This PR is limited to `kafka_quota` and `kafka_user_scram_credential`.

Not included:

- `kafka_acl`
- unrelated Kafka provider changes

## Validation

- `go test ./providers/kafka/...`
- `go test ./cmd/...`
- `go test ./providers -run 'TestUnsupportedResourcesMetadata|TestUnsupportedResourceStatusesAreDocumented' -count=1`
- `jq . providers/kafka/unsupported_resources.json`
- `git diff --check`

Ref: #481


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Documents Kafka quota and SCRAM credential import limitations and marks them unsupported to avoid broken imports and secret exposure. Adds `providers/kafka/unsupported_resources.json` with tests and docs; Terraformer will not emit `kafka_quota` (no importer and ID mismatch in `Mongey/kafka` v0.13.1) or `kafka_user_scram_credential` (password cannot be recovered).

<sup>Written for commit 3f9f4f16ad4917e86cafc71cf7fbfb009a414cf0. Summary will update on new commits. <a href="https://cubic.dev/pr/chenrui333/terraformer/pull/482?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

