### PR TITLE
ci: add Helm provider labeler rule

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -184,6 +184,13 @@ provider/heroku:
           - "docs/heroku.md"
           - "cmd/provider_cmd_heroku.go"
 
+provider/helm:
+  - changed-files:
+      - any-glob-to-any-file:
+          - "providers/helm/**"
+          - "docs/helm.md"
+          - "cmd/provider_cmd_helm.go"
+
 provider/honeycombio:
   - changed-files:
       - any-glob-to-any-file:


### PR DESCRIPTION
## Summary

Add `provider/helm` labeler support for upcoming Helm provider work.

## Changes

- Add `.github/labeler.yml` entry for:
  - `providers/helm/**`
  - `docs/helm.md`
  - `cmd/provider_cmd_helm.go`

## Notes

- Supports Helm provider tracking issue #489.
- No provider implementation changes.

## Validation

- `git diff --check`

Ref: #489


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a labeler rule to auto-apply the `provider/helm` label when Helm-related files change (covers `providers/helm/**`, `docs/helm.md`, `cmd/provider_cmd_helm.go`); no provider code changes. Supports #489.

<sup>Written for commit 9a1aa2e0e051f134cf788f56729556f8ef09de15. Summary will update on new commits. <a href="https://cubic.dev/pr/chenrui333/terraformer/pull/490?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

