### PR TITLE
docs(cloudflare): refresh provider gap close-out metadata

### DIFF
--- a/providers/cloudflare/unsupported_resources.json
+++ b/providers/cloudflare/unsupported_resources.json
@@ -46,6 +46,17 @@
       ]
     },
     {
+      "resource": "cloudflare_ai_search_instance",
+      "service_family": "ai",
+      "reason": "AI Search instances are not importable through the Terraform provider.",
+      "evidence": "Terraform provider v5.19.1 documents cloudflare_ai_search_instance as not currently supporting terraform import. The resource also owns AI Search source, indexing, retrieval, public endpoint, and token attachment configuration that needs a dedicated reconstruction design before broad import.",
+      "status": "not-importable",
+      "references": [
+        "https://github.com/chenrui333/terraformer/issues/335",
+        "https://registry.terraform.io/providers/cloudflare/cloudflare/latest/docs/resources/ai_search_instance"
+      ]
+    },
+    {
       "resource": "cloudflare_ai_search_token",
       "service_family": "ai",
       "reason": "AI Search tokens require Cloudflare API credential material that broad import cannot safely reconstruct.",
@@ -170,6 +181,28 @@
       ]
     },
     {
+      "resource": "cloudflare_calls_sfu_app",
+      "service_family": "calls",
+      "reason": "Calls SFU apps are not importable through the Terraform provider.",
+      "evidence": "Terraform provider v5.19.1 documents cloudflare_calls_sfu_app as not currently supporting terraform import and exposes the generated app secret as a Sensitive read-only value.",
+      "status": "not-importable",
+      "references": [
+        "https://github.com/chenrui333/terraformer/issues/335",
+        "https://registry.terraform.io/providers/cloudflare/cloudflare/latest/docs/resources/calls_sfu_app"
+      ]
+    },
+    {
+      "resource": "cloudflare_calls_turn_app",
+      "service_family": "calls",
+      "reason": "Calls TURN apps are not importable through the Terraform provider.",
+      "evidence": "Terraform provider v5.19.1 documents cloudflare_calls_turn_app as not currently supporting terraform import and exposes the generated TURN key as a Sensitive read-only value.",
+      "status": "not-importable",
+      "references": [
+        "https://github.com/chenrui333/terraformer/issues/335",
+        "https://registry.terraform.io/providers/cloudflare/cloudflare/latest/docs/resources/calls_turn_app"
+      ]
+    },
+    {
       "resource": "cloudflare_cloudforce_one_request",
       "service_family": "cloudforce_one",
       "reason": "Cloudforce One requests represent submitted analysis work rather than stable infrastructure inventory.",
@@ -181,6 +214,17 @@
       ]
     },
     {
+      "resource": "cloudflare_cloudforce_one_request_asset",
+      "service_family": "cloudforce_one",
+      "reason": "Cloudforce One request assets are child records of submitted analysis work rather than stable infrastructure inventory.",
+      "evidence": "Terraform provider v5.19.1 imports cloudflare_cloudforce_one_request_asset by account_id/request_id/asset_id and ties the resource to a Cloudforce One request. Broad import would reproduce request attachments and analysis workflow history instead of durable configuration.",
+      "status": "request-style",
+      "references": [
+        "https://github.com/chenrui333/terraformer/issues/335",
+        "https://registry.terraform.io/providers/cloudflare/cloudflare/latest/docs/resources/cloudforce_one_request_asset"
+      ]
+    },
+    {
       "resource": "cloudflare_cloudforce_one_request_message",
       "service_family": "cloudforce_one",
       "reason": "Request messages are action-style updates to an existing Cloudforce One request.",
@@ -189,6 +233,17 @@
       "references": [
         "https://github.com/chenrui333/terraformer/issues/335",
         "https://registry.terraform.io/providers/cloudflare/cloudflare/latest/docs/resources/cloudforce_one_request_message"
+      ]
+    },
+    {
+      "resource": "cloudflare_cloudforce_one_request_priority",
+      "service_family": "cloudforce_one",
+      "reason": "Cloudforce One request priorities are request workflow records rather than stable infrastructure inventory.",
+      "evidence": "Terraform provider v5.19.1 models cloudflare_cloudforce_one_request_priority with priority, TLP, labels, content, request status, token counts, and requested information. Broad import would claim Cloudforce One request triage state as Terraform-owned configuration.",
+      "status": "request-style",
+      "references": [
+        "https://github.com/chenrui333/terraformer/issues/335",
+        "https://registry.terraform.io/providers/cloudflare/cloudflare/latest/docs/resources/cloudforce_one_request_priority"
       ]
     },
     {
@@ -423,6 +478,39 @@
       ]
     },
     {
+      "resource": "cloudflare_stream",
+      "service_family": "stream",
+      "reason": "Stream videos are media content/runtime encoding records and are not importable through the Terraform provider.",
+      "evidence": "Terraform provider v5.19.1 documents cloudflare_stream as not currently supporting terraform import. The resource exposes media upload, encoding, playback, thumbnail, and processing status fields rather than stable provider-level infrastructure configuration.",
+      "status": "not-importable",
+      "references": [
+        "https://github.com/chenrui333/terraformer/issues/335",
+        "https://registry.terraform.io/providers/cloudflare/cloudflare/latest/docs/resources/stream"
+      ]
+    },
+    {
+      "resource": "cloudflare_stream_audio_track",
+      "service_family": "stream",
+      "reason": "Stream audio tracks are media content attachments and are not importable through the Terraform provider.",
+      "evidence": "Terraform provider v5.19.1 documents cloudflare_stream_audio_track as not currently supporting terraform import. The resource attaches or selects audio tracks on a media item and reads generated processing status.",
+      "status": "not-importable",
+      "references": [
+        "https://github.com/chenrui333/terraformer/issues/335",
+        "https://registry.terraform.io/providers/cloudflare/cloudflare/latest/docs/resources/stream_audio_track"
+      ]
+    },
+    {
+      "resource": "cloudflare_stream_caption_language",
+      "service_family": "stream",
+      "reason": "Stream caption language resources require media caption file ownership and are not importable through the Terraform provider.",
+      "evidence": "Terraform provider v5.19.1 documents cloudflare_stream_caption_language as not currently supporting terraform import. The resource can own a WebVTT caption file while reads expose generated caption status, so broad import cannot reconstruct caption source safely.",
+      "status": "not-importable",
+      "references": [
+        "https://github.com/chenrui333/terraformer/issues/335",
+        "https://registry.terraform.io/providers/cloudflare/cloudflare/latest/docs/resources/stream_caption_language"
+      ]
+    },
+    {
       "resource": "cloudflare_stream_download",
       "service_family": "stream",
       "reason": "Stream download resources represent generated media output state instead of durable infrastructure configuration.",
@@ -453,6 +541,17 @@
       "references": [
         "https://github.com/chenrui333/terraformer/issues/335",
         "https://registry.terraform.io/providers/cloudflare/cloudflare/latest/docs/resources/stream_live_input"
+      ]
+    },
+    {
+      "resource": "cloudflare_stream_watermark",
+      "service_family": "stream",
+      "reason": "Stream watermark resources are media asset records and are not importable through the Terraform provider.",
+      "evidence": "Terraform provider v5.19.1 documents cloudflare_stream_watermark as not currently supporting terraform import. The resource owns a copied watermark image URL and reads generated media dimensions and asset metadata.",
+      "status": "not-importable",
+      "references": [
+        "https://github.com/chenrui333/terraformer/issues/335",
+        "https://registry.terraform.io/providers/cloudflare/cloudflare/latest/docs/resources/stream_watermark"
       ]
     },
     {
@@ -508,6 +607,17 @@
       "references": [
         "https://github.com/chenrui333/terraformer/issues/335",
         "https://registry.terraform.io/providers/cloudflare/cloudflare/latest/docs/resources/vulnerability_scanner_credential"
+      ]
+    },
+    {
+      "resource": "cloudflare_web_analytics_rule",
+      "service_family": "web_analytics",
+      "reason": "Web Analytics rules are not importable through the Terraform provider.",
+      "evidence": "Terraform provider v5.19.1 documents cloudflare_web_analytics_rule as not currently supporting terraform import. Terraformer imports cloudflare_web_analytics_site, but individual rules need provider import support before broad discovery can seed them reliably.",
+      "status": "not-importable",
+      "references": [
+        "https://github.com/chenrui333/terraformer/issues/335",
+        "https://registry.terraform.io/providers/cloudflare/cloudflare/latest/docs/resources/web_analytics_rule"
       ]
     },
     {
@@ -589,6 +699,28 @@
       ]
     },
     {
+      "resource": "cloudflare_zero_trust_access_mtls_hostname_settings",
+      "service_family": "zero_trust_access",
+      "reason": "Access mTLS hostname settings are not importable through the Terraform provider.",
+      "evidence": "Terraform provider v5.19.1 documents cloudflare_zero_trust_access_mtls_hostname_settings as not currently supporting terraform import. The resource owns an account or zone hostname settings list, so broad import cannot safely seed it without provider import support.",
+      "status": "not-importable",
+      "references": [
+        "https://github.com/chenrui333/terraformer/issues/335",
+        "https://registry.terraform.io/providers/cloudflare/cloudflare/latest/docs/resources/zero_trust_access_mtls_hostname_settings"
+      ]
+    },
+    {
+      "resource": "cloudflare_zero_trust_device_default_profile_certificates",
+      "service_family": "zero_trust_device",
+      "reason": "Zero Trust device default profile certificate settings are not importable through the Terraform provider.",
+      "evidence": "Terraform provider v5.19.1 documents cloudflare_zero_trust_device_default_profile_certificates as not currently supporting terraform import. Broad import should not synthesize this WARP client certificate provisioning toggle without provider import support.",
+      "status": "not-importable",
+      "references": [
+        "https://github.com/chenrui333/terraformer/issues/335",
+        "https://registry.terraform.io/providers/cloudflare/cloudflare/latest/docs/resources/zero_trust_device_default_profile_certificates"
+      ]
+    },
+    {
       "resource": "cloudflare_zero_trust_device_posture_integration",
       "service_family": "zero_trust_device_posture",
       "reason": "Device posture integrations require provider-specific credential/configuration material that needs a dedicated reconstruction design.",
@@ -597,6 +729,17 @@
       "references": [
         "https://github.com/chenrui333/terraformer/issues/335",
         "https://registry.terraform.io/providers/cloudflare/cloudflare/latest/docs/resources/zero_trust_device_posture_integration"
+      ]
+    },
+    {
+      "resource": "cloudflare_zero_trust_device_settings",
+      "service_family": "zero_trust_device",
+      "reason": "Zero Trust device settings are not importable through the Terraform provider.",
+      "evidence": "Terraform provider v5.19.1 documents cloudflare_zero_trust_device_settings as not currently supporting terraform import. The account singleton owns WARP device defaults and emergency disconnect settings that need provider import support before Terraformer can seed them safely.",
+      "status": "not-importable",
+      "references": [
+        "https://github.com/chenrui333/terraformer/issues/335",
+        "https://registry.terraform.io/providers/cloudflare/cloudflare/latest/docs/resources/zero_trust_device_settings"
       ]
     },
     {
@@ -685,6 +828,17 @@
       "references": [
         "https://github.com/chenrui333/terraformer/issues/335",
         "https://registry.terraform.io/providers/cloudflare/cloudflare/5.19.1/docs/resources/zero_trust_organization"
+      ]
+    },
+    {
+      "resource": "cloudflare_zero_trust_risk_behavior",
+      "service_family": "zero_trust_risk",
+      "reason": "Zero Trust risk behavior settings are not importable through the Terraform provider.",
+      "evidence": "Terraform provider v5.19.1 documents cloudflare_zero_trust_risk_behavior as not currently supporting terraform import. The account-level behavior map should not be synthesized by broad import until the provider exposes an import contract.",
+      "status": "not-importable",
+      "references": [
+        "https://github.com/chenrui333/terraformer/issues/335",
+        "https://registry.terraform.io/providers/cloudflare/cloudflare/latest/docs/resources/zero_trust_risk_behavior"
       ]
     },
     {


### PR DESCRIPTION
## Summary

Refresh Cloudflare provider gap close-out metadata after the recent #335 feature waves.

## Audit Scope

Reviewed supported resources, docs, and unsupported metadata after recent Cloudflare PRs covering:

- settings and DNSSEC
- storage/R2/queues/Hyperdrive
- Zero Trust Gateway
- Security / API Shield / Page Shield
- network edge
- media/platform
- Workers

## Changes

Added evidence-backed unsupported/deferred metadata for provider v5.19.1 resources that are not safe broad-import targets:

- `cloudflare_ai_search_instance`
- `cloudflare_calls_sfu_app`
- `cloudflare_calls_turn_app`
- `cloudflare_cloudforce_one_request_asset`
- `cloudflare_cloudforce_one_request_priority`
- `cloudflare_stream`
- `cloudflare_stream_audio_track`
- `cloudflare_stream_caption_language`
- `cloudflare_stream_watermark`
- `cloudflare_web_analytics_rule`
- `cloudflare_zero_trust_access_mtls_hostname_settings`
- `cloudflare_zero_trust_device_default_profile_certificates`
- `cloudflare_zero_trust_device_settings`
- `cloudflare_zero_trust_risk_behavior`

## Remaining Work

#335 does not look fully closeable yet from latest `main`.

The remaining unclassified Cloudflare v5.19.1 resources are importable in the provider docs and need focused implementation/design review rather than unsupported metadata. Recommended follow-up lanes:

- Media/platform imports already in flight in PR #477.
- Zero Trust Device/Posture/DLP/DEX/Risk follow-up.
- Smaller security/access/network long-tail follow-up for certificate/TLS/custom pages/email security/token validation/tunnel config resources.

## Validation

- `go test ./providers/cloudflare/...`
- `go test ./cmd/...`
- `go test ./providers -run 'TestUnsupportedResourcesMetadata|TestUnsupportedResourceStatusesAreDocumented' -count=1`
- `jq . providers/cloudflare/unsupported_resources.json`
- `git diff --check`

Ref: #335


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Refreshes Cloudflare provider gap close-out metadata to align with provider v5.19.1 after recent feature waves. Marks non-importable or request-style resources as unsupported/deferred (AI Search, Calls SFU/TURN, Cloudforce One request asset/priority, Stream media assets, Web Analytics rule, and several Zero Trust Access/Device/Risk settings) to keep broad import safe; ties into #335.

<sup>Written for commit 78c97614bab7f01c4e9db3b595595b8302b252fe. Summary will update on new commits. <a href="https://cubic.dev/pr/chenrui333/terraformer/pull/485?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

