### PR TITLE
feat(aws): add S3 and storage imports

### DIFF
--- a/docs/aws.md
+++ b/docs/aws.md
@@ -675,9 +675,14 @@ For AWS provider gap audits and unsupported-resource skip-list maintenance, see 
 *   `s3`
     * `aws_s3_bucket`
     * `aws_s3_bucket_accelerate_configuration`
+    * `aws_s3_bucket_acl`
+    * `aws_s3_bucket_analytics_configuration`
     * `aws_s3_bucket_cors_configuration`
+    * `aws_s3_bucket_intelligent_tiering_configuration`
+    * `aws_s3_bucket_inventory`
     * `aws_s3_bucket_lifecycle_configuration`
     * `aws_s3_bucket_logging`
+    * `aws_s3_bucket_metric`
     * `aws_s3_bucket_notification`
     * `aws_s3_bucket_object_lock_configuration`
     * `aws_s3_bucket_ownership_controls`
@@ -689,10 +694,17 @@ For AWS provider gap audits and unsupported-resource skip-list maintenance, see 
     * `aws_s3_bucket_versioning`
     * `aws_s3_bucket_website_configuration`
 *   `s3control`
+    * `aws_s3_account_public_access_block`
     * `aws_s3_access_point`
+    * `aws_s3control_access_grant`
+    * `aws_s3control_access_grants_instance`
+    * `aws_s3control_access_grants_instance_resource_policy`
+    * `aws_s3control_access_grants_location`
     * `aws_s3control_access_point_policy`
+    * `aws_s3control_multi_region_access_point`
     * `aws_s3control_object_lambda_access_point`
     * `aws_s3control_object_lambda_access_point_policy`
+    * `aws_s3control_storage_lens_configuration`
 *   `s3tables`
     * `aws_s3tables_table_bucket`
     * `aws_s3tables_namespace`

--- a/providers/aws/s3.go
+++ b/providers/aws/s3.go
@@ -27,6 +27,8 @@ const (
 	s3BucketIntelligentTieringConfigurationResourceType = "aws_s3_bucket_intelligent_tiering_configuration"
 	s3BucketInventoryResourceType                       = "aws_s3_bucket_inventory"
 	s3BucketMetricResourceType                          = "aws_s3_bucket_metric"
+	s3BucketACLIDSeparator                              = ","
+	s3BucketCannedACLLogDeliveryWrite                   = "log-delivery-write"
 	s3BucketNamedConfigurationIDSeparator               = ":"
 )
 
@@ -209,7 +211,7 @@ func (g *S3Generator) addBucketACLResource(svc *s3.Client, resources *[]terrafor
 		return
 	}
 	if s3BucketACLImportable(output) {
-		addS3BucketConfigurationResource(resources, bucketName, s3BucketACLResourceType)
+		addS3BucketACLResource(resources, bucketName, s3BucketCannedACL(output))
 	}
 }
 
@@ -311,6 +313,29 @@ func addS3BucketConfigurationResource(resources *[]terraformutils.Resource, buck
 	))
 }
 
+func addS3BucketACLResource(resources *[]terraformutils.Resource, bucketName, acl string) {
+	if bucketName == "" {
+		return
+	}
+	importID := bucketName
+	attributes := map[string]string{
+		"bucket": bucketName,
+	}
+	if acl != "" {
+		importID = strings.Join([]string{bucketName, acl}, s3BucketACLIDSeparator)
+		attributes["acl"] = acl
+	}
+	*resources = append(*resources, terraformutils.NewResource(
+		importID,
+		bucketName,
+		s3BucketACLResourceType,
+		"aws",
+		attributes,
+		S3AllowEmptyValues,
+		S3AdditionalFields,
+	))
+}
+
 func addS3BucketNamedConfigurationResource(resources *[]terraformutils.Resource, bucketName, configurationName, resourceType string) {
 	if bucketName == "" || configurationName == "" {
 		return
@@ -345,8 +370,105 @@ func s3BucketACLImportable(output *s3.GetBucketAclOutput) bool {
 	return output != nil && !s3BucketACLIsDefaultPrivate(output)
 }
 
+func s3BucketCannedACL(output *s3.GetBucketAclOutput) string {
+	if output == nil || output.Owner == nil {
+		return ""
+	}
+	ownerID := StringValue(output.Owner.ID)
+	if ownerID == "" {
+		return ""
+	}
+	ownerFullControl := s3BucketACLGrantMatcher{
+		granteeType: types.TypeCanonicalUser,
+		id:          ownerID,
+		permission:  types.PermissionFullControl,
+	}
+	allUsersRead := s3BucketACLGrantMatcher{
+		granteeType: types.TypeGroup,
+		uriSuffix:   "/groups/global/AllUsers",
+		permission:  types.PermissionRead,
+	}
+	allUsersWrite := s3BucketACLGrantMatcher{
+		granteeType: types.TypeGroup,
+		uriSuffix:   "/groups/global/AllUsers",
+		permission:  types.PermissionWrite,
+	}
+	authenticatedUsersRead := s3BucketACLGrantMatcher{
+		granteeType: types.TypeGroup,
+		uriSuffix:   "/groups/global/AuthenticatedUsers",
+		permission:  types.PermissionRead,
+	}
+	logDeliveryWrite := s3BucketACLGrantMatcher{
+		granteeType: types.TypeGroup,
+		uriSuffix:   "/groups/s3/LogDelivery",
+		permission:  types.PermissionWrite,
+	}
+	logDeliveryReadACP := s3BucketACLGrantMatcher{
+		granteeType: types.TypeGroup,
+		uriSuffix:   "/groups/s3/LogDelivery",
+		permission:  types.PermissionReadAcp,
+	}
+	switch {
+	case s3BucketACLHasOnlyGrants(output, ownerFullControl, allUsersRead):
+		return string(types.BucketCannedACLPublicRead)
+	case s3BucketACLHasOnlyGrants(output, ownerFullControl, allUsersRead, allUsersWrite):
+		return string(types.BucketCannedACLPublicReadWrite)
+	case s3BucketACLHasOnlyGrants(output, ownerFullControl, authenticatedUsersRead):
+		return string(types.BucketCannedACLAuthenticatedRead)
+	case s3BucketACLHasOnlyGrants(output, ownerFullControl, logDeliveryWrite, logDeliveryReadACP):
+		return s3BucketCannedACLLogDeliveryWrite
+	default:
+		return ""
+	}
+}
+
+type s3BucketACLGrantMatcher struct {
+	granteeType types.Type
+	id          string
+	uriSuffix   string
+	permission  types.Permission
+}
+
+func s3BucketACLHasOnlyGrants(output *s3.GetBucketAclOutput, matchers ...s3BucketACLGrantMatcher) bool {
+	if output == nil || len(output.Grants) != len(matchers) {
+		return false
+	}
+	matched := make([]bool, len(output.Grants))
+	for _, matcher := range matchers {
+		matcherFound := false
+		for i, grant := range output.Grants {
+			if matched[i] || !matcher.matches(grant) {
+				continue
+			}
+			matched[i] = true
+			matcherFound = true
+			break
+		}
+		if !matcherFound {
+			return false
+		}
+	}
+	return true
+}
+
+func (m s3BucketACLGrantMatcher) matches(grant types.Grant) bool {
+	if grant.Grantee == nil || grant.Permission != m.permission || grant.Grantee.Type != m.granteeType {
+		return false
+	}
+	if m.id != "" && StringValue(grant.Grantee.ID) != m.id {
+		return false
+	}
+	if m.uriSuffix != "" && !strings.HasSuffix(StringValue(grant.Grantee.URI), m.uriSuffix) {
+		return false
+	}
+	return true
+}
+
 func s3BucketACLIsDefaultPrivate(output *s3.GetBucketAclOutput) bool {
 	if output == nil || len(output.Grants) != 1 {
+		return false
+	}
+	if output.Owner == nil {
 		return false
 	}
 	ownerID := StringValue(output.Owner.ID)

--- a/providers/aws/s3.go
+++ b/providers/aws/s3.go
@@ -580,6 +580,8 @@ POLICY`, g.escapeAwsInterpolation(val.(string)))
 %s
 POLICY`, g.escapeAwsInterpolation(val.(string)))
 			}
+		case s3BucketACLResourceType:
+			removeS3BucketACLComputedPolicy(&g.Resources[i])
 		}
 	}
 	return nil
@@ -629,6 +631,30 @@ func removeS3BucketInlineFields(resource *terraformutils.Resource, fields map[st
 		if resource.InstanceState != nil {
 			deleteFlatmapAttribute(resource.InstanceState.Attributes, field)
 		}
+	}
+}
+
+func removeS3BucketACLComputedPolicy(resource *terraformutils.Resource) {
+	if resource == nil {
+		return
+	}
+	acl := ""
+	if resource.Item != nil {
+		if val, ok := resource.Item["acl"].(string); ok {
+			acl = val
+		}
+	}
+	if acl == "" && resource.InstanceState != nil && resource.InstanceState.Attributes != nil {
+		acl = resource.InstanceState.Attributes["acl"]
+	}
+	if acl == "" {
+		return
+	}
+	if resource.Item != nil {
+		delete(resource.Item, "access_control_policy")
+	}
+	if resource.InstanceState != nil {
+		deleteFlatmapAttribute(resource.InstanceState.Attributes, "access_control_policy")
 	}
 }
 

--- a/providers/aws/s3.go
+++ b/providers/aws/s3.go
@@ -21,7 +21,17 @@ var S3AllowEmptyValues = []string{"tags."}
 
 var S3AdditionalFields = map[string]interface{}{}
 
