### PR TITLE
docs: update Helm provider maintenance guidance

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -397,6 +397,44 @@ Rules:
 - Add table-driven tests for allowed and skipped states.
 - Treat transient states as deferred, not unsupported, unless provider import is fundamentally impossible.
 
+## Release, Version, and History Resources
+
+Resources that expose releases, revisions, snapshots, rollouts, or history need
+extra boundaries before broad import.
+
+Rules:
+
+- Import only the latest durable managed revision by default. Skip historical,
+  superseded, deleted, pending, failed, or rollback states unless provider
+  refresh and follow-up plan behavior are verified safe.
+- Use exact ID filters for resource families where broad discovery is
+  permission-sensitive, noisy, or only partially safe. Keep filter IDs in the
+  upstream provider-compatible shape, and preserve exact-filter matches through
+  post-refresh cleanup if provider read normalizes state IDs.
+- When skipped variants are lifecycle states of an otherwise supported
+  Terraform resource, document and test the skip predicates in provider docs and
+  tests instead of adding unsupported-resource metadata for each state.
+
+## Discovery Auth and Refresh-State Hygiene
+
+Discovery clients and Terraform provider refresh must target the same account,
+cluster, project, namespace, or region context.
+
+Rules:
+
+- Bridge provider-supported auth and context settings into provider or domain
+  SDK discovery clients when Terraformer discovers with one client and refreshes
+  with the Terraform provider. Keep credentials in environment variables,
+  profiles, kubeconfig files, or provider config; do not write them into
+  generated HCL.
+- Partial imports of safe metadata are acceptable when the provider can refresh
+  the resource and unrecoverable authored fields are optional or intentionally
+  omitted. Document the omitted fields and any manual follow-up in
+  `docs/<provider>.md`.
+- If provider refresh exposes runtime, source, rendered, or sensitive fields
+  that Terraformer should not own or export, scrub them from flat state, typed
+  state, and generated item data before writing output.
+
 ## Singleton and Default Settings
 
 Account, project, workspace, catalog, dataset, and region singleton settings should be imported carefully.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -405,8 +405,8 @@ extra boundaries before broad import.
 Rules:
 
 - Import only the latest durable managed revision by default. Skip historical,
-  superseded, deleted, pending, failed, or rollback states unless provider
-  refresh and follow-up plan behavior are verified safe.
+  superseded, deleted, pending, rollback, or otherwise non-manageable states
+  unless provider refresh and follow-up plan behavior are verified safe.
 - Use exact ID filters for resource families where broad discovery is
   permission-sensitive, noisy, or only partially safe. Keep filter IDs in the
   upstream provider-compatible shape, and preserve exact-filter matches through
@@ -422,11 +422,10 @@ cluster, project, namespace, or region context.
 
 Rules:
 
-- Bridge provider-supported auth and context settings into provider or domain
-  SDK discovery clients when Terraformer discovers with one client and refreshes
-  with the Terraform provider. Keep credentials in environment variables,
-  profiles, kubeconfig files, or provider config; do not write them into
-  generated HCL.
+- Align provider-supported auth and context settings between provider/domain SDK
+  discovery clients and Terraform provider refresh. Keep credentials in
+  environment variables, profiles, kubeconfig files, or provider config; do not
+  write them into generated HCL.
 - Partial imports of safe metadata are acceptable when the provider can refresh
   the resource and unrecoverable authored fields are optional or intentionally
   omitted. Document the omitted fields and any manual follow-up in


### PR DESCRIPTION
## Summary

Update repo-local engineering and agent guidance with durable lessons from Helm release import work.

## Notes

- Clarifies partial imports for safe metadata.
- Clarifies skipped states of supported resources versus unsupported Terraform resource types.
- Clarifies scrubbing unsafe provider refresh state.
- Clarifies aligning discovery and provider refresh auth without exporting credentials.
- No provider behavior changes.

## Validation

- `git diff --check`
- `markdownlint` if available

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updated Helm provider maintenance docs to tighten release/version/history import rules: use exact ID filters, document/test skip predicates, and align discovery auth/context with provider refresh. Also clarifies partial imports (document omitted fields) and scrubbing runtime/rendered/sensitive data from flat, typed, and generated outputs; no provider behavior changes.

<sup>Written for commit 9fac560c166ae96b06671dd6bb5c015530c74599. Summary will update on new commits. <a href="https://cubic.dev/pr/chenrui333/terraformer/pull/500?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

