### PR TITLE
feat(cloudflare): add security email adjunct imports

### DIFF
--- a/docs/cloudflare.md
+++ b/docs/cloudflare.md
@@ -99,7 +99,6 @@ List of supported Cloudflare services:
   * `cloudflare_custom_pages`
   * `cloudflare_email_security_block_sender`
   * `cloudflare_email_security_impersonation_registry`
-  * `cloudflare_email_security_trusted_domains`
   * `cloudflare_leaked_credential_check_rule`
   * `cloudflare_page_shield_policy`
   * `cloudflare_schema_validation_schemas`

--- a/docs/cloudflare.md
+++ b/docs/cloudflare.md
@@ -23,6 +23,7 @@ List of supported Cloudflare services:
   * `cloudflare_zero_trust_access_custom_page`
   * `cloudflare_zero_trust_access_group`
   * `cloudflare_zero_trust_access_identity_provider`
+  * `cloudflare_zero_trust_access_infrastructure_target`
   * `cloudflare_zero_trust_access_mtls_certificate`
   * `cloudflare_zero_trust_access_policy`
   * `cloudflare_zero_trust_access_service_token`
@@ -93,10 +94,24 @@ List of supported Cloudflare services:
 * `security`
   * `cloudflare_api_shield`
   * `cloudflare_api_shield_operation`
+  * `cloudflare_cloud_connector_rules`
+  * `cloudflare_custom_page_asset`
+  * `cloudflare_custom_pages`
+  * `cloudflare_email_security_block_sender`
+  * `cloudflare_email_security_impersonation_registry`
+  * `cloudflare_email_security_trusted_domains`
+  * `cloudflare_leaked_credential_check_rule`
   * `cloudflare_page_shield_policy`
   * `cloudflare_schema_validation_schemas`
+  * `cloudflare_token_validation_config`
+  * `cloudflare_token_validation_rules`
+  * `cloudflare_user_agent_blocking_rule`
   * `cloudflare_vulnerability_scanner_credential_set`
   * `cloudflare_vulnerability_scanner_target_environment`
+
+  `security` requires `CLOUDFLARE_ACCOUNT_ID` for account-scoped Email Security
+  and custom page resources. Default Cloudflare custom pages are skipped; only
+  customized pages are imported.
 * `settings`
   * `cloudflare_account_dns_settings_internal_view`
   * `cloudflare_argo_smart_routing`

--- a/providers/cloudflare/access.go
+++ b/providers/cloudflare/access.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"log"
 	"net/http"
 	"net/url"
 	"strconv"
