### PR TITLE
feat(kafka): add ACL imports

### DIFF
--- a/cmd/provider_cmd_kafka.go
+++ b/cmd/provider_cmd_kafka.go
@@ -27,7 +27,7 @@ func newCmdKafkaImporter(options ImportOptions) *cobra.Command {
 	}
 
 	cmd.AddCommand(listCmd(newKafkaProvider()))
-	baseProviderFlags(cmd.PersistentFlags(), &options, "topics", "topic=topic1:topic2")
+	baseProviderFlags(cmd.PersistentFlags(), &options, "topics,acls", "topic=topic1:topic2")
 	cmd.PersistentFlags().StringSliceVar(&config.BootstrapServers, "bootstrap-servers", config.BootstrapServers, "Kafka bootstrap servers or KAFKA_BOOTSTRAP_SERVERS")
 	cmd.PersistentFlags().StringVar(&config.KafkaVersion, "kafka-version", config.KafkaVersion, "Kafka protocol version or KAFKA_VERSION")
 	cmd.PersistentFlags().BoolVar(&config.TLSEnabled, "tls-enabled", config.TLSEnabled, "Enable TLS or KAFKA_ENABLE_TLS")

--- a/cmd/provider_cmd_kafka_test.go
+++ b/cmd/provider_cmd_kafka_test.go
@@ -12,6 +12,9 @@ func TestKafkaProviderCommandRegistration(t *testing.T) {
 	if _, ok := provider.GetSupportedService()["topics"]; !ok {
 		t.Fatal("kafka topics service is not registered")
 	}
+	if _, ok := provider.GetSupportedService()["acls"]; !ok {
+		t.Fatal("kafka ACL service is not registered")
+	}
 
 	importers := providerImporterSubcommands()
 	foundImporter := false

--- a/docs/kafka.md
+++ b/docs/kafka.md
@@ -7,6 +7,8 @@ Example:
 
     terraformer import kafka --resources=topics
     terraformer import kafka --resources=topics --filter=topic=orders:payments.events
+    terraformer import kafka --resources=acls
+    terraformer import kafka --resources=acls --filter='acls=User:producer|*|Write|Allow|Topic|orders|Literal'
 
 The Kafka provider also accepts bootstrap servers through the CLI:
 
@@ -47,7 +49,11 @@ OAuthBearer imports use KAFKA_SASL_TOKEN_URL with KAFKA_SASL_USERNAME, KAFKA_SAS
 
 Terraformer intentionally does not write generated HCL containing SASL passwords, TLS private keys, AWS access keys, AWS secret keys, AWS session tokens, OAuth tokens, or SCRAM passwords.
 
+Kafka ACL import IDs are pipe-delimited to match the upstream Mongey/kafka provider. ACL tuple fields containing literal `|` characters are skipped because the upstream importer does not provide an escaping mechanism for those values.
+
 List of supported Kafka services:
 
+* acls
+    * kafka_acl
 * topics
     * kafka_topic

--- a/providers/kafka/acl.go
+++ b/providers/kafka/acl.go
@@ -1,0 +1,504 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package kafka
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"log"
+	"sort"
+	"strings"
+	"unicode"
+
+	"github.com/IBM/sarama"
+	"github.com/chenrui333/terraformer/terraformutils"
+)
+
+type ACLGenerator struct {
+	Service
+}
+
+type ACL struct {
+	Principal                 string
+	Host                      string
+	Operation                 string
+	PermissionType            string
+	ResourceType              string
+	ResourceName              string
+	ResourcePatternTypeFilter string
+}
+
+var ACLAllowEmptyValues = []string{}
+
+func (g *ACLGenerator) InitResources() error {
+	config := g.Args["config"].(Config)
+	admin, err := g.admin(config)
+	if err != nil {
+		return err
+	}
+	defer func() {
+		if closeErr := admin.Close(); closeErr != nil {
+			log.Printf("kafka: close admin client: %v", closeErr)
+		}
+	}()
+
+	acls, err := g.listACLs(admin)
+	if err != nil {
+		return err
+	}
+	g.Resources = g.createResources(acls)
+	return nil
+}
+
+func (g *ACLGenerator) ParseFilter(rawFilter string) []terraformutils.ResourceFilter {
+	for _, prefix := range []string{"kafka_acl=", "acls=", "acl="} {
+		if strings.HasPrefix(rawFilter, prefix) {
+			return []terraformutils.ResourceFilter{{
+				ServiceName:      "acl",
+				FieldPath:        "id",
+				AcceptableValues: []string{strings.TrimPrefix(rawFilter, prefix)},
+			}}
+		}
+	}
+	return g.Service.ParseFilter(rawFilter)
+}
+
+func (g *ACLGenerator) ParseFilters(rawFilters []string) {
+	g.Filter = []terraformutils.ResourceFilter{}
+	for _, rawFilter := range rawFilters {
+		g.Filter = append(g.Filter, g.ParseFilter(rawFilter)...)
+	}
+}
+
+func (g *ACLGenerator) listACLs(admin adminClient) ([]ACL, error) {
+	explicitACLs, err := g.explicitlyRequestedACLs()
+	if err != nil {
+		return nil, err
+	}
+	if len(explicitACLs) > 0 {
+		return g.listExplicitACLs(admin, explicitACLs)
+	}
+	return g.listAllACLs(admin)
+}
+
+func (g *ACLGenerator) explicitlyRequestedACLs() ([]ACL, error) {
+	seen := map[string]struct{}{}
+	acls := []ACL{}
+	for _, filter := range g.Filter {
+		if filter.FieldPath != "id" || !filter.IsApplicable("acl") {
+			continue
+		}
+		for _, value := range filter.AcceptableValues {
+			acl, err := parseKafkaACLImportID(value)
+			if err != nil {
+				return nil, err
+			}
+			id := acl.ImportID()
+			if _, ok := seen[id]; ok {
+				continue
+			}
+			seen[id] = struct{}{}
+			acls = append(acls, acl)
+		}
+	}
+	sortACLs(acls)
+	return acls, nil
+}
+
+func (g *ACLGenerator) listExplicitACLs(admin adminClient, requested []ACL) ([]ACL, error) {
+	acls := []ACL{}
+	for _, acl := range requested {
+		filter, err := acl.SaramaFilter()
+		if err != nil {
+			return nil, err
+		}
+		resourceACLs, err := admin.ListAcls(filter)
+		if err != nil {
+			return nil, err
+		}
+		for _, found := range aclsFromResourceACLs(resourceACLs) {
+			if found.ImportID() == acl.ImportID() {
+				acls = append(acls, found)
+			}
+		}
+	}
+	return uniqueSortedACLs(acls), nil
+}
+
+func (g *ACLGenerator) listAllACLs(admin adminClient) ([]ACL, error) {
+	resourceTypes := []sarama.AclResourceType{
+		sarama.AclResourceTopic,
+		sarama.AclResourceGroup,
+		sarama.AclResourceCluster,
+		sarama.AclResourceTransactionalID,
+		sarama.AclResourceDelegationToken,
+	}
+	acls := []ACL{}
+	for _, resourceType := range resourceTypes {
+		resourceACLs, err := admin.ListAcls(sarama.AclFilter{
+			ResourceType:              resourceType,
+			ResourcePatternTypeFilter: sarama.AclPatternAny,
+			Operation:                 sarama.AclOperationAny,
+			PermissionType:            sarama.AclPermissionAny,
+		})
+		if err != nil {
+			return nil, err
+		}
+		acls = append(acls, aclsFromResourceACLs(resourceACLs)...)
+	}
+	return uniqueSortedACLs(acls), nil
+}
+
+func aclsFromResourceACLs(resourceACLs []sarama.ResourceAcls) []ACL {
+	acls := []ACL{}
+	for _, resourceACL := range resourceACLs {
+		for _, saramaACL := range resourceACL.Acls {
+			if saramaACL == nil {
+				continue
+			}
+			acl := ACL{
+				Principal:                 saramaACL.Principal,
+				Host:                      saramaACL.Host,
+				Operation:                 aclOperationToString(saramaACL.Operation),
+				PermissionType:            aclPermissionTypeToString(saramaACL.PermissionType),
+				ResourceType:              aclResourceTypeToString(resourceACL.ResourceType),
+				ResourceName:              resourceACL.ResourceName,
+				ResourcePatternTypeFilter: aclResourcePatternTypeToString(resourceACL.ResourcePatternType),
+			}
+			if !acl.hasProviderSupportedPatternType() {
+				log.Printf("kafka: skipping ACL %q because resource_pattern_type_filter %q is not supported by kafka_acl", acl.ImportID(), acl.ResourcePatternTypeFilter)
+				continue
+			}
+			if !acl.isPipeDelimitedImportable() {
+				log.Printf("kafka: skipping ACL for resource %q because kafka_acl import IDs cannot escape pipe characters", acl.ResourceName)
+				continue
+			}
+			acls = append(acls, acl)
+		}
+	}
+	return acls
+}
+
+func (g ACLGenerator) createResources(acls []ACL) []terraformutils.Resource {
+	resources := make([]terraformutils.Resource, 0, len(acls))
+	for _, acl := range acls {
+		attributes := acl.attributes()
+		additionalFields := map[string]interface{}{}
+		for key, value := range attributes {
+			additionalFields[key] = value
+		}
+		resources = append(resources, terraformutils.NewResource(
+			acl.ImportID(),
+			kafkaACLResourceName(acl),
+			"kafka_acl",
+			"kafka",
+			attributes,
+			ACLAllowEmptyValues,
+			additionalFields,
+		))
+	}
+	return resources
+}
+
+func (a ACL) attributes() map[string]string {
+	return map[string]string{
+		"acl_principal":                a.Principal,
+		"acl_host":                     a.Host,
+		"acl_operation":                a.Operation,
+		"acl_permission_type":          a.PermissionType,
+		"resource_type":                a.ResourceType,
+		"resource_name":                a.ResourceName,
+		"resource_pattern_type_filter": a.ResourcePatternTypeFilter,
+	}
+}
+
+func (a ACL) ImportID() string {
+	return strings.Join([]string{
+		a.Principal,
+		a.Host,
+		a.Operation,
+		a.PermissionType,
+		a.ResourceType,
+		a.ResourceName,
+		a.ResourcePatternTypeFilter,
+	}, "|")
+}
+
+func parseKafkaACLImportID(id string) (ACL, error) {
+	parts := strings.Split(id, "|")
+	if len(parts) != 7 {
+		return ACL{}, fmt.Errorf("kafka acl import ID must have 7 pipe-delimited segments, got %d", len(parts))
+	}
+	return ACL{
+		Principal:                 parts[0],
+		Host:                      parts[1],
+		Operation:                 parts[2],
+		PermissionType:            parts[3],
+		ResourceType:              parts[4],
+		ResourceName:              parts[5],
+		ResourcePatternTypeFilter: parts[6],
+	}, nil
+}
+
+func (a ACL) SaramaFilter() (sarama.AclFilter, error) {
+	resourceType, err := aclResourceTypeFromString(a.ResourceType)
+	if err != nil {
+		return sarama.AclFilter{}, err
+	}
+	patternType, err := aclResourcePatternTypeFromString(a.ResourcePatternTypeFilter)
+	if err != nil {
+		return sarama.AclFilter{}, err
+	}
+	operation, err := aclOperationFromString(a.Operation)
+	if err != nil {
+		return sarama.AclFilter{}, err
+	}
+	permissionType, err := aclPermissionTypeFromString(a.PermissionType)
+	if err != nil {
+		return sarama.AclFilter{}, err
+	}
+	principal := a.Principal
+	host := a.Host
+	resourceName := a.ResourceName
+	return sarama.AclFilter{
+		ResourceType:              resourceType,
+		ResourceName:              &resourceName,
+		ResourcePatternTypeFilter: patternType,
+		Principal:                 &principal,
+		Host:                      &host,
+		Operation:                 operation,
+		PermissionType:            permissionType,
+	}, nil
+}
+
+func (a ACL) hasProviderSupportedPatternType() bool {
+	return a.ResourcePatternTypeFilter == "Literal" || a.ResourcePatternTypeFilter == "Prefixed"
+}
+
+func (a ACL) isPipeDelimitedImportable() bool {
+	for _, part := range []string{
+		a.Principal,
+		a.Host,
+		a.Operation,
+		a.PermissionType,
+		a.ResourceType,
+		a.ResourceName,
+		a.ResourcePatternTypeFilter,
+	} {
+		if strings.Contains(part, "|") {
+			return false
+		}
+	}
+	return true
+}
+
+func kafkaACLResourceName(acl ACL) string {
+	id := acl.ImportID()
+	hash := sha256.Sum256([]byte(id))
+	return "acl_" + normalizeACLResourceName(id) + "_" + hex.EncodeToString(hash[:4])
+}
+
+func normalizeACLResourceName(value string) string {
+	var builder strings.Builder
+	for _, r := range value {
+		switch {
+		case r >= 'a' && r <= 'z', r >= 'A' && r <= 'Z', r >= '0' && r <= '9', r == '_', r == '-':
+			builder.WriteRune(r)
+		case unicode.IsSpace(r):
+			builder.WriteByte('_')
+		default:
+			fmt.Fprintf(&builder, "_x%04X_", r)
+		}
+	}
+	name := strings.Trim(builder.String(), "_")
+	if name == "" {
+		return "acl"
+	}
+	return name
+}
+
+func uniqueSortedACLs(acls []ACL) []ACL {
+	seen := map[string]struct{}{}
+	unique := make([]ACL, 0, len(acls))
+	for _, acl := range acls {
+		id := acl.ImportID()
+		if _, ok := seen[id]; ok {
+			continue
+		}
+		seen[id] = struct{}{}
+		unique = append(unique, acl)
+	}
+	sortACLs(unique)
+	return unique
+}
+
+func sortACLs(acls []ACL) {
+	sort.Slice(acls, func(i, j int) bool {
+		return acls[i].ImportID() < acls[j].ImportID()
+	})
+}
+
+func aclOperationToString(in sarama.AclOperation) string {
+	switch in {
+	case sarama.AclOperationUnknown:
+		return "Unknown"
+	case sarama.AclOperationAny:
+		return "Any"
+	case sarama.AclOperationAll:
+		return "All"
+	case sarama.AclOperationRead:
+		return "Read"
+	case sarama.AclOperationWrite:
+		return "Write"
+	case sarama.AclOperationCreate:
+		return "Create"
+	case sarama.AclOperationDelete:
+		return "Delete"
+	case sarama.AclOperationAlter:
+		return "Alter"
+	case sarama.AclOperationDescribe:
+		return "Describe"
+	case sarama.AclOperationClusterAction:
+		return "ClusterAction"
+	case sarama.AclOperationDescribeConfigs:
+		return "DescribeConfigs"
+	case sarama.AclOperationAlterConfigs:
+		return "AlterConfigs"
+	case sarama.AclOperationIdempotentWrite:
+		return "IdempotentWrite"
+	}
+	return "Unknown"
+}
+
+func aclOperationFromString(in string) (sarama.AclOperation, error) {
+	switch in {
+	case "Unknown":
+		return sarama.AclOperationUnknown, nil
+	case "Any":
+		return sarama.AclOperationAny, nil
+	case "All":
+		return sarama.AclOperationAll, nil
+	case "Read":
+		return sarama.AclOperationRead, nil
+	case "Write":
+		return sarama.AclOperationWrite, nil
+	case "Create":
+		return sarama.AclOperationCreate, nil
+	case "Delete":
+		return sarama.AclOperationDelete, nil
+	case "Alter":
+		return sarama.AclOperationAlter, nil
+	case "Describe":
+		return sarama.AclOperationDescribe, nil
+	case "ClusterAction":
+		return sarama.AclOperationClusterAction, nil
+	case "DescribeConfigs":
+		return sarama.AclOperationDescribeConfigs, nil
+	case "AlterConfigs":
+		return sarama.AclOperationAlterConfigs, nil
+	case "IdempotentWrite":
+		return sarama.AclOperationIdempotentWrite, nil
+	}
+	return sarama.AclOperationUnknown, fmt.Errorf("kafka acl: unknown operation %q", in)
+}
+
+func aclPermissionTypeToString(in sarama.AclPermissionType) string {
+	switch in {
+	case sarama.AclPermissionUnknown:
+		return "Unknown"
+	case sarama.AclPermissionAny:
+		return "Any"
+	case sarama.AclPermissionDeny:
+		return "Deny"
+	case sarama.AclPermissionAllow:
+		return "Allow"
+	}
+	return "Unknown"
+}
+
+func aclPermissionTypeFromString(in string) (sarama.AclPermissionType, error) {
+	switch in {
+	case "Unknown":
+		return sarama.AclPermissionUnknown, nil
+	case "Any":
+		return sarama.AclPermissionAny, nil
+	case "Deny":
+		return sarama.AclPermissionDeny, nil
+	case "Allow":
+		return sarama.AclPermissionAllow, nil
+	}
+	return sarama.AclPermissionUnknown, fmt.Errorf("kafka acl: unknown permission type %q", in)
+}
+
+func aclResourceTypeToString(in sarama.AclResourceType) string {
+	switch in {
+	case sarama.AclResourceUnknown:
+		return "Unknown"
+	case sarama.AclResourceAny:
+		return "Any"
+	case sarama.AclResourceTopic:
+		return "Topic"
+	case sarama.AclResourceGroup:
+		return "Group"
+	case sarama.AclResourceCluster:
+		return "Cluster"
+	case sarama.AclResourceTransactionalID:
+		return "TransactionalID"
+	case sarama.AclResourceDelegationToken:
+		return "DelegationToken"
+	}
+	return "Unknown"
+}
+
+func aclResourceTypeFromString(in string) (sarama.AclResourceType, error) {
+	switch in {
+	case "Unknown":
+		return sarama.AclResourceUnknown, nil
+	case "Any":
+		return sarama.AclResourceAny, nil
+	case "Topic":
+		return sarama.AclResourceTopic, nil
+	case "Group":
+		return sarama.AclResourceGroup, nil
+	case "Cluster":
+		return sarama.AclResourceCluster, nil
+	case "TransactionalID":
+		return sarama.AclResourceTransactionalID, nil
+	case "DelegationToken":
+		return sarama.AclResourceDelegationToken, nil
+	}
+	return sarama.AclResourceUnknown, fmt.Errorf("kafka acl: unknown resource type %q", in)
+}
+
+func aclResourcePatternTypeToString(in sarama.AclResourcePatternType) string {
+	switch in {
+	case sarama.AclPatternUnknown:
+		return "Unknown"
+	case sarama.AclPatternAny:
+		return "Any"
+	case sarama.AclPatternMatch:
+		return "Match"
+	case sarama.AclPatternLiteral:
+		return "Literal"
+	case sarama.AclPatternPrefixed:
+		return "Prefixed"
+	}
+	return "Unknown"
+}
+
+func aclResourcePatternTypeFromString(in string) (sarama.AclResourcePatternType, error) {
+	switch in {
+	case "Unknown":
+		return sarama.AclPatternUnknown, nil
+	case "Any":
+		return sarama.AclPatternAny, nil
+	case "Match":
+		return sarama.AclPatternMatch, nil
+	case "Literal":
+		return sarama.AclPatternLiteral, nil
+	case "Prefixed":
+		return sarama.AclPatternPrefixed, nil
+	}
+	return sarama.AclPatternUnknown, fmt.Errorf("kafka acl: unknown resource pattern type filter %q", in)
+}