+const (
+	s3BucketACLResourceType                             = "aws_s3_bucket_acl"
+	s3BucketAnalyticsConfigurationResourceType          = "aws_s3_bucket_analytics_configuration"
+	s3BucketIntelligentTieringConfigurationResourceType = "aws_s3_bucket_intelligent_tiering_configuration"
+	s3BucketInventoryResourceType                       = "aws_s3_bucket_inventory"
+	s3BucketMetricResourceType                          = "aws_s3_bucket_metric"
+	s3BucketNamedConfigurationIDSeparator               = ":"
+)
+
 var s3BucketSplitResourceInlineFields = map[string][]string{
+	s3BucketACLResourceType:                              {"acl", "grant"},
 	"aws_s3_bucket_accelerate_configuration":             {"acceleration_status"},
 	"aws_s3_bucket_cors_configuration":                   {"cors_rule"},
 	"aws_s3_bucket_lifecycle_configuration":              {"lifecycle_rule"},
@@ -94,6 +104,7 @@ func (g *S3Generator) addBucketConfigurationResources(svc *s3.Client, resources 
 	if bucketName == "" {
 		return
 	}
+	g.addBucketACLResource(svc, resources, bucketName)
 	if output, err := svc.GetBucketAccelerateConfiguration(context.TODO(), &s3.GetBucketAccelerateConfigurationInput{Bucket: &bucketName}); err == nil {
 		if output.Status == types.BucketAccelerateStatusEnabled {
 			addS3BucketConfigurationResource(resources, bucketName, "aws_s3_bucket_accelerate_configuration")
@@ -185,6 +196,105 @@ func (g *S3Generator) addBucketConfigurationResources(svc *s3.Client, resources 
 	} else {
 		logS3OptionalBucketConfigurationError(bucketName, "aws_s3_bucket_website_configuration", err)
 	}
+	g.addBucketAnalyticsConfigurations(svc, resources, bucketName)
+	g.addBucketIntelligentTieringConfigurations(svc, resources, bucketName)
+	g.addBucketInventoryConfigurations(svc, resources, bucketName)
+	g.addBucketMetricConfigurations(svc, resources, bucketName)
+}
+
+func (g *S3Generator) addBucketACLResource(svc *s3.Client, resources *[]terraformutils.Resource, bucketName string) {
+	output, err := svc.GetBucketAcl(context.TODO(), &s3.GetBucketAclInput{Bucket: &bucketName})
+	if err != nil {
+		logS3OptionalBucketConfigurationError(bucketName, s3BucketACLResourceType, err)
+		return
+	}
+	if s3BucketACLImportable(output) {
+		addS3BucketConfigurationResource(resources, bucketName, s3BucketACLResourceType)
+	}
+}
+
+func (g *S3Generator) addBucketAnalyticsConfigurations(svc *s3.Client, resources *[]terraformutils.Resource, bucketName string) {
+	var continuationToken *string
+	for {
+		page, err := svc.ListBucketAnalyticsConfigurations(context.TODO(), &s3.ListBucketAnalyticsConfigurationsInput{
+			Bucket:            &bucketName,
+			ContinuationToken: continuationToken,
+		})
+		if err != nil {
+			logS3OptionalBucketConfigurationError(bucketName, s3BucketAnalyticsConfigurationResourceType, err)
+			return
+		}
+		for _, configuration := range page.AnalyticsConfigurationList {
+			addS3BucketNamedConfigurationResource(resources, bucketName, StringValue(configuration.Id), s3BucketAnalyticsConfigurationResourceType)
+		}
+		if !aws.ToBool(page.IsTruncated) || StringValue(page.NextContinuationToken) == "" {
+			return
+		}
+		continuationToken = page.NextContinuationToken
+	}
+}
+
+func (g *S3Generator) addBucketIntelligentTieringConfigurations(svc *s3.Client, resources *[]terraformutils.Resource, bucketName string) {
+	var continuationToken *string
+	for {
+		page, err := svc.ListBucketIntelligentTieringConfigurations(context.TODO(), &s3.ListBucketIntelligentTieringConfigurationsInput{
+			Bucket:            &bucketName,
+			ContinuationToken: continuationToken,
+		})
+		if err != nil {
+			logS3OptionalBucketConfigurationError(bucketName, s3BucketIntelligentTieringConfigurationResourceType, err)
+			return
+		}
+		for _, configuration := range page.IntelligentTieringConfigurationList {
+			addS3BucketNamedConfigurationResource(resources, bucketName, StringValue(configuration.Id), s3BucketIntelligentTieringConfigurationResourceType)
+		}
+		if !aws.ToBool(page.IsTruncated) || StringValue(page.NextContinuationToken) == "" {
+			return
+		}
+		continuationToken = page.NextContinuationToken
+	}
+}
+
+func (g *S3Generator) addBucketInventoryConfigurations(svc *s3.Client, resources *[]terraformutils.Resource, bucketName string) {
+	var continuationToken *string
+	for {
+		page, err := svc.ListBucketInventoryConfigurations(context.TODO(), &s3.ListBucketInventoryConfigurationsInput{
+			Bucket:            &bucketName,
+			ContinuationToken: continuationToken,
+		})
+		if err != nil {
+			logS3OptionalBucketConfigurationError(bucketName, s3BucketInventoryResourceType, err)
+			return
+		}
+		for _, configuration := range page.InventoryConfigurationList {
+			addS3BucketNamedConfigurationResource(resources, bucketName, StringValue(configuration.Id), s3BucketInventoryResourceType)
+		}
+		if !aws.ToBool(page.IsTruncated) || StringValue(page.NextContinuationToken) == "" {
+			return
+		}
+		continuationToken = page.NextContinuationToken
+	}
+}
+
+func (g *S3Generator) addBucketMetricConfigurations(svc *s3.Client, resources *[]terraformutils.Resource, bucketName string) {
+	var continuationToken *string
+	for {
+		page, err := svc.ListBucketMetricsConfigurations(context.TODO(), &s3.ListBucketMetricsConfigurationsInput{
+			Bucket:            &bucketName,
+			ContinuationToken: continuationToken,
+		})
+		if err != nil {
+			logS3OptionalBucketConfigurationError(bucketName, s3BucketMetricResourceType, err)
+			return
+		}
+		for _, configuration := range page.MetricsConfigurationList {
+			addS3BucketNamedConfigurationResource(resources, bucketName, StringValue(configuration.Id), s3BucketMetricResourceType)
+		}
+		if !aws.ToBool(page.IsTruncated) || StringValue(page.NextContinuationToken) == "" {
+			return
+		}
+		continuationToken = page.NextContinuationToken
+	}
 }
 
 func addS3BucketConfigurationResource(resources *[]terraformutils.Resource, bucketName, resourceType string) {
@@ -199,6 +309,54 @@ func addS3BucketConfigurationResource(resources *[]terraformutils.Resource, buck
 		S3AllowEmptyValues,
 		S3AdditionalFields,
 	))
+}
+
+func addS3BucketNamedConfigurationResource(resources *[]terraformutils.Resource, bucketName, configurationName, resourceType string) {
+	if bucketName == "" || configurationName == "" {
+		return
+	}
+	*resources = append(*resources, terraformutils.NewResource(
+		s3BucketNamedConfigurationImportID(bucketName, configurationName),
+		s3BucketNamedConfigurationResourceName(resourceType, bucketName, configurationName),
+		resourceType,
+		"aws",
+		map[string]string{
+			"bucket": bucketName,
+			"name":   configurationName,
+		},
+		S3AllowEmptyValues,
+		S3AdditionalFields,
+	))
+}
+
+func s3BucketNamedConfigurationImportID(bucketName, configurationName string) string {
+	return strings.Join([]string{bucketName, configurationName}, s3BucketNamedConfigurationIDSeparator)
+}
+
+func s3BucketNamedConfigurationResourceName(resourceType, bucketName, configurationName string) string {
+	return strings.Join([]string{strings.TrimPrefix(resourceType, s3BucketResourceTypePrefix()), bucketName, configurationName}, "_")
+}
+
+func s3BucketResourceTypePrefix() string {
+	return "aws" + "_s3_bucket_"
+}
+
+func s3BucketACLImportable(output *s3.GetBucketAclOutput) bool {
+	return output != nil && !s3BucketACLIsDefaultPrivate(output)
+}
+
+func s3BucketACLIsDefaultPrivate(output *s3.GetBucketAclOutput) bool {
+	if output == nil || len(output.Grants) != 1 {
+		return false
+	}
+	ownerID := StringValue(output.Owner.ID)
+	grant := output.Grants[0]
+	if grant.Grantee == nil || ownerID == "" {
+		return false
+	}
+	return grant.Permission == types.PermissionFullControl &&
+		grant.Grantee.Type == types.TypeCanonicalUser &&
+		StringValue(grant.Grantee.ID) == ownerID
 }
 
 func s3BucketNotificationConfigured(output *s3.GetBucketNotificationConfigurationOutput) bool {
@@ -245,6 +403,7 @@ func s3BucketConfigurationMissing(err error) bool {
 	}
 	switch apiErr.ErrorCode() {
 	case "NoSuchBucket",
+		"NoSuchConfiguration",
 		"NoSuchBucketPolicy",
 		"NoSuchCORSConfiguration",
 		"NoSuchLifecycleConfiguration",

--- a/providers/aws/s3_test.go
+++ b/providers/aws/s3_test.go
@@ -60,6 +60,38 @@ func TestAddS3BucketNamedConfigurationResource(t *testing.T) {
 	}
 }
 
+func TestAddS3BucketACLResource(t *testing.T) {
+	var resources []terraformutils.Resource
+	addS3BucketACLResource(&resources, "example-bucket", string(types.BucketCannedACLPublicRead))
+	addS3BucketACLResource(&resources, "custom-bucket", "")
+	addS3BucketACLResource(&resources, "", string(types.BucketCannedACLPublicRead))
+
+	if len(resources) != 2 {
+		t.Fatalf("len(resources) = %d, want 2", len(resources))
+	}
+	cannedACL := resources[0]
+	if cannedACL.InstanceState.ID != "example-bucket,public-read" {
+		t.Fatalf("canned ACL InstanceState.ID = %q, want %q", cannedACL.InstanceState.ID, "example-bucket,public-read")
+	}
+	if cannedACL.InstanceInfo.Type != s3BucketACLResourceType {
+		t.Fatalf("canned ACL InstanceInfo.Type = %q, want %q", cannedACL.InstanceInfo.Type, s3BucketACLResourceType)
+	}
+	if cannedACL.InstanceState.Attributes["bucket"] != "example-bucket" {
+		t.Fatalf("bucket attribute = %q, want example-bucket", cannedACL.InstanceState.Attributes["bucket"])
+	}
+	if cannedACL.InstanceState.Attributes["acl"] != "public-read" {
+		t.Fatalf("acl attribute = %q, want public-read", cannedACL.InstanceState.Attributes["acl"])
+	}
+
+	customACL := resources[1]
+	if customACL.InstanceState.ID != "custom-bucket" {
+		t.Fatalf("custom ACL InstanceState.ID = %q, want custom-bucket", customACL.InstanceState.ID)
+	}
+	if _, ok := customACL.InstanceState.Attributes["acl"]; ok {
+		t.Fatalf("custom ACL resource unexpectedly set canned acl attribute: %#v", customACL.InstanceState.Attributes)
+	}
+}
+
 func TestS3BucketMetricConfigurationsPaginate(t *testing.T) {
 	requests := 0
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -142,6 +174,73 @@ func TestS3BucketACLImportable(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			if got := s3BucketACLImportable(tt.output); got != tt.want {
 				t.Fatalf("s3BucketACLImportable() = %t, want %t", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestS3BucketCannedACL(t *testing.T) {
+	ownerID := "owner-canonical-id"
+	tests := []struct {
+		name   string
+		grants []types.Grant
+		want   string
+	}{
+		{
+			name: "public read",
+			grants: []types.Grant{
+				s3OwnerGrant(ownerID),
+				s3GroupGrant("/groups/global/AllUsers", types.PermissionRead),
+			},
+			want: string(types.BucketCannedACLPublicRead),
+		},
+		{
+			name: "public read write",
+			grants: []types.Grant{
+				s3GroupGrant("/groups/global/AllUsers", types.PermissionWrite),
+				s3OwnerGrant(ownerID),
+				s3GroupGrant("/groups/global/AllUsers", types.PermissionRead),
+			},
+			want: string(types.BucketCannedACLPublicReadWrite),
+		},
+		{
+			name: "authenticated read",
+			grants: []types.Grant{
+				s3OwnerGrant(ownerID),
+				s3GroupGrant("/groups/global/AuthenticatedUsers", types.PermissionRead),
+			},
+			want: string(types.BucketCannedACLAuthenticatedRead),
+		},
+		{
+			name: "log delivery write",
+			grants: []types.Grant{
+				s3OwnerGrant(ownerID),
+				s3GroupGrant("/groups/s3/LogDelivery", types.PermissionWrite),
+				s3GroupGrant("/groups/s3/LogDelivery", types.PermissionReadAcp),
+			},
+			want: s3BucketCannedACLLogDeliveryWrite,
+		},
+		{
+			name: "custom grant",
+			grants: []types.Grant{
+				s3OwnerGrant(ownerID),
+				{
+					Grantee:    &types.Grantee{ID: aws.String("other-canonical-id"), Type: types.TypeCanonicalUser},
+					Permission: types.PermissionRead,
+				},
+			},
+			want: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			output := &s3.GetBucketAclOutput{
+				Owner:  &types.Owner{ID: aws.String(ownerID)},
+				Grants: tt.grants,
+			}
+			if got := s3BucketCannedACL(output); got != tt.want {
+				t.Fatalf("s3BucketCannedACL() = %q, want %q", got, tt.want)
 			}
 		})
 	}
@@ -410,4 +509,18 @@ func writeS3XML(w http.ResponseWriter, status int, body string) {
 	w.Header().Set("Content-Type", "application/xml")
 	w.WriteHeader(status)
 	_, _ = w.Write([]byte(body))
+}
+
+func s3OwnerGrant(ownerID string) types.Grant {
+	return types.Grant{
+		Grantee:    &types.Grantee{ID: aws.String(ownerID), Type: types.TypeCanonicalUser},
+		Permission: types.PermissionFullControl,
+	}
+}
+
+func s3GroupGrant(uriSuffix string, permission types.Permission) types.Grant {
+	return types.Grant{
+		Grantee:    &types.Grantee{Type: types.TypeGroup, URI: aws.String("http://acs.amazonaws.com" + uriSuffix)},
+		Permission: permission,
+	}
 }

--- a/providers/aws/s3_test.go
+++ b/providers/aws/s3_test.go
@@ -3,9 +3,15 @@
 package aws
 
 import (
+	"encoding/json"
 	"errors"
+	"net/http"
+	"net/http/httptest"
+	"os"
 	"testing"
 
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/credentials"
 	"github.com/aws/aws-sdk-go-v2/service/s3"
 	"github.com/aws/aws-sdk-go-v2/service/s3/types"
 	"github.com/aws/smithy-go"
@@ -27,6 +33,117 @@ func TestAddS3BucketConfigurationResource(t *testing.T) {
 	}
 	if resource.InstanceState.Attributes["bucket"] != "example-bucket" {
 		t.Fatalf("bucket attribute = %q, want %q", resource.InstanceState.Attributes["bucket"], "example-bucket")
+	}
+}
+
+func TestAddS3BucketNamedConfigurationResource(t *testing.T) {
+	var resources []terraformutils.Resource
+	addS3BucketNamedConfigurationResource(&resources, "example-bucket", "EntireBucket", s3BucketMetricResourceType)
+	addS3BucketNamedConfigurationResource(&resources, "", "skip", s3BucketMetricResourceType)
+	addS3BucketNamedConfigurationResource(&resources, "example-bucket", "", s3BucketMetricResourceType)
+
+	if len(resources) != 1 {
+		t.Fatalf("len(resources) = %d, want 1", len(resources))
+	}
+	resource := resources[0]
+	if resource.InstanceState.ID != "example-bucket:EntireBucket" {
+		t.Fatalf("InstanceState.ID = %q, want %q", resource.InstanceState.ID, "example-bucket:EntireBucket")
+	}
+	if resource.InstanceInfo.Type != s3BucketMetricResourceType {
+		t.Fatalf("InstanceInfo.Type = %q, want %q", resource.InstanceInfo.Type, s3BucketMetricResourceType)
+	}
+	if resource.InstanceState.Attributes["bucket"] != "example-bucket" {
+		t.Fatalf("bucket attribute = %q, want example-bucket", resource.InstanceState.Attributes["bucket"])
+	}
+	if resource.InstanceState.Attributes["name"] != "EntireBucket" {
+		t.Fatalf("name attribute = %q, want EntireBucket", resource.InstanceState.Attributes["name"])
+	}
+}
+
+func TestS3BucketMetricConfigurationsPaginate(t *testing.T) {
+	requests := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/example-bucket" {
+			t.Errorf("path = %q, want /example-bucket", r.URL.Path)
+		}
+		if _, ok := r.URL.Query()["metrics"]; !ok {
+			t.Errorf("missing metrics query in %q", r.URL.RawQuery)
+		}
+		requests++
+		switch requests {
+		case 1:
+			if got := r.URL.Query().Get("continuation-token"); got != "" {
+				t.Errorf("first continuation-token = %q, want empty", got)
+			}
+			writeS3XML(w, http.StatusOK, "<ListMetricsConfigurationsResult xmlns=\"http://s3.amazonaws.com/doc/2006-03-01/\"><IsTruncated>true</IsTruncated><NextContinuationToken>page-2</NextContinuationToken><MetricsConfiguration><Id>EntireBucket</Id></MetricsConfiguration></ListMetricsConfigurationsResult>")
+		case 2:
+			if got := r.URL.Query().Get("continuation-token"); got != "page-2" {
+				t.Errorf("second continuation-token = %q, want page-2", got)
+			}
+			writeS3XML(w, http.StatusOK, "<ListMetricsConfigurationsResult xmlns=\"http://s3.amazonaws.com/doc/2006-03-01/\"><IsTruncated>false</IsTruncated><MetricsConfiguration><Id>LogsOnly</Id></MetricsConfiguration></ListMetricsConfigurationsResult>")
+		default:
+			t.Errorf("unexpected metrics request %d", requests)
+			writeS3XML(w, http.StatusOK, "<ListMetricsConfigurationsResult xmlns=\"http://s3.amazonaws.com/doc/2006-03-01/\"><IsTruncated>false</IsTruncated></ListMetricsConfigurationsResult>")
+		}
+	}))
+	t.Cleanup(server.Close)
+
+	var resources []terraformutils.Resource
+	generator := &S3Generator{}
+	generator.addBucketMetricConfigurations(newTestS3Client(server), &resources, "example-bucket")
+
+	if requests != 2 {
+		t.Fatalf("requests = %d, want 2", requests)
+	}
+	wantIDs := []string{"example-bucket:EntireBucket", "example-bucket:LogsOnly"}
+	if len(resources) != len(wantIDs) {
+		t.Fatalf("len(resources) = %d, want %d", len(resources), len(wantIDs))
+	}
+	for i, wantID := range wantIDs {
+		if got := resources[i].InstanceState.ID; got != wantID {
+			t.Fatalf("resource[%d] ID = %q, want %q", i, got, wantID)
+		}
+	}
+}
+
+func TestS3BucketACLImportable(t *testing.T) {
+	ownerID := "owner-canonical-id"
+	tests := []struct {
+		name   string
+		output *s3.GetBucketAclOutput
+		want   bool
+	}{
+		{name: "nil", want: false},
+		{
+			name: "default private",
+			output: &s3.GetBucketAclOutput{
+				Owner: &types.Owner{ID: aws.String(ownerID)},
+				Grants: []types.Grant{{
+					Grantee:    &types.Grantee{ID: aws.String(ownerID), Type: types.TypeCanonicalUser},
+					Permission: types.PermissionFullControl,
+				}},
+			},
+			want: false,
+		},
+		{
+			name: "non-owner grant",
+			output: &s3.GetBucketAclOutput{
+				Owner: &types.Owner{ID: aws.String(ownerID)},
+				Grants: []types.Grant{{
+					Grantee:    &types.Grantee{ID: aws.String("other-canonical-id"), Type: types.TypeCanonicalUser},
+					Permission: types.PermissionRead,
+				}},
+			},
+			want: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := s3BucketACLImportable(tt.output); got != tt.want {
+				t.Fatalf("s3BucketACLImportable() = %t, want %t", got, tt.want)
+			}
+		})
 	}
 }
 
@@ -142,13 +259,25 @@ func TestS3BucketInlineFieldsByBucket(t *testing.T) {
 		S3AllowEmptyValues,
 		S3AdditionalFields,
 	)
+	acl := terraformutils.NewResource(
+		"acl-bucket",
+		"acl-bucket",
+		s3BucketACLResourceType,
+		"aws",
+		map[string]string{"bucket": "acl-bucket"},
+		S3AllowEmptyValues,
+		S3AdditionalFields,
+	)
 
-	fieldsByBucket := s3BucketInlineFieldsByBucket([]terraformutils.Resource{versioning, policy})
+	fieldsByBucket := s3BucketInlineFieldsByBucket([]terraformutils.Resource{versioning, policy, acl})
 	if _, ok := fieldsByBucket["versioned-bucket"]["versioning"]; !ok {
 		t.Fatalf("versioning inline field was not tracked: %#v", fieldsByBucket)
 	}
 	if _, ok := fieldsByBucket["policy-bucket"]["policy"]; !ok {
 		t.Fatalf("policy inline field was not tracked from resource ID fallback: %#v", fieldsByBucket)
+	}
+	if _, ok := fieldsByBucket["acl-bucket"]["acl"]; !ok {
+		t.Fatalf("acl inline field was not tracked: %#v", fieldsByBucket)
 	}
 }
 
@@ -200,4 +329,85 @@ func TestRemoveS3BucketInlineFields(t *testing.T) {
 	if _, ok := resource.InstanceState.Attributes["lifecycle_rule.#"]; !ok {
 		t.Fatal("unselected lifecycle_rule flatmap prefix was removed")
 	}
+}
+
+func TestS3NamedConfigurationFilterBehavior(t *testing.T) {
+	var resources []terraformutils.Resource
+	addS3BucketNamedConfigurationResource(&resources, "example-bucket", "prod", s3BucketMetricResourceType)
+	resource := resources[0]
+
+	if !(&terraformutils.ResourceFilter{ServiceName: "s3_bucket_metric", FieldPath: "name", AcceptableValues: []string{"prod"}}).Filter(resource) {
+		t.Fatal("expected typed name filter to keep S3 metric configuration")
+	}
+	if (&terraformutils.ResourceFilter{ServiceName: "s3_bucket_metric", FieldPath: "name", AcceptableValues: []string{"dev"}}).Filter(resource) {
+		t.Fatal("expected typed name filter to drop non-matching S3 metric configuration")
+	}
+}
+
+func TestS3UnsupportedResourceEntries(t *testing.T) {
+	data, err := os.ReadFile("unsupported_resources.json")
+	if err != nil {
+		t.Fatalf("read unsupported resources: %v", err)
+	}
+	var unsupported map[string]interface{}
+	if err := json.Unmarshal(data, &unsupported); err != nil {
+		t.Fatalf("decode unsupported resources: %v", err)
+	}
+	entries, ok := unsupported["resources"].([]interface{})
+	if !ok {
+		t.Fatal("unsupported resources file is missing resources list")
+	}
+
+	found := map[string]bool{
+		"aws_s3_bucket_object": false,
+		"aws_s3_object":        false,
+		"aws_s3_object_copy":   false,
+	}
+	for _, rawEntry := range entries {
+		entry, ok := rawEntry.(map[string]interface{})
+		if !ok {
+			t.Fatalf("unsupported resource entry has unexpected type %T", rawEntry)
+		}
+		resource, _ := entry["resource"].(string)
+		if _, ok := found[resource]; !ok {
+			continue
+		}
+		found[resource] = true
+		if serviceFamily, _ := entry["service_family"].(string); serviceFamily != "s3" {
+			t.Fatalf("%s service family = %q, want s3", resource, serviceFamily)
+		}
+		if status, _ := entry["status"].(string); status != "unsupported" {
+			t.Fatalf("%s status = %q, want unsupported", resource, status)
+		}
+		references, _ := entry["references"].([]interface{})
+		reason, _ := entry["reason"].(string)
+		evidence, _ := entry["evidence"].(string)
+		if reason == "" || evidence == "" || len(references) == 0 {
+			t.Fatalf("%s unsupported entry is missing reason, evidence, or references", resource)
+		}
+	}
+	for resource, ok := range found {
+		if !ok {
+			t.Fatalf("%s unsupported entry was not found", resource)
+		}
+	}
+}
+
+func newTestS3Client(server *httptest.Server) *s3.Client {
+	config := aws.Config{
+		Region:           "us-east-1",
+		Credentials:      credentials.NewStaticCredentialsProvider("test", "test", ""),
+		HTTPClient:       server.Client(),
+		RetryMaxAttempts: 1,
+	}
+	return s3.NewFromConfig(config, func(options *s3.Options) {
+		options.BaseEndpoint = aws.String(server.URL)
+		options.UsePathStyle = true
+	})
+}
+
+func writeS3XML(w http.ResponseWriter, status int, body string) {
+	w.Header().Set("Content-Type", "application/xml")
+	w.WriteHeader(status)
+	_, _ = w.Write([]byte(body))
 }

--- a/providers/aws/s3_test.go
+++ b/providers/aws/s3_test.go
@@ -430,6 +430,94 @@ func TestRemoveS3BucketInlineFields(t *testing.T) {
 	}
 }
 
