### PR TITLE
docs: update Kafka provider maintenance guidance

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -514,6 +514,8 @@ Rules:
 - Add explicit helper functions for import ID construction.
 - Add tests for every composite import ID shape.
 - Use stable resource names that include enough parent/child context to avoid sanitized name collisions.
+- Treat composite and tuple ID filters as literal import identities; do not pass them through generic parsers that split on delimiters which may also appear inside tuple fields unless the provider format guarantees escaping.
+- If a discovered identity contains a delimiter that the upstream importer cannot escape or represent, skip or defer it with evidence instead of emitting a broken import ID.
 - If provider refresh normalizes or drops an import ID, use the project's ID preservation metadata only after verifying the behavior.
 
 ## Parent/Child Dependency References


### PR DESCRIPTION
## Summary

Update repo-local engineering and agent guidance with durable lessons from Kafka ACL import work.

## Notes

- Clarifies composite/tuple import ID handling.
- Clarifies collision-resistant Terraform naming for identity tuples.
- Clarifies when to skip/defer unrepresentable import identities.
- No provider behavior changes.

## Validation

- `go test ./providers/kafka/...`
- `go test ./cmd/...`
- `go test ./providers -run 'TestUnsupportedResourcesMetadata|TestUnsupportedResourceStatusesAreDocumented' -count=1`
- `jq . providers/kafka/unsupported_resources.json`
- `git diff --check`


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Clarifies Kafka provider maintenance docs for composite/tuple import IDs. Treat filters as literal IDs (no generic delimiter splitting) and skip/defer identities with unescapable delimiters; no provider behavior changes.

<sup>Written for commit d7b026f98a60ef8c597475fedd4236662c12ab9f. Summary will update on new commits. <a href="https://cubic.dev/pr/chenrui333/terraformer/pull/488?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added guidelines for handling import IDs in composite and tuple identity scenarios to ensure proper configuration and prevent invalid imports.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/chenrui333/terraformer/pull/488?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->