@@ -16,6 +17,11 @@ import (
 
 type AccessGenerator struct {
 	CloudflareService
+}
+
+type accessInfrastructureTarget struct {
+	ID       string `json:"id,omitempty"`
+	Hostname string `json:"hostname,omitempty"`
 }
 
 func accessScopeAttributes(scopeType, scopeID string) map[string]string {
@@ -323,6 +329,60 @@ func listAccessTags(ctx context.Context, api *cf.API, rc *cf.ResourceContainer) 
 	return tags, nil
 }
 
+func (g *AccessGenerator) appendAccountAccessInfrastructureTargetResources(ctx context.Context, api *cf.API, accountID string) error {
+	targets, err := listAccessInfrastructureTargets(ctx, api, accountID)
+	if err != nil {
+		if cloudflareNotFoundError(err) || cloudflareSecurityOptionalDiscoveryError(err) {
+			log.Printf("Skipping Cloudflare Access infrastructure target discovery for account %s: %v", accountID, err)
+			return nil
+		}
+		return err
+	}
+	for _, target := range targets {
+		if target.ID == "" {
+			continue
+		}
+		resource := terraformutils.NewResource(
+			target.ID,
+			cloudflareResourceName("accounts", accountID, target.Hostname, target.ID),
+			"cloudflare_zero_trust_access_infrastructure_target",
+			"cloudflare",
+			map[string]string{"account_id": accountID},
+			[]string{},
+			map[string]interface{}{},
+		)
+		setCloudflareImportID(&resource, fmt.Sprintf("%s/%s", accountID, target.ID))
+		g.Resources = append(g.Resources, resource)
+	}
+	return nil
+}
+
+func listAccessInfrastructureTargets(ctx context.Context, api *cf.API, accountID string) ([]accessInfrastructureTarget, error) {
+	var targets []accessInfrastructureTarget
+	page, cursor := 1, ""
+	for {
+		response, err := api.Raw(
+			ctx,
+			http.MethodGet,
+			fmt.Sprintf("/accounts/%s/infrastructure/targets?%s", accountID, cloudflarePaginationQuery(page, cursor)),
+			nil,
+			nil,
+		)
+		if err != nil {
+			return nil, err
+		}
+		var pageTargets []accessInfrastructureTarget
+		if err := json.Unmarshal(response.Result, &pageTargets); err != nil {
+			return nil, err
+		}
+		targets = append(targets, pageTargets...)
+		if !cloudflareAdvancePagination(response.ResultInfo, &page, &cursor) {
+			break
+		}
+	}
+	return targets, nil
+}
+
 func (g *AccessGenerator) appendScopedAccessResources(ctx context.Context, api *cf.API, rc *cf.ResourceContainer, scopeType string) error {
 	for _, f := range []func(context.Context, *cf.API, *cf.ResourceContainer, string) error{
 		g.appendAccessApplicationResources,
@@ -355,6 +415,7 @@ func (g *AccessGenerator) InitResources() error {
 			g.appendAccountAccessPolicyResources,
 			g.appendAccountAccessCustomPageResources,
 			g.appendAccountAccessTagResources,
+			g.appendAccountAccessInfrastructureTargetResources,
 		} {
 			if err := f(ctx, api, accountID); err != nil {
 				return err

--- a/providers/cloudflare/access_test.go
+++ b/providers/cloudflare/access_test.go
@@ -1,0 +1,61 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package cloudflare
+
+import (
+	"context"
+	"net/http"
+	"reflect"
+	"testing"
+)
+
+func TestAppendAccountAccessInfrastructureTargetResources(t *testing.T) {
+	api := newCloudflareSecurityTestAPI(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/accounts/account-123/infrastructure/targets" {
+			t.Fatalf("path = %q, want /accounts/account-123/infrastructure/targets", r.URL.Path)
+		}
+		switch r.URL.Query().Get("page") {
+		case "1":
+			writeCloudflareSecurityTestResponse(t, w, []map[string]string{
+				{"id": "target-1", "hostname": "ssh.example.com"},
+			}, map[string]int{
+				"page":        1,
+				"per_page":    cloudflarePageSize,
+				"total_pages": 2,
+			})
+		case "2":
+			writeCloudflareSecurityTestResponse(t, w, []map[string]string{
+				{"id": "target-2", "hostname": "db.example.com"},
+			}, map[string]int{
+				"page":        2,
+				"per_page":    cloudflarePageSize,
+				"total_pages": 2,
+			})
+		default:
+			t.Fatalf("page query = %q, want 1 or 2", r.URL.Query().Get("page"))
+		}
+	}))
+	g := &AccessGenerator{}
+
+	if err := g.appendAccountAccessInfrastructureTargetResources(context.Background(), api, "account-123"); err != nil {
+		t.Fatalf("appendAccountAccessInfrastructureTargetResources() error = %v", err)
+	}
+
+	got := map[string]string{}
+	for _, resource := range g.Resources {
+		if resource.InstanceInfo.Type != "cloudflare_zero_trust_access_infrastructure_target" {
+			t.Fatalf("resource type = %q, want cloudflare_zero_trust_access_infrastructure_target", resource.InstanceInfo.Type)
+		}
+		if gotAccountID := resource.InstanceState.Attributes["account_id"]; gotAccountID != "account-123" {
+			t.Fatalf("account_id = %q, want account-123", gotAccountID)
+		}
+		got[resource.InstanceState.ID] = resource.InstanceState.Meta["import_id"].(string)
+	}
+	want := map[string]string{
+		"target-1": "account-123/target-1",
+		"target-2": "account-123/target-2",
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("resources = %#v, want %#v", got, want)
+	}
+}

--- a/providers/cloudflare/security.go
+++ b/providers/cloudflare/security.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"log"
 	"net/http"
+	"strconv"
 	"strings"
 
 	"github.com/chenrui333/terraformer/terraformutils"
@@ -32,6 +33,26 @@ func cloudflareSecurityString(resource cloudflareSecurityRawResource, keys ...st
 		value, ok := resource[key].(string)
 		if ok && value != "" {
 			return value
+		}
+	}
+	return ""
+}
+
+func cloudflareSecurityIDString(resource cloudflareSecurityRawResource, keys ...string) string {
+	for _, key := range keys {
+		value, ok := resource[key]
+		if !ok {
+			continue
+		}
+		switch id := value.(type) {
+		case string:
+			if id != "" {
+				return id
+			}
+		case float64:
+			if id == float64(int64(id)) {
+				return strconv.FormatInt(int64(id), 10)
+			}
 		}
 	}
 	return ""
@@ -215,6 +236,32 @@ func cloudflareAccountSecurityResource(
 	return resource, true
 }
 
+func cloudflareScopedSecurityResource(
+	scopeType string,
+	scopeID string,
+	id string,
+	resourceType string,
+	resourceNamePrefix string,
+	nameParts ...string,
+) (terraformutils.Resource, bool) {
+	if scopeID == "" || id == "" {
+		return terraformutils.Resource{}, false
+	}
+	parts := append([]string{scopeType, scopeID, resourceNamePrefix}, nameParts...)
+	parts = append(parts, id)
+	resource := terraformutils.NewResource(
+		id,
+		cloudflareResourceName(parts...),
+		resourceType,
+		"cloudflare",
+		accessScopeAttributes(scopeType, scopeID),
+		[]string{},
+		map[string]interface{}{},
+	)
+	setCloudflareImportID(&resource, fmt.Sprintf("%s/%s/%s", scopeType, scopeID, id))
+	return resource, true
+}
+
 func apiShieldConfigImportable(config cloudflareSecurityRawResource) bool {
 	characteristics, ok := config["auth_id_characteristics"].([]interface{})
 	return ok && len(characteristics) > 0
@@ -302,6 +349,167 @@ func (g *SecurityGenerator) appendPageShieldPolicyResources(ctx context.Context,
 	return nil
 }
 
+func (g *SecurityGenerator) appendCloudConnectorRulesResource(ctx context.Context, api *cf.API, zone cf.Zone) error {
+	rules, err := listCloudflareSecurityResources(ctx, api, fmt.Sprintf("/zones/%s/cloud_connector/rules", zone.ID))
+	if err != nil {
+		return err
+	}
+	if len(rules) == 0 {
+		return nil
+	}
+	resource, ok := cloudflareZoneSecuritySingletonResource(zone, "cloudflare_cloud_connector_rules", "cloud_connector_rules")
+	if ok {
+		g.Resources = append(g.Resources, resource)
+	}
+	return nil
+}
+
+func (g *SecurityGenerator) appendCustomPageResources(
+	ctx context.Context,
+	api *cf.API,
+	scopeType string,
+	scopeID string,
+	scopeName string,
+) error {
+	pages, err := listCloudflareSecurityResources(ctx, api, fmt.Sprintf("/%s/%s/custom_pages", scopeType, scopeID))
+	if err != nil {
+		return err
+	}
+	for _, page := range pages {
+		if cloudflareSecurityString(page, "state") != "customized" {
+			continue
+		}
+		id := cloudflareSecurityIDString(page, "identifier", "id")
+		resource, ok := cloudflareScopedSecurityResource(
+			scopeType,
+			scopeID,
+			id,
+			"cloudflare_custom_pages",
+			"custom_page",
+			scopeName,
+			cloudflareSecurityString(page, "description", "state"),
+		)
+		if ok {
+			g.Resources = append(g.Resources, resource)
+		}
+	}
+	return nil
+}
+
+func (g *SecurityGenerator) appendCustomPageAssetResources(
+	ctx context.Context,
+	api *cf.API,
+	scopeType string,
+	scopeID string,
+	scopeName string,
+) error {
+	assets, err := listCloudflareSecurityResources(ctx, api, fmt.Sprintf("/%s/%s/custom_pages/assets", scopeType, scopeID))
+	if err != nil {
+		return err
+	}
+	for _, asset := range assets {
+		id := cloudflareSecurityIDString(asset, "name", "id")
+		resource, ok := cloudflareScopedSecurityResource(
+			scopeType,
+			scopeID,
+			id,
+			"cloudflare_custom_page_asset",
+			"custom_page_asset",
+			scopeName,
+			cloudflareSecurityString(asset, "description"),
+		)
+		if ok {
+			g.Resources = append(g.Resources, resource)
+		}
+	}
+	return nil
+}
+
+func (g *SecurityGenerator) appendLeakedCredentialCheckRuleResources(ctx context.Context, api *cf.API, zone cf.Zone) error {
+	detections, err := listCloudflareSecurityResources(ctx, api, fmt.Sprintf("/zones/%s/leaked-credential-checks/detections", zone.ID))
+	if err != nil {
+		return err
+	}
+	for _, detection := range detections {
+		id := cloudflareSecurityIDString(detection, "id")
+		resource, ok := cloudflareZoneSecurityResource(
+			zone,
+			id,
+			"cloudflare_leaked_credential_check_rule",
+			"leaked_credential_check_rule",
+			cloudflareSecurityString(detection, "username"),
+			cloudflareSecurityString(detection, "password"),
+		)
+		if ok {
+			g.Resources = append(g.Resources, resource)
+		}
+	}
+	return nil
+}
+
+func (g *SecurityGenerator) appendTokenValidationConfigResources(ctx context.Context, api *cf.API, zone cf.Zone) error {
+	configs, err := listCloudflareSecurityResources(ctx, api, fmt.Sprintf("/zones/%s/token_validation/config", zone.ID))
+	if err != nil {
+		return err
+	}
+	for _, config := range configs {
+		id := cloudflareSecurityIDString(config, "id")
+		resource, ok := cloudflareZoneSecurityResource(
+			zone,
+			id,
+			"cloudflare_token_validation_config",
+			"token_validation_config",
+			cloudflareSecurityString(config, "title"),
+		)
+		if ok {
+			g.Resources = append(g.Resources, resource)
+		}
+	}
+	return nil
+}
+
+func (g *SecurityGenerator) appendTokenValidationRuleResources(ctx context.Context, api *cf.API, zone cf.Zone) error {
+	rules, err := listCloudflareSecurityResources(ctx, api, fmt.Sprintf("/zones/%s/token_validation/rules", zone.ID))
+	if err != nil {
+		return err
+	}
+	for _, rule := range rules {
+		id := cloudflareSecurityIDString(rule, "id")
+		resource, ok := cloudflareZoneSecurityResource(
+			zone,
+			id,
+			"cloudflare_token_validation_rules",
+			"token_validation_rule",
+			cloudflareSecurityString(rule, "title", "action"),
+		)
+		if ok {
+			g.Resources = append(g.Resources, resource)
+		}
+	}
+	return nil
+}
+
+func (g *SecurityGenerator) appendUserAgentBlockingRuleResources(ctx context.Context, api *cf.API, zone cf.Zone) error {
+	rules, err := listCloudflareSecurityResources(ctx, api, fmt.Sprintf("/zones/%s/firewall/ua_rules", zone.ID))
+	if err != nil {
+		return err
+	}
+	for _, rule := range rules {
+		id := cloudflareSecurityIDString(rule, "id")
+		resource, ok := cloudflareZoneSecurityResource(
+			zone,
+			id,
+			"cloudflare_user_agent_blocking_rule",
+			"user_agent_blocking_rule",
+			cloudflareSecurityString(rule, "description", "mode"),
+		)
+		if ok {
+			g.Resources = append(g.Resources, resource)
+		}
+	}
+	return nil
+}
+
 func (g *SecurityGenerator) appendVulnerabilityScannerCredentialSetResources(
 	ctx context.Context,
 	api *cf.API,
@@ -352,6 +560,69 @@ func (g *SecurityGenerator) appendVulnerabilityScannerTargetEnvironmentResources
 	return nil
 }
 
+func (g *SecurityGenerator) appendEmailSecurityBlockSenderResources(ctx context.Context, api *cf.API, accountID string) error {
+	senders, err := listCloudflareSecurityResources(ctx, api, fmt.Sprintf("/accounts/%s/email-security/settings/block_senders", accountID))
+	if err != nil {
+		return err
+	}
+	for _, sender := range senders {
+		id := cloudflareSecurityIDString(sender, "id")
+		resource, ok := cloudflareAccountSecurityResource(
+			accountID,
+			id,
+			"cloudflare_email_security_block_sender",
+			"email_security_block_sender",
+			cloudflareSecurityString(sender, "pattern", "pattern_type"),
+		)
+		if ok {
+			g.Resources = append(g.Resources, resource)
+		}
+	}
+	return nil
+}
+
+func (g *SecurityGenerator) appendEmailSecurityImpersonationRegistryResources(ctx context.Context, api *cf.API, accountID string) error {
+	registries, err := listCloudflareSecurityResources(ctx, api, fmt.Sprintf("/accounts/%s/email-security/settings/impersonation_registry", accountID))
+	if err != nil {
+		return err
+	}
+	for _, registry := range registries {
+		id := cloudflareSecurityIDString(registry, "id")
+		resource, ok := cloudflareAccountSecurityResource(
+			accountID,
+			id,
+			"cloudflare_email_security_impersonation_registry",
+			"email_security_impersonation_registry",
+			cloudflareSecurityString(registry, "name", "email"),
+		)
+		if ok {
+			g.Resources = append(g.Resources, resource)
+		}
+	}
+	return nil
+}
+
+func (g *SecurityGenerator) appendEmailSecurityTrustedDomainResources(ctx context.Context, api *cf.API, accountID string) error {
+	domains, err := listCloudflareSecurityResources(ctx, api, fmt.Sprintf("/accounts/%s/email-security/settings/trusted_domains", accountID))
+	if err != nil {
+		return err
+	}
+	for _, domain := range domains {
+		id := cloudflareSecurityIDString(domain, "id")
+		resource, ok := cloudflareAccountSecurityResource(
+			accountID,
+			id,
+			"cloudflare_email_security_trusted_domains",
+			"email_security_trusted_domain",
+			cloudflareSecurityString(domain, "pattern"),
+		)
+		if ok {
+			g.Resources = append(g.Resources, resource)
+		}
+	}
+	return nil
+}
+
 func (g *SecurityGenerator) appendZoneSecurityResources(ctx context.Context, api *cf.API, zone cf.Zone) error {
 	return runCloudflareSecurityDiscoveries([]cloudflareSecurityDiscovery{
 		{
@@ -382,6 +653,55 @@ func (g *SecurityGenerator) appendZoneSecurityResources(ctx context.Context, api
 				return g.appendPageShieldPolicyResources(ctx, api, zone)
 			},
 		},
+		{
+			name:  "Cloud Connector rules",
+			scope: zone.ID,
+			discover: func() error {
+				return g.appendCloudConnectorRulesResource(ctx, api, zone)
+			},
+		},
+		{
+			name:  "zone custom pages",
+			scope: zone.ID,
+			discover: func() error {
+				return g.appendCustomPageResources(ctx, api, "zones", zone.ID, zone.Name)
+			},
+		},
+		{
+			name:  "zone custom page assets",
+			scope: zone.ID,
+			discover: func() error {
+				return g.appendCustomPageAssetResources(ctx, api, "zones", zone.ID, zone.Name)
+			},
+		},
+		{
+			name:  "leaked credential check rules",
+			scope: zone.ID,
+			discover: func() error {
+				return g.appendLeakedCredentialCheckRuleResources(ctx, api, zone)
+			},
+		},
+		{
+			name:  "token validation configs",
+			scope: zone.ID,
+			discover: func() error {
+				return g.appendTokenValidationConfigResources(ctx, api, zone)
+			},
+		},
+		{
+			name:  "token validation rules",
+			scope: zone.ID,
+			discover: func() error {
+				return g.appendTokenValidationRuleResources(ctx, api, zone)
+			},
+		},
+		{
+			name:  "user-agent blocking rules",
+			scope: zone.ID,
+			discover: func() error {
+				return g.appendUserAgentBlockingRuleResources(ctx, api, zone)
+			},
+		},
 	})
 }
 
@@ -399,6 +719,41 @@ func (g *SecurityGenerator) appendAccountSecurityResources(ctx context.Context, 
 			scope: accountID,
 			discover: func() error {
 				return g.appendVulnerabilityScannerTargetEnvironmentResources(ctx, api, accountID)
+			},
+		},
+		{
+			name:  "account custom pages",
+			scope: accountID,
+			discover: func() error {
+				return g.appendCustomPageResources(ctx, api, "accounts", accountID, accountID)
+			},
+		},
+		{
+			name:  "account custom page assets",
+			scope: accountID,
+			discover: func() error {
+				return g.appendCustomPageAssetResources(ctx, api, "accounts", accountID, accountID)
+			},
+		},
+		{
+			name:  "Email Security block senders",
+			scope: accountID,
+			discover: func() error {
+				return g.appendEmailSecurityBlockSenderResources(ctx, api, accountID)
+			},
+		},
+		{
+			name:  "Email Security impersonation registry",
+			scope: accountID,
+			discover: func() error {
+				return g.appendEmailSecurityImpersonationRegistryResources(ctx, api, accountID)
+			},
+		},
+		{
+			name:  "Email Security trusted domains",
+			scope: accountID,
+			discover: func() error {
+				return g.appendEmailSecurityTrustedDomainResources(ctx, api, accountID)
 			},
 		},
 	})

--- a/providers/cloudflare/security.go
+++ b/providers/cloudflare/security.go
@@ -602,27 +602,6 @@ func (g *SecurityGenerator) appendEmailSecurityImpersonationRegistryResources(ct
 	return nil
 }
 
-func (g *SecurityGenerator) appendEmailSecurityTrustedDomainResources(ctx context.Context, api *cf.API, accountID string) error {
-	domains, err := listCloudflareSecurityResources(ctx, api, fmt.Sprintf("/accounts/%s/email-security/settings/trusted_domains", accountID))
-	if err != nil {
-		return err
-	}
-	for _, domain := range domains {
-		id := cloudflareSecurityIDString(domain, "id")
-		resource, ok := cloudflareAccountSecurityResource(
-			accountID,
-			id,
-			"cloudflare_email_security_trusted_domains",
-			"email_security_trusted_domain",
-			cloudflareSecurityString(domain, "pattern"),
-		)
-		if ok {
-			g.Resources = append(g.Resources, resource)
-		}
-	}
-	return nil
-}
-
 func (g *SecurityGenerator) appendZoneSecurityResources(ctx context.Context, api *cf.API, zone cf.Zone) error {
 	return runCloudflareSecurityDiscoveries([]cloudflareSecurityDiscovery{
 		{
@@ -747,13 +726,6 @@ func (g *SecurityGenerator) appendAccountSecurityResources(ctx context.Context, 
 			scope: accountID,
 			discover: func() error {
 				return g.appendEmailSecurityImpersonationRegistryResources(ctx, api, accountID)
-			},
-		},
-		{
-			name:  "Email Security trusted domains",
-			scope: accountID,
-			discover: func() error {
-				return g.appendEmailSecurityTrustedDomainResources(ctx, api, accountID)
 			},
 		},
 	})

--- a/providers/cloudflare/security_test.go
+++ b/providers/cloudflare/security_test.go
@@ -399,9 +399,6 @@ func TestAppendSecurityEmailResources(t *testing.T) {
 		"/accounts/account-123/email-security/settings/impersonation_registry": []map[string]interface{}{
 			{"id": 202.0, "name": "Finance", "email": "finance@example.com"},
 		},
-		"/accounts/account-123/email-security/settings/trusted_domains": []map[string]interface{}{
-			{"id": 303.0, "pattern": "partner.example.com"},
-		},
 	}
 	api := newCloudflareSecurityTestAPI(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		result, ok := responses[r.URL.Path]
@@ -415,7 +412,6 @@ func TestAppendSecurityEmailResources(t *testing.T) {
 	for _, appendResources := range []func(context.Context, *cf.API, string) error{
 		g.appendEmailSecurityBlockSenderResources,
 		g.appendEmailSecurityImpersonationRegistryResources,
-		g.appendEmailSecurityTrustedDomainResources,
 	} {
 		if err := appendResources(context.Background(), api, "account-123"); err != nil {
 			t.Fatalf("appendResources() error = %v", err)
@@ -429,7 +425,6 @@ func TestAppendSecurityEmailResources(t *testing.T) {
 	want := map[string]string{
 		"cloudflare_email_security_block_sender":           "account-123/101",
 		"cloudflare_email_security_impersonation_registry": "account-123/202",
-		"cloudflare_email_security_trusted_domains":        "account-123/303",
 	}
 	if !reflect.DeepEqual(got, want) {
 		t.Fatalf("resources = %#v, want %#v", got, want)
@@ -537,6 +532,7 @@ func TestCloudflareSecurityUnsupportedMetadataCoversDeferredResources(t *testing
 		"cloudflare_bot_management",
 		"cloudflare_content_scanning",
 		"cloudflare_content_scanning_expression",
+		"cloudflare_email_security_trusted_domains",
 		"cloudflare_observatory_scheduled_test",
 		"cloudflare_schema_validation_operation_settings",
 		"cloudflare_schema_validation_settings",
@@ -592,7 +588,6 @@ func ExampleSecurityGenerator_resources() {
 		"cloudflare_custom_pages",
 		"cloudflare_email_security_block_sender",
 		"cloudflare_email_security_impersonation_registry",
-		"cloudflare_email_security_trusted_domains",
 		"cloudflare_leaked_credential_check_rule",
 		"cloudflare_page_shield_policy",
 		"cloudflare_schema_validation_schemas",
@@ -603,5 +598,5 @@ func ExampleSecurityGenerator_resources() {
 		"cloudflare_vulnerability_scanner_target_environment",
 	}
 	fmt.Println(strings.Join(resources, ", "))
-	// Output: cloudflare_api_shield, cloudflare_api_shield_operation, cloudflare_cloud_connector_rules, cloudflare_custom_page_asset, cloudflare_custom_pages, cloudflare_email_security_block_sender, cloudflare_email_security_impersonation_registry, cloudflare_email_security_trusted_domains, cloudflare_leaked_credential_check_rule, cloudflare_page_shield_policy, cloudflare_schema_validation_schemas, cloudflare_token_validation_config, cloudflare_token_validation_rules, cloudflare_user_agent_blocking_rule, cloudflare_vulnerability_scanner_credential_set, cloudflare_vulnerability_scanner_target_environment
+	// Output: cloudflare_api_shield, cloudflare_api_shield_operation, cloudflare_cloud_connector_rules, cloudflare_custom_page_asset, cloudflare_custom_pages, cloudflare_email_security_block_sender, cloudflare_email_security_impersonation_registry, cloudflare_leaked_credential_check_rule, cloudflare_page_shield_policy, cloudflare_schema_validation_schemas, cloudflare_token_validation_config, cloudflare_token_validation_rules, cloudflare_user_agent_blocking_rule, cloudflare_vulnerability_scanner_credential_set, cloudflare_vulnerability_scanner_target_environment
 }

--- a/providers/cloudflare/security_test.go
+++ b/providers/cloudflare/security_test.go
@@ -82,6 +82,85 @@ func TestCloudflareAccountSecurityResourceUsesCompositeImportID(t *testing.T) {
 	}
 }
 
+func TestCloudflareSecurityIDStringHandlesStringAndNumericIDs(t *testing.T) {
+	tests := []struct {
+		name     string
+		resource cloudflareSecurityRawResource
+		keys     []string
+		want     string
+	}{
+		{
+			name:     "string ID",
+			resource: cloudflareSecurityRawResource{"id": "rule-123"},
+			keys:     []string{"id"},
+			want:     "rule-123",
+		},
+		{
+			name:     "numeric ID",
+			resource: cloudflareSecurityRawResource{"id": 12345.0},
+			keys:     []string{"id"},
+			want:     "12345",
+		},
+		{
+			name:     "fallback key",
+			resource: cloudflareSecurityRawResource{"name": "asset-123"},
+			keys:     []string{"id", "name"},
+			want:     "asset-123",
+		},
+		{
+			name:     "fractional numeric ID skipped",
+			resource: cloudflareSecurityRawResource{"id": 1.5},
+			keys:     []string{"id"},
+			want:     "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := cloudflareSecurityIDString(tt.resource, tt.keys...); got != tt.want {
+				t.Fatalf("cloudflareSecurityIDString() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestCloudflareScopedSecurityResourceUsesScopedImportID(t *testing.T) {
+	resource, ok := cloudflareScopedSecurityResource(
+		"zones",
+		"zone-123",
+		"waf_block",
+		"cloudflare_custom_pages",
+		"custom_page",
+		"example.com",
+	)
+	if !ok {
+		t.Fatal("expected scoped security resource")
+	}
+	if got := resource.InstanceState.Attributes["zone_id"]; got != "zone-123" {
+		t.Fatalf("zone_id = %q, want zone-123", got)
+	}
+	if got := resource.InstanceState.Meta["import_id"]; got != "zones/zone-123/waf_block" {
+		t.Fatalf("import_id = %q, want zones/zone-123/waf_block", got)
+	}
+
+	accountResource, ok := cloudflareScopedSecurityResource(
+		"accounts",
+		"account-123",
+		"asset-123",
+		"cloudflare_custom_page_asset",
+		"custom_page_asset",
+	)
+	if !ok {
+		t.Fatal("expected account-scoped security resource")
+	}
+	if got := accountResource.InstanceState.Attributes["account_id"]; got != "account-123" {
+		t.Fatalf("account_id = %q, want account-123", got)
+	}
+	if got := accountResource.InstanceState.Meta["import_id"]; got != "accounts/account-123/asset-123" {
+		t.Fatalf("import_id = %q, want accounts/account-123/asset-123", got)
+	}
+}
+
 func TestCloudflareSecurityResourceConstructorsSkipMissingIDs(t *testing.T) {
 	if _, ok := cloudflareZoneSecurityResource(cf.Zone{ID: "zone-123"}, "", "cloudflare_api_shield_operation", "api_shield_operation"); ok {
 		t.Fatal("expected zone resource without resource ID to be skipped")
@@ -241,6 +320,122 @@ func TestAppendAPIShieldOperationResources(t *testing.T) {
 	}
 }
 
+func TestAppendSecurityZoneAdjunctResources(t *testing.T) {
+	responses := map[string]interface{}{
+		"/zones/zone-123/cloud_connector/rules": []map[string]string{
+			{"id": "connector-rule-123"},
+		},
+		"/zones/zone-123/custom_pages": []map[string]string{
+			{"identifier": "waf_block", "state": "customized", "description": "WAF block"},
+			{"identifier": "basic_challenge", "state": "default", "description": "Default challenge"},
+		},
+		"/zones/zone-123/custom_pages/assets": []map[string]string{
+			{"name": "error_asset", "description": "Error page"},
+		},
+		"/zones/zone-123/leaked-credential-checks/detections": []map[string]string{
+			{"id": "detection-123", "username": "lookup_json_string(http.request.body.raw, \"user\")", "password": "lookup_json_string(http.request.body.raw, \"password\")"},
+		},
+		"/zones/zone-123/token_validation/config": []map[string]string{
+			{"id": "config-123", "title": "JWT config"},
+		},
+		"/zones/zone-123/token_validation/rules": []map[string]string{
+			{"id": "rule-123", "title": "JWT rule"},
+		},
+		"/zones/zone-123/firewall/ua_rules": []map[string]string{
+			{"id": "ua-123", "description": "Legacy client"},
+		},
+	}
+	api := newCloudflareSecurityTestAPI(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		result, ok := responses[r.URL.Path]
+		if !ok {
+			t.Fatalf("unexpected path %q", r.URL.Path)
+		}
+		writeCloudflareSecurityTestResponse(t, w, result, nil)
+	}))
+	g := &SecurityGenerator{}
+	zone := cf.Zone{ID: "zone-123", Name: "example.com"}
+
+	for _, appendResources := range []func(context.Context, *cf.API, cf.Zone) error{
+		g.appendCloudConnectorRulesResource,
+		func(ctx context.Context, api *cf.API, zone cf.Zone) error {
+			return g.appendCustomPageResources(ctx, api, "zones", zone.ID, zone.Name)
+		},
+		func(ctx context.Context, api *cf.API, zone cf.Zone) error {
+			return g.appendCustomPageAssetResources(ctx, api, "zones", zone.ID, zone.Name)
+		},
+		g.appendLeakedCredentialCheckRuleResources,
+		g.appendTokenValidationConfigResources,
+		g.appendTokenValidationRuleResources,
+		g.appendUserAgentBlockingRuleResources,
+	} {
+		if err := appendResources(context.Background(), api, zone); err != nil {
+			t.Fatalf("appendResources() error = %v", err)
+		}
+	}
+
+	got := map[string]string{}
+	for _, resource := range g.Resources {
+		got[resource.InstanceInfo.Type] = resource.InstanceState.Meta["import_id"].(string)
+	}
+	want := map[string]string{
+		"cloudflare_cloud_connector_rules":        "zone-123",
+		"cloudflare_custom_pages":                 "zones/zone-123/waf_block",
+		"cloudflare_custom_page_asset":            "zones/zone-123/error_asset",
+		"cloudflare_leaked_credential_check_rule": "zone-123/detection-123",
+		"cloudflare_token_validation_config":      "zone-123/config-123",
+		"cloudflare_token_validation_rules":       "zone-123/rule-123",
+		"cloudflare_user_agent_blocking_rule":     "zone-123/ua-123",
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("resources = %#v, want %#v", got, want)
+	}
+}
+
+func TestAppendSecurityEmailResources(t *testing.T) {
+	responses := map[string]interface{}{
+		"/accounts/account-123/email-security/settings/block_senders": []map[string]interface{}{
+			{"id": 101.0, "pattern": "bad.example.com", "pattern_type": "domain"},
+		},
+		"/accounts/account-123/email-security/settings/impersonation_registry": []map[string]interface{}{
+			{"id": 202.0, "name": "Finance", "email": "finance@example.com"},
+		},
+		"/accounts/account-123/email-security/settings/trusted_domains": []map[string]interface{}{
+			{"id": 303.0, "pattern": "partner.example.com"},
+		},
+	}
+	api := newCloudflareSecurityTestAPI(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		result, ok := responses[r.URL.Path]
+		if !ok {
+			t.Fatalf("unexpected path %q", r.URL.Path)
+		}
+		writeCloudflareSecurityTestResponse(t, w, result, nil)
+	}))
+	g := &SecurityGenerator{}
+
+	for _, appendResources := range []func(context.Context, *cf.API, string) error{
+		g.appendEmailSecurityBlockSenderResources,
+		g.appendEmailSecurityImpersonationRegistryResources,
+		g.appendEmailSecurityTrustedDomainResources,
+	} {
+		if err := appendResources(context.Background(), api, "account-123"); err != nil {
+			t.Fatalf("appendResources() error = %v", err)
+		}
+	}
+
+	got := map[string]string{}
+	for _, resource := range g.Resources {
+		got[resource.InstanceInfo.Type] = resource.InstanceState.Meta["import_id"].(string)
+	}
+	want := map[string]string{
+		"cloudflare_email_security_block_sender":           "account-123/101",
+		"cloudflare_email_security_impersonation_registry": "account-123/202",
+		"cloudflare_email_security_trusted_domains":        "account-123/303",
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("resources = %#v, want %#v", got, want)
+	}
+}
+
 func TestRunCloudflareSecurityDiscoveriesSkipsOptionalErrors(t *testing.T) {
 	calls := []string{}
 	err := runCloudflareSecurityDiscoveries([]cloudflareSecurityDiscovery{
@@ -342,8 +537,11 @@ func TestCloudflareSecurityUnsupportedMetadataCoversDeferredResources(t *testing
 		"cloudflare_bot_management",
 		"cloudflare_content_scanning",
 		"cloudflare_content_scanning_expression",
+		"cloudflare_observatory_scheduled_test",
 		"cloudflare_schema_validation_operation_settings",
 		"cloudflare_schema_validation_settings",
+		"cloudflare_zero_trust_access_ai_controls_mcp_portal",
+		"cloudflare_zero_trust_access_key_configuration",
 	} {
 		if !seen[resource] {
 			t.Fatalf("unsupported metadata is missing %s", resource)
@@ -389,11 +587,21 @@ func ExampleSecurityGenerator_resources() {
 	resources := []string{
 		"cloudflare_api_shield",
 		"cloudflare_api_shield_operation",
+		"cloudflare_cloud_connector_rules",
+		"cloudflare_custom_page_asset",
+		"cloudflare_custom_pages",
+		"cloudflare_email_security_block_sender",
+		"cloudflare_email_security_impersonation_registry",
+		"cloudflare_email_security_trusted_domains",
+		"cloudflare_leaked_credential_check_rule",
 		"cloudflare_page_shield_policy",
 		"cloudflare_schema_validation_schemas",
+		"cloudflare_token_validation_config",
+		"cloudflare_token_validation_rules",
+		"cloudflare_user_agent_blocking_rule",
 		"cloudflare_vulnerability_scanner_credential_set",
 		"cloudflare_vulnerability_scanner_target_environment",
 	}
 	fmt.Println(strings.Join(resources, ", "))
-	// Output: cloudflare_api_shield, cloudflare_api_shield_operation, cloudflare_page_shield_policy, cloudflare_schema_validation_schemas, cloudflare_vulnerability_scanner_credential_set, cloudflare_vulnerability_scanner_target_environment
+	// Output: cloudflare_api_shield, cloudflare_api_shield_operation, cloudflare_cloud_connector_rules, cloudflare_custom_page_asset, cloudflare_custom_pages, cloudflare_email_security_block_sender, cloudflare_email_security_impersonation_registry, cloudflare_email_security_trusted_domains, cloudflare_leaked_credential_check_rule, cloudflare_page_shield_policy, cloudflare_schema_validation_schemas, cloudflare_token_validation_config, cloudflare_token_validation_rules, cloudflare_user_agent_blocking_rule, cloudflare_vulnerability_scanner_credential_set, cloudflare_vulnerability_scanner_target_environment
 }

--- a/providers/cloudflare/unsupported_resources.json
+++ b/providers/cloudflare/unsupported_resources.json
@@ -368,6 +368,17 @@
       ]
     },
     {
+      "resource": "cloudflare_observatory_scheduled_test",
+      "service_family": "observatory",
+      "reason": "Observatory scheduled tests are keyed by URL but do not expose broad list discovery for Terraformer.",
+      "evidence": "Terraform provider v5.19.1 imports cloudflare_observatory_scheduled_test by zone_id/url and reads through the Speed Schedule Get API, but the provider does not expose a list data source or list path for scheduled test URLs. Without user-supplied URLs, Terraformer cannot exhaustively discover durable schedules, and Lighthouse report fields are runtime results rather than desired configuration.",
+      "status": "deferred",
+      "references": [
+        "https://github.com/chenrui333/terraformer/issues/335",
+        "https://registry.terraform.io/providers/cloudflare/cloudflare/latest/docs/resources/observatory_scheduled_test"
+      ]
+    },
+    {
       "resource": "cloudflare_organization",
       "service_family": "account",
       "reason": "Organization resources model Cloudflare organization identity lifecycle rather than zone or account settings inventory.",
@@ -710,6 +721,17 @@
       ]
     },
     {
+      "resource": "cloudflare_zero_trust_access_ai_controls_mcp_portal",
+      "service_family": "zero_trust_access",
+      "reason": "AI Controls MCP portals mix durable portal settings with runtime server sync state that needs a dedicated reconstruction pass.",
+      "evidence": "Terraform provider v5.19.1 can import cloudflare_zero_trust_access_ai_controls_mcp_portal by account_id/id and exposes list/read APIs, but nested server fields include no_refresh aliases while the provider reads prompt, tool, sync status, error, and last-synced runtime data. Broad import should not infer server prompt/tool override intent from runtime sync output.",
+      "status": "deferred",
+      "references": [
+        "https://github.com/chenrui333/terraformer/issues/335",
+        "https://registry.terraform.io/providers/cloudflare/cloudflare/latest/docs/resources/zero_trust_access_ai_controls_mcp_portal"
+      ]
+    },
+    {
       "resource": "cloudflare_zero_trust_access_ai_controls_mcp_server",
       "service_family": "zero_trust_access",
       "reason": "MCP server resources can require write-only authentication credentials and expose sync/runtime state.",
@@ -718,6 +740,17 @@
       "references": [
         "https://github.com/chenrui333/terraformer/issues/335",
         "https://registry.terraform.io/providers/cloudflare/cloudflare/latest/docs/resources/zero_trust_access_ai_controls_mcp_server"
+      ]
+    },
+    {
+      "resource": "cloudflare_zero_trust_access_key_configuration",
+      "service_family": "zero_trust_access",
+      "reason": "Access key configuration is an account singleton whose API value can represent an effective default rather than explicit Terraform-owned configuration.",
+      "evidence": "Terraform provider v5.19.1 imports cloudflare_zero_trust_access_key_configuration by account_id and requires key_rotation_interval_days while reading days_until_next_rotation and last_key_rotation_at as computed rotation state. Terraformer cannot currently distinguish explicit user-owned rotation policy from inherited account defaults, so broad import could claim platform-managed Access key settings.",
+      "status": "deferred",
+      "references": [
+        "https://github.com/chenrui333/terraformer/issues/335",
+        "https://registry.terraform.io/providers/cloudflare/cloudflare/latest/docs/resources/zero_trust_access_key_configuration"
       ]
     },
     {

--- a/providers/cloudflare/unsupported_resources.json
+++ b/providers/cloudflare/unsupported_resources.json
@@ -302,6 +302,17 @@
       ]
     },
     {
+      "resource": "cloudflare_email_security_trusted_domains",
+      "service_family": "email_security",
+      "reason": "Email Security trusted domains are deferred until provider import/read preserves the trusted-domain configuration fields.",
+      "evidence": "Terraform provider v5.19.1 imports cloudflare_email_security_trusted_domains by account_id/trusted_domain_id, but the generated model stores the domain definition under a body field marked no_refresh while pattern, is_recent, is_regex, and is_similarity are not repopulated by the importer/read path. Terraformer cannot safely emit recreateable HCL for discovered trusted domains until provider refresh preserves those fields.",
+      "status": "deferred",
+      "references": [
+        "https://github.com/chenrui333/terraformer/issues/335",
+        "https://registry.terraform.io/providers/cloudflare/cloudflare/latest/docs/resources/email_security_trusted_domains"
+      ]
+    },
+    {
       "resource": "cloudflare_hyperdrive_config",
       "service_family": "storage",
       "reason": "Hyperdrive configs require write-only origin credential material.",


### PR DESCRIPTION
## Summary

Add or classify remaining Cloudflare security, email, and zone adjunct resources.

## Resources

- cloudflare_zero_trust_access_infrastructure_target
- cloudflare_cloud_connector_rules
- cloudflare_custom_page_asset
- cloudflare_custom_pages
- cloudflare_email_security_block_sender
- cloudflare_email_security_impersonation_registry
- cloudflare_leaked_credential_check_rule
- cloudflare_token_validation_config
- cloudflare_token_validation_rules
- cloudflare_user_agent_blocking_rule

## Deferred / Unsupported

- cloudflare_email_security_trusted_domains: deferred because provider import/read does not preserve the trusted-domain pattern and matching flags needed to reconstruct HCL.
- cloudflare_observatory_scheduled_test: deferred because scheduled tests are keyed by URL and the provider/API surface does not expose broad list discovery for Terraformer.
- cloudflare_zero_trust_access_ai_controls_mcp_portal: deferred because portal reads include runtime MCP server sync state and no_refresh prompt/tool override fields.
- cloudflare_zero_trust_access_key_configuration: deferred because the account singleton can represent effective/default Access key rotation state rather than explicit user-owned configuration.

## Scope

This PR is limited to security/email/zone adjunct resources.

## Validation

- `go test ./providers/cloudflare/...`
- `go test ./cmd/...`
- `go test ./providers -run 'TestUnsupportedResourcesMetadata|TestUnsupportedResourceStatusesAreDocumented' -count=1`
- `jq . providers/cloudflare/unsupported_resources.json`
- `git diff --check`

Ref: #335
