### PR TITLE
docs: update provider gap close-out guidance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -23,6 +23,10 @@
 - Keep generated HCL secret-free. Prefer environment variables, profiles, or existing provider config paths for authentication, and keep refresh-time auth config separate from generated provider data.
 - Apply filters before broad, expensive, or permission-sensitive reads. Skip system, internal, default, or provider-managed resources unless explicitly filtered and verified as safely user-owned.
 - Preserve required identity and shape fields through refresh/import fallback. Defer resources with unrecoverable write-only fields, importer mismatches, or unreadable required config into unsupported metadata with evidence.
+- For large provider gap close-outs, report lane closure separately from tracking-issue closure. A lane can be complete while the issue remains open for focused follow-up lanes.
+- Treat practical close-out as every reviewed candidate being supported, evidence-backed deferred/unsupported, or assigned to a named remaining lane. Do not chase literal provider parity when broad import would be unsafe or noisy.
+- Settings and singleton imports must be gated on durable user-owned configuration, not merely effective API values. Do not claim platform defaults as Terraform-owned state.
+- Use unsupported metadata to bound future work and prevent repeated resource chasing; turn close-out findings into focused next lanes rather than another open-ended sweep.
 
 ## Validation
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -587,6 +587,19 @@ For large lane PRs that span several related services:
 - add strong helper tests because service-specific behavior is less likely to be covered by existing patterns;
 - defer schema-heavy service families that need focused handling instead of forcing fragile support into a broad sweep.
 
+## Provider Gap Close-Out Audits
+
+Close-out audits are different from feature lanes. They should make the remaining work explicit, not restart parity chasing.
+
+Rules:
+
+- Report lane closure separately from tracking-issue closure. A lane can be complete while the broader issue remains open.
+- For large provider schemas, practical close-out means every reviewed candidate is supported, evidence-backed deferred/unsupported, or assigned to a named focused follow-up lane.
+- Do not treat literal Terraform provider parity as the goal when resources are request-style, runtime/media output, high-cardinality content, provider-managed, source/body-heavy, or secret-required.
+- For settings and singleton resources, distinguish durable user-owned configuration from effective API values and platform defaults before moving a resource from deferred metadata to supported import.
+- Use close-out audits to reduce repeated search work: update unsupported metadata when evidence is clear, and group remaining importable resources into focused next lanes.
+- If the audit finds no durable metadata or guidance changes, report that directly instead of creating a docs-only PR.
+
 ## Implementation Rules
 
 - Seed state with the ID shape expected by the Terraform provider read path, not necessarily the human import ID.


### PR DESCRIPTION
## Summary

Update repo-local engineering and agent guidance with durable lessons from the Cloudflare provider gap close-out work.

## Notes

- Clarifies lane closure versus issue closure.
- Documents practical close-out criteria for large provider schemas.
- Reinforces default/effective-state ownership gates for singleton/settings resources.
- Reinforces using unsupported metadata to bound future work rather than chasing literal parity.
- No provider behavior changes.

## Validation

- `git diff --check`
- `markdownlint` if available

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updates AGENTS.md and CLAUDE.md with guidance for provider gap close-out audits: separate lane vs issue closure, close-out criteria, gate settings/singletons on durable user config, unsupported metadata to bound follow-ups, and avoid unsafe parity. Docs-only; skip docs-only PRs when nothing changes.

<sup>Written for commit eb34d9d335307f87bf06c045dc707ff6767d7f36. Summary will update on new commits. <a href="https://cubic.dev/pr/chenrui333/terraformer/pull/487?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