+func TestS3PostConvertHookRemovesComputedACLPolicyForCannedACL(t *testing.T) {
+	cannedACL := terraformutils.NewResource(
+		"example-bucket,public-read",
+		"example-bucket",
+		s3BucketACLResourceType,
+		"aws",
+		map[string]string{
+			"bucket":                                     "example-bucket",
+			"acl":                                        "public-read",
+			"access_control_policy.#":                    "1",
+			"access_control_policy.0.grant.#":            "1",
+			"access_control_policy.0.grant.0.type":       "Group",
+			"access_control_policy.0.grant.0.uri":        "http://acs.amazonaws.com/groups/global/AllUsers",
+			"access_control_policy.0.grant.0.permission": "READ",
+		},
+		S3AllowEmptyValues,
+		S3AdditionalFields,
+	)
+	cannedACL.Item = map[string]interface{}{
+		"bucket": "example-bucket",
+		"acl":    "public-read",
+		"access_control_policy": []interface{}{
+			map[string]interface{}{
+				"grant": []interface{}{
+					map[string]interface{}{
+						"type":       "Group",
+						"uri":        "http://acs.amazonaws.com/groups/global/AllUsers",
+						"permission": "READ",
+					},
+				},
+			},
+		},
+	}
+	customACL := terraformutils.NewResource(
+		"custom-bucket",
+		"custom-bucket",
+		s3BucketACLResourceType,
+		"aws",
+		map[string]string{
+			"bucket":                                     "custom-bucket",
+			"access_control_policy.#":                    "1",
+			"access_control_policy.0.grant.#":            "1",
+			"access_control_policy.0.grant.0.id":         "canonical-user-id",
+			"access_control_policy.0.grant.0.permission": "READ",
+		},
+		S3AllowEmptyValues,
+		S3AdditionalFields,
+	)
+	customACL.Item = map[string]interface{}{
+		"bucket": "custom-bucket",
+		"access_control_policy": []interface{}{
+			map[string]interface{}{
+				"grant": []interface{}{
+					map[string]interface{}{
+						"id":         "canonical-user-id",
+						"permission": "READ",
+					},
+				},
+			},
+		},
+	}
+	generator := &S3Generator{}
+	generator.Resources = []terraformutils.Resource{cannedACL, customACL}
+
+	if err := generator.PostConvertHook(); err != nil {
+		t.Fatalf("PostConvertHook() error = %v", err)
+	}
+
+	if got := generator.Resources[0].Item["acl"]; got != "public-read" {
+		t.Fatalf("canned ACL acl = %v, want public-read", got)
+	}
+	if _, ok := generator.Resources[0].Item["access_control_policy"]; ok {
+		t.Fatal("canned ACL access_control_policy was not removed from rendered item")
+	}
+	if _, ok := generator.Resources[0].InstanceState.Attributes["access_control_policy.#"]; ok {
+		t.Fatal("canned ACL access_control_policy flatmap prefix was not removed")
+	}
+	if _, ok := generator.Resources[0].InstanceState.Attributes["access_control_policy.0.grant.0.uri"]; ok {
+		t.Fatal("canned ACL nested access_control_policy flatmap field was not removed")
+	}
+	if _, ok := generator.Resources[1].Item["access_control_policy"]; !ok {
+		t.Fatal("custom ACL access_control_policy was removed from rendered item")
+	}
+	if _, ok := generator.Resources[1].InstanceState.Attributes["access_control_policy.#"]; !ok {
+		t.Fatal("custom ACL access_control_policy flatmap prefix was removed")
+	}
+}
+
 func TestS3NamedConfigurationFilterBehavior(t *testing.T) {
 	var resources []terraformutils.Resource
 	addS3BucketNamedConfigurationResource(&resources, "example-bucket", "prod", s3BucketMetricResourceType)

--- a/providers/aws/s3control.go
+++ b/providers/aws/s3control.go
@@ -32,6 +32,7 @@ const (
 	s3ControlStorageLensConfigurationResourceType      = "aws_s3control_storage_lens_configuration"
 	s3ControlAccessPointIDSeparator                    = ":"
 	s3ControlCommaIDSeparator                          = ","
+	s3ControlMultiRegionAccessPointRegion              = "us-west-2"
 )
 
 var s3ControlAllowEmptyValues = []string{"tags."}
@@ -210,7 +211,7 @@ func (g *S3ControlGenerator) loadMultiRegionAccessPoints(svc *s3control.Client, 
 		AccountId: aws.String(accountID),
 	})
 	for paginator.HasMorePages() {
-		page, err := paginator.NextPage(context.TODO())
+		page, err := paginator.NextPage(context.TODO(), s3ControlMultiRegionAccessPointOperationOption)
 		if s3ControlResourceNotFound(err) {
 			return nil
 		}
@@ -780,6 +781,10 @@ func s3ControlMultiRegionAccessPointImportable(accessPoint s3controltypes.MultiR
 	default:
 		return false
 	}
+}
+
+func s3ControlMultiRegionAccessPointOperationOption(options *s3control.Options) {
+	options.Region = s3ControlMultiRegionAccessPointRegion
 }
 
 func s3ControlResourceName(parts ...string) string {

--- a/providers/aws/s3control.go
+++ b/providers/aws/s3control.go
@@ -57,13 +57,13 @@ func (g *S3ControlGenerator) InitResources() error {
 	svc := s3control.NewFromConfig(config)
 	g.addAccountPublicAccessBlock(svc, *accountID)
 	if err := g.loadAccessGrants(svc, *accountID); err != nil {
-		return err
+		log.Printf("skipping S3 Control Access Grants discovery for %s: %v", *accountID, err)
 	}
 	if err := g.loadMultiRegionAccessPoints(svc, *accountID); err != nil {
-		return err
+		log.Printf("skipping S3 Control Multi-Region Access Point discovery for %s: %v", *accountID, err)
 	}
 	if err := g.loadStorageLensConfigurations(svc, *accountID); err != nil {
-		return err
+		log.Printf("skipping S3 Control Storage Lens discovery for %s: %v", *accountID, err)
 	}
 	if err := g.loadAccessPoints(svc, *accountID); err != nil {
 		return err

--- a/providers/aws/s3control.go
+++ b/providers/aws/s3control.go
@@ -19,11 +19,19 @@ import (
 )
 
 const (
+	s3AccountPublicAccessBlockResourceType             = "aws_s3_account_public_access_block"
 	s3ControlAccessPointResourceType                   = "aws_s3_access_point"
 	s3ControlAccessPointPolicyResourceType             = "aws_s3control_access_point_policy"
+	s3ControlAccessGrantResourceType                   = "aws_s3control_access_grant"
+	s3ControlAccessGrantsInstanceResourceType          = "aws_s3control_access_grants_instance"
+	s3ControlAccessGrantsInstanceResourcePolicyType    = "aws_s3control_access_grants_instance_resource_policy"
+	s3ControlAccessGrantsLocationResourceType          = "aws_s3control_access_grants_location"
+	s3ControlMultiRegionAccessPointResourceType        = "aws_s3control_multi_region_access_point"
 	s3ControlObjectLambdaAccessPointResourceType       = "aws_s3control_object_lambda_access_point"
 	s3ControlObjectLambdaAccessPointPolicyResourceType = "aws_s3control_object_lambda_access_point_policy"
+	s3ControlStorageLensConfigurationResourceType      = "aws_s3control_storage_lens_configuration"
 	s3ControlAccessPointIDSeparator                    = ":"
+	s3ControlCommaIDSeparator                          = ","
 )
 
 var s3ControlAllowEmptyValues = []string{"tags."}
@@ -46,6 +54,16 @@ func (g *S3ControlGenerator) InitResources() error {
 	}
 
 	svc := s3control.NewFromConfig(config)
+	g.addAccountPublicAccessBlock(svc, *accountID)
+	if err := g.loadAccessGrants(svc, *accountID); err != nil {
+		return err
+	}
+	if err := g.loadMultiRegionAccessPoints(svc, *accountID); err != nil {
+		return err
+	}
+	if err := g.loadStorageLensConfigurations(svc, *accountID); err != nil {
+		return err
+	}
 	if err := g.loadAccessPoints(svc, *accountID); err != nil {
 		return err
 	}
@@ -70,8 +88,160 @@ func (g *S3ControlGenerator) PostConvertHook() error {
 			}
 			wrapS3ControlPolicyHeredoc(g, &g.Resources[i])
 		case s3ControlAccessPointPolicyResourceType,
+			s3ControlAccessGrantsInstanceResourcePolicyType,
 			s3ControlObjectLambdaAccessPointPolicyResourceType:
 			wrapS3ControlPolicyHeredoc(g, &g.Resources[i])
+		}
+	}
+	return nil
+}
+
+func (g *S3ControlGenerator) addAccountPublicAccessBlock(svc *s3control.Client, accountID string) {
+	if accountID == "" {
+		return
+	}
+	output, err := svc.GetPublicAccessBlock(context.TODO(), &s3control.GetPublicAccessBlockInput{
+		AccountId: aws.String(accountID),
+	})
+	if s3ControlResourceNotFound(err) {
+		return
+	}
+	if err != nil {
+		log.Printf("skipping S3 account public access block discovery for %s: %v", accountID, err)
+		return
+	}
+	if output == nil || output.PublicAccessBlockConfiguration == nil {
+		return
+	}
+	if resource, ok := newS3AccountPublicAccessBlockResource(accountID, output.PublicAccessBlockConfiguration); ok {
+		g.Resources = append(g.Resources, resource)
+	}
+}
+
+func (g *S3ControlGenerator) loadAccessGrants(svc *s3control.Client, accountID string) error {
+	if accountID == "" {
+		return nil
+	}
+	if err := g.loadAccessGrantsInstances(svc, accountID); err != nil {
+		return err
+	}
+	if err := g.loadAccessGrantsLocations(svc, accountID); err != nil {
+		return err
+	}
+	return g.loadAccessGrantResources(svc, accountID)
+}
+
+func (g *S3ControlGenerator) loadAccessGrantsInstances(svc *s3control.Client, accountID string) error {
+	paginator := s3control.NewListAccessGrantsInstancesPaginator(svc, &s3control.ListAccessGrantsInstancesInput{
+		AccountId: aws.String(accountID),
+	})
+	for paginator.HasMorePages() {
+		page, err := paginator.NextPage(context.TODO())
+		if s3ControlResourceNotFound(err) {
+			return nil
+		}
+		if err != nil {
+			return err
+		}
+		for _, instance := range page.AccessGrantsInstancesList {
+			if resource, ok := newS3ControlAccessGrantsInstanceResource(accountID, instance); ok {
+				g.Resources = append(g.Resources, resource)
+			}
+		}
+	}
+	g.addAccessGrantsInstanceResourcePolicy(svc, accountID)
+	return nil
+}
+
+func (g *S3ControlGenerator) addAccessGrantsInstanceResourcePolicy(svc *s3control.Client, accountID string) {
+	policy, ok := getS3ControlAccessGrantsInstanceResourcePolicy(svc, accountID)
+	if !ok {
+		return
+	}
+	if resource, ok := newS3ControlAccessGrantsInstanceResourcePolicyResource(accountID, policy); ok {
+		g.Resources = append(g.Resources, resource)
+	}
+}
+
+func (g *S3ControlGenerator) loadAccessGrantsLocations(svc *s3control.Client, accountID string) error {
+	paginator := s3control.NewListAccessGrantsLocationsPaginator(svc, &s3control.ListAccessGrantsLocationsInput{
+		AccountId: aws.String(accountID),
+	})
+	for paginator.HasMorePages() {
+		page, err := paginator.NextPage(context.TODO())
+		if s3ControlResourceNotFound(err) {
+			return nil
+		}
+		if err != nil {
+			return err
+		}
+		for _, location := range page.AccessGrantsLocationsList {
+			if resource, ok := newS3ControlAccessGrantsLocationResource(accountID, location); ok {
+				g.Resources = append(g.Resources, resource)
+			}
+		}
+	}
+	return nil
+}
+
+func (g *S3ControlGenerator) loadAccessGrantResources(svc *s3control.Client, accountID string) error {
+	paginator := s3control.NewListAccessGrantsPaginator(svc, &s3control.ListAccessGrantsInput{
+		AccountId: aws.String(accountID),
+	})
+	for paginator.HasMorePages() {
+		page, err := paginator.NextPage(context.TODO())
+		if s3ControlResourceNotFound(err) {
+			return nil
+		}
+		if err != nil {
+			return err
+		}
+		for _, grant := range page.AccessGrantsList {
+			if resource, ok := newS3ControlAccessGrantResource(accountID, grant); ok {
+				g.Resources = append(g.Resources, resource)
+			}
+		}
+	}
+	return nil
+}
+
+func (g *S3ControlGenerator) loadMultiRegionAccessPoints(svc *s3control.Client, accountID string) error {
+	paginator := s3control.NewListMultiRegionAccessPointsPaginator(svc, &s3control.ListMultiRegionAccessPointsInput{
+		AccountId: aws.String(accountID),
+	})
+	for paginator.HasMorePages() {
+		page, err := paginator.NextPage(context.TODO())
+		if s3ControlResourceNotFound(err) {
+			return nil
+		}
+		if err != nil {
+			return err
+		}
+		for _, accessPoint := range page.AccessPoints {
+			if resource, ok := newS3ControlMultiRegionAccessPointResource(accountID, accessPoint); ok {
+				g.Resources = append(g.Resources, resource)
+			}
+		}
+	}
+	return nil
+}
+
+func (g *S3ControlGenerator) loadStorageLensConfigurations(svc *s3control.Client, accountID string) error {
+	paginator := s3control.NewListStorageLensConfigurationsPaginator(svc, &s3control.ListStorageLensConfigurationsInput{
+		AccountId: aws.String(accountID),
+	})
+	for paginator.HasMorePages() {
+		page, err := paginator.NextPage(context.TODO())
+		if s3ControlResourceNotFound(err) {
+			return nil
+		}
+		if err != nil {
+			return err
+		}
+		for _, configuration := range page.StorageLensConfigurationList {
+			if resource, ok := newS3ControlStorageLensConfigurationResource(accountID, configuration); ok {
+				g.Resources = append(g.Resources, resource)
+			}
 		}
 	}
 	return nil
@@ -191,6 +361,153 @@ func (g *S3ControlGenerator) addObjectLambdaAccessPointPolicy(svc *s3control.Cli
 	if resource, ok := newS3ControlObjectLambdaAccessPointPolicyResource(accountID, name, policy); ok {
 		g.Resources = append(g.Resources, resource)
 	}
+}
+
+func newS3AccountPublicAccessBlockResource(accountID string, configuration *s3controltypes.PublicAccessBlockConfiguration) (terraformutils.Resource, bool) {
+	if accountID == "" || configuration == nil {
+		return terraformutils.Resource{}, false
+	}
+	return terraformutils.NewResource(
+		accountID,
+		s3ControlResourceName("account_public_access_block", accountID),
+		s3AccountPublicAccessBlockResourceType,
+		"aws",
+		map[string]string{
+			"account_id": accountID,
+		},
+		s3ControlAllowEmptyValues,
+		map[string]interface{}{},
+	), true
+}
+
+func newS3ControlAccessGrantsInstanceResource(accountID string, instance s3controltypes.ListAccessGrantsInstanceEntry) (terraformutils.Resource, bool) {
+	instanceID := StringValue(instance.AccessGrantsInstanceId)
+	if accountID == "" || instanceID == "" {
+		return terraformutils.Resource{}, false
+	}
+	resource := terraformutils.NewResource(
+		accountID,
+		s3ControlResourceName("access_grants_instance", accountID, instanceID),
+		s3ControlAccessGrantsInstanceResourceType,
+		"aws",
+		map[string]string{
+			"account_id": accountID,
+		},
+		s3ControlAllowEmptyValues,
+		map[string]interface{}{},
+	)
+	setAwsFrameworkResourcePreserveIDAfterRefresh(&resource)
+	return resource, true
+}
+
+func newS3ControlAccessGrantsInstanceResourcePolicyResource(accountID, policy string) (terraformutils.Resource, bool) {
+	if accountID == "" || policy == "" {
+		return terraformutils.Resource{}, false
+	}
+	resource := terraformutils.NewResource(
+		accountID,
+		s3ControlResourceName("access_grants_instance_resource_policy", accountID),
+		s3ControlAccessGrantsInstanceResourcePolicyType,
+		"aws",
+		map[string]string{
+			"account_id": accountID,
+			"policy":     policy,
+		},
+		s3ControlAllowEmptyValues,
+		map[string]interface{}{},
+	)
+	setAwsFrameworkResourcePreserveIDAfterRefresh(&resource)
+	return resource, true
+}
+
+func newS3ControlAccessGrantsLocationResource(accountID string, location s3controltypes.ListAccessGrantsLocationsEntry) (terraformutils.Resource, bool) {
+	locationID := StringValue(location.AccessGrantsLocationId)
+	locationScope := StringValue(location.LocationScope)
+	iamRoleARN := StringValue(location.IAMRoleArn)
+	if accountID == "" || locationID == "" || locationScope == "" || iamRoleARN == "" {
+		return terraformutils.Resource{}, false
+	}
+	resource := terraformutils.NewResource(
+		s3ControlCommaImportID(accountID, locationID),
+		s3ControlResourceName("access_grants_location", accountID, locationID),
+		s3ControlAccessGrantsLocationResourceType,
+		"aws",
+		map[string]string{
+			"access_grants_location_id": locationID,
+			"account_id":                accountID,
+			"iam_role_arn":              iamRoleARN,
+			"location_scope":            locationScope,
+		},
+		s3ControlAllowEmptyValues,
+		map[string]interface{}{},
+	)
+	setAwsFrameworkResourcePreserveIDAfterRefresh(&resource)
+	return resource, true
+}
+
+func newS3ControlAccessGrantResource(accountID string, grant s3controltypes.ListAccessGrantEntry) (terraformutils.Resource, bool) {
+	grantID := StringValue(grant.AccessGrantId)
+	locationID := StringValue(grant.AccessGrantsLocationId)
+	permission := string(grant.Permission)
+	if accountID == "" || grantID == "" || locationID == "" || permission == "" || grant.Grantee == nil {
+		return terraformutils.Resource{}, false
+	}
+	if StringValue(grant.Grantee.GranteeIdentifier) == "" || grant.Grantee.GranteeType == "" {
+		return terraformutils.Resource{}, false
+	}
+	resource := terraformutils.NewResource(
+		s3ControlCommaImportID(accountID, grantID),
+		s3ControlResourceName("access_grant", accountID, grantID),
+		s3ControlAccessGrantResourceType,
+		"aws",
+		map[string]string{
+			"access_grant_id":           grantID,
+			"access_grants_location_id": locationID,
+			"account_id":                accountID,
+			"permission":                permission,
+		},
+		s3ControlAllowEmptyValues,
+		map[string]interface{}{},
+	)
+	setAwsFrameworkResourcePreserveIDAfterRefresh(&resource)
+	return resource, true
+}
+
+func newS3ControlMultiRegionAccessPointResource(accountID string, accessPoint s3controltypes.MultiRegionAccessPointReport) (terraformutils.Resource, bool) {
+	name := StringValue(accessPoint.Name)
+	if accountID == "" || name == "" || !s3ControlMultiRegionAccessPointImportable(accessPoint) {
+		return terraformutils.Resource{}, false
+	}
+	return terraformutils.NewResource(
+		s3ControlColonImportID(accountID, name),
+		s3ControlResourceName("multi_region_access_point", accountID, name),
+		s3ControlMultiRegionAccessPointResourceType,
+		"aws",
+		map[string]string{
+			"account_id": accountID,
+		},
+		s3ControlAllowEmptyValues,
+		map[string]interface{}{},
+	), true
+}
+
+func newS3ControlStorageLensConfigurationResource(accountID string, configuration s3controltypes.ListStorageLensConfigurationEntry) (terraformutils.Resource, bool) {
+	configID := StringValue(configuration.Id)
+	if accountID == "" || configID == "" {
+		return terraformutils.Resource{}, false
+	}
+	return terraformutils.NewResource(
+		s3ControlColonImportID(accountID, configID),
+		s3ControlResourceName("storage_lens_configuration", accountID, configID),
+		s3ControlStorageLensConfigurationResourceType,
+		"aws",
+		map[string]string{
+			"account_id": accountID,
+			"config_id":  configID,
+		},
+		s3ControlAllowEmptyValues,
+		map[string]interface{}{},
+	), true
 }
 
 func newS3ControlAccessPointResource(accountID string, accessPoint *s3control.GetAccessPointOutput) (terraformutils.Resource, bool) {
@@ -366,6 +683,30 @@ func getS3ControlObjectLambdaAccessPointPolicy(svc *s3control.Client, accountID,
 	return policy, true
 }
 
+func getS3ControlAccessGrantsInstanceResourcePolicy(svc *s3control.Client, accountID string) (string, bool) {
+	if accountID == "" {
+		return "", false
+	}
+	policyOutput, err := svc.GetAccessGrantsInstanceResourcePolicy(context.TODO(), &s3control.GetAccessGrantsInstanceResourcePolicyInput{
+		AccountId: aws.String(accountID),
+	})
+	if s3ControlResourceNotFound(err) {
+		return "", false
+	}
+	if err != nil {
+		log.Printf("skipping S3 Control Access Grants instance resource policy discovery for %s: %v", accountID, err)
+		return "", false
+	}
+	if policyOutput == nil {
+		return "", false
+	}
+	policy := StringValue(policyOutput.Policy)
+	if policy == "" {
+		return "", false
+	}
+	return policy, true
+}
+
 func s3ControlAccessPointImportID(accountID, accessPointName, accessPointARN string) string {
 	if s3ControlARNService(accessPointARN) == "s3-outposts" {
 		return accessPointARN
@@ -396,6 +737,14 @@ func s3ControlObjectLambdaAccessPointImportID(accountID, accessPointName string)
 	return strings.Join([]string{accountID, accessPointName}, s3ControlAccessPointIDSeparator)
 }
 
+func s3ControlCommaImportID(parts ...string) string {
+	return strings.Join(parts, s3ControlCommaIDSeparator)
+}
+
+func s3ControlColonImportID(parts ...string) string {
+	return strings.Join(parts, s3ControlAccessPointIDSeparator)
+}
+
 func s3ControlAccessPointAPIName(accessPointName, accessPointARN string) string {
 	if s3ControlARNService(accessPointARN) == "s3-outposts" {
 		return accessPointARN
@@ -421,6 +770,16 @@ func s3ControlObjectLambdaAccessPointImportable(configuration *s3control.GetAcce
 
 func s3ControlObjectLambdaAccessPointReadable(accessPoint *s3control.GetAccessPointForObjectLambdaOutput) bool {
 	return accessPoint != nil && accessPoint.Alias != nil
+}
+
+func s3ControlMultiRegionAccessPointImportable(accessPoint s3controltypes.MultiRegionAccessPointReport) bool {
+	switch accessPoint.Status {
+	case s3controltypes.MultiRegionAccessPointStatusReady,
+		s3controltypes.MultiRegionAccessPointStatusInconsistentAcrossRegions:
+		return true
+	default:
+		return false
+	}
 }
 
 func s3ControlResourceName(parts ...string) string {
@@ -452,11 +811,16 @@ func s3ControlResourceNotFound(err error) bool {
 		return false
 	}
 	switch apiErr.ErrorCode() {
-	case "NoSuchAccessPoint",
+	case "NoSuchAccessGrant",
+		"NoSuchAccessGrantsInstance",
+		"NoSuchAccessGrantsLocation",
+		"NoSuchAccessPoint",
 		"NoSuchAccessPointPolicy",
 		"NoSuchBucket",
+		"NoSuchPublicAccessBlockConfiguration",
 		"NotFound",
-		"NotFoundException":
+		"NotFoundException",
+		"ResourceNotFoundException":
 		return true
 	default:
 		return false

--- a/providers/aws/s3control.go
+++ b/providers/aws/s3control.go
@@ -55,12 +55,17 @@ func (g *S3ControlGenerator) InitResources() error {
 	}
 
 	svc := s3control.NewFromConfig(config)
-	g.addAccountPublicAccessBlock(svc, *accountID)
+	loadAccountGlobalResources := s3ControlShouldLoadAccountGlobalResources(g.GetArgs()["region"].(string))
+	if loadAccountGlobalResources {
+		g.addAccountPublicAccessBlock(svc, *accountID)
+	}
 	if err := g.loadAccessGrants(svc, *accountID); err != nil {
 		log.Printf("skipping S3 Control Access Grants discovery for %s: %v", *accountID, err)
 	}
-	if err := g.loadMultiRegionAccessPoints(svc, *accountID); err != nil {
-		log.Printf("skipping S3 Control Multi-Region Access Point discovery for %s: %v", *accountID, err)
+	if loadAccountGlobalResources {
+		if err := g.loadMultiRegionAccessPoints(svc, *accountID); err != nil {
+			log.Printf("skipping S3 Control Multi-Region Access Point discovery for %s: %v", *accountID, err)
+		}
 	}
 	if err := g.loadStorageLensConfigurations(svc, *accountID); err != nil {
 		log.Printf("skipping S3 Control Storage Lens discovery for %s: %v", *accountID, err)
@@ -785,6 +790,10 @@ func s3ControlMultiRegionAccessPointImportable(accessPoint s3controltypes.MultiR
 
 func s3ControlMultiRegionAccessPointOperationOption(options *s3control.Options) {
 	options.Region = s3ControlMultiRegionAccessPointRegion
+}
+
+func s3ControlShouldLoadAccountGlobalResources(region string) bool {
+	return region == NoRegion || region == MainRegionPublicPartition
 }
 
 func s3ControlResourceName(parts ...string) string {

--- a/providers/aws/s3control_test.go
+++ b/providers/aws/s3control_test.go
@@ -357,6 +357,14 @@ func TestS3ControlMultiRegionAccessPointImportable(t *testing.T) {
 	}
 }
 
+func TestS3ControlMultiRegionAccessPointOperationOption(t *testing.T) {
+	options := &s3control.Options{Region: "eu-central-1"}
+	s3ControlMultiRegionAccessPointOperationOption(options)
+	if options.Region != s3ControlMultiRegionAccessPointRegion {
+		t.Fatalf("Region = %q, want %q", options.Region, s3ControlMultiRegionAccessPointRegion)
+	}
+}
+
 func TestS3ControlResourceNameAvoidsSanitizedCollisions(t *testing.T) {
 	left := terraformutils.TfSanitize(s3ControlResourceName("access_point", testS3ControlAccountID, "a_b", "c"))
 	right := terraformutils.TfSanitize(s3ControlResourceName("access_point", testS3ControlAccountID, "a", "b_c"))

--- a/providers/aws/s3control_test.go
+++ b/providers/aws/s3control_test.go
@@ -365,6 +365,28 @@ func TestS3ControlMultiRegionAccessPointOperationOption(t *testing.T) {
 	}
 }
 
+func TestS3ControlShouldLoadAccountGlobalResources(t *testing.T) {
+	tests := []struct {
+		name   string
+		region string
+		want   bool
+	}{
+		{name: "default import", region: NoRegion, want: true},
+		{name: "canonical public partition region", region: MainRegionPublicPartition, want: true},
+		{name: "global sentinel", region: GlobalRegion, want: false},
+		{name: "mrap control plane region", region: s3ControlMultiRegionAccessPointRegion, want: false},
+		{name: "other regional import", region: "eu-central-1", want: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := s3ControlShouldLoadAccountGlobalResources(tt.region); got != tt.want {
+				t.Fatalf("s3ControlShouldLoadAccountGlobalResources(%q) = %t, want %t", tt.region, got, tt.want)
+			}
+		})
+	}
+}
+
 func TestS3ControlResourceNameAvoidsSanitizedCollisions(t *testing.T) {
 	left := terraformutils.TfSanitize(s3ControlResourceName("access_point", testS3ControlAccountID, "a_b", "c"))
 	right := terraformutils.TfSanitize(s3ControlResourceName("access_point", testS3ControlAccountID, "a", "b_c"))

--- a/providers/aws/s3control_test.go
+++ b/providers/aws/s3control_test.go
@@ -185,6 +185,77 @@ func TestNewS3ControlObjectLambdaAccessPointPolicyResource(t *testing.T) {
 	}
 }
 
+func TestNewS3ControlStorageReleaseResources(t *testing.T) {
+	accountPublicAccessBlock, ok := newS3AccountPublicAccessBlockResource(testS3ControlAccountID, &s3controltypes.PublicAccessBlockConfiguration{})
+	assertS3ControlResourceAttributes(t, accountPublicAccessBlock, ok, s3AccountPublicAccessBlockResourceType, testS3ControlAccountID,
+		[]string{"account_public_access_block", testS3ControlAccountID},
+		map[string]string{"account_id": testS3ControlAccountID})
+
+	instance, ok := newS3ControlAccessGrantsInstanceResource(testS3ControlAccountID, s3controltypes.ListAccessGrantsInstanceEntry{
+		AccessGrantsInstanceId: aws.String("default"),
+	})
+	assertS3ControlResourceAttributes(t, instance, ok, s3ControlAccessGrantsInstanceResourceType, testS3ControlAccountID,
+		[]string{"access_grants_instance", testS3ControlAccountID, "default"},
+		map[string]string{"account_id": testS3ControlAccountID})
+	assertAwsFrameworkResourcePreserveIDAfterRefresh(t, instance)
+
+	policyBody := `{"Version":"2012-10-17"}`
+	resourcePolicy, ok := newS3ControlAccessGrantsInstanceResourcePolicyResource(testS3ControlAccountID, policyBody)
+	assertS3ControlResourceAttributes(t, resourcePolicy, ok, s3ControlAccessGrantsInstanceResourcePolicyType, testS3ControlAccountID,
+		[]string{"access_grants_instance_resource_policy", testS3ControlAccountID},
+		map[string]string{"account_id": testS3ControlAccountID, "policy": policyBody})
+	assertAwsFrameworkResourcePreserveIDAfterRefresh(t, resourcePolicy)
+
+	location, ok := newS3ControlAccessGrantsLocationResource(testS3ControlAccountID, s3controltypes.ListAccessGrantsLocationsEntry{
+		AccessGrantsLocationId: aws.String("default"),
+		IAMRoleArn:             aws.String("arn:aws:iam::123456789012:role/access-grants"),
+		LocationScope:          aws.String("s3://"),
+	})
+	assertS3ControlResourceAttributes(t, location, ok, s3ControlAccessGrantsLocationResourceType, "123456789012,default",
+		[]string{"access_grants_location", testS3ControlAccountID, "default"},
+		map[string]string{
+			"access_grants_location_id": "default",
+			"account_id":                testS3ControlAccountID,
+			"iam_role_arn":              "arn:aws:iam::123456789012:role/access-grants",
+			"location_scope":            "s3://",
+		})
+	assertAwsFrameworkResourcePreserveIDAfterRefresh(t, location)
+
+	grant, ok := newS3ControlAccessGrantResource(testS3ControlAccountID, s3controltypes.ListAccessGrantEntry{
+		AccessGrantId:          aws.String("grant-123"),
+		AccessGrantsLocationId: aws.String("default"),
+		Grantee: &s3controltypes.Grantee{
+			GranteeIdentifier: aws.String("arn:aws:iam::123456789012:role/app"),
+			GranteeType:       s3controltypes.GranteeTypeIam,
+		},
+		Permission: s3controltypes.PermissionRead,
+	})
+	assertS3ControlResourceAttributes(t, grant, ok, s3ControlAccessGrantResourceType, "123456789012,grant-123",
+		[]string{"access_grant", testS3ControlAccountID, "grant-123"},
+		map[string]string{
+			"access_grant_id":           "grant-123",
+			"access_grants_location_id": "default",
+			"account_id":                testS3ControlAccountID,
+			"permission":                "READ",
+		})
+	assertAwsFrameworkResourcePreserveIDAfterRefresh(t, grant)
+
+	mrap, ok := newS3ControlMultiRegionAccessPointResource(testS3ControlAccountID, s3controltypes.MultiRegionAccessPointReport{
+		Name:   aws.String("global-assets"),
+		Status: s3controltypes.MultiRegionAccessPointStatusReady,
+	})
+	assertS3ControlResourceAttributes(t, mrap, ok, s3ControlMultiRegionAccessPointResourceType, "123456789012:global-assets",
+		[]string{"multi_region_access_point", testS3ControlAccountID, "global-assets"},
+		map[string]string{"account_id": testS3ControlAccountID})
+
+	storageLens, ok := newS3ControlStorageLensConfigurationResource(testS3ControlAccountID, s3controltypes.ListStorageLensConfigurationEntry{
+		Id: aws.String("org-lens"),
+	})
+	assertS3ControlResourceAttributes(t, storageLens, ok, s3ControlStorageLensConfigurationResourceType, "123456789012:org-lens",
+		[]string{"storage_lens_configuration", testS3ControlAccountID, "org-lens"},
+		map[string]string{"account_id": testS3ControlAccountID, "config_id": "org-lens"})
+}
+
 func TestS3ControlAccessPointImportIDFromARN(t *testing.T) {
 	outpostsARN := "arn:aws:s3-outposts:us-east-1:123456789012:outpost/op-1234567890123456/accesspoint/core-ap"
 	tests := []struct {
@@ -264,6 +335,28 @@ func TestS3ControlObjectLambdaAccessPointReadable(t *testing.T) {
 	}
 }
 
+func TestS3ControlMultiRegionAccessPointImportable(t *testing.T) {
+	tests := []struct {
+		name   string
+		status s3controltypes.MultiRegionAccessPointStatus
+		want   bool
+	}{
+		{name: "ready", status: s3controltypes.MultiRegionAccessPointStatusReady, want: true},
+		{name: "inconsistent", status: s3controltypes.MultiRegionAccessPointStatusInconsistentAcrossRegions, want: true},
+		{name: "creating", status: s3controltypes.MultiRegionAccessPointStatusCreating, want: false},
+		{name: "deleting", status: s3controltypes.MultiRegionAccessPointStatusDeleting, want: false},
+		{name: "empty", want: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := s3ControlMultiRegionAccessPointImportable(s3controltypes.MultiRegionAccessPointReport{Status: tt.status}); got != tt.want {
+				t.Fatalf("importable = %t, want %t", got, tt.want)
+			}
+		})
+	}
+}
+
 func TestS3ControlResourceNameAvoidsSanitizedCollisions(t *testing.T) {
 	left := terraformutils.TfSanitize(s3ControlResourceName("access_point", testS3ControlAccountID, "a_b", "c"))
 	right := terraformutils.TfSanitize(s3ControlResourceName("access_point", testS3ControlAccountID, "a", "b_c"))
@@ -280,7 +373,10 @@ func TestS3ControlResourceNotFound(t *testing.T) {
 	}{
 		{name: "nil", want: false},
 		{name: "typed not found", err: &s3controltypes.NotFoundException{}, want: true},
+		{name: "no such access grant", err: &smithy.GenericAPIError{Code: "NoSuchAccessGrant"}, want: true},
+		{name: "no such access grants instance", err: &smithy.GenericAPIError{Code: "NoSuchAccessGrantsInstance"}, want: true},
 		{name: "no such access point", err: &smithy.GenericAPIError{Code: "NoSuchAccessPoint"}, want: true},
+		{name: "no account public access block", err: &smithy.GenericAPIError{Code: "NoSuchPublicAccessBlockConfiguration"}, want: true},
 		{name: "no such policy", err: &smithy.GenericAPIError{Code: "NoSuchAccessPointPolicy"}, want: true},
 		{name: "wrapped not found", err: errors.Join(errors.New("lookup failed"), &s3controltypes.NotFoundException{}), want: true},
 		{name: "access denied", err: &smithy.GenericAPIError{Code: "AccessDenied"}, want: false},

--- a/providers/aws/unsupported_resources.json
+++ b/providers/aws/unsupported_resources.json
@@ -467,6 +467,42 @@
       ]
     },
     {
+      "resource": "aws_s3_bucket_object",
+      "service_family": "s3",
+      "reason": "S3 bucket objects are high-cardinality object content, not durable infrastructure configuration for broad account inventory.",
+      "evidence": "Terraform AWS provider models aws_s3_bucket_object around object bodies, sources, checksums, and metadata. S3 ListObjectsV2 can enumerate object keys but cannot reconstruct local source files or safe generated HCL for arbitrary bucket contents.",
+      "status": "unsupported",
+      "references": [
+        "https://github.com/chenrui333/terraformer/issues/338",
+        "https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_object",
+        "https://docs.aws.amazon.com/AmazonS3/latest/API/API_ListObjectsV2.html"
+      ]
+    },
+    {
+      "resource": "aws_s3_object",
+      "service_family": "s3",
+      "reason": "S3 objects are high-cardinality object content, not durable infrastructure configuration for broad account inventory.",
+      "evidence": "Terraform AWS provider models aws_s3_object around object content, source paths, checksums, and metadata. S3 ListObjectsV2 can enumerate object keys but cannot reconstruct local source files or safe generated HCL for arbitrary bucket contents.",
+      "status": "unsupported",
+      "references": [
+        "https://github.com/chenrui333/terraformer/issues/338",
+        "https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_object",
+        "https://docs.aws.amazon.com/AmazonS3/latest/API/API_ListObjectsV2.html"
+      ]
+    },
+    {
+      "resource": "aws_s3_object_copy",
+      "service_family": "s3",
+      "reason": "S3 object copies are action-style resources; broad discovery can see destination objects but cannot reconstruct the original copy operation as stable infrastructure ownership.",
+      "evidence": "Terraform AWS provider requires source and destination object copy configuration. S3 object listing and HeadObject describe the resulting object, not the original copy request, source object lifecycle, or copy-time options.",
+      "status": "unsupported",
+      "references": [
+        "https://github.com/chenrui333/terraformer/issues/338",
+        "https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_object_copy",
+        "https://docs.aws.amazon.com/AmazonS3/latest/API/API_CopyObject.html"
+      ]
+    },
+    {
       "resource": "aws_sagemaker_human_task_ui",
       "service_family": "sagemaker",
       "reason": "SageMaker Human Task UI imports cannot reconstruct the required ui_template.content field from SageMaker APIs.",


### PR DESCRIPTION
## Summary

Add release-critical AWS S3 / storage import coverage.

## Resources

- aws_s3_bucket_acl
- aws_s3_bucket_analytics_configuration
- aws_s3_bucket_intelligent_tiering_configuration
- aws_s3_bucket_inventory
- aws_s3_bucket_metric
- aws_s3_account_public_access_block
- aws_s3control_access_grant
- aws_s3control_access_grants_instance
- aws_s3control_access_grants_instance_resource_policy
- aws_s3control_access_grants_location
- aws_s3control_multi_region_access_point
- aws_s3control_storage_lens_configuration

## Deferred / Unsupported

- aws_s3_bucket_object
- aws_s3_object
- aws_s3_object_copy

## Scope

This PR is limited to AWS S3 / storage release-critical inventory coverage.

## Validation

- `go test ./providers/aws -run 'Test.*S3|Test.*s3|Test.*S3Control|Test.*s3control|Test.*FSX|Test.*Fsx|Test.*fsx|Test.*DataSync|Test.*Datasync|Test.*datasync|Test.*StorageGateway|Test.*Storagegateway|Test.*storagegateway|Test.*Transfer|Test.*transfer'`
- `go test ./providers/aws/... ./terraformutils/... ./tools/aws-gap-inventory/...`
- `go run ./tools/aws-gap-inventory -docs docs/aws.md -aws-dir providers/aws -skip-list providers/aws/unsupported_resources.json -format markdown`
- `jq . providers/aws/unsupported_resources.json`
- `git diff --check`

Ref: #338

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds AWS S3 and S3 Control importers for release‑critical storage resources to close remaining inventory gaps. Hardens discovery paths, gates global S3 Control discovery, and prevents duplicate S3 ACL fields.

- **New Features**
  - S3: `aws_s3_bucket_acl`, `aws_s3_bucket_analytics_configuration`, `aws_s3_bucket_intelligent_tiering_configuration`, `aws_s3_bucket_inventory`, `aws_s3_bucket_metric` (analytics/intelligent‑tiering/inventory/metric paginate; ACLs only when non‑default private).
  - S3Control: `aws_s3_account_public_access_block`, `aws_s3control_access_grant`, `aws_s3control_access_grants_instance`, `aws_s3control_access_grants_instance_resource_policy`, `aws_s3control_access_grants_location`, `aws_s3control_multi_region_access_point`, `aws_s3control_storage_lens_configuration` (MRAPs imported only when ready/consistent).
  - Unsupported (documented): `aws_s3_bucket_object`, `aws_s3_object`, `aws_s3_object_copy`.

- **Bug Fixes**
  - S3: safer optional config handling and pagination; ignore default‑private ACLs; remove computed ACL policy for canned ACLs to avoid duplicate fields; treat `NoSuchConfiguration` as missing.
  - S3Control: route MRAP listing via `us-west-2`; broaden not‑found handling for access grants and account public access block; gate account‑global discovery (account public access block, MRAPs, Storage Lens) to default/`us-east-1` runs to avoid noise in regional imports.

<sup>Written for commit c5e8cdac227841e940ef9c868416647258c85d5e. Summary will update on new commits. <a href="https://cubic.dev/pr/chenrui333/terraformer/pull/499?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