--- a/providers/kafka/acl.go
+++ b/providers/kafka/acl.go
@@ -54,12 +54,11 @@ func (g *ACLGenerator) InitResources() error {
 func (g *ACLGenerator) ParseFilter(rawFilter string) []terraformutils.ResourceFilter {
 	for _, prefix := range []string{"kafka_acl=", "acls=", "acl="} {
 		if strings.HasPrefix(rawFilter, prefix) {
-			return []terraformutils.ResourceFilter{{
-				ServiceName:      "acl",
-				FieldPath:        "id",
-				AcceptableValues: []string{strings.TrimPrefix(rawFilter, prefix)},
-			}}
+			return []terraformutils.ResourceFilter{aclIDFilter(strings.TrimPrefix(rawFilter, prefix))}
 		}
+	}
+	if filter, ok := parseACLIDFilter(rawFilter); ok {
+		return []terraformutils.ResourceFilter{filter}
 	}
 	return g.Service.ParseFilter(rawFilter)
 }
@@ -68,6 +67,23 @@ func (g *ACLGenerator) ParseFilters(rawFilters []string) {
 	g.Filter = []terraformutils.ResourceFilter{}
 	for _, rawFilter := range rawFilters {
 		g.Filter = append(g.Filter, g.ParseFilter(rawFilter)...)
+	}
+}
+
+func parseACLIDFilter(rawFilter string) (terraformutils.ResourceFilter, bool) {
+	for _, prefix := range []string{"Type=acl;Name=id;Value=", "Name=id;Value="} {
+		if strings.HasPrefix(rawFilter, prefix) {
+			return aclIDFilter(strings.TrimPrefix(rawFilter, prefix)), true
+		}
+	}
+	return terraformutils.ResourceFilter{}, false
+}
+
+func aclIDFilter(id string) terraformutils.ResourceFilter {
+	return terraformutils.ResourceFilter{
+		ServiceName:      "acl",
+		FieldPath:        "id",
+		AcceptableValues: []string{id},
 	}
 }
 

--- a/providers/kafka/acl_test.go
+++ b/providers/kafka/acl_test.go
@@ -1,0 +1,279 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package kafka
+
+import (
+	"reflect"
+	"regexp"
+	"strings"
+	"testing"
+
+	"github.com/IBM/sarama"
+	"github.com/chenrui333/terraformer/terraformutils"
+	"github.com/zclconf/go-cty/cty"
+)
+
+func TestACLImportIDConstruction(t *testing.T) {
+	acl := ACL{
+		Principal:                 "User:producer",
+		Host:                      "*",
+		Operation:                 "Write",
+		PermissionType:            "Allow",
+		ResourceType:              "Topic",
+		ResourceName:              "orders",
+		ResourcePatternTypeFilter: "Literal",
+	}
+	want := "User:producer|*|Write|Allow|Topic|orders|Literal"
+	if got := acl.ImportID(); got != want {
+		t.Fatalf("ImportID() = %q, want %q", got, want)
+	}
+	parsed, err := parseKafkaACLImportID(want)
+	if err != nil {
+		t.Fatalf("parseKafkaACLImportID() error = %v", err)
+	}
+	if !reflect.DeepEqual(parsed, acl) {
+		t.Fatalf("parsed ACL = %#v, want %#v", parsed, acl)
+	}
+}
+
+func TestACLImportIDHandlesWildcardValues(t *testing.T) {
+	acl := ACL{
+		Principal:                 "User:*",
+		Host:                      "*",
+		Operation:                 "All",
+		PermissionType:            "Allow",
+		ResourceType:              "Cluster",
+		ResourceName:              "*",
+		ResourcePatternTypeFilter: "Literal",
+	}
+	resource := ACLGenerator{}.createResources([]ACL{acl})[0]
+	if resource.InstanceState.ID != "User:*|*|All|Allow|Cluster|*|Literal" {
+		t.Fatalf("resource ID = %q", resource.InstanceState.ID)
+	}
+	for key, want := range acl.attributes() {
+		if got := resource.InstanceState.Attributes[key]; got != want {
+			t.Fatalf("attribute %s = %q, want %q", key, got, want)
+		}
+	}
+}
+
+func TestACLResourceNamesAvoidCollisions(t *testing.T) {
+	base := ACL{
+		Principal:                 "User:svc/prod",
+		Host:                      "*",
+		Operation:                 "Read",
+		PermissionType:            "Allow",
+		ResourceType:              "Topic",
+		ResourceName:              "payments.events/v1",
+		ResourcePatternTypeFilter: "Literal",
+	}
+	other := base
+	other.Operation = "Write"
+
+	first := kafkaACLResourceName(base)
+	second := kafkaACLResourceName(other)
+	if first == second {
+		t.Fatalf("resource names collided: %q", first)
+	}
+	if kafkaACLResourceName(base) != first {
+		t.Fatalf("resource name was not stable: %q", first)
+	}
+	for _, disallowed := range []string{".", "/", ":", "|", "*"} {
+		if strings.Contains(first, disallowed) {
+			t.Fatalf("resource name = %q contains %q", first, disallowed)
+		}
+	}
+}
+
+func TestACLInitResourcesImportsMultipleACLsForSamePrincipalResource(t *testing.T) {
+	admin := &mockAdmin{
+		acls: []sarama.ResourceAcls{{
+			Resource: sarama.Resource{
+				ResourceType:        sarama.AclResourceTopic,
+				ResourceName:        "orders",
+				ResourcePatternType: sarama.AclPatternLiteral,
+			},
+			Acls: []*sarama.Acl{
+				{
+					Principal:      "User:consumer",
+					Host:           "*",
+					Operation:      sarama.AclOperationRead,
+					PermissionType: sarama.AclPermissionAllow,
+				},
+				{
+					Principal:      "User:consumer",
+					Host:           "*",
+					Operation:      sarama.AclOperationDescribe,
+					PermissionType: sarama.AclPermissionAllow,
+				},
+			},
+		}},
+	}
+	generator := &ACLGenerator{}
+	generator.SetArgs(map[string]interface{}{
+		"config": Config{BootstrapServers: []string{"broker1.example.com:9092"}},
+	})
+	generator.newAdmin = func(Config) (adminClient, error) { return admin, nil }
+
+	if err := generator.InitResources(); err != nil {
+		t.Fatalf("InitResources() error = %v", err)
+	}
+	if len(generator.Resources) != 2 {
+		t.Fatalf("resources len = %d, want 2", len(generator.Resources))
+	}
+	ids := []string{generator.Resources[0].InstanceState.ID, generator.Resources[1].InstanceState.ID}
+	want := []string{
+		"User:consumer|*|Describe|Allow|Topic|orders|Literal",
+		"User:consumer|*|Read|Allow|Topic|orders|Literal",
+	}
+	if !reflect.DeepEqual(ids, want) {
+		t.Fatalf("resource IDs = %#v, want %#v", ids, want)
+	}
+}
+
+func TestACLInitResourcesHandlesEmptyACLList(t *testing.T) {
+	admin := &mockAdmin{}
+	generator := &ACLGenerator{}
+	generator.SetArgs(map[string]interface{}{
+		"config": Config{BootstrapServers: []string{"broker1.example.com:9092"}},
+	})
+	generator.newAdmin = func(Config) (adminClient, error) { return admin, nil }
+
+	if err := generator.InitResources(); err != nil {
+		t.Fatalf("InitResources() error = %v", err)
+	}
+	if len(generator.Resources) != 0 {
+		t.Fatalf("resources len = %d, want 0", len(generator.Resources))
+	}
+	if len(admin.listACLFilters) != 5 {
+		t.Fatalf("ListAcls calls = %d, want one per Kafka ACL resource type", len(admin.listACLFilters))
+	}
+}
+
+func TestACLInitResourcesAppliesIDFilter(t *testing.T) {
+	admin := &mockAdmin{
+		acls: []sarama.ResourceAcls{{
+			Resource: sarama.Resource{
+				ResourceType:        sarama.AclResourceTopic,
+				ResourceName:        "orders",
+				ResourcePatternType: sarama.AclPatternLiteral,
+			},
+			Acls: []*sarama.Acl{
+				{
+					Principal:      "User:producer",
+					Host:           "*",
+					Operation:      sarama.AclOperationWrite,
+					PermissionType: sarama.AclPermissionAllow,
+				},
+				{
+					Principal:      "User:auditor",
+					Host:           "*",
+					Operation:      sarama.AclOperationRead,
+					PermissionType: sarama.AclPermissionAllow,
+				},
+			},
+		}},
+	}
+	generator := &ACLGenerator{}
+	generator.SetArgs(map[string]interface{}{
+		"config": Config{BootstrapServers: []string{"broker1.example.com:9092"}},
+	})
+	generator.ParseFilters([]string{"acls=User:producer|*|Write|Allow|Topic|orders|Literal"})
+	generator.newAdmin = func(Config) (adminClient, error) { return admin, nil }
+
+	if err := generator.InitResources(); err != nil {
+		t.Fatalf("InitResources() error = %v", err)
+	}
+	if len(admin.listACLFilters) != 1 {
+		t.Fatalf("ListAcls calls = %d, want 1", len(admin.listACLFilters))
+	}
+	filter := admin.listACLFilters[0]
+	if filter.ResourceType != sarama.AclResourceTopic {
+		t.Fatalf("filter resource type = %v, want Topic", filter.ResourceType)
+	}
+	if filter.ResourceName == nil || *filter.ResourceName != "orders" {
+		t.Fatalf("filter resource name = %#v, want orders", filter.ResourceName)
+	}
+	if filter.Principal == nil || *filter.Principal != "User:producer" {
+		t.Fatalf("filter principal = %#v, want User:producer", filter.Principal)
+	}
+	if filter.Operation != sarama.AclOperationWrite {
+		t.Fatalf("filter operation = %v, want Write", filter.Operation)
+	}
+	if len(generator.Resources) != 1 {
+		t.Fatalf("resources len = %d, want 1", len(generator.Resources))
+	}
+	if got := generator.Resources[0].InstanceState.ID; got != "User:producer|*|Write|Allow|Topic|orders|Literal" {
+		t.Fatalf("resource ID = %q", got)
+	}
+}
+
+func TestACLPreservesRequiredFieldsAfterImportFallback(t *testing.T) {
+	acl := ACL{
+		Principal:                 "User:ANONYMOUS",
+		Host:                      "*",
+		Operation:                 "Read",
+		PermissionType:            "Deny",
+		ResourceType:              "Group",
+		ResourceName:              "payments.events/v1",
+		ResourcePatternTypeFilter: "Prefixed",
+	}
+	resource := ACLGenerator{}.createResources([]ACL{acl})[0]
+	resource.InstanceState.Attributes = map[string]string{"id": acl.ImportID()}
+	parser := terraformutils.NewFlatmapParser(
+		resource.InstanceState.Attributes,
+		[]*regexp.Regexp{regexp.MustCompile("^id$")},
+		nil,
+	)
+	if err := resource.ParseTFstate(parser, cty.Object(map[string]cty.Type{
+		"id":                           cty.String,
+		"acl_principal":                cty.String,
+		"acl_host":                     cty.String,
+		"acl_operation":                cty.String,
+		"acl_permission_type":          cty.String,
+		"resource_type":                cty.String,
+		"resource_name":                cty.String,
+		"resource_pattern_type_filter": cty.String,
+	})); err != nil {
+		t.Fatalf("ParseTFstate() error = %v", err)
+	}
+
+	for key, want := range acl.attributes() {
+		if got := resource.Item[key]; got != want {
+			t.Fatalf("Item[%q] = %#v, want %#v", key, got, want)
+		}
+	}
+	if _, ok := resource.Item["id"]; ok {
+		t.Fatal("id attribute was not filtered from generated config item")
+	}
+}
+
+func TestACLSkipsPipeDelimitedUnencodableFields(t *testing.T) {
+	admin := &mockAdmin{
+		acls: []sarama.ResourceAcls{{
+			Resource: sarama.Resource{
+				ResourceType:        sarama.AclResourceTopic,
+				ResourceName:        "orders|archive",
+				ResourcePatternType: sarama.AclPatternLiteral,
+			},
+			Acls: []*sarama.Acl{{
+				Principal:      "User:producer",
+				Host:           "*",
+				Operation:      sarama.AclOperationWrite,
+				PermissionType: sarama.AclPermissionAllow,
+			}},
+		}},
+	}
+	generator := &ACLGenerator{}
+	generator.SetArgs(map[string]interface{}{
+		"config": Config{BootstrapServers: []string{"broker1.example.com:9092"}},
+	})
+	generator.newAdmin = func(Config) (adminClient, error) { return admin, nil }
+
+	if err := generator.InitResources(); err != nil {
+		t.Fatalf("InitResources() error = %v", err)
+	}
+	if len(generator.Resources) != 0 {
+		t.Fatalf("resources len = %d, want 0", len(generator.Resources))
+	}
+}

--- a/providers/kafka/acl_test.go
+++ b/providers/kafka/acl_test.go
@@ -208,6 +208,36 @@ func TestACLInitResourcesAppliesIDFilter(t *testing.T) {
 	}
 }
 
