### PR TITLE
docs(datadog): refresh provider gap close-out metadata

### DIFF
--- a/docs/datadog.md
+++ b/docs/datadog.md
@@ -410,12 +410,14 @@ The following Terraform provider resources have been evaluated and cannot be saf
 | `datadog_integration_fastly_account` | `api_key` is required and sensitive; read API does not return it. |
 | `datadog_integration_ms_teams_workflows_webhook_handle` | `url` is required and sensitive; read API does not return it. |
 | `datadog_integration_opsgenie_service_object` | `opsgenie_api_key` is required and sensitive; Datadog API explicitly never returns it. |
+| `datadog_logs_custom_destination` | Deferred because credential-backed destination variants preserve secret values from existing Terraform state and the Datadog API does not return those values. |
 | `datadog_secure_embed_dashboard` | Deferred because Datadog exposes secure embeds by `dashboard_id:token` only; the API and provider import path require the token and do not provide a list/token discovery endpoint. |
 | `datadog_app_key_registration` | Required `id` configuration attribute is stripped during Terraformer HCL conversion, producing an empty resource block that fails validation. |
 | `datadog_org_group_policy_override` | Delete resets the target org config value to the parent policy, and server-created overrides make broad discovery noisy and potentially ephemeral. |
 | `datadog_webhook_custom_variable` | Provider import seeds only `id`, but provider read looks up the variable by `name`; Terraformer cannot safely refresh the required name/value state from a broad ID import. |
 | `datadog_integration_aws_external_id` | Creates a short-lived external ID operation; provider read is a no-op and delete only removes Terraform state. |
 | `datadog_action_connection` | Deferred until a dedicated importer handles AWS versus HTTP credential-backed variants and the HTTP token-auth read path that omits sensitive token values. |
+| `datadog_datastore_item` | Datastore items are high-cardinality datastore row data; broad import would turn arbitrary data-plane records into Terraform-owned configuration. |
 | `datadog_child_organization` | The provider read path is a no-op after create, delete is not supported, and create returns sensitive generated API/application key material that cannot be reconstructed by broad import. |
 | `datadog_cloud_workload_security_agent_rule` | Deprecated in favor of the already registered `datadog_csm_threats_agent_rule`, so broad import would risk duplicate ownership of the same agent rules. |
 | `datadog_compliance_custom_framework` | Deferred because the API supports get/update/delete by `handle/version` but exposes no broad list endpoint to discover custom framework handles and versions. |

--- a/providers/datadog/unsupported_resources.json
+++ b/providers/datadog/unsupported_resources.json
@@ -79,6 +79,18 @@
       ]
     },
     {
+      "resource": "datadog_logs_custom_destination",
+      "service_family": "logs",
+      "reason": "Credential-backed destination variants cannot be reconstructed from import/read state.",
+      "evidence": "Provider v4.9.0 imports by destination ID and Read calls GetLogsCustomDestination. The provider read mapping preserves existing state for HTTP basic auth, HTTP custom header values, Elasticsearch basic auth, and Splunk access tokens because those values are not returned by the API. The resource config validators require exactly one destination/auth variant, so broad import would generate invalid HCL for credential-backed destinations. Microsoft Sentinel destinations may be reconstructible but need a variant-aware importer to avoid silently skipping credential-backed destinations.",
+      "status": "deferred",
+      "references": [
+        "https://registry.terraform.io/providers/DataDog/datadog/latest/docs/resources/logs_custom_destination",
+        "https://github.com/DataDog/terraform-provider-datadog/blob/v4.9.0/datadog/fwprovider/resource_datadog_logs_custom_destination.go",
+        "https://github.com/DataDog/datadog-api-client-go/blob/v2.59.0/api/datadogV2/api_logs_custom_destinations.go"
+      ]
+    },
+    {
       "resource": "datadog_app_key_registration",
       "service_family": "app_key_registration",
       "reason": "Required id configuration attribute is stripped during Terraformer HCL conversion.",
@@ -143,6 +155,18 @@
       "references": [
         "https://registry.terraform.io/providers/DataDog/datadog/latest/docs/resources/action_connection",
         "https://github.com/DataDog/terraform-provider-datadog/blob/master/datadog/fwprovider/resource_datadog_action_connection.go"
+      ]
+    },
+    {
+      "resource": "datadog_datastore_item",
+      "service_family": "datastore",
+      "reason": "Datastore items are high-cardinality row data rather than provider configuration metadata.",
+      "evidence": "Provider v4.9.0 models datadog_datastore_item as per-row data with required datastore_id, item_key, and value map fields, imported as datastore-id:item-key. Broad discovery would enumerate application data records through ListDatastoreItems and turn arbitrary datastore row contents into Terraform-owned configuration. Terraformer already imports datadog_datastore metadata separately, while datastore item contents are data-plane records.",
+      "status": "runtime-data",
+      "references": [
+        "https://registry.terraform.io/providers/DataDog/datadog/latest/docs/resources/datastore_item",
+        "https://github.com/DataDog/terraform-provider-datadog/blob/v4.9.0/datadog/fwprovider/resource_datadog_datastore_item.go",
+        "https://github.com/chenrui333/terraformer/issues/336"
       ]
     },
     {


### PR DESCRIPTION
## Summary

Refresh Datadog provider gap close-out metadata after the recent #336 feature waves.

## Audit Scope

Reviewed supported resources, docs, and unsupported metadata after recent Datadog PRs covering:

- cloud cost / usage config
- modern integrations
- org controls
- IAM / access / keys
- security platform / CSM / AppSec
- dashboarding
- synthetics / downtime
- incident / webhook / workflow automation
- product/platform resources
- service catalog / software catalog
- observability pipeline / logs destinations if present on main

## Changes

- Added `datadog_logs_custom_destination` as deferred because credential-backed destination variants preserve secret state values that the Datadog API does not return.
- Added `datadog_datastore_item` as runtime data because datastore items are high-cardinality row data rather than provider configuration metadata.
- Updated `docs/datadog.md` unsupported/deferred resource notes for those entries.

## Remaining Work

#336 does not appear fully closeable from latest main yet.

A final focused feature lane remains for upstream DataDog/datadog v4.9.0 resources still missing from both supported docs and unsupported metadata:

- `datadog_custom_allocation_rules`
- `datadog_tag_pipeline_rulesets`
- `datadog_integration_gcp_sts`

## Validation

- `go test ./providers/datadog -count=1`
- `go test ./providers -run 'TestUnsupportedResourcesMetadata|TestUnsupportedResourceStatusesAreDocumented' -count=1`
- `jq . providers/datadog/unsupported_resources.json`
- `git diff --check`

Ref: #336



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Refreshes Datadog gap close-out metadata and docs after recent provider updates. Marks `datadog_logs_custom_destination` as deferred and `datadog_datastore_item` as runtime data to avoid unsafe imports. Progress toward #336.

- **Changes**
  - Deferred `datadog_logs_custom_destination` because credential-backed variants keep secret values that the API does not return.
  - Classified `datadog_datastore_item` as runtime data (high-cardinality row data, not config).
  - Updated unsupported/deferred notes in `docs/datadog.md`.

- **Follow-ups**
  - To fully close #336, add support/metadata for: `datadog_custom_allocation_rules`, `datadog_tag_pipeline_rulesets`, `datadog_integration_gcp_sts`.

<sup>Written for commit d5e544d7dfb16890201e2a780c2e6826a20c4a85. Summary will update on new commits. <a href="https://cubic.dev/pr/chenrui333/terraformer/pull/484?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

