### PR TITLE
feat(cloudflare): add cert and TLS imports

### DIFF
--- a/docs/cloudflare.md
+++ b/docs/cloudflare.md
@@ -26,12 +26,18 @@ List of supported Cloudflare services:
   * `cloudflare_zero_trust_access_mtls_certificate`
   * `cloudflare_zero_trust_access_policy`
   * `cloudflare_zero_trust_access_service_token`
+  * `cloudflare_zero_trust_access_short_lived_certificate`
   * `cloudflare_zero_trust_access_tag`
 * `account_member`
   * `cloudflare_account_member`
 * `certificates`
+  * `cloudflare_certificate_authorities_hostname_associations`
+  * `cloudflare_certificate_pack`
+  * `cloudflare_client_certificate`
   * `cloudflare_custom_hostname`
+  * `cloudflare_custom_origin_trust_store`
   * `cloudflare_mtls_certificate`
+  * `cloudflare_origin_ca_certificate`
 * `dns`
   * `cloudflare_dns_record`
   * `cloudflare_zone`

--- a/providers/cloudflare/access.go
+++ b/providers/cloudflare/access.go
@@ -21,7 +21,8 @@ type AccessGenerator struct {
 }
 
 type cloudflareAccessShortLivedCertificate struct {
-	ID string `json:"id"`
+	Aud       string `json:"aud"`
+	PublicKey string `json:"public_key"`
 }
 
 func cloudflareAccessShortLivedCertificateOptionalError(err error) bool {
@@ -206,16 +207,15 @@ func cloudflareAccessShortLivedCertificateResource(
 	scopeType string,
 	scopeID string,
 	appID string,
-	certificate cloudflareAccessShortLivedCertificate,
 ) (terraformutils.Resource, bool) {
-	if scopeID == "" || appID == "" || certificate.ID == "" {
+	if scopeID == "" || appID == "" {
 		return terraformutils.Resource{}, false
 	}
 	attributes := accessScopeAttributes(scopeType, scopeID)
 	attributes["app_id"] = appID
 	resource := terraformutils.NewResource(
 		appID,
-		cloudflareResourceName(scopeType, scopeID, "short_lived_certificate", appID, certificate.ID),
+		cloudflareResourceName(scopeType, scopeID, "short_lived_certificate", appID),
 		"cloudflare_zero_trust_access_short_lived_certificate",
 		"cloudflare",
 		attributes,
@@ -237,15 +237,14 @@ func (g *AccessGenerator) appendAccessShortLivedCertificateResources(
 		if app.ID == "" {
 			continue
 		}
-		certificate, err := getAccessShortLivedCertificate(ctx, api, rc, app.ID)
-		if err != nil {
+		if _, err := getAccessShortLivedCertificate(ctx, api, rc, app.ID); err != nil {
 			if cloudflareAccessShortLivedCertificateOptionalError(err) {
 				log.Printf("Skipping Cloudflare Access short-lived certificate discovery for %s/%s app %s: %v", scopeType, rc.Identifier, app.ID, err)
 				continue
 			}
 			return err
 		}
-		resource, ok := cloudflareAccessShortLivedCertificateResource(scopeType, rc.Identifier, app.ID, certificate)
+		resource, ok := cloudflareAccessShortLivedCertificateResource(scopeType, rc.Identifier, app.ID)
 		if ok {
 			g.Resources = append(g.Resources, resource)
 		}

--- a/providers/cloudflare/access.go
+++ b/providers/cloudflare/access.go
@@ -5,7 +5,9 @@ package cloudflare
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
+	"log"
 	"net/http"
 	"net/url"
 	"strconv"
@@ -16,6 +18,18 @@ import (
 
 type AccessGenerator struct {
 	CloudflareService
+}
+
+type cloudflareAccessShortLivedCertificate struct {
+	ID string `json:"id"`
+}
+
+func cloudflareAccessShortLivedCertificateOptionalError(err error) bool {
+	var notFoundErr *cf.NotFoundError
+	if errors.As(err, &notFoundErr) {
+		return true
+	}
+	return cloudflareCertificateOptionalDiscoveryError(err)
 }
 
 func accessScopeAttributes(scopeType, scopeID string) map[string]string {
@@ -31,29 +45,39 @@ func (g *AccessGenerator) appendAccessApplicationResources(
 	rc *cf.ResourceContainer,
 	scopeType string,
 ) error {
+	applications, err := listAccessApplications(ctx, api, rc)
+	if err != nil {
+		return err
+	}
+	for _, app := range applications {
+		g.Resources = append(g.Resources, terraformutils.NewResource(
+			app.ID,
+			cloudflareResourceName(scopeType, rc.Identifier, app.Name, app.ID),
+			"cloudflare_zero_trust_access_application",
+			"cloudflare",
+			accessScopeAttributes(scopeType, rc.Identifier),
+			[]string{},
+			map[string]interface{}{},
+		))
+	}
+	return nil
+}
+
+func listAccessApplications(ctx context.Context, api *cf.API, rc *cf.ResourceContainer) ([]cf.AccessApplication, error) {
+	var allApplications []cf.AccessApplication
 	params := cf.ListAccessApplicationsParams{ResultInfo: cf.ResultInfo{Page: 1, PerPage: cloudflarePageSize}}
 	for {
 		applications, info, err := api.ListAccessApplications(ctx, rc, params)
 		if err != nil {
-			return err
+			return nil, err
 		}
-		for _, app := range applications {
-			g.Resources = append(g.Resources, terraformutils.NewResource(
-				app.ID,
-				cloudflareResourceName(scopeType, rc.Identifier, app.Name, app.ID),
-				"cloudflare_zero_trust_access_application",
-				"cloudflare",
-				accessScopeAttributes(scopeType, rc.Identifier),
-				[]string{},
-				map[string]interface{}{},
-			))
-		}
+		allApplications = append(allApplications, applications...)
 		if info == nil || !info.HasMorePages() {
 			break
 		}
 		params.ResultInfo = info.Next()
 	}
-	return nil
+	return allApplications, nil
 }
 
 func (g *AccessGenerator) appendAccessGroupResources(
@@ -177,6 +201,78 @@ func (g *AccessGenerator) appendAccessServiceTokenResources(ctx context.Context,
 		))
 	}
 	return nil
+}
+
+func cloudflareAccessShortLivedCertificateResource(
+	scopeType string,
+	scopeID string,
+	appID string,
+	certificate cloudflareAccessShortLivedCertificate,
+) (terraformutils.Resource, bool) {
+	if scopeID == "" || appID == "" || certificate.ID == "" {
+		return terraformutils.Resource{}, false
+	}
+	attributes := accessScopeAttributes(scopeType, scopeID)
+	attributes["app_id"] = appID
+	resource := terraformutils.NewResource(
+		appID,
+		cloudflareResourceName(scopeType, scopeID, "short_lived_certificate", appID, certificate.ID),
+		"cloudflare_zero_trust_access_short_lived_certificate",
+		"cloudflare",
+		attributes,
+		[]string{},
+		map[string]interface{}{},
+	)
+	setCloudflareImportID(&resource, fmt.Sprintf("%s/%s/%s", scopeType, scopeID, appID))
+	return resource, true
+}
+
+func (g *AccessGenerator) appendAccessShortLivedCertificateResources(
+	ctx context.Context,
+	api *cf.API,
+	rc *cf.ResourceContainer,
+	scopeType string,
+) error {
+	applications, err := listAccessApplications(ctx, api, rc)
+	if err != nil {
+		return err
+	}
+	for _, app := range applications {
+		if app.ID == "" {
+			continue
+		}
+		certificate, err := getAccessShortLivedCertificate(ctx, api, rc, app.ID)
+		if err != nil {
+			if cloudflareAccessShortLivedCertificateOptionalError(err) {
+				log.Printf("Skipping Cloudflare Access short-lived certificate discovery for %s/%s app %s: %v", scopeType, rc.Identifier, app.ID, err)
+				continue
+			}
+			return err
+		}
+		resource, ok := cloudflareAccessShortLivedCertificateResource(scopeType, rc.Identifier, app.ID, certificate)
+		if ok {
+			g.Resources = append(g.Resources, resource)
+		}
+	}
+	return nil
+}
+
+func getAccessShortLivedCertificate(ctx context.Context, api *cf.API, rc *cf.ResourceContainer, appID string) (cloudflareAccessShortLivedCertificate, error) {
+	response, err := api.Raw(
+		ctx,
+		http.MethodGet,
+		fmt.Sprintf("/%s/%s/access/apps/%s/ca", rc.Level, rc.Identifier, appID),
+		nil,
+		nil,
+	)
+	if err != nil {
+		return cloudflareAccessShortLivedCertificate{}, err
+	}
+	var certificate cloudflareAccessShortLivedCertificate
+	if err := json.Unmarshal(response.Result, &certificate); err != nil {
+		return cloudflareAccessShortLivedCertificate{}, err
+	}
+	return certificate, nil
 }
 
 func listAccessServiceTokens(ctx context.Context, api *cf.API, rc *cf.ResourceContainer) ([]cf.AccessServiceToken, error) {
@@ -330,6 +426,7 @@ func (g *AccessGenerator) appendScopedAccessResources(ctx context.Context, api *
 		g.appendAccessIdentityProviderResources,
 		g.appendAccessMTLSCertificateResources,
 		g.appendAccessServiceTokenResources,
+		g.appendAccessShortLivedCertificateResources,
 	} {
 		if err := f(ctx, api, rc, scopeType); err != nil {
 			return fmt.Errorf("%s/%s: %w", scopeType, rc.Identifier, err)

--- a/providers/cloudflare/access.go
+++ b/providers/cloudflare/access.go
@@ -40,15 +40,10 @@ func accessScopeAttributes(scopeType, scopeID string) map[string]string {
 }
 
 func (g *AccessGenerator) appendAccessApplicationResources(
-	ctx context.Context,
-	api *cf.API,
+	applications []cf.AccessApplication,
 	rc *cf.ResourceContainer,
 	scopeType string,
-) error {
-	applications, err := listAccessApplications(ctx, api, rc)
-	if err != nil {
-		return err
-	}
+) {
 	for _, app := range applications {
 		g.Resources = append(g.Resources, terraformutils.NewResource(
 			app.ID,
@@ -60,7 +55,6 @@ func (g *AccessGenerator) appendAccessApplicationResources(
 			map[string]interface{}{},
 		))
 	}
-	return nil
 }
 
 func listAccessApplications(ctx context.Context, api *cf.API, rc *cf.ResourceContainer) ([]cf.AccessApplication, error) {
@@ -232,11 +226,8 @@ func (g *AccessGenerator) appendAccessShortLivedCertificateResources(
 	api *cf.API,
 	rc *cf.ResourceContainer,
 	scopeType string,
+	applications []cf.AccessApplication,
 ) error {
-	applications, err := listAccessApplications(ctx, api, rc)
-	if err != nil {
-		return err
-	}
 	for _, app := range applications {
 		if app.ID == "" {
 			continue
@@ -420,17 +411,24 @@ func listAccessTags(ctx context.Context, api *cf.API, rc *cf.ResourceContainer) 
 }
 
 func (g *AccessGenerator) appendScopedAccessResources(ctx context.Context, api *cf.API, rc *cf.ResourceContainer, scopeType string) error {
+	applications, err := listAccessApplications(ctx, api, rc)
+	if err != nil {
+		return fmt.Errorf("%s/%s: %w", scopeType, rc.Identifier, err)
+	}
+	g.appendAccessApplicationResources(applications, rc, scopeType)
+
 	for _, f := range []func(context.Context, *cf.API, *cf.ResourceContainer, string) error{
-		g.appendAccessApplicationResources,
 		g.appendAccessGroupResources,
 		g.appendAccessIdentityProviderResources,
 		g.appendAccessMTLSCertificateResources,
 		g.appendAccessServiceTokenResources,
-		g.appendAccessShortLivedCertificateResources,
 	} {
 		if err := f(ctx, api, rc, scopeType); err != nil {
 			return fmt.Errorf("%s/%s: %w", scopeType, rc.Identifier, err)
 		}
+	}
+	if err := g.appendAccessShortLivedCertificateResources(ctx, api, rc, scopeType, applications); err != nil {
+		return fmt.Errorf("%s/%s: %w", scopeType, rc.Identifier, err)
 	}
 	return nil
 }

--- a/providers/cloudflare/access_test.go
+++ b/providers/cloudflare/access_test.go
@@ -67,7 +67,6 @@ func TestCloudflareAccessShortLivedCertificateResourceUsesScopedImportID(t *test
 		"accounts",
 		"account-123",
 		"app-456",
-		cloudflareAccessShortLivedCertificate{ID: "ca-789"},
 	)
 	if !ok {
 		t.Fatal("expected Access short-lived certificate resource")
@@ -91,7 +90,6 @@ func TestCloudflareAccessShortLivedCertificateResourceUsesScopedImportID(t *test
 		"zones",
 		"",
 		"app-456",
-		cloudflareAccessShortLivedCertificate{ID: "app-456"},
 	); ok {
 		t.Fatal("expected missing scope ID to be skipped")
 	}
@@ -102,15 +100,21 @@ func TestGetAccessShortLivedCertificateUsesApplicationPath(t *testing.T) {
 		if r.URL.Path != "/accounts/account-123/access/apps/app-456/ca" {
 			t.Fatalf("path = %q, want /accounts/account-123/access/apps/app-456/ca", r.URL.Path)
 		}
-		writeCloudflareNetworkEdgeTestResponse(t, w, map[string]string{"id": "ca-789"}, nil)
+		writeCloudflareNetworkEdgeTestResponse(t, w, map[string]string{
+			"aud":        "aud-789",
+			"public_key": "-----BEGIN PUBLIC KEY-----",
+		}, nil)
 	}))
 
 	certificate, err := getAccessShortLivedCertificate(context.Background(), api, cf.AccountIdentifier("account-123"), "app-456")
 	if err != nil {
 		t.Fatalf("getAccessShortLivedCertificate() error = %v", err)
 	}
-	if certificate.ID != "ca-789" {
-		t.Fatalf("certificate ID = %q, want ca-789", certificate.ID)
+	if certificate.Aud != "aud-789" {
+		t.Fatalf("certificate aud = %q, want aud-789", certificate.Aud)
+	}
+	if certificate.PublicKey != "-----BEGIN PUBLIC KEY-----" {
+		t.Fatalf("certificate public key = %q, want -----BEGIN PUBLIC KEY-----", certificate.PublicKey)
 	}
 }
 
@@ -141,7 +145,10 @@ func TestAppendScopedAccessResourcesListsApplicationsOnce(t *testing.T) {
 			"/accounts/account-123/access/service_tokens":
 			writeCloudflareNetworkEdgeTestResponse(t, w, []map[string]string{}, nil)
 		case "/accounts/account-123/access/apps/app-456/ca":
-			writeCloudflareNetworkEdgeTestResponse(t, w, map[string]string{"id": "ca-789"}, nil)
+			writeCloudflareNetworkEdgeTestResponse(t, w, map[string]string{
+				"aud":        "aud-789",
+				"public_key": "-----BEGIN PUBLIC KEY-----",
+			}, nil)
 		default:
 			t.Fatalf("unexpected path %q", r.URL.Path)
 		}
@@ -153,5 +160,21 @@ func TestAppendScopedAccessResourcesListsApplicationsOnce(t *testing.T) {
 	}
 	if appListCalls != 1 {
 		t.Fatalf("application list calls = %d, want 1", appListCalls)
+	}
+	shortLivedCertificates := 0
+	for _, resource := range generator.Resources {
+		if resource.InstanceInfo.Type != "cloudflare_zero_trust_access_short_lived_certificate" {
+			continue
+		}
+		shortLivedCertificates++
+		if got := resource.InstanceState.ID; got != "app-456" {
+			t.Fatalf("short-lived certificate ID = %q, want app-456", got)
+		}
+		if got := resource.InstanceState.Meta["import_id"]; got != "accounts/account-123/app-456" {
+			t.Fatalf("short-lived certificate import_id = %q, want accounts/account-123/app-456", got)
+		}
+	}
+	if shortLivedCertificates != 1 {
+		t.Fatalf("short-lived certificate resources = %d, want 1", shortLivedCertificates)
 	}
 }

--- a/providers/cloudflare/access_test.go
+++ b/providers/cloudflare/access_test.go
@@ -72,3 +72,34 @@ func TestCloudflareAccessShortLivedCertificateOptionalError(t *testing.T) {
 		t.Fatal("permission-gated CA lookup should be optional")
 	}
 }
+
+func TestAppendScopedAccessResourcesListsApplicationsOnce(t *testing.T) {
+	appListCalls := 0
+	api := newCloudflareNetworkEdgeTestAPI(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/accounts/account-123/access/apps":
+			appListCalls++
+			writeCloudflareNetworkEdgeTestResponse(t, w, []map[string]string{{
+				"id":   "app-456",
+				"name": "internal-app",
+			}}, nil)
+		case "/accounts/account-123/access/groups",
+			"/accounts/account-123/access/identity_providers",
+			"/accounts/account-123/access/certificates",
+			"/accounts/account-123/access/service_tokens":
+			writeCloudflareNetworkEdgeTestResponse(t, w, []map[string]string{}, nil)
+		case "/accounts/account-123/access/apps/app-456/ca":
+			writeCloudflareNetworkEdgeTestResponse(t, w, map[string]string{"id": "ca-789"}, nil)
+		default:
+			t.Fatalf("unexpected path %q", r.URL.Path)
+		}
+	}))
+
+	var generator AccessGenerator
+	if err := generator.appendScopedAccessResources(context.Background(), api, cf.AccountIdentifier("account-123"), "accounts"); err != nil {
+		t.Fatalf("appendScopedAccessResources() error = %v", err)
+	}
+	if appListCalls != 1 {
+		t.Fatalf("application list calls = %d, want 1", appListCalls)
+	}
+}

--- a/providers/cloudflare/access_test.go
+++ b/providers/cloudflare/access_test.go
@@ -1,0 +1,74 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package cloudflare
+
+import (
+	"context"
+	"net/http"
+	"testing"
+
+	cf "github.com/cloudflare/cloudflare-go"
+)
+
+func TestCloudflareAccessShortLivedCertificateResourceUsesScopedImportID(t *testing.T) {
+	resource, ok := cloudflareAccessShortLivedCertificateResource(
+		"accounts",
+		"account-123",
+		"app-456",
+		cloudflareAccessShortLivedCertificate{ID: "ca-789"},
+	)
+	if !ok {
+		t.Fatal("expected Access short-lived certificate resource")
+	}
+	if resource.InstanceInfo.Type != "cloudflare_zero_trust_access_short_lived_certificate" {
+		t.Fatalf("resource type = %q, want cloudflare_zero_trust_access_short_lived_certificate", resource.InstanceInfo.Type)
+	}
+	if got := resource.InstanceState.Attributes["account_id"]; got != "account-123" {
+		t.Fatalf("account_id = %q, want account-123", got)
+	}
+	if got := resource.InstanceState.Attributes["app_id"]; got != "app-456" {
+		t.Fatalf("app_id = %q, want app-456", got)
+	}
+	if got := resource.InstanceState.ID; got != "app-456" {
+		t.Fatalf("resource ID = %q, want app-456", got)
+	}
+	if got := resource.InstanceState.Meta["import_id"]; got != "accounts/account-123/app-456" {
+		t.Fatalf("import_id = %q, want accounts/account-123/app-456", got)
+	}
+	if _, ok := cloudflareAccessShortLivedCertificateResource(
+		"zones",
+		"",
+		"app-456",
+		cloudflareAccessShortLivedCertificate{ID: "app-456"},
+	); ok {
+		t.Fatal("expected missing scope ID to be skipped")
+	}
+}
+
+func TestGetAccessShortLivedCertificateUsesApplicationPath(t *testing.T) {
+	api := newCloudflareNetworkEdgeTestAPI(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/accounts/account-123/access/apps/app-456/ca" {
+			t.Fatalf("path = %q, want /accounts/account-123/access/apps/app-456/ca", r.URL.Path)
+		}
+		writeCloudflareNetworkEdgeTestResponse(t, w, map[string]string{"id": "ca-789"}, nil)
+	}))
+
+	certificate, err := getAccessShortLivedCertificate(context.Background(), api, cf.AccountIdentifier("account-123"), "app-456")
+	if err != nil {
+		t.Fatalf("getAccessShortLivedCertificate() error = %v", err)
+	}
+	if certificate.ID != "ca-789" {
+		t.Fatalf("certificate ID = %q, want ca-789", certificate.ID)
+	}
+}
+
+func TestCloudflareAccessShortLivedCertificateOptionalError(t *testing.T) {
+	notFoundErr := cf.NewNotFoundError(&cf.Error{ErrorMessages: []string{"not found"}})
+	if !cloudflareAccessShortLivedCertificateOptionalError(&notFoundErr) {
+		t.Fatal("per-application CA not found should be optional")
+	}
+	requestErr := cf.NewRequestError(&cf.Error{ErrorMessages: []string{"missing permission"}})
+	if !cloudflareAccessShortLivedCertificateOptionalError(&requestErr) {
+		t.Fatal("permission-gated CA lookup should be optional")
+	}
+}

--- a/providers/cloudflare/certificates.go
+++ b/providers/cloudflare/certificates.go
@@ -571,7 +571,7 @@ func (g *CertificatesGenerator) appendCertificateAuthorityHostnameAssociationsRe
 	}
 
 	for _, certificate := range mtlsCertificates {
-		if certificate.ID == "" {
+		if certificate.ID == "" || !certificate.CA {
 			continue
 		}
 		hostnames, err := api.ListCertificateAuthoritiesHostnameAssociations(

--- a/providers/cloudflare/certificates.go
+++ b/providers/cloudflare/certificates.go
@@ -126,6 +126,8 @@ func cloudflareCertificateOptionalDiscoveryError(err error) bool {
 		return cloudflareCertificateOptionalErrorMessage(requestErr.Error(), requestErr.ErrorMessages())
 	}
 
+	// cloudflare-go can surface permission-gated 403 responses as AuthenticationError.
+	// Only marker-matching non-admin/feature-gated responses are optional; credential failures still propagate.
 	var authenticationErr *cf.AuthenticationError
 	if errors.As(err, &authenticationErr) {
 		return cloudflareCertificateOptionalErrorMessage(authenticationErr.Error(), authenticationErr.ErrorMessages())

--- a/providers/cloudflare/certificates.go
+++ b/providers/cloudflare/certificates.go
@@ -88,6 +88,25 @@ func cloudflareCertificateNumberString(resource cloudflareCertificateRawResource
 	}
 }
 
+func cloudflareCertificateBool(resource cloudflareCertificateRawResource, key string) (bool, bool) {
+	value, ok := resource[key]
+	if !ok {
+		return false, false
+	}
+	switch v := value.(type) {
+	case bool:
+		return v, true
+	case string:
+		parsed, err := strconv.ParseBool(v)
+		if err != nil {
+			return false, false
+		}
+		return parsed, true
+	default:
+		return false, false
+	}
+}
+
 func cloudflareCertificateDeletedStatus(status string) bool {
 	switch strings.ToLower(status) {
 	case "deleted", "pending_deletion", "deletion_timed_out":
@@ -338,13 +357,18 @@ func cloudflareCertificatePackResource(zone cf.Zone, certificatePack cloudflareC
 		"validation_method":     cloudflareCertificateString(certificatePack, "validation_method"),
 		"validity_days":         validityDays,
 	}
+	additionalFields := map[string]interface{}{}
+	if cloudflareBranding, ok := cloudflareCertificateBool(certificatePack, "cloudflare_branding"); ok && cloudflareBranding {
+		attributes["cloudflare_branding"] = strconv.FormatBool(cloudflareBranding)
+		additionalFields["cloudflare_branding"] = cloudflareBranding
+	}
 	return cloudflareZoneCertificateResource(
 		zone,
 		id,
 		"cloudflare_certificate_pack",
 		"certificate_pack",
 		attributes,
-		map[string]interface{}{},
+		additionalFields,
 		cloudflareCertificateString(certificatePack, "status"),
 	)
 }

--- a/providers/cloudflare/certificates.go
+++ b/providers/cloudflare/certificates.go
@@ -10,7 +10,6 @@ import (
 	"log"
 	"net/http"
 	"net/url"
-	"sort"
 	"strconv"
 	"strings"
 
@@ -338,7 +337,6 @@ func cloudflareOriginCACertificateImportable(certificate cloudflareCertificateRa
 }
 
 func cloudflareCertificateListAttributes(field string, values []string, attributes map[string]string, additionalFields map[string]interface{}) {
-	sort.Strings(values)
 	attributes[field+".#"] = strconv.Itoa(len(values))
 	list := make([]interface{}, 0, len(values))
 	for i, value := range values {

--- a/providers/cloudflare/certificates.go
+++ b/providers/cloudflare/certificates.go
@@ -283,7 +283,7 @@ func cloudflareCertificatePackImportable(certificatePack cloudflareCertificateRa
 		return false
 	}
 	if cloudflareCertificateString(certificatePack, "certificate_authority") == "" ||
-		cloudflareCertificateString(certificatePack, "type") == "" ||
+		!strings.EqualFold(cloudflareCertificateString(certificatePack, "type"), "advanced") ||
 		cloudflareCertificateString(certificatePack, "validation_method") == "" {
 		return false
 	}

--- a/providers/cloudflare/certificates.go
+++ b/providers/cloudflare/certificates.go
@@ -4,6 +4,15 @@ package cloudflare
 
 import (
 	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"log"
+	"net/http"
+	"net/url"
+	"sort"
+	"strconv"
+	"strings"
 
 	"github.com/chenrui333/terraformer/terraformutils"
 	cf "github.com/cloudflare/cloudflare-go"
@@ -13,28 +22,547 @@ type CertificatesGenerator struct {
 	CloudflareService
 }
 
-func (g *CertificatesGenerator) appendMTLSCertificateResources(ctx context.Context, api *cf.API, accountID string) error {
+type cloudflareCertificateRawResource map[string]interface{}
+
+type cloudflareCertificateDiscovery struct {
+	name      string
+	scope     string
+	resources *[]terraformutils.Resource
+	discover  func() error
+}
+
+func cloudflareCertificateString(resource cloudflareCertificateRawResource, keys ...string) string {
+	for _, key := range keys {
+		value, ok := resource[key].(string)
+		if ok && value != "" {
+			return value
+		}
+	}
+	return ""
+}
+
+func cloudflareCertificateStringSlice(resource cloudflareCertificateRawResource, key string) []string {
+	value, ok := resource[key]
+	if !ok {
+		return nil
+	}
+	switch values := value.(type) {
+	case []string:
+		return values
+	case []interface{}:
+		result := make([]string, 0, len(values))
+		for _, item := range values {
+			if s, ok := item.(string); ok && s != "" {
+				result = append(result, s)
+			}
+		}
+		return result
+	default:
+		return nil
+	}
+}
+
+func cloudflareCertificateNumberString(resource cloudflareCertificateRawResource, key string) (string, bool) {
+	value, ok := resource[key]
+	if !ok {
+		return "", false
+	}
+	switch v := value.(type) {
+	case float64:
+		if v == 0 {
+			return "", false
+		}
+		return strconv.Itoa(int(v)), true
+	case int:
+		if v == 0 {
+			return "", false
+		}
+		return strconv.Itoa(v), true
+	case json.Number:
+		if v == "0" || v == "" {
+			return "", false
+		}
+		return v.String(), true
+	default:
+		return "", false
+	}
+}
+
+func cloudflareCertificateDeletedStatus(status string) bool {
+	switch strings.ToLower(status) {
+	case "deleted", "pending_deletion", "deletion_timed_out":
+		return true
+	default:
+		return false
+	}
+}
+
+func cloudflareCertificateOptionalDiscoveryError(err error) bool {
+	var notFoundErr *cf.NotFoundError
+	if errors.As(err, &notFoundErr) {
+		return cloudflareCertificateOptionalErrorMessage(notFoundErr.Error(), notFoundErr.ErrorMessages())
+	}
+
+	var requestErr *cf.RequestError
+	if errors.As(err, &requestErr) {
+		return cloudflareCertificateOptionalErrorMessage(requestErr.Error(), requestErr.ErrorMessages())
+	}
+
+	var authenticationErr *cf.AuthenticationError
+	if errors.As(err, &authenticationErr) {
+		return cloudflareCertificateOptionalErrorMessage(authenticationErr.Error(), authenticationErr.ErrorMessages())
+	}
+
+	var authorizationErr *cf.AuthorizationError
+	if errors.As(err, &authorizationErr) {
+		return cloudflareCertificateOptionalErrorMessage(authorizationErr.Error(), authorizationErr.ErrorMessages())
+	}
+
+	return false
+}
+
+func cloudflareCertificateOptionalErrorMessage(message string, errorMessages []string) bool {
+	messages := append([]string{message}, errorMessages...)
+	for _, msg := range messages {
+		normalized := strings.ToLower(msg)
+		for _, marker := range []string{
+			"access denied",
+			"feature is not available",
+			"missing permission",
+			"not authorized",
+			"not configured",
+			"not enabled",
+			"not entitled",
+			"permission denied",
+			"requires a paid plan",
+			"unauthorized",
+			"upgrade your plan",
+		} {
+			if strings.Contains(normalized, marker) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func runCloudflareCertificateDiscoveries(discoveries []cloudflareCertificateDiscovery) error {
+	for _, discovery := range discoveries {
+		if discovery.discover == nil {
+			continue
+		}
+		resourceCount := 0
+		if discovery.resources != nil {
+			resourceCount = len(*discovery.resources)
+		}
+		if err := discovery.discover(); err != nil {
+			if discovery.resources != nil && resourceCount <= len(*discovery.resources) {
+				*discovery.resources = (*discovery.resources)[:resourceCount]
+			}
+			if cloudflareCertificateOptionalDiscoveryError(err) {
+				log.Printf("Skipping Cloudflare certificate %s discovery for %s: %v", discovery.name, discovery.scope, err)
+				continue
+			}
+			return fmt.Errorf("discover Cloudflare certificate %s for %s: %w", discovery.name, discovery.scope, err)
+		}
+	}
+	return nil
+}
+
+func cloudflareCertificatePagedPath(path string, page int, cursor string) string {
+	separator := "?"
+	if strings.Contains(path, "?") {
+		separator = "&"
+	}
+	return fmt.Sprintf("%s%s%s", path, separator, cloudflarePaginationQuery(page, cursor))
+}
+
+func listCloudflareCertificateResources(
+	ctx context.Context,
+	api *cf.API,
+	path string,
+) ([]cloudflareCertificateRawResource, error) {
+	var resources []cloudflareCertificateRawResource
+	page, cursor := 1, ""
+	for {
+		response, err := api.Raw(ctx, http.MethodGet, cloudflareCertificatePagedPath(path, page, cursor), nil, nil)
+		if err != nil {
+			return nil, err
+		}
+		if len(response.Result) == 0 || string(response.Result) == "null" {
+			return resources, nil
+		}
+
+		var pageResources []cloudflareCertificateRawResource
+		if err := json.Unmarshal(response.Result, &pageResources); err != nil {
+			return nil, err
+		}
+		resources = append(resources, pageResources...)
+		if !cloudflareAdvancePagination(response.ResultInfo, &page, &cursor) {
+			break
+		}
+	}
+	return resources, nil
+}
+
+func listCloudflareMTLSCertificates(ctx context.Context, api *cf.API, accountID string) ([]cf.MTLSCertificate, error) {
+	var allCertificates []cf.MTLSCertificate
 	params := cf.ListMTLSCertificatesParams{PaginationOptions: cf.PaginationOptions{Page: 1, PerPage: cloudflarePageSize}}
 	for {
 		certificates, info, err := api.ListMTLSCertificates(ctx, cf.AccountIdentifier(accountID), params)
 		if err != nil {
-			return err
+			return nil, err
 		}
-		for _, certificate := range certificates {
-			g.Resources = append(g.Resources, terraformutils.NewResource(
-				certificate.ID,
-				cloudflareResourceName(accountID, certificate.Name, certificate.ID),
-				"cloudflare_mtls_certificate",
-				"cloudflare",
-				map[string]string{"account_id": accountID},
-				[]string{},
-				map[string]interface{}{},
-			))
-		}
+		allCertificates = append(allCertificates, certificates...)
 		if !info.HasMorePages() {
 			break
 		}
 		params.Page++
+	}
+	return allCertificates, nil
+}
+
+func (g *CertificatesGenerator) appendMTLSCertificateResources(ctx context.Context, api *cf.API, accountID string) ([]cf.MTLSCertificate, error) {
+	certificates, err := listCloudflareMTLSCertificates(ctx, api, accountID)
+	if err != nil {
+		return nil, err
+	}
+	for _, certificate := range certificates {
+		g.Resources = append(g.Resources, terraformutils.NewResource(
+			certificate.ID,
+			cloudflareResourceName(accountID, certificate.Name, certificate.ID),
+			"cloudflare_mtls_certificate",
+			"cloudflare",
+			map[string]string{"account_id": accountID},
+			[]string{},
+			map[string]interface{}{},
+		))
+	}
+	return certificates, nil
+}
+
+func cloudflareZoneCertificateResource(
+	zone cf.Zone,
+	id string,
+	resourceType string,
+	resourceNamePrefix string,
+	attributes map[string]string,
+	additionalFields map[string]interface{},
+	nameParts ...string,
+) (terraformutils.Resource, bool) {
+	if zone.ID == "" || id == "" {
+		return terraformutils.Resource{}, false
+	}
+	if attributes == nil {
+		attributes = map[string]string{}
+	}
+	attributes["zone_id"] = zone.ID
+	if additionalFields == nil {
+		additionalFields = map[string]interface{}{}
+	}
+	parts := append([]string{zone.Name, resourceNamePrefix}, nameParts...)
+	parts = append(parts, id)
+	resource := terraformutils.NewResource(
+		id,
+		cloudflareResourceName(parts...),
+		resourceType,
+		"cloudflare",
+		attributes,
+		[]string{},
+		additionalFields,
+	)
+	setCloudflareImportID(&resource, zone.ID+"/"+id)
+	return resource, true
+}
+
+func cloudflareCertificatePackImportable(certificatePack cloudflareCertificateRawResource) bool {
+	if cloudflareCertificateString(certificatePack, "id") == "" {
+		return false
+	}
+	if cloudflareCertificateDeletedStatus(cloudflareCertificateString(certificatePack, "status")) {
+		return false
+	}
+	if cloudflareCertificateString(certificatePack, "certificate_authority") == "" ||
+		cloudflareCertificateString(certificatePack, "type") == "" ||
+		cloudflareCertificateString(certificatePack, "validation_method") == "" {
+		return false
+	}
+	_, ok := cloudflareCertificateNumberString(certificatePack, "validity_days")
+	return ok
+}
+
+func cloudflareClientCertificateImportable(certificate cloudflareCertificateRawResource) bool {
+	if cloudflareCertificateString(certificate, "id") == "" ||
+		cloudflareCertificateString(certificate, "csr") == "" {
+		return false
+	}
+	switch strings.ToLower(cloudflareCertificateString(certificate, "status")) {
+	case "revoked", "pending_revocation":
+		return false
+	}
+	_, ok := cloudflareCertificateNumberString(certificate, "validity_days")
+	return ok
+}
+
+func cloudflareCustomOriginTrustStoreImportable(trustStore cloudflareCertificateRawResource) bool {
+	return cloudflareCertificateString(trustStore, "id") != "" &&
+		cloudflareCertificateString(trustStore, "certificate") != "" &&
+		!cloudflareCertificateDeletedStatus(cloudflareCertificateString(trustStore, "status"))
+}
+
+func cloudflareOriginCACertificateImportable(certificate cloudflareCertificateRawResource) bool {
+	return cloudflareCertificateString(certificate, "id") != "" &&
+		cloudflareCertificateString(certificate, "csr") != "" &&
+		cloudflareCertificateString(certificate, "request_type") != "" &&
+		cloudflareCertificateString(certificate, "revoked_at") == "" &&
+		len(cloudflareCertificateStringSlice(certificate, "hostnames")) > 0
+}
+
+func cloudflareCertificateListAttributes(field string, values []string, attributes map[string]string, additionalFields map[string]interface{}) {
+	sort.Strings(values)
+	attributes[field+".#"] = strconv.Itoa(len(values))
+	list := make([]interface{}, 0, len(values))
+	for i, value := range values {
+		attributes[fmt.Sprintf("%s.%d", field, i)] = value
+		list = append(list, value)
+	}
+	additionalFields[field] = list
+}
+
+func cloudflareCertificatePackResource(zone cf.Zone, certificatePack cloudflareCertificateRawResource) (terraformutils.Resource, bool) {
+	id := cloudflareCertificateString(certificatePack, "id")
+	validityDays, _ := cloudflareCertificateNumberString(certificatePack, "validity_days")
+	attributes := map[string]string{
+		"certificate_authority": cloudflareCertificateString(certificatePack, "certificate_authority"),
+		"type":                  cloudflareCertificateString(certificatePack, "type"),
+		"validation_method":     cloudflareCertificateString(certificatePack, "validation_method"),
+		"validity_days":         validityDays,
+	}
+	return cloudflareZoneCertificateResource(
+		zone,
+		id,
+		"cloudflare_certificate_pack",
+		"certificate_pack",
+		attributes,
+		map[string]interface{}{},
+		cloudflareCertificateString(certificatePack, "status"),
+	)
+}
+
+func cloudflareClientCertificateResource(zone cf.Zone, certificate cloudflareCertificateRawResource) (terraformutils.Resource, bool) {
+	id := cloudflareCertificateString(certificate, "id")
+	validityDays, _ := cloudflareCertificateNumberString(certificate, "validity_days")
+	attributes := map[string]string{
+		"csr":           cloudflareCertificateString(certificate, "csr"),
+		"validity_days": validityDays,
+	}
+	return cloudflareZoneCertificateResource(
+		zone,
+		id,
+		"cloudflare_client_certificate",
+		"client_certificate",
+		attributes,
+		map[string]interface{}{},
+		cloudflareCertificateString(certificate, "common_name", "fingerprint_sha256"),
+	)
+}
+
+func cloudflareCustomOriginTrustStoreResource(zone cf.Zone, trustStore cloudflareCertificateRawResource) (terraformutils.Resource, bool) {
+	id := cloudflareCertificateString(trustStore, "id")
+	attributes := map[string]string{"certificate": cloudflareCertificateString(trustStore, "certificate")}
+	return cloudflareZoneCertificateResource(
+		zone,
+		id,
+		"cloudflare_custom_origin_trust_store",
+		"custom_origin_trust_store",
+		attributes,
+		map[string]interface{}{},
+		cloudflareCertificateString(trustStore, "issuer", "status"),
+	)
+}
+
+func cloudflareOriginCACertificateResource(zone cf.Zone, certificate cloudflareCertificateRawResource) (terraformutils.Resource, bool) {
+	id := cloudflareCertificateString(certificate, "id")
+	attributes := map[string]string{
+		"csr":          cloudflareCertificateString(certificate, "csr"),
+		"request_type": cloudflareCertificateString(certificate, "request_type"),
+	}
+	if requestedValidity, ok := cloudflareCertificateNumberString(certificate, "requested_validity"); ok {
+		attributes["requested_validity"] = requestedValidity
+	}
+	hostnames := cloudflareCertificateStringSlice(certificate, "hostnames")
+	additionalFields := map[string]interface{}{}
+	cloudflareCertificateListAttributes("hostnames", hostnames, attributes, additionalFields)
+	resource := terraformutils.NewResource(
+		id,
+		cloudflareResourceName(zone.Name, "origin_ca_certificate", strings.Join(hostnames, "_"), id),
+		"cloudflare_origin_ca_certificate",
+		"cloudflare",
+		attributes,
+		[]string{},
+		additionalFields,
+	)
+	return resource, id != ""
+}
+
+func cloudflareCertificateAuthorityHostnameAssociationsResource(
+	zone cf.Zone,
+	mtlsCertificateID string,
+	hostnames []cf.HostnameAssociation,
+) (terraformutils.Resource, bool) {
+	if zone.ID == "" || len(hostnames) == 0 {
+		return terraformutils.Resource{}, false
+	}
+	attributes := map[string]string{"zone_id": zone.ID}
+	if mtlsCertificateID != "" {
+		attributes["mtls_certificate_id"] = mtlsCertificateID
+	}
+	additionalFields := map[string]interface{}{}
+	values := make([]string, 0, len(hostnames))
+	for _, hostname := range hostnames {
+		if hostname != "" {
+			values = append(values, string(hostname))
+		}
+	}
+	if len(values) == 0 {
+		return terraformutils.Resource{}, false
+	}
+	cloudflareCertificateListAttributes("hostnames", values, attributes, additionalFields)
+
+	importID := zone.ID
+	nameParts := []string{zone.Name, "certificate_authorities_hostname_associations"}
+	if mtlsCertificateID != "" {
+		importID += "/" + mtlsCertificateID
+		nameParts = append(nameParts, mtlsCertificateID)
+	} else {
+		nameParts = append(nameParts, "managed_ca")
+	}
+	resource := terraformutils.NewResource(
+		zone.ID,
+		cloudflareResourceName(nameParts...),
+		"cloudflare_certificate_authorities_hostname_associations",
+		"cloudflare",
+		attributes,
+		[]string{},
+		additionalFields,
+	)
+	setCloudflareImportID(&resource, importID)
+	return resource, true
+}
+
+func (g *CertificatesGenerator) appendCertificatePackResources(ctx context.Context, api *cf.API, zone cf.Zone) error {
+	certificatePacks, err := listCloudflareCertificateResources(ctx, api, fmt.Sprintf("/zones/%s/ssl/certificate_packs?status=all", zone.ID))
+	if err != nil {
+		return err
+	}
+	for _, certificatePack := range certificatePacks {
+		if !cloudflareCertificatePackImportable(certificatePack) {
+			continue
+		}
+		resource, ok := cloudflareCertificatePackResource(zone, certificatePack)
+		if ok {
+			g.Resources = append(g.Resources, resource)
+		}
+	}
+	return nil
+}
+
+func (g *CertificatesGenerator) appendClientCertificateResources(ctx context.Context, api *cf.API, zone cf.Zone) error {
+	certificates, err := listCloudflareCertificateResources(ctx, api, fmt.Sprintf("/zones/%s/client_certificates?status=all", zone.ID))
+	if err != nil {
+		return err
+	}
+	for _, certificate := range certificates {
+		if !cloudflareClientCertificateImportable(certificate) {
+			continue
+		}
+		resource, ok := cloudflareClientCertificateResource(zone, certificate)
+		if ok {
+			g.Resources = append(g.Resources, resource)
+		}
+	}
+	return nil
+}
+
+func (g *CertificatesGenerator) appendCustomOriginTrustStoreResources(ctx context.Context, api *cf.API, zone cf.Zone) error {
+	trustStores, err := listCloudflareCertificateResources(ctx, api, fmt.Sprintf("/zones/%s/acm/custom_trust_store", zone.ID))
+	if err != nil {
+		return err
+	}
+	for _, trustStore := range trustStores {
+		if !cloudflareCustomOriginTrustStoreImportable(trustStore) {
+			continue
+		}
+		resource, ok := cloudflareCustomOriginTrustStoreResource(zone, trustStore)
+		if ok {
+			g.Resources = append(g.Resources, resource)
+		}
+	}
+	return nil
+}
+
+func (g *CertificatesGenerator) appendOriginCACertificateResources(
+	ctx context.Context,
+	api *cf.API,
+	zone cf.Zone,
+	seen map[string]struct{},
+) error {
+	values := url.Values{}
+	values.Set("zone_id", zone.ID)
+	certificates, err := listCloudflareCertificateResources(ctx, api, "/certificates?"+values.Encode())
+	if err != nil {
+		return err
+	}
+	for _, certificate := range certificates {
+		if !cloudflareOriginCACertificateImportable(certificate) {
+			continue
+		}
+		id := cloudflareCertificateString(certificate, "id")
+		if _, ok := seen[id]; ok {
+			continue
+		}
+		resource, ok := cloudflareOriginCACertificateResource(zone, certificate)
+		if ok {
+			g.Resources = append(g.Resources, resource)
+			seen[id] = struct{}{}
+		}
+	}
+	return nil
+}
+
+func (g *CertificatesGenerator) appendCertificateAuthorityHostnameAssociationsResources(
+	ctx context.Context,
+	api *cf.API,
+	zone cf.Zone,
+	mtlsCertificates []cf.MTLSCertificate,
+) error {
+	hostnames, err := api.ListCertificateAuthoritiesHostnameAssociations(
+		ctx,
+		cf.ZoneIdentifier(zone.ID),
+		cf.ListCertificateAuthoritiesHostnameAssociationsParams{},
+	)
+	if err != nil {
+		return err
+	}
+	if resource, ok := cloudflareCertificateAuthorityHostnameAssociationsResource(zone, "", hostnames); ok {
+		g.Resources = append(g.Resources, resource)
+	}
+
+	for _, certificate := range mtlsCertificates {
+		if certificate.ID == "" {
+			continue
+		}
+		hostnames, err := api.ListCertificateAuthoritiesHostnameAssociations(
+			ctx,
+			cf.ZoneIdentifier(zone.ID),
+			cf.ListCertificateAuthoritiesHostnameAssociationsParams{MTLSCertificateID: certificate.ID},
+		)
+		if err != nil {
+			return err
+		}
+		if resource, ok := cloudflareCertificateAuthorityHostnameAssociationsResource(zone, certificate.ID, hostnames); ok {
+			g.Resources = append(g.Resources, resource)
+		}
 	}
 	return nil
 }
@@ -63,14 +591,67 @@ func (g *CertificatesGenerator) appendCustomHostnameResources(ctx context.Contex
 	return nil
 }
 
+func (g *CertificatesGenerator) appendZoneCertificateResources(
+	ctx context.Context,
+	api *cf.API,
+	zone cf.Zone,
+	mtlsCertificates []cf.MTLSCertificate,
+	seenOriginCACertificates map[string]struct{},
+) error {
+	return runCloudflareCertificateDiscoveries([]cloudflareCertificateDiscovery{
+		{
+			name:      "certificate packs",
+			scope:     zone.ID,
+			resources: &g.Resources,
+			discover: func() error {
+				return g.appendCertificatePackResources(ctx, api, zone)
+			},
+		},
+		{
+			name:      "client certificates",
+			scope:     zone.ID,
+			resources: &g.Resources,
+			discover: func() error {
+				return g.appendClientCertificateResources(ctx, api, zone)
+			},
+		},
+		{
+			name:      "custom origin trust stores",
+			scope:     zone.ID,
+			resources: &g.Resources,
+			discover: func() error {
+				return g.appendCustomOriginTrustStoreResources(ctx, api, zone)
+			},
+		},
+		{
+			name:      "origin CA certificates",
+			scope:     zone.ID,
+			resources: &g.Resources,
+			discover: func() error {
+				return g.appendOriginCACertificateResources(ctx, api, zone, seenOriginCACertificates)
+			},
+		},
+		{
+			name:      "certificate authority hostname associations",
+			scope:     zone.ID,
+			resources: &g.Resources,
+			discover: func() error {
+				return g.appendCertificateAuthorityHostnameAssociationsResources(ctx, api, zone, mtlsCertificates)
+			},
+		},
+	})
+}
+
 func (g *CertificatesGenerator) InitResources() error {
 	ctx := context.Background()
 	api, err := g.initializeAPI()
 	if err != nil {
 		return err
 	}
+	var mtlsCertificates []cf.MTLSCertificate
 	if g.accountID() != "" {
-		if err := g.appendMTLSCertificateResources(ctx, api, g.accountID()); err != nil {
+		mtlsCertificates, err = g.appendMTLSCertificateResources(ctx, api, g.accountID())
+		if err != nil {
 			return err
 		}
 	}
@@ -78,8 +659,12 @@ func (g *CertificatesGenerator) InitResources() error {
 	if err != nil {
 		return err
 	}
+	seenOriginCACertificates := map[string]struct{}{}
 	for _, zone := range zones {
 		if err := g.appendCustomHostnameResources(ctx, api, zone); err != nil {
+			return err
+		}
+		if err := g.appendZoneCertificateResources(ctx, api, zone, mtlsCertificates, seenOriginCACertificates); err != nil {
 			return err
 		}
 	}

--- a/providers/cloudflare/certificates.go
+++ b/providers/cloudflare/certificates.go
@@ -445,7 +445,7 @@ func cloudflareCertificateAuthorityHostnameAssociationsResource(
 	values := make([]string, 0, len(hostnames))
 	for _, hostname := range hostnames {
 		if hostname != "" {
-			values = append(values, string(hostname))
+			values = append(values, hostname)
 		}
 	}
 	if len(values) == 0 {

--- a/providers/cloudflare/certificates.go
+++ b/providers/cloudflare/certificates.go
@@ -356,7 +356,7 @@ func cloudflareCertificatePackResource(zone cf.Zone, certificatePack cloudflareC
 		"validity_days":         validityDays,
 	}
 	additionalFields := map[string]interface{}{}
-	if cloudflareBranding, ok := cloudflareCertificateBool(certificatePack, "cloudflare_branding"); ok && cloudflareBranding {
+	if cloudflareBranding, ok := cloudflareCertificateBool(certificatePack, "cloudflare_branding"); ok {
 		attributes["cloudflare_branding"] = strconv.FormatBool(cloudflareBranding)
 		additionalFields["cloudflare_branding"] = cloudflareBranding
 	}

--- a/providers/cloudflare/certificates_test.go
+++ b/providers/cloudflare/certificates_test.go
@@ -9,6 +9,7 @@ import (
 	"net/http"
 	"os"
 	"reflect"
+	"strconv"
 	"testing"
 
 	cf "github.com/cloudflare/cloudflare-go"
@@ -45,24 +46,26 @@ func TestCloudflareZoneCertificateResourceUsesCompositeImportID(t *testing.T) {
 }
 
 func TestCloudflareCertificatePackResourcePreservesBranding(t *testing.T) {
-	zone := cf.Zone{ID: "zone-123", Name: "example.com"}
-	resource, ok := cloudflareCertificatePackResource(zone, cloudflareCertificateRawResource{
-		"id":                    "pack-456",
-		"certificate_authority": "lets_encrypt",
-		"type":                  "advanced",
-		"validation_method":     "txt",
-		"validity_days":         float64(90),
-		"cloudflare_branding":   true,
-		"status":                "active",
-	})
-	if !ok {
-		t.Fatal("expected certificate pack resource")
-	}
-	if got := resource.InstanceState.Attributes["cloudflare_branding"]; got != "true" {
-		t.Fatalf("cloudflare_branding attribute = %q, want true", got)
-	}
-	if got := resource.AdditionalFields["cloudflare_branding"]; got != true {
-		t.Fatalf("cloudflare_branding AdditionalFields = %#v, want true", got)
+	for _, cloudflareBranding := range []bool{true, false} {
+		resource, ok := cloudflareCertificatePackResource(cf.Zone{ID: "zone-123", Name: "example.com"}, cloudflareCertificateRawResource{
+			"id":                    "pack-456",
+			"certificate_authority": "lets_encrypt",
+			"type":                  "advanced",
+			"validation_method":     "txt",
+			"validity_days":         float64(90),
+			"cloudflare_branding":   cloudflareBranding,
+			"status":                "active",
+		})
+		if !ok {
+			t.Fatal("expected certificate pack resource")
+		}
+		want := strconv.FormatBool(cloudflareBranding)
+		if got := resource.InstanceState.Attributes["cloudflare_branding"]; got != want {
+			t.Fatalf("cloudflare_branding attribute = %q, want %s", got, want)
+		}
+		if got := resource.AdditionalFields["cloudflare_branding"]; got != cloudflareBranding {
+			t.Fatalf("cloudflare_branding AdditionalFields = %#v, want %t", got, cloudflareBranding)
+		}
 	}
 }
 

--- a/providers/cloudflare/certificates_test.go
+++ b/providers/cloudflare/certificates_test.go
@@ -97,6 +97,16 @@ func TestCloudflareCertificateImportPolicies(t *testing.T) {
 	}) {
 		t.Fatal("pending deletion certificate pack should be skipped")
 	}
+	if cloudflareCertificatePackImportable(cloudflareCertificateRawResource{
+		"id":                    "pack-123",
+		"certificate_authority": "lets_encrypt",
+		"type":                  "universal",
+		"validation_method":     "txt",
+		"validity_days":         float64(90),
+		"status":                "active",
+	}) {
+		t.Fatal("non-advanced certificate pack should be skipped")
+	}
 	if !cloudflareClientCertificateImportable(cloudflareCertificateRawResource{
 		"id":            "client-123",
 		"csr":           "-----BEGIN CERTIFICATE REQUEST-----",

--- a/providers/cloudflare/certificates_test.go
+++ b/providers/cloudflare/certificates_test.go
@@ -8,6 +8,7 @@ import (
 	"errors"
 	"net/http"
 	"os"
+	"reflect"
 	"testing"
 
 	cf "github.com/cloudflare/cloudflare-go"
@@ -123,6 +124,46 @@ func TestCloudflareCertificateAuthorityHostnameAssociationsResource(t *testing.T
 		nil,
 	); ok {
 		t.Fatal("expected empty hostname associations to be skipped")
+	}
+}
+
+func TestAppendCertificateAuthorityHostnameAssociationsResourcesSkipsNonCAMTLSCertificates(t *testing.T) {
+	var requestedMTLSIDs []string
+	api := newCloudflareNetworkEdgeTestAPI(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/zones/zone-123/certificate_authorities/hostname_associations" {
+			t.Fatalf("path = %q, want /zones/zone-123/certificate_authorities/hostname_associations", r.URL.Path)
+		}
+		mtlsCertificateID := r.URL.Query().Get("mtls_certificate_id")
+		requestedMTLSIDs = append(requestedMTLSIDs, mtlsCertificateID)
+		switch mtlsCertificateID {
+		case "":
+			writeCloudflareNetworkEdgeTestResponse(t, w, map[string][]string{"hostnames": {"managed.example.com"}}, nil)
+		case "ca-cert":
+			writeCloudflareNetworkEdgeTestResponse(t, w, map[string][]string{"hostnames": {"ca.example.com"}}, nil)
+		default:
+			t.Fatalf("unexpected mtls_certificate_id query = %q", mtlsCertificateID)
+		}
+	}))
+
+	var generator CertificatesGenerator
+	err := generator.appendCertificateAuthorityHostnameAssociationsResources(
+		context.Background(),
+		api,
+		cf.Zone{ID: "zone-123", Name: "example.com"},
+		[]cf.MTLSCertificate{
+			{ID: "leaf-cert", CA: false},
+			{ID: "ca-cert", CA: true},
+		},
+	)
+	if err != nil {
+		t.Fatalf("appendCertificateAuthorityHostnameAssociationsResources() error = %v", err)
+	}
+	wantMTLSIDs := []string{"", "ca-cert"}
+	if !reflect.DeepEqual(requestedMTLSIDs, wantMTLSIDs) {
+		t.Fatalf("requested mtls_certificate_id values = %#v, want %#v", requestedMTLSIDs, wantMTLSIDs)
+	}
+	if len(generator.Resources) != 2 {
+		t.Fatalf("resource count = %d, want 2", len(generator.Resources))
 	}
 }
 

--- a/providers/cloudflare/certificates_test.go
+++ b/providers/cloudflare/certificates_test.go
@@ -43,6 +43,28 @@ func TestCloudflareZoneCertificateResourceUsesCompositeImportID(t *testing.T) {
 	}
 }
 
+func TestCloudflareCertificatePackResourcePreservesBranding(t *testing.T) {
+	zone := cf.Zone{ID: "zone-123", Name: "example.com"}
+	resource, ok := cloudflareCertificatePackResource(zone, cloudflareCertificateRawResource{
+		"id":                    "pack-456",
+		"certificate_authority": "lets_encrypt",
+		"type":                  "advanced",
+		"validation_method":     "txt",
+		"validity_days":         float64(90),
+		"cloudflare_branding":   true,
+		"status":                "active",
+	})
+	if !ok {
+		t.Fatal("expected certificate pack resource")
+	}
+	if got := resource.InstanceState.Attributes["cloudflare_branding"]; got != "true" {
+		t.Fatalf("cloudflare_branding attribute = %q, want true", got)
+	}
+	if got := resource.AdditionalFields["cloudflare_branding"]; got != true {
+		t.Fatalf("cloudflare_branding AdditionalFields = %#v, want true", got)
+	}
+}
+
 func TestCloudflareCertificateAuthorityHostnameAssociationsResource(t *testing.T) {
 	resource, ok := cloudflareCertificateAuthorityHostnameAssociationsResource(
 		cf.Zone{ID: "zone-123", Name: "example.com"},

--- a/providers/cloudflare/certificates_test.go
+++ b/providers/cloudflare/certificates_test.go
@@ -65,6 +65,34 @@ func TestCloudflareCertificatePackResourcePreservesBranding(t *testing.T) {
 	}
 }
 
+func TestCloudflareOriginCACertificateResourcePreservesHostnameOrder(t *testing.T) {
+	resource, ok := cloudflareOriginCACertificateResource(cf.Zone{ID: "zone-123", Name: "example.com"}, cloudflareCertificateRawResource{
+		"id":           "origin-456",
+		"csr":          "-----BEGIN CERTIFICATE REQUEST-----",
+		"request_type": "origin-rsa",
+		"hostnames":    []interface{}{"z.example.com", "a.example.com"},
+	})
+	if !ok {
+		t.Fatal("expected origin CA certificate resource")
+	}
+	if got := resource.InstanceState.Attributes["hostnames.0"]; got != "z.example.com" {
+		t.Fatalf("hostnames.0 = %q, want z.example.com", got)
+	}
+	if got := resource.InstanceState.Attributes["hostnames.1"]; got != "a.example.com" {
+		t.Fatalf("hostnames.1 = %q, want a.example.com", got)
+	}
+	hostnames, ok := resource.AdditionalFields["hostnames"].([]interface{})
+	if !ok {
+		t.Fatalf("AdditionalFields[hostnames] = %#v, want []interface{}", resource.AdditionalFields["hostnames"])
+	}
+	if got := hostnames[0]; got != "z.example.com" {
+		t.Fatalf("AdditionalFields[hostnames][0] = %#v, want z.example.com", got)
+	}
+	if got := hostnames[1]; got != "a.example.com" {
+		t.Fatalf("AdditionalFields[hostnames][1] = %#v, want a.example.com", got)
+	}
+}
+
 func TestCloudflareCertificateAuthorityHostnameAssociationsResource(t *testing.T) {
 	resource, ok := cloudflareCertificateAuthorityHostnameAssociationsResource(
 		cf.Zone{ID: "zone-123", Name: "example.com"},

--- a/providers/cloudflare/certificates_test.go
+++ b/providers/cloudflare/certificates_test.go
@@ -97,6 +97,18 @@ func TestCloudflareOriginCACertificateResourcePreservesHostnameOrder(t *testing.
 	}
 }
 
+func TestCloudflareCertificateOptionalDiscoveryErrorHandlesAuthErrors(t *testing.T) {
+	authenticationErr := cf.NewAuthenticationError(&cf.Error{ErrorMessages: []string{"not authorized"}})
+	if !cloudflareCertificateOptionalDiscoveryError(&authenticationErr) {
+		t.Fatal("permission-gated authentication errors should be treated as optional")
+	}
+
+	authenticationErrWithoutMarker := cf.NewAuthenticationError(&cf.Error{ErrorMessages: []string{"invalid token"}})
+	if cloudflareCertificateOptionalDiscoveryError(&authenticationErrWithoutMarker) {
+		t.Fatal("credential authentication errors should propagate")
+	}
+}
+
 func TestCloudflareCertificateAuthorityHostnameAssociationsResource(t *testing.T) {
 	resource, ok := cloudflareCertificateAuthorityHostnameAssociationsResource(
 		cf.Zone{ID: "zone-123", Name: "example.com"},

--- a/providers/cloudflare/certificates_test.go
+++ b/providers/cloudflare/certificates_test.go
@@ -1,0 +1,249 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package cloudflare
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"os"
+	"testing"
+
+	cf "github.com/cloudflare/cloudflare-go"
+)
+
+func TestCloudflareZoneCertificateResourceUsesCompositeImportID(t *testing.T) {
+	zone := cf.Zone{ID: "zone-123", Name: "example.com"}
+	resource, ok := cloudflareCertificatePackResource(zone, cloudflareCertificateRawResource{
+		"id":                    "pack-456",
+		"certificate_authority": "lets_encrypt",
+		"type":                  "advanced",
+		"validation_method":     "txt",
+		"validity_days":         float64(90),
+		"status":                "active",
+	})
+	if !ok {
+		t.Fatal("expected certificate pack resource")
+	}
+	if resource.InstanceInfo.Type != "cloudflare_certificate_pack" {
+		t.Fatalf("resource type = %q, want cloudflare_certificate_pack", resource.InstanceInfo.Type)
+	}
+	if got := resource.InstanceState.ID; got != "pack-456" {
+		t.Fatalf("resource ID = %q, want pack-456", got)
+	}
+	if got := resource.InstanceState.Attributes["zone_id"]; got != "zone-123" {
+		t.Fatalf("zone_id = %q, want zone-123", got)
+	}
+	if got := resource.InstanceState.Attributes["validity_days"]; got != "90" {
+		t.Fatalf("validity_days = %q, want 90", got)
+	}
+	if got := resource.InstanceState.Meta["import_id"]; got != "zone-123/pack-456" {
+		t.Fatalf("import_id = %q, want zone-123/pack-456", got)
+	}
+}
+
+func TestCloudflareCertificateAuthorityHostnameAssociationsResource(t *testing.T) {
+	resource, ok := cloudflareCertificateAuthorityHostnameAssociationsResource(
+		cf.Zone{ID: "zone-123", Name: "example.com"},
+		"mtls-456",
+		[]cf.HostnameAssociation{"api.example.com", "admin.example.com"},
+	)
+	if !ok {
+		t.Fatal("expected hostname association resource")
+	}
+	if resource.InstanceInfo.Type != "cloudflare_certificate_authorities_hostname_associations" {
+		t.Fatalf("resource type = %q, want cloudflare_certificate_authorities_hostname_associations", resource.InstanceInfo.Type)
+	}
+	if got := resource.InstanceState.ID; got != "zone-123" {
+		t.Fatalf("resource ID = %q, want zone-123", got)
+	}
+	if got := resource.InstanceState.Attributes["mtls_certificate_id"]; got != "mtls-456" {
+		t.Fatalf("mtls_certificate_id = %q, want mtls-456", got)
+	}
+	if got := resource.InstanceState.Meta["import_id"]; got != "zone-123/mtls-456" {
+		t.Fatalf("import_id = %q, want zone-123/mtls-456", got)
+	}
+	if got := resource.InstanceState.Attributes["hostnames.#"]; got != "2" {
+		t.Fatalf("hostnames.# = %q, want 2", got)
+	}
+	if _, ok := cloudflareCertificateAuthorityHostnameAssociationsResource(
+		cf.Zone{ID: "zone-123", Name: "example.com"},
+		"",
+		nil,
+	); ok {
+		t.Fatal("expected empty hostname associations to be skipped")
+	}
+}
+
+func TestCloudflareCertificateImportPolicies(t *testing.T) {
+	if !cloudflareCertificatePackImportable(cloudflareCertificateRawResource{
+		"id":                    "pack-123",
+		"certificate_authority": "lets_encrypt",
+		"type":                  "advanced",
+		"validation_method":     "txt",
+		"validity_days":         float64(90),
+		"status":                "active",
+	}) {
+		t.Fatal("active certificate pack with required fields should import")
+	}
+	if cloudflareCertificatePackImportable(cloudflareCertificateRawResource{
+		"id":                    "pack-123",
+		"certificate_authority": "lets_encrypt",
+		"type":                  "advanced",
+		"validation_method":     "txt",
+		"validity_days":         float64(90),
+		"status":                "pending_deletion",
+	}) {
+		t.Fatal("pending deletion certificate pack should be skipped")
+	}
+	if !cloudflareClientCertificateImportable(cloudflareCertificateRawResource{
+		"id":            "client-123",
+		"csr":           "-----BEGIN CERTIFICATE REQUEST-----",
+		"validity_days": float64(365),
+		"status":        "active",
+	}) {
+		t.Fatal("client certificate with public CSR and validity should import")
+	}
+	if cloudflareClientCertificateImportable(cloudflareCertificateRawResource{
+		"id":            "client-123",
+		"validity_days": float64(365),
+		"status":        "active",
+	}) {
+		t.Fatal("client certificate without required CSR should be skipped")
+	}
+	if !cloudflareCustomOriginTrustStoreImportable(cloudflareCertificateRawResource{
+		"id":          "trust-123",
+		"certificate": "-----BEGIN CERTIFICATE-----",
+		"status":      "active",
+	}) {
+		t.Fatal("custom origin trust store with certificate should import")
+	}
+	if cloudflareCustomOriginTrustStoreImportable(cloudflareCertificateRawResource{
+		"id":     "trust-123",
+		"status": "active",
+	}) {
+		t.Fatal("custom origin trust store without certificate should be skipped")
+	}
+	if !cloudflareOriginCACertificateImportable(cloudflareCertificateRawResource{
+		"id":           "origin-123",
+		"csr":          "-----BEGIN CERTIFICATE REQUEST-----",
+		"request_type": "origin-rsa",
+		"hostnames":    []interface{}{"example.com"},
+	}) {
+		t.Fatal("origin CA certificate with CSR, request type, and hostnames should import")
+	}
+	if cloudflareOriginCACertificateImportable(cloudflareCertificateRawResource{
+		"id":           "origin-123",
+		"csr":          "-----BEGIN CERTIFICATE REQUEST-----",
+		"request_type": "origin-rsa",
+		"hostnames":    []interface{}{"example.com"},
+		"revoked_at":   "2026-05-17T00:00:00Z",
+	}) {
+		t.Fatal("revoked origin CA certificate should be skipped")
+	}
+}
+
+func TestRunCloudflareCertificateDiscoveriesContinuesAfterOptionalError(t *testing.T) {
+	resources := []cloudflareCertificateRawResource{}
+	err := runCloudflareCertificateDiscoveries([]cloudflareCertificateDiscovery{
+		{
+			name:  "permission gated",
+			scope: "zone-123",
+			discover: func() error {
+				requestErr := cf.NewRequestError(&cf.Error{ErrorMessages: []string{"missing permission"}})
+				return &requestErr
+			},
+		},
+		{
+			name:  "succeeds",
+			scope: "zone-123",
+			discover: func() error {
+				resources = append(resources, cloudflareCertificateRawResource{"id": "ok"})
+				return nil
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("runCloudflareCertificateDiscoveries() error = %v, want nil", err)
+	}
+	if len(resources) != 1 {
+		t.Fatalf("resource count = %d, want 1", len(resources))
+	}
+
+	err = runCloudflareCertificateDiscoveries([]cloudflareCertificateDiscovery{
+		{
+			name:  "fails",
+			scope: "zone-123",
+			discover: func() error {
+				return errors.New("temporary Cloudflare failure")
+			},
+		},
+	})
+	if err == nil {
+		t.Fatal("expected non-optional discovery error")
+	}
+}
+
+func TestListCloudflareCertificateResourcesPaginates(t *testing.T) {
+	api := newCloudflareNetworkEdgeTestAPI(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/zones/zone-123/client_certificates" {
+			t.Fatalf("path = %q, want /zones/zone-123/client_certificates", r.URL.Path)
+		}
+		switch r.URL.Query().Get("cursor") {
+		case "":
+			if got := r.URL.Query().Get("page"); got != "1" {
+				t.Fatalf("page query = %q, want 1", got)
+			}
+			writeCloudflareNetworkEdgeTestResponse(t, w, []map[string]string{{"id": "cert-1"}}, map[string]interface{}{
+				"cursors": map[string]string{"after": "cursor-2"},
+			})
+		case "cursor-2":
+			writeCloudflareNetworkEdgeTestResponse(t, w, []map[string]string{{"id": "cert-2"}}, map[string]interface{}{
+				"cursors": map[string]string{},
+			})
+		default:
+			t.Fatalf("cursor query = %q, want empty or cursor-2", r.URL.Query().Get("cursor"))
+		}
+	}))
+
+	resources, err := listCloudflareCertificateResources(context.Background(), api, "/zones/zone-123/client_certificates")
+	if err != nil {
+		t.Fatalf("listCloudflareCertificateResources() error = %v", err)
+	}
+	if len(resources) != 2 {
+		t.Fatalf("resource count = %d, want 2", len(resources))
+	}
+	if got := cloudflareCertificateString(resources[0], "id"); got != "cert-1" {
+		t.Fatalf("first id = %q, want cert-1", got)
+	}
+	if got := cloudflareCertificateString(resources[1], "id"); got != "cert-2" {
+		t.Fatalf("second id = %q, want cert-2", got)
+	}
+}
+
+func TestCloudflareCertificateUnsupportedResourcesMetadata(t *testing.T) {
+	data, err := os.ReadFile("unsupported_resources.json")
+	if err != nil {
+		t.Fatalf("read unsupported resources: %v", err)
+	}
+	var metadata cloudflareUnsupportedResourcesFile
+	if err := json.Unmarshal(data, &metadata); err != nil {
+		t.Fatalf("decode unsupported resources: %v", err)
+	}
+	statuses := map[string]string{}
+	for _, resource := range metadata.Resources {
+		statuses[resource.Resource] = resource.Status
+	}
+	for resource, wantStatus := range map[string]string{
+		"cloudflare_authenticated_origin_pulls_certificate":          "secret-required",
+		"cloudflare_authenticated_origin_pulls_hostname_certificate": "secret-required",
+		"cloudflare_custom_ssl":                                      "secret-required",
+		"cloudflare_hostname_tls_setting":                            "deferred",
+		"cloudflare_keyless_certificate":                             "unsupported",
+	} {
+		if got := statuses[resource]; got != wantStatus {
+			t.Fatalf("%s status = %q, want %q", resource, got, wantStatus)
+		}
+	}
+}

--- a/providers/cloudflare/unsupported_resources.json
+++ b/providers/cloudflare/unsupported_resources.json
@@ -302,6 +302,17 @@
       ]
     },
     {
+      "resource": "cloudflare_hostname_tls_setting",
+      "service_family": "certificates",
+      "reason": "Per-hostname TLS settings need a provider import shape that uniquely identifies the hostname.",
+      "evidence": "Terraform provider v5.19.1 imports cloudflare_hostname_tls_setting by zone_id/setting_id even though the schema requires hostname and the Cloudflare list API returns one record per hostname and setting. Broad import would create colliding zone_id/setting_id import IDs for multiple hostnames.",
+      "status": "deferred",
+      "references": [
+        "https://github.com/chenrui333/terraformer/issues/335",
+        "https://registry.terraform.io/providers/cloudflare/cloudflare/latest/docs/resources/hostname_tls_setting"
+      ]
+    },
+    {
       "resource": "cloudflare_hyperdrive_config",
       "service_family": "storage",
       "reason": "Hyperdrive configs require write-only origin credential material.",
@@ -321,6 +332,17 @@
       "references": [
         "https://github.com/chenrui333/terraformer/issues/335",
         "https://registry.terraform.io/providers/cloudflare/cloudflare/latest/docs/resources/image"
+      ]
+    },
+    {
+      "resource": "cloudflare_keyless_certificate",
+      "service_family": "certificates",
+      "reason": "Keyless certificate resources require certificate body configuration that Cloudflare APIs do not return on list/read.",
+      "evidence": "Terraform provider v5.19.1 requires certificate and host for cloudflare_keyless_certificate, but the provider API list/read models return durable metadata such as id, host, port, status, tunnel, and permissions while omitting certificate. Terraformer cannot reconstruct valid HCL from the discovered keyless certificate ID alone.",
+      "status": "unsupported",
+      "references": [
+        "https://github.com/chenrui333/terraformer/issues/335",
+        "https://registry.terraform.io/providers/cloudflare/cloudflare/latest/docs/resources/keyless_certificate"
       ]
     },
     {


### PR DESCRIPTION
## Summary

Add or classify remaining Cloudflare cert/TLS/hostname certificate resources.

## Resources

- `cloudflare_certificate_authorities_hostname_associations`
- `cloudflare_certificate_pack`
- `cloudflare_client_certificate`
- `cloudflare_custom_origin_trust_store`
- `cloudflare_origin_ca_certificate`
- `cloudflare_zero_trust_access_short_lived_certificate`

## Deferred / Unsupported

- `cloudflare_hostname_tls_setting`: deferred because provider import uses `zone_id/setting_id` while the API returns one record per hostname and setting.
- `cloudflare_keyless_certificate`: unsupported because provider-required certificate body is not returned by Cloudflare list/read APIs.

## Scope

This PR is limited to cert/TLS/hostname certificate resources.

## Validation

- `go test ./providers/cloudflare/...`
- `go test ./cmd/...`
- `go test ./providers -run 'TestUnsupportedResourcesMetadata|TestUnsupportedResourceStatusesAreDocumented' -count=1`
- `jq . providers/cloudflare/unsupported_resources.json`
- `git diff --check`

Ref: #335

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds import support for Cloudflare cert/TLS resources and Access short‑lived certificates with correct zone/app‑scoped import IDs, robust pagination, and optional handling for permission/not‑found/auth‑gated APIs. Defers `cloudflare_hostname_tls_setting` and marks `cloudflare_keyless_certificate` unsupported to align with #335.

- **New Features**
  - Import support for `cloudflare_certificate_pack`, `cloudflare_client_certificate`, `cloudflare_custom_origin_trust_store`, `cloudflare_origin_ca_certificate`, `cloudflare_certificate_authorities_hostname_associations` (managed and per‑mTLS), and `cloudflare_zero_trust_access_short_lived_certificate`.
  - Composite import IDs (zone/app scoped), page/cursor pagination, and graceful skips for plan/permission/not‑found/auth‑gated endpoints.
  - Docs updated to list new resources.
  - `cloudflare_hostname_tls_setting` deferred; `cloudflare_keyless_certificate` unsupported.

- **Bug Fixes**
  - Import Access short‑lived certificates by application ID.
  - Skip non‑advanced certificate packs.
  - Preserve `cloudflare_certificate_pack` branding flag, including false values.
  - List Access applications once to avoid duplicate API calls.
  - Remove redundant hostname conversion in hostname associations.
  - Preserve `cloudflare_origin_ca_certificate` hostname order.
  - Skip hostname association probes for leaf (non‑CA) mTLS certificates.

<sup>Written for commit a8ffe674fa45cebe0d255061631b42df0f9568a3. Summary will update on new commits. <a href="https://cubic.dev/pr/chenrui333/terraformer/pull/497?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added support for Cloudflare Access short-lived certificates
  * Added support for certificate packs, client certificates, custom origin trust stores, origin CA certificates, and certificate authority hostname associations
  * Improved certificate resource discovery with pagination support

* **Documentation**
  * Updated supported Cloudflare services documentation with newly supported certificate and access resources

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/chenrui333/terraformer/pull/497?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->