+func TestACLIDFilterSyntaxKeepsPrincipalColon(t *testing.T) {
+	generator := &ACLGenerator{}
+	generator.ParseFilters([]string{"Type=acl;Name=id;Value=User:producer|*|Write|Allow|Topic|orders|Literal"})
+	if len(generator.Filter) != 1 {
+		t.Fatalf("filter len = %d, want 1", len(generator.Filter))
+	}
+	filter := generator.Filter[0]
+	if filter.ServiceName != "acl" {
+		t.Fatalf("filter service = %q, want acl", filter.ServiceName)
+	}
+	if filter.FieldPath != "id" {
+		t.Fatalf("filter field = %q, want id", filter.FieldPath)
+	}
+	want := []string{"User:producer|*|Write|Allow|Topic|orders|Literal"}
+	if !reflect.DeepEqual(filter.AcceptableValues, want) {
+		t.Fatalf("filter values = %#v, want %#v", filter.AcceptableValues, want)
+	}
+
+	acls, err := generator.explicitlyRequestedACLs()
+	if err != nil {
+		t.Fatalf("explicitlyRequestedACLs() error = %v", err)
+	}
+	if len(acls) != 1 {
+		t.Fatalf("explicit ACLs len = %d, want 1", len(acls))
+	}
+	if acls[0].Principal != "User:producer" {
+		t.Fatalf("principal = %q, want User:producer", acls[0].Principal)
+	}
+}
+
 func TestACLPreservesRequiredFieldsAfterImportFallback(t *testing.T) {
 	acl := ACL{
 		Principal:                 "User:ANONYMOUS",

--- a/providers/kafka/acl_test.go
+++ b/providers/kafka/acl_test.go
@@ -277,3 +277,61 @@ func TestACLSkipsPipeDelimitedUnencodableFields(t *testing.T) {
 		t.Fatalf("resources len = %d, want 0", len(generator.Resources))
 	}
 }
+
+func TestACLDescribeResponseErrorsFailImport(t *testing.T) {
+	message := "ACL authorization failed"
+	_, err := resourceACLsFromDescribeResponse(&sarama.DescribeAclsResponse{
+		Err:    sarama.ErrClusterAuthorizationFailed,
+		ErrMsg: &message,
+	})
+	if err == nil {
+		t.Fatal("expected describe ACLs error")
+	}
+	if !strings.Contains(err.Error(), "not authorized") {
+		t.Fatalf("error = %q, want authorization context", err)
+	}
+	if !strings.Contains(err.Error(), message) {
+		t.Fatalf("error = %q, want broker message %q", err, message)
+	}
+
+	_, err = resourceACLsFromDescribeResponse(&sarama.DescribeAclsResponse{
+		Err: sarama.ErrSecurityDisabled,
+	})
+	if err == nil {
+		t.Fatal("expected security-disabled describe ACLs error")
+	}
+	if !strings.Contains(err.Error(), "Security features are disabled") {
+		t.Fatalf("error = %q, want security-disabled context", err)
+	}
+}
+
+func TestACLDescribeResponseResources(t *testing.T) {
+	resources, err := resourceACLsFromDescribeResponse(&sarama.DescribeAclsResponse{
+		Err: sarama.ErrNoError,
+		ResourceAcls: []*sarama.ResourceAcls{
+			nil,
+			{
+				Resource: sarama.Resource{
+					ResourceType:        sarama.AclResourceTopic,
+					ResourceName:        "orders",
+					ResourcePatternType: sarama.AclPatternLiteral,
+				},
+				Acls: []*sarama.Acl{{
+					Principal:      "User:producer",
+					Host:           "*",
+					Operation:      sarama.AclOperationWrite,
+					PermissionType: sarama.AclPermissionAllow,
+				}},
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("resourceACLsFromDescribeResponse() error = %v", err)
+	}
+	if len(resources) != 1 {
+		t.Fatalf("resources len = %d, want 1", len(resources))
+	}
+	if resources[0].ResourceName != "orders" {
+		t.Fatalf("resource name = %q, want orders", resources[0].ResourceName)
+	}
+}

--- a/providers/kafka/kafka_provider.go
+++ b/providers/kafka/kafka_provider.go
@@ -59,6 +59,7 @@ func (p *Provider) InitService(serviceName string, verbose bool) error {
 
 func (p *Provider) GetSupportedService() map[string]terraformutils.ServiceGenerator {
 	return map[string]terraformutils.ServiceGenerator{
+		"acls":   &ACLGenerator{},
 		"topics": &TopicGenerator{},
 	}
 }

--- a/providers/kafka/kafka_provider_test.go
+++ b/providers/kafka/kafka_provider_test.go
@@ -83,8 +83,17 @@ func TestProviderSafeConfigHandling(t *testing.T) {
 func TestProviderSupportedServices(t *testing.T) {
 	provider := &Provider{}
 	services := provider.GetSupportedService()
+	if _, ok := services["acls"]; !ok {
+		t.Fatalf("acls service not registered: %#v", services)
+	}
 	if _, ok := services["topics"]; !ok {
 		t.Fatalf("topics service not registered: %#v", services)
+	}
+	if err := provider.InitService("acls", false); err != nil {
+		t.Fatalf("InitService(acls) error = %v", err)
+	}
+	if provider.GetService() == nil {
+		t.Fatal("InitService(acls) did not set service")
 	}
 	if err := provider.InitService("topics", false); err != nil {
 		t.Fatalf("InitService(topics) error = %v", err)

--- a/providers/kafka/kafka_service.go
+++ b/providers/kafka/kafka_service.go
@@ -10,6 +10,7 @@ import (
 type adminClient interface {
 	DescribeTopics(topics []string) ([]*sarama.TopicMetadata, error)
 	DescribeConfig(resource sarama.ConfigResource) ([]sarama.ConfigEntry, error)
+	ListAcls(filter sarama.AclFilter) ([]sarama.ResourceAcls, error)
 	Close() error
 }
 

--- a/providers/kafka/kafka_service.go
+++ b/providers/kafka/kafka_service.go
@@ -3,6 +3,9 @@
 package kafka
 
 import (
+	"errors"
+	"fmt"
+
 	"github.com/IBM/sarama"
 	"github.com/chenrui333/terraformer/terraformutils"
 )
@@ -26,7 +29,57 @@ func defaultAdminFactory(config Config) (adminClient, error) {
 	if err != nil {
 		return nil, err
 	}
-	return sarama.NewClusterAdmin(config.BootstrapServers, saramaConfig)
+	admin, err := sarama.NewClusterAdmin(config.BootstrapServers, saramaConfig)
+	if err != nil {
+		return nil, err
+	}
+	return saramaAdminClient{
+		ClusterAdmin: admin,
+		config:       saramaConfig,
+	}, nil
+}
+
+type saramaAdminClient struct {
+	sarama.ClusterAdmin
+	config *sarama.Config
+}
+
+func (c saramaAdminClient) ListAcls(filter sarama.AclFilter) ([]sarama.ResourceAcls, error) {
+	request := &sarama.DescribeAclsRequest{AclFilter: filter}
+	if c.config != nil && c.config.Version.IsAtLeast(sarama.V2_0_0_0) {
+		request.Version = 1
+	}
+
+	broker, err := c.Controller()
+	if err != nil {
+		return nil, err
+	}
+	response, err := broker.DescribeAcls(request)
+	if err != nil {
+		return nil, err
+	}
+	return resourceACLsFromDescribeResponse(response)
+}
+
+func resourceACLsFromDescribeResponse(response *sarama.DescribeAclsResponse) ([]sarama.ResourceAcls, error) {
+	if response == nil {
+		return nil, errors.New("kafka acl: empty describe ACLs response")
+	}
+	if response.Err != sarama.ErrNoError {
+		if response.ErrMsg != nil && *response.ErrMsg != "" {
+			return nil, fmt.Errorf("kafka acl: describe ACLs failed: %w: %s", response.Err, *response.ErrMsg)
+		}
+		return nil, fmt.Errorf("kafka acl: describe ACLs failed: %w", response.Err)
+	}
+
+	resources := make([]sarama.ResourceAcls, 0, len(response.ResourceAcls))
+	for _, resourceACLs := range response.ResourceAcls {
+		if resourceACLs == nil {
+			continue
+		}
+		resources = append(resources, *resourceACLs)
+	}
+	return resources, nil
 }
 
 func (s *Service) admin(config Config) (adminClient, error) {

--- a/providers/kafka/topic_test.go
+++ b/providers/kafka/topic_test.go
@@ -20,8 +20,10 @@ type mockAdmin struct {
 	metadata        map[string]*sarama.TopicMetadata
 	configs         map[string][]sarama.ConfigEntry
 	configErrors    map[string]error
+	acls            []sarama.ResourceAcls
 	describeTopics  [][]string
 	describeConfigs []sarama.ConfigResource
+	listACLFilters  []sarama.AclFilter
 	closed          bool
 }
 
@@ -105,6 +107,86 @@ func (m *mockAdmin) DescribeConfig(resource sarama.ConfigResource) ([]sarama.Con
 		return nil, err
 	}
 	return m.configs[resource.Name], nil
+}
+
+func (m *mockAdmin) ListAcls(filter sarama.AclFilter) ([]sarama.ResourceAcls, error) {
+	m.listACLFilters = append(m.listACLFilters, cloneACLFilter(filter))
+	resources := []sarama.ResourceAcls{}
+	for _, resourceACLs := range m.acls {
+		if !aclResourceMatchesFilter(resourceACLs, filter) {
+			continue
+		}
+		matched := sarama.ResourceAcls{
+			Resource: resourceACLs.Resource,
+			Acls:     []*sarama.Acl{},
+		}
+		for _, acl := range resourceACLs.Acls {
+			if aclMatchesFilter(acl, filter) {
+				matched.Acls = append(matched.Acls, acl)
+			}
+		}
+		if len(matched.Acls) > 0 {
+			resources = append(resources, matched)
+		}
+	}
+	return resources, nil
+}
+
+func cloneACLFilter(filter sarama.AclFilter) sarama.AclFilter {
+	cloned := filter
+	if filter.ResourceName != nil {
+		resourceName := *filter.ResourceName
+		cloned.ResourceName = &resourceName
+	}
+	if filter.Principal != nil {
+		principal := *filter.Principal
+		cloned.Principal = &principal
+	}
+	if filter.Host != nil {
+		host := *filter.Host
+		cloned.Host = &host
+	}
+	return cloned
+}
+
+func aclResourceMatchesFilter(resourceACLs sarama.ResourceAcls, filter sarama.AclFilter) bool {
+	if filter.ResourceType != sarama.AclResourceUnknown &&
+		filter.ResourceType != sarama.AclResourceAny &&
+		filter.ResourceType != resourceACLs.ResourceType {
+		return false
+	}
+	if filter.ResourceName != nil && *filter.ResourceName != resourceACLs.ResourceName {
+		return false
+	}
+	if filter.ResourcePatternTypeFilter != sarama.AclPatternUnknown &&
+		filter.ResourcePatternTypeFilter != sarama.AclPatternAny &&
+		filter.ResourcePatternTypeFilter != resourceACLs.ResourcePatternType {
+		return false
+	}
+	return true
+}
+
+func aclMatchesFilter(acl *sarama.Acl, filter sarama.AclFilter) bool {
+	if acl == nil {
+		return false
+	}
+	if filter.Principal != nil && *filter.Principal != acl.Principal {
+		return false
+	}
+	if filter.Host != nil && *filter.Host != acl.Host {
+		return false
+	}
+	if filter.Operation != sarama.AclOperationUnknown &&
+		filter.Operation != sarama.AclOperationAny &&
+		filter.Operation != acl.Operation {
+		return false
+	}
+	if filter.PermissionType != sarama.AclPermissionUnknown &&
+		filter.PermissionType != sarama.AclPermissionAny &&
+		filter.PermissionType != acl.PermissionType {
+		return false
+	}
+	return true
 }
 
 func (m *mockAdmin) Close() error {


### PR DESCRIPTION
## Summary

Add Terraformer import support for Kafka ACLs using the upstream `Mongey/kafka` Terraform provider.

## Implementation

- Discovers ACLs through Kafka admin APIs.
- Generates provider-compatible pipe-delimited import IDs:
  `acl_principal|acl_host|acl_operation|acl_permission_type|resource_type|resource_name|resource_pattern_type_filter`
- Seeds required fields for provider refresh.
- Generates stable Terraform resource names from ACL tuples.
- Adds focused tests for import ID construction, wildcard values, filtering, and collision-prone ACL tuples.

## Scope

This PR is limited to `kafka_acl`.

Not included:

- `kafka_quota`
- `kafka_user_scram_credential`
- unrelated Kafka provider refactors

## Validation

- `go test ./providers/kafka/...`
- `go test ./cmd/...`
- `go test ./providers -run 'TestUnsupportedResourcesMetadata|TestUnsupportedResourceStatusesAreDocumented' -count=1`
- `git diff --check`

Ref: #481

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds Terraformer import support for Kafka ACLs using the upstream `Mongey/kafka` provider. You can now import `kafka_acl` resources with provider-compatible IDs and stable resource names.

- **New Features**
  - Adds `acls` service and CLI support (`--resources=acls`, `--filter=acls=...`).
  - Discovers ACLs via admin APIs across resource types.
  - Generates pipe-delimited import IDs: principal|host|operation|permission_type|resource_type|resource_name|resource_pattern_type_filter.
  - Creates stable `kafka_acl` names with a short hash.
  - Supports ID filtering; lists all when none provided.
  - Skips unsupported pattern types and values containing `|`; seeds required fields for refresh.

- **Bug Fixes**
  - Parses ACL ID filters literally to preserve principals with colons (e.g., `User:producer`).
  - Surfaces broker errors from DescribeAcls (e.g., authorization and security-disabled) with clear message context.

<sup>Written for commit be2dd32c42137ddc3715b4676094fd51f1c90293. Summary will update on new commits. <a href="https://cubic.dev/pr/chenrui333/terraformer/pull/483?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

