### PR TITLE
docs: update provider close-out guidance

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -82,8 +82,8 @@ Rules:
   Terraformer-supported resources, evidence-backed unsupported/deferred
   resources, and still-unclassified resources.
 - Separate unclassified resources already covered by open PRs from truly
-  remaining work; do not close the tracker while open PRs are still required for
-  closure.
+  remaining work; do not close the tracker until required open PRs have merged
+  or the remaining work is moved to narrower follow-up issues.
 - For large provider schemas, practical close-out means every reviewed candidate is supported, evidence-backed deferred/unsupported, or assigned to a named focused follow-up lane.
 - Reduce final follow-up lanes to exact resource names whenever possible, so the
   next lane is bounded before implementation starts.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -78,7 +78,15 @@ Close-out audits are different from feature lanes. They should make the remainin
 Rules:
 
 - Report lane closure separately from tracking-issue closure. A lane can be complete while the broader issue remains open.
+- For large provider schemas, report counts for upstream provider resources,
+  Terraformer-supported resources, evidence-backed unsupported/deferred
+  resources, and still-unclassified resources.
+- Separate unclassified resources already covered by open PRs from truly
+  remaining work; do not close the tracker while open PRs are still required for
+  closure.
 - For large provider schemas, practical close-out means every reviewed candidate is supported, evidence-backed deferred/unsupported, or assigned to a named focused follow-up lane.
+- Reduce final follow-up lanes to exact resource names whenever possible, so the
+  next lane is bounded before implementation starts.
 - Do not treat literal Terraform provider parity as the goal when resources are request-style, runtime/media output, high-cardinality content, provider-managed, source/body-heavy, or secret-required.
 - For settings and singleton resources, distinguish durable user-owned configuration from effective API values and platform defaults before moving a resource from deferred metadata to supported import.
 - Use close-out audits to reduce repeated search work: update unsupported metadata when evidence is clear, and group remaining importable resources into focused next lanes.

--- a/docs/provider-architecture.md
+++ b/docs/provider-architecture.md
@@ -143,9 +143,18 @@ complete, compare:
 - Issue tracker buckets.
 - Stale or superseded PR branches.
 
+For broad-provider close-outs, include counts for upstream provider resources,
+Terraformer-supported resources, evidence-backed unsupported or deferred
+resources, and still-unclassified resources. Separate unclassified resources
+already covered by open PRs from truly remaining work, and reduce final
+follow-up lanes to exact resource names whenever possible.
+
 A lane can close while the broader tracking issue remains open. A large-provider
 issue is closeable only when remaining resources are supported, evidence-backed
 deferred or unsupported, or assigned to focused follow-up lanes.
+
+If a clean audit finds no metadata or documentation corrections, leave the
+worktree unchanged instead of creating a docs-only record of the no-op.
 
 ## Testing expectations
 


### PR DESCRIPTION
## Summary

Update provider-maintenance guidance with durable close-out lessons from the Cloudflare CF-C lane.

## Notes

- Clarifies lane closure versus tracker closure.
- Clarifies close-out count reporting.
- Clarifies handling of open-PR-covered unclassified resources.
- Clarifies that no-op audits should not force docs churn.
- No provider behavior changes.

## Validation

- `git diff --check`
- `markdownlint` if available

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Refines provider close-out guidance for large providers to make audits and reporting more durable.
Adds clear rules for lane vs tracker closure (don’t close trackers until required PRs merge or work is split), resource count categories, separating open-PR-covered unclassified resources, narrowing follow-ups to exact resources, and avoiding docs churn on no-op audits.

<sup>Written for commit edfa86371875ed7bb93fc5688adfbf505e29ac3d. Summary will update on new commits. <a href="https://cubic.dev/pr/chenrui333/terraformer/pull/498?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

