### PR TITLE
docs: update provider gap engineering guidance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -23,6 +23,9 @@
 - Keep generated HCL secret-free. Prefer environment variables, profiles, or existing provider config paths for authentication, and keep refresh-time auth config separate from generated provider data.
 - Apply filters before broad, expensive, or permission-sensitive reads. Skip system, internal, default, or provider-managed resources unless explicitly filtered and verified as safely user-owned.
 - Preserve required identity and shape fields through refresh/import fallback. Defer resources with unrecoverable write-only fields, importer mismatches, or unreadable required config into unsupported metadata with evidence.
+- Before closing a provider gap issue, compare provider registration, docs, unsupported metadata, and the issue's resource buckets; detect stale or superseded PR branches after parallel provider lanes merge.
+- Preserve empty-but-meaningful provider fields, nested state, and source variant markers required for refresh-stable HCL. Reject discovered resources whose source shape is not supported by the Terraform provider.
+- Import durable configuration metadata only. Classify high-cardinality row, item, event, or runtime data as unsupported or deferred unless provider read can reconstruct stable configuration.
 
 ## Validation
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -66,6 +66,18 @@ Mark a resource unsupported when:
 - the resource represents an operation rather than stable inventory;
 - the resource represents an acceptance or handshake lifecycle that cannot be inferred safely from discovery.
 
+## Provider Gap Close-Out And Data Shape Checks
+
+Before claiming a provider gap issue is complete, compare all four sources of truth: Terraformer provider registration, provider docs, provider-local unsupported metadata, and the issue's resource buckets. Also check whether open or stale PR branches were superseded by later merged lanes before continuing work.
+
+When evaluating product, platform, dataset, table, pipeline, API-definition, or deployment-style resources:
+
+- preserve empty-but-meaningful strings, lists, maps, nested blocks, and variant markers when provider refresh needs them for stable HCL;
+- seed nested state that provider read only reconciles when it is already present, such as rule or schedule blocks;
+- validate source-shape restrictions before appending discovered IDs, and skip or document source variants the Terraform provider cannot validate or refresh;
+- import durable configuration metadata, not high-cardinality rows, items, events, or runtime observations;
+- prefer unsupported or deferred metadata over exposing a resource that produces invalid, lossy, or destructive follow-up plans.
+
 ## Duplicate Ownership Across Related Resources
 
 Before adding a resource, check whether another Terraformer-supported resource already owns the same upstream object or configuration.


### PR DESCRIPTION
## Summary

Update repo-local engineering guidance with durable lessons from the Datadog lane 1 provider-gap work.

## Notes

- Adds guidance only for repeatable provider-maintenance patterns.
- Focuses on close-out audits, refresh-stable data shapes, runtime/high-cardinality data classification, and stale PR detection.
- No provider behavior changes.

## Validation

- `git diff --check`
- `markdownlint` if available


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Expand repo-local engineering guidance with repeatable patterns from the Datadog lane 1 provider-gap work. Adds close-out audits, refresh-stable HCL and source-shape rules, classification of high-cardinality/runtime data, and stale PR branch detection; docs only, no provider behavior changes.

<sup>Written for commit f851074c424d649d0e28734fcae9d9820b3a3997. Summary will update on new commits. <a href="https://cubic.dev/pr/chenrui333/terraformer/pull/486?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

