### PR TITLE
feat(helm): add provider skeleton

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ A CLI tool that generates `tf`/`json` and `tfstate` files based on existing infr
         * [Yandex Cloud](/docs/yandex.md)
         * [Ionos Cloud](/docs/ionoscloud.md)
     * Infrastructure Software
+        * [Helm](/docs/helm.md)
         * [Kafka](/docs/kafka.md)
         * [Kubernetes](/docs/kubernetes.md)
         * [OctopusDeploy](/docs/octopus.md)
@@ -272,6 +273,7 @@ Links to download Terraform provider plugins:
     * Yandex provider >0.42.0 - [here](https://releases.hashicorp.com/terraform-provider-yandex/)
     * Ionoscloud provider >6.3.3 - [here](https://github.com/ionos-cloud/terraform-provider-ionoscloud/releases)
 * Infrastructure Software
+    * Helm provider - [here](https://releases.hashicorp.com/terraform-provider-helm/)
     * Kafka provider >=0.13.1 - [here](https://github.com/Mongey/terraform-provider-kafka/releases)
     * Kubernetes provider >=1.9.0 - [here](https://releases.hashicorp.com/terraform-provider-kubernetes/)
     * RabbitMQ provider >=1.1.0 - [here](https://releases.hashicorp.com/terraform-provider-rabbitmq/)

--- a/cmd/provider_cmd_helm.go
+++ b/cmd/provider_cmd_helm.go
@@ -1,0 +1,33 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package cmd
+
+import (
+	helm_terraforming "github.com/chenrui333/terraformer/providers/helm"
+	"github.com/chenrui333/terraformer/terraformutils"
+	"github.com/spf13/cobra"
+)
+
+func newCmdHelmImporter(options ImportOptions) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "helm",
+		Short: "Import current state to Terraform configuration from Helm",
+		Long:  "Import current state to Terraform configuration from Helm",
+		RunE: func(_ *cobra.Command, _ []string) error {
+			provider := newHelmProvider()
+			err := Import(provider, options, []string{})
+			if err != nil {
+				return err
+			}
+			return nil
+		},
+	}
+
+	cmd.AddCommand(listCmd(newHelmProvider()))
+	baseProviderFlags(cmd.PersistentFlags(), &options, "release", "release=namespace/name")
+	return cmd
+}
+
+func newHelmProvider() terraformutils.ProviderGenerator {
+	return &helm_terraforming.Provider{}
+}

--- a/cmd/provider_cmd_helm_test.go
+++ b/cmd/provider_cmd_helm_test.go
@@ -1,0 +1,36 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package cmd
+
+import "testing"
+
+func TestHelmProviderCommandRegistration(t *testing.T) {
+	provider := newHelmProvider()
+	if provider.GetName() != "helm" {
+		t.Fatalf("provider name = %q, want helm", provider.GetName())
+	}
+	if _, ok := provider.GetSupportedService()["release"]; !ok {
+		t.Fatal("helm release service is not registered")
+	}
+
+	importers := providerImporterSubcommands()
+	foundImporter := false
+	for _, importer := range importers {
+		cmd := importer(ImportOptions{})
+		if cmd.Use == "helm" {
+			foundImporter = true
+			if cmd.PersistentFlags().Lookup("resources") == nil {
+				t.Fatal("helm command missing resources flag")
+			}
+			break
+		}
+	}
+	if !foundImporter {
+		t.Fatal("helm import subcommand is not registered")
+	}
+
+	generators := providerGenerators()
+	if _, ok := generators["helm"]; !ok {
+		t.Fatal("helm provider generator is not registered")
+	}
+}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -45,6 +45,7 @@ func providerImporterSubcommands() []func(options ImportOptions) *cobra.Command 
 		newCmdYandexImporter,
 		newCmdIonosCloudImporter,
 		// Infrastructure Software
+		newCmdHelmImporter,
 		newCmdKafkaImporter,
 		newCmdKubernetesImporter,
 		newCmdOctopusDeployImporter,
@@ -104,6 +105,7 @@ func providerGeneratorConstructors() []func() terraformutils.ProviderGenerator {
 		newVultrProvider,
 		newYandexProvider,
 		// Infrastructure Software
+		newHelmProvider,
 		newKafkaProvider,
 		newKubernetesProvider,
 		newOctopusDeployProvider,

--- a/docs/helm.md
+++ b/docs/helm.md
@@ -1,0 +1,16 @@
+### Use with Helm
+
+Terraformer has initial Helm provider wiring for the `helm` provider. Helm
+release discovery and import support is tracked in issue #489 and is not
+implemented yet.
+
+Reserved service key:
+
+* `release`
+
+The `release` service key is reserved for future `helm_release` import support.
+This skeleton intentionally does not discover Helm releases or emit
+`helm_release` resources.
+
+Follow-up release import work should use Helm SDK discovery and provider
+compatible `namespace/name` import IDs.

--- a/providers/helm/helm_provider.go
+++ b/providers/helm/helm_provider.go
@@ -1,0 +1,66 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package helm
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/chenrui333/terraformer/terraformutils"
+	"github.com/zclconf/go-cty/cty"
+)
+
+type Provider struct {
+	terraformutils.Provider
+}
+
+func (p *Provider) Init(_ []string) error {
+	return nil
+}
+
+func (p *Provider) GetName() string {
+	return "helm"
+}
+
+func (p *Provider) GetProviderData(_ ...string) map[string]interface{} {
+	return map[string]interface{}{}
+}
+
+func (Provider) GetResourceConnections() map[string]map[string][]string {
+	return map[string]map[string][]string{}
+}
+
+func (p *Provider) GetConfig() cty.Value {
+	return cty.EmptyObjectVal
+}
+
+func (p *Provider) GetBasicConfig() cty.Value {
+	return p.GetConfig()
+}
+
+func (p *Provider) InitService(serviceName string, verbose bool) error {
+	if !terraformutils.SelectProviderService(&p.Provider, p.GetSupportedService(), serviceName, verbose, p.GetName()) {
+		return fmt.Errorf("helm: %s not supported service", serviceName)
+	}
+	return nil
+}
+
+func (p *Provider) GetSupportedService() map[string]terraformutils.ServiceGenerator {
+	return map[string]terraformutils.ServiceGenerator{
+		"release": &ReleaseGenerator{},
+	}
+}
+
+func (p *Provider) ValidateImport(resources []string) error {
+	for _, resource := range resources {
+		if resource == "release" {
+			return ErrReleaseImportNotImplemented
+		}
+		if _, ok := p.GetSupportedService()[resource]; !ok {
+			return fmt.Errorf("helm: %s not supported service", resource)
+		}
+	}
+	return nil
+}
+
+var ErrReleaseImportNotImplemented = errors.New("helm: release import is not implemented yet")

--- a/providers/helm/helm_provider_test.go
+++ b/providers/helm/helm_provider_test.go
@@ -1,0 +1,56 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package helm
+
+import (
+	"errors"
+	"strings"
+	"testing"
+)
+
+func TestProviderInit(t *testing.T) {
+	provider := &Provider{}
+	if err := provider.Init(nil); err != nil {
+		t.Fatalf("Init() error = %v", err)
+	}
+}
+
+func TestProviderSupportedServices(t *testing.T) {
+	provider := &Provider{}
+	services := provider.GetSupportedService()
+	if _, ok := services["release"]; !ok {
+		t.Fatalf("release service not registered: %#v", services)
+	}
+	if err := provider.InitService("release", false); err != nil {
+		t.Fatalf("InitService(release) error = %v", err)
+	}
+	if provider.GetService() == nil {
+		t.Fatal("InitService(release) did not set service")
+	}
+	if provider.GetService().GetName() != "release" {
+		t.Fatalf("service name = %q, want release", provider.GetService().GetName())
+	}
+	if provider.GetService().GetProviderName() != "helm" {
+		t.Fatalf("service provider name = %q, want helm", provider.GetService().GetProviderName())
+	}
+}
+
+func TestProviderRejectsUnsupportedService(t *testing.T) {
+	provider := &Provider{}
+	if err := provider.InitService("chart", false); err == nil {
+		t.Fatal("expected unsupported service error")
+	} else if !strings.Contains(err.Error(), "chart not supported service") {
+		t.Fatalf("InitService error = %q, want unsupported service", err)
+	}
+	if provider.GetService() != nil {
+		t.Fatalf("unsupported service left stale service %T", provider.GetService())
+	}
+}
+
+func TestProviderValidateImportRejectsReleaseUntilImplemented(t *testing.T) {
+	provider := &Provider{}
+	err := provider.ValidateImport([]string{"release"})
+	if !errors.Is(err, ErrReleaseImportNotImplemented) {
+		t.Fatalf("ValidateImport(release) error = %v, want %v", err, ErrReleaseImportNotImplemented)
+	}
+}

--- a/providers/helm/release.go
+++ b/providers/helm/release.go
@@ -1,0 +1,13 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package helm
+
+import "github.com/chenrui333/terraformer/terraformutils"
+
+type ReleaseGenerator struct {
+	terraformutils.Service
+}
+
+func (g *ReleaseGenerator) InitResources() error {
+	return ErrReleaseImportNotImplemented
+}

--- a/providers/helm/release_test.go
+++ b/providers/helm/release_test.go
@@ -1,0 +1,15 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package helm
+
+import (
+	"errors"
+	"testing"
+)
+
+func TestReleaseGeneratorInitResourcesNotImplemented(t *testing.T) {
+	generator := &ReleaseGenerator{}
+	if err := generator.InitResources(); !errors.Is(err, ErrReleaseImportNotImplemented) {
+		t.Fatalf("InitResources() error = %v, want %v", err, ErrReleaseImportNotImplemented)
+	}
+}

--- a/terraformutils/provider_source_test.go
+++ b/terraformutils/provider_source_test.go
@@ -28,6 +28,7 @@ func TestProviderSource(t *testing.T) {
 		"google-beta":                 "hashicorp/google-beta",
 		"grafana":                     "grafana/grafana",
 		"heroku":                      "heroku/heroku",
+		"helm":                        "hashicorp/helm",
 		"honeycombio":                 "honeycombio/honeycombio",
 		"ibm":                         "IBM-Cloud/ibm",
 		"ionoscloud":                  "ionos-cloud/ionoscloud",


### PR DESCRIPTION
## Summary

Add the initial Terraformer Helm provider skeleton.

## Changes

- Add `helm` provider wiring.
- Add provider command registration.
- Add provider source mapping/tests as needed.
- Add initial Helm docs/README wiring.
- Add provider/service registration tests.

## Scope

This PR intentionally does not implement `helm_release` discovery/import yet.

## Follow-ups

- Add `helm_release` import support using Helm SDK discovery and `namespace/name` import IDs.
- Add unsupported/deferred metadata for unsafe Helm release classes if needed.

## Validation

- `go test ./providers/helm/...`
- `go test ./cmd/...`
- `go test ./terraformutils/...`
- `git diff --check`

Ref: #489


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds the initial `helm` provider skeleton with CLI wiring and docs. Registers the provider and a placeholder `release` service; `helm_release` discovery/import is not implemented yet (see #489).

- **New Features**
  - Registers `helm` provider and import subcommand in the CLI.
  - Adds `release` service generator stub that returns a not-implemented error.
  - Adds provider source mapping to `hashicorp/helm`.
  - Adds basic docs (`docs/helm.md`) and tests for provider and command wiring.

<sup>Written for commit 898dd86053d2914be370188a0b492e700cb32a5a. Summary will update on new commits. <a href="https://cubic.dev/pr/chenrui333/terraformer/pull/492?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

