### PR TITLE
feat(cloudflare): add connectivity directory service and tunnel route imports

### DIFF
--- a/docs/cloudflare.md
+++ b/docs/cloudflare.md
@@ -39,6 +39,8 @@ List of supported Cloudflare services:
   * `cloudflare_custom_origin_trust_store`
   * `cloudflare_mtls_certificate`
   * `cloudflare_origin_ca_certificate`
+* `connectivity`
+  * `cloudflare_connectivity_directory_service`
 * `dns`
   * `cloudflare_dns_record`
   * `cloudflare_zone`
@@ -164,6 +166,7 @@ List of supported Cloudflare services:
   * `cloudflare_turnstile_widget`
 * `tunnel`
   * `cloudflare_zero_trust_tunnel_cloudflared`
+  * `cloudflare_zero_trust_tunnel_cloudflared_route`
   * `cloudflare_zero_trust_tunnel_cloudflared_virtual_network`
 * `waiting_room`
   * `cloudflare_waiting_room`

--- a/providers/cloudflare/cloudflare_provider.go
+++ b/providers/cloudflare/cloudflare_provider.go
@@ -36,6 +36,7 @@ func (p *CloudflareProvider) GetSupportedService() map[string]terraformutils.Ser
 		"page_rule":             &PageRulesGenerator{},
 		"account_member":        &AccountMemberGenerator{},
 		"certificates":          &CertificatesGenerator{},
+		"connectivity":          &ConnectivityGenerator{},
 		"lists":                 &ListsGenerator{},
 		"email_routing":         &EmailRoutingGenerator{},
 		"load_balancing":        &LoadBalancingGenerator{},

--- a/providers/cloudflare/cloudflare_service.go
+++ b/providers/cloudflare/cloudflare_service.go
@@ -105,6 +105,33 @@ func cloudflareAdvancePagination(info *cf.ResultInfo, page *int, cursor *string)
 	return false
 }
 
+func cloudflareAdvancePaginationWithItemCount(info *cf.ResultInfo, page *int, cursor *string, itemCount int) bool {
+	if cloudflareAdvancePagination(info, page, cursor) {
+		return true
+	}
+	if info == nil || *cursor != "" {
+		return false
+	}
+
+	pageSize := cloudflarePageSize
+	if info.PerPage > 0 {
+		pageSize = info.PerPage
+	}
+	if itemCount < pageSize {
+		return false
+	}
+	if info.Page > 0 {
+		nextPage := info.Page + 1
+		if nextPage <= *page {
+			return false
+		}
+		*page = nextPage
+		return true
+	}
+	*page++
+	return true
+}
+
 func cloudflareZones(ctx context.Context, api *cf.API) ([]cf.Zone, error) {
 	return api.ListZones(ctx)
 }

--- a/providers/cloudflare/connectivity.go
+++ b/providers/cloudflare/connectivity.go
@@ -1,0 +1,121 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package cloudflare
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+
+	"github.com/chenrui333/terraformer/terraformutils"
+	cf "github.com/cloudflare/cloudflare-go"
+)
+
+type ConnectivityGenerator struct {
+	CloudflareService
+}
+
+type cloudflareConnectivityDirectoryService struct {
+	ID        string `json:"id"`
+	ServiceID string `json:"service_id"`
+	Name      string `json:"name"`
+	Type      string `json:"type"`
+}
+
+func (s cloudflareConnectivityDirectoryService) resourceID() string {
+	if s.ServiceID != "" {
+		return s.ServiceID
+	}
+	return s.ID
+}
+
+func (g *ConnectivityGenerator) appendConnectivityDirectoryServiceResources(ctx context.Context, api *cf.API, accountID string) error {
+	services, err := listConnectivityDirectoryServices(ctx, api, accountID)
+	if err != nil {
+		return err
+	}
+	for _, service := range services {
+		resource, ok := cloudflareConnectivityDirectoryServiceResource(accountID, service)
+		if ok {
+			g.Resources = append(g.Resources, resource)
+		}
+	}
+	return nil
+}
+
+func listConnectivityDirectoryServices(ctx context.Context, api *cf.API, accountID string) ([]cloudflareConnectivityDirectoryService, error) {
+	var services []cloudflareConnectivityDirectoryService
+	page, cursor := 1, ""
+	for {
+		response, err := api.Raw(
+			ctx,
+			http.MethodGet,
+			fmt.Sprintf("/accounts/%s/connectivity/directory/services?%s", accountID, cloudflarePaginationQuery(page, cursor)),
+			nil,
+			nil,
+		)
+		if err != nil {
+			return nil, err
+		}
+		if len(response.Result) == 0 || string(response.Result) == "null" {
+			return services, nil
+		}
+
+		var pageServices []cloudflareConnectivityDirectoryService
+		if err := json.Unmarshal(response.Result, &pageServices); err != nil {
+			return nil, err
+		}
+		services = append(services, pageServices...)
+		if !cloudflareAdvancePaginationWithItemCount(response.ResultInfo, &page, &cursor, len(pageServices)) {
+			break
+		}
+	}
+	return services, nil
+}
+
+func cloudflareConnectivityDirectoryServiceResource(
+	accountID string,
+	service cloudflareConnectivityDirectoryService,
+) (terraformutils.Resource, bool) {
+	serviceID := service.resourceID()
+	if accountID == "" || serviceID == "" {
+		return terraformutils.Resource{}, false
+	}
+
+	attributes := map[string]string{
+		"account_id": accountID,
+		"service_id": serviceID,
+	}
+	if service.Name != "" {
+		attributes["name"] = service.Name
+	}
+	if service.Type != "" {
+		attributes["type"] = service.Type
+	}
+
+	resource := terraformutils.NewResource(
+		serviceID,
+		cloudflareResourceName(accountID, "connectivity_directory_service", service.Name, serviceID),
+		"cloudflare_connectivity_directory_service",
+		"cloudflare",
+		attributes,
+		[]string{},
+		map[string]interface{}{},
+	)
+	setCloudflareImportID(&resource, accountID+"/"+serviceID)
+	return resource, true
+}
+
+func (g *ConnectivityGenerator) InitResources() error {
+	ctx := context.Background()
+	api, err := g.initializeAPI()
+	if err != nil {
+		return err
+	}
+	account, err := g.accountResourceContainer()
+	if err != nil {
+		return err
+	}
+	return g.appendConnectivityDirectoryServiceResources(ctx, api, account.Identifier)
+}

--- a/providers/cloudflare/connectivity_test.go
+++ b/providers/cloudflare/connectivity_test.go
@@ -1,0 +1,103 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package cloudflare
+
+import (
+	"context"
+	"net/http"
+	"testing"
+
+	"github.com/chenrui333/terraformer/terraformutils"
+)
+
+func TestCloudflareConnectivityDirectoryServiceResource(t *testing.T) {
+	resource, ok := cloudflareConnectivityDirectoryServiceResource("account-123", cloudflareConnectivityDirectoryService{
+		ServiceID: "service-456",
+		Name:      "private-api",
+		Type:      "http",
+	})
+	if !ok {
+		t.Fatal("expected connectivity directory service resource")
+	}
+	if got := resource.InstanceInfo.Type; got != "cloudflare_connectivity_directory_service" {
+		t.Fatalf("resource type = %q, want cloudflare_connectivity_directory_service", got)
+	}
+	if got := resource.InstanceState.ID; got != "service-456" {
+		t.Fatalf("resource ID = %q, want service-456", got)
+	}
+	if got := resource.InstanceState.Attributes["account_id"]; got != "account-123" {
+		t.Fatalf("account_id = %q, want account-123", got)
+	}
+	if got := resource.InstanceState.Attributes["service_id"]; got != "service-456" {
+		t.Fatalf("service_id = %q, want service-456", got)
+	}
+	if got := resource.InstanceState.Attributes["name"]; got != "private-api" {
+		t.Fatalf("name = %q, want private-api", got)
+	}
+	if got := resource.InstanceState.Attributes["type"]; got != "http" {
+		t.Fatalf("type = %q, want http", got)
+	}
+	if got, want := resource.ResourceName, terraformutils.TfSanitize(cloudflareResourceName("account-123", "connectivity_directory_service", "private-api", "service-456")); got != want {
+		t.Fatalf("resource name = %q, want %q", got, want)
+	}
+	if got := resource.InstanceState.Meta["import_id"]; got != "account-123/service-456" {
+		t.Fatalf("import_id = %q, want account-123/service-456", got)
+	}
+}
+
+func TestCloudflareConnectivityDirectoryServiceResourceSkipsMalformedServices(t *testing.T) {
+	if _, ok := cloudflareConnectivityDirectoryServiceResource("", cloudflareConnectivityDirectoryService{ServiceID: "service-456"}); ok {
+		t.Fatal("expected service without account ID to be skipped")
+	}
+	if _, ok := cloudflareConnectivityDirectoryServiceResource("account-123", cloudflareConnectivityDirectoryService{}); ok {
+		t.Fatal("expected service without service ID to be skipped")
+	}
+	resource, ok := cloudflareConnectivityDirectoryServiceResource("account-123", cloudflareConnectivityDirectoryService{ID: "id-fallback"})
+	if !ok {
+		t.Fatal("expected legacy id fallback to be accepted")
+	}
+	if got := resource.InstanceState.Attributes["service_id"]; got != "id-fallback" {
+		t.Fatalf("service_id = %q, want id-fallback", got)
+	}
+}
+
+func TestAppendConnectivityDirectoryServiceResourcesPaginates(t *testing.T) {
+	api := newCloudflareNetworkEdgeTestAPI(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/accounts/account-123/connectivity/directory/services" {
+			t.Fatalf("path = %q, want /accounts/account-123/connectivity/directory/services", r.URL.Path)
+		}
+		switch r.URL.Query().Get("cursor") {
+		case "":
+			if got := r.URL.Query().Get("page"); got != "1" {
+				t.Fatalf("page query = %q, want 1", got)
+			}
+			writeCloudflareNetworkEdgeTestResponse(t, w, []map[string]string{
+				{"service_id": "service-1", "name": "api", "type": "http"},
+			}, map[string]interface{}{
+				"cursors": map[string]string{"after": "cursor-2"},
+			})
+		case "cursor-2":
+			writeCloudflareNetworkEdgeTestResponse(t, w, []map[string]string{
+				{"service_id": "service-2", "name": "ssh", "type": "tcp"},
+			}, map[string]interface{}{
+				"cursors": map[string]string{},
+			})
+		default:
+			t.Fatalf("cursor query = %q, want empty or cursor-2", r.URL.Query().Get("cursor"))
+		}
+	}))
+
+	generator := &ConnectivityGenerator{}
+	if err := generator.appendConnectivityDirectoryServiceResources(context.Background(), api, "account-123"); err != nil {
+		t.Fatalf("appendConnectivityDirectoryServiceResources() error = %v", err)
+	}
+	if len(generator.Resources) != 2 {
+		t.Fatalf("resource count = %d, want 2", len(generator.Resources))
+	}
+	if got := generator.Resources[0].InstanceState.Meta["import_id"]; got != "account-123/service-1" {
+		t.Fatalf("first import_id = %q, want account-123/service-1", got)
+	}
+	if got := generator.Resources[1].InstanceState.Meta["import_id"]; got != "account-123/service-2" {
+		t.Fatalf("second import_id = %q, want account-123/service-2", got)
+	}
+}

--- a/providers/cloudflare/final_four_test.go
+++ b/providers/cloudflare/final_four_test.go
@@ -1,0 +1,41 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package cloudflare
+
+import (
+	"encoding/json"
+	"os"
+	"testing"
+)
+
+func TestCloudflareFinalFourUnsupportedResourcesMetadata(t *testing.T) {
+	data, err := os.ReadFile("unsupported_resources.json")
+	if err != nil {
+		t.Fatalf("read unsupported resources: %v", err)
+	}
+	var metadata cloudflareUnsupportedResourcesFile
+	if err := json.Unmarshal(data, &metadata); err != nil {
+		t.Fatalf("decode unsupported resources: %v", err)
+	}
+
+	statuses := map[string]string{}
+	for _, resource := range metadata.Resources {
+		statuses[resource.Resource] = resource.Status
+	}
+	for _, resource := range []string{
+		"cloudflare_ai_gateway_dynamic_routing",
+		"cloudflare_zero_trust_tunnel_cloudflared_config",
+	} {
+		if got := statuses[resource]; got != "deferred" {
+			t.Fatalf("%s status = %q, want deferred", resource, got)
+		}
+	}
+	for _, implemented := range []string{
+		"cloudflare_connectivity_directory_service",
+		"cloudflare_zero_trust_tunnel_cloudflared_route",
+	} {
+		if _, ok := statuses[implemented]; ok {
+			t.Fatalf("implemented resource %s should not have unsupported metadata", implemented)
+		}
+	}
+}

--- a/providers/cloudflare/media_platform.go
+++ b/providers/cloudflare/media_platform.go
@@ -161,30 +161,7 @@ func listCloudflareMediaPlatformResources(
 }
 
 func cloudflareAdvanceMediaPlatformPagination(info *cf.ResultInfo, page *int, cursor *string, itemCount int) bool {
-	if cloudflareAdvancePagination(info, page, cursor) {
-		return true
-	}
-	if info == nil || *cursor != "" {
-		return false
-	}
-
-	pageSize := cloudflarePageSize
-	if info.PerPage > 0 {
-		pageSize = info.PerPage
-	}
-	if itemCount < pageSize {
-		return false
-	}
-	if info.Page > 0 {
-		nextPage := info.Page + 1
-		if nextPage <= *page {
-			return false
-		}
-		*page = nextPage
-		return true
-	}
-	*page++
-	return true
+	return cloudflareAdvancePaginationWithItemCount(info, page, cursor, itemCount)
 }
 
 func listCloudflareImageVariantResources(

--- a/providers/cloudflare/tunnel.go
+++ b/providers/cloudflare/tunnel.go
@@ -4,6 +4,11 @@ package cloudflare
 
 import (
 	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/url"
+	"strconv"
 
 	"github.com/chenrui333/terraformer/terraformutils"
 	cf "github.com/cloudflare/cloudflare-go"
@@ -11,6 +16,16 @@ import (
 
 type TunnelGenerator struct {
 	CloudflareService
+}
+
+type cloudflareTunnelRoute struct {
+	ID               string  `json:"id"`
+	Network          string  `json:"network"`
+	TunnelID         string  `json:"tunnel_id"`
+	Comment          string  `json:"comment"`
+	DeletedAt        *string `json:"deleted_at"`
+	TunType          string  `json:"tun_type"`
+	VirtualNetworkID string  `json:"virtual_network_id"`
 }
 
 func (g *TunnelGenerator) appendTunnelResources(ctx context.Context, api *cf.API, accountID string) error {
@@ -42,6 +57,96 @@ func (g *TunnelGenerator) appendTunnelResources(ctx context.Context, api *cf.API
 		params.ResultInfo = info.Next()
 	}
 	return nil
+}
+
+func (g *TunnelGenerator) appendTunnelRouteResources(ctx context.Context, api *cf.API, accountID string) error {
+	routes, err := listTunnelRoutes(ctx, api, accountID)
+	if err != nil {
+		return err
+	}
+	for _, route := range routes {
+		resource, ok := cloudflareTunnelRouteResource(accountID, route)
+		if ok {
+			g.Resources = append(g.Resources, resource)
+		}
+	}
+	return nil
+}
+
+func listTunnelRoutes(ctx context.Context, api *cf.API, accountID string) ([]cloudflareTunnelRoute, error) {
+	var routes []cloudflareTunnelRoute
+	page, cursor := 1, ""
+	for {
+		response, err := api.Raw(ctx, http.MethodGet, cloudflareTunnelRoutePath(accountID, page, cursor), nil, nil)
+		if err != nil {
+			return nil, err
+		}
+		if len(response.Result) == 0 || string(response.Result) == "null" {
+			return routes, nil
+		}
+
+		var pageRoutes []cloudflareTunnelRoute
+		if err := json.Unmarshal(response.Result, &pageRoutes); err != nil {
+			return nil, err
+		}
+		routes = append(routes, pageRoutes...)
+		if !cloudflareAdvancePaginationWithItemCount(response.ResultInfo, &page, &cursor, len(pageRoutes)) {
+			break
+		}
+	}
+	return routes, nil
+}
+
+func cloudflareTunnelRoutePath(accountID string, page int, cursor string) string {
+	values := url.Values{}
+	values.Set("is_deleted", "false")
+	values.Set("per_page", strconv.Itoa(cloudflarePageSize))
+	values.Add("tun_types", "cfd_tunnel")
+	if cursor != "" {
+		values.Set("cursor", cursor)
+	} else {
+		values.Set("page", strconv.Itoa(page))
+	}
+	return fmt.Sprintf("/accounts/%s/teamnet/routes?%s", accountID, values.Encode())
+}
+
+func cloudflareTunnelRouteResource(accountID string, route cloudflareTunnelRoute) (terraformutils.Resource, bool) {
+	if accountID == "" || !cloudflareTunnelRouteImportable(route) {
+		return terraformutils.Resource{}, false
+	}
+	attributes := map[string]string{
+		"account_id": accountID,
+		"network":    route.Network,
+		"tunnel_id":  route.TunnelID,
+	}
+	if route.Comment != "" {
+		attributes["comment"] = route.Comment
+	}
+	if route.VirtualNetworkID != "" {
+		attributes["virtual_network_id"] = route.VirtualNetworkID
+	}
+
+	resource := terraformutils.NewResource(
+		route.ID,
+		cloudflareResourceName(accountID, "tunnel_route", route.Network, route.ID),
+		"cloudflare_zero_trust_tunnel_cloudflared_route",
+		"cloudflare",
+		attributes,
+		[]string{},
+		map[string]interface{}{},
+	)
+	setCloudflareImportID(&resource, accountID+"/"+route.ID)
+	return resource, true
+}
+
+func cloudflareTunnelRouteImportable(route cloudflareTunnelRoute) bool {
+	if route.ID == "" || route.Network == "" || route.TunnelID == "" {
+		return false
+	}
+	if route.DeletedAt != nil && *route.DeletedAt != "" {
+		return false
+	}
+	return route.TunType == "" || route.TunType == "cfd_tunnel"
 }
 
 func tunnelConfigSource(remoteConfig bool) string {
@@ -94,5 +199,8 @@ func (g *TunnelGenerator) InitResources() error {
 	if err := g.appendTunnelResources(ctx, api, account.Identifier); err != nil {
 		return err
 	}
-	return g.appendTunnelVirtualNetworkResources(ctx, api, account.Identifier)
+	if err := g.appendTunnelVirtualNetworkResources(ctx, api, account.Identifier); err != nil {
+		return err
+	}
+	return g.appendTunnelRouteResources(ctx, api, account.Identifier)
 }

--- a/providers/cloudflare/tunnel_test.go
+++ b/providers/cloudflare/tunnel_test.go
@@ -1,0 +1,123 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package cloudflare
+
+import (
+	"context"
+	"net/http"
+	"testing"
+
+	"github.com/chenrui333/terraformer/terraformutils"
+)
+
+func TestCloudflareTunnelRouteResource(t *testing.T) {
+	resource, ok := cloudflareTunnelRouteResource("account-123", cloudflareTunnelRoute{
+		ID:               "route-456",
+		Network:          "10.0.0.0/16",
+		TunnelID:         "tunnel-789",
+		Comment:          "private network",
+		TunType:          "cfd_tunnel",
+		VirtualNetworkID: "vnet-123",
+	})
+	if !ok {
+		t.Fatal("expected tunnel route resource")
+	}
+	if got := resource.InstanceInfo.Type; got != "cloudflare_zero_trust_tunnel_cloudflared_route" {
+		t.Fatalf("resource type = %q, want cloudflare_zero_trust_tunnel_cloudflared_route", got)
+	}
+	if got := resource.InstanceState.ID; got != "route-456" {
+		t.Fatalf("resource ID = %q, want route-456", got)
+	}
+	if got := resource.InstanceState.Attributes["account_id"]; got != "account-123" {
+		t.Fatalf("account_id = %q, want account-123", got)
+	}
+	if got := resource.InstanceState.Attributes["network"]; got != "10.0.0.0/16" {
+		t.Fatalf("network = %q, want 10.0.0.0/16", got)
+	}
+	if got := resource.InstanceState.Attributes["tunnel_id"]; got != "tunnel-789" {
+		t.Fatalf("tunnel_id = %q, want tunnel-789", got)
+	}
+	if got := resource.InstanceState.Attributes["comment"]; got != "private network" {
+		t.Fatalf("comment = %q, want private network", got)
+	}
+	if got := resource.InstanceState.Attributes["virtual_network_id"]; got != "vnet-123" {
+		t.Fatalf("virtual_network_id = %q, want vnet-123", got)
+	}
+	if got, want := resource.ResourceName, terraformutils.TfSanitize(cloudflareResourceName("account-123", "tunnel_route", "10.0.0.0/16", "route-456")); got != want {
+		t.Fatalf("resource name = %q, want %q", got, want)
+	}
+	if got := resource.InstanceState.Meta["import_id"]; got != "account-123/route-456" {
+		t.Fatalf("import_id = %q, want account-123/route-456", got)
+	}
+}
+
+func TestCloudflareTunnelRouteResourceSkipsUnsafeRoutes(t *testing.T) {
+	deletedAt := "2026-01-02T03:04:05Z"
+	tests := []struct {
+		name    string
+		account string
+		route   cloudflareTunnelRoute
+	}{
+		{name: "missing account", account: "", route: cloudflareTunnelRoute{ID: "route-1", Network: "10.0.0.0/16", TunnelID: "tunnel-1"}},
+		{name: "missing id", account: "account-123", route: cloudflareTunnelRoute{Network: "10.0.0.0/16", TunnelID: "tunnel-1"}},
+		{name: "missing network", account: "account-123", route: cloudflareTunnelRoute{ID: "route-1", TunnelID: "tunnel-1"}},
+		{name: "missing tunnel", account: "account-123", route: cloudflareTunnelRoute{ID: "route-1", Network: "10.0.0.0/16"}},
+		{name: "deleted", account: "account-123", route: cloudflareTunnelRoute{ID: "route-1", Network: "10.0.0.0/16", TunnelID: "tunnel-1", DeletedAt: &deletedAt}},
+		{name: "warp connector", account: "account-123", route: cloudflareTunnelRoute{ID: "route-1", Network: "10.0.0.0/16", TunnelID: "tunnel-1", TunType: "warp_connector"}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if _, ok := cloudflareTunnelRouteResource(tt.account, tt.route); ok {
+				t.Fatal("expected unsafe tunnel route to be skipped")
+			}
+		})
+	}
+}
+
+func TestAppendTunnelRouteResourcesPaginatesAndSkipsNonCloudflaredRoutes(t *testing.T) {
+	api := newCloudflareNetworkEdgeTestAPI(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/accounts/account-123/teamnet/routes" {
+			t.Fatalf("path = %q, want /accounts/account-123/teamnet/routes", r.URL.Path)
+		}
+		if got := r.URL.Query().Get("is_deleted"); got != "false" {
+			t.Fatalf("is_deleted query = %q, want false", got)
+		}
+		if got := r.URL.Query().Get("tun_types"); got != "cfd_tunnel" {
+			t.Fatalf("tun_types query = %q, want cfd_tunnel", got)
+		}
+		switch r.URL.Query().Get("cursor") {
+		case "":
+			if got := r.URL.Query().Get("page"); got != "1" {
+				t.Fatalf("page query = %q, want 1", got)
+			}
+			writeCloudflareNetworkEdgeTestResponse(t, w, []map[string]string{
+				{"id": "route-1", "network": "10.0.0.0/16", "tunnel_id": "tunnel-1", "tun_type": "cfd_tunnel"},
+				{"id": "route-warp", "network": "10.1.0.0/16", "tunnel_id": "tunnel-warp", "tun_type": "warp_connector"},
+			}, map[string]interface{}{
+				"cursors": map[string]string{"after": "cursor-2"},
+			})
+		case "cursor-2":
+			writeCloudflareNetworkEdgeTestResponse(t, w, []map[string]string{
+				{"id": "route-2", "network": "10.2.0.0/16", "tunnel_id": "tunnel-2", "tun_type": "cfd_tunnel"},
+			}, map[string]interface{}{
+				"cursors": map[string]string{},
+			})
+		default:
+			t.Fatalf("cursor query = %q, want empty or cursor-2", r.URL.Query().Get("cursor"))
+		}
+	}))
+
+	generator := &TunnelGenerator{}
+	if err := generator.appendTunnelRouteResources(context.Background(), api, "account-123"); err != nil {
+		t.Fatalf("appendTunnelRouteResources() error = %v", err)
+	}
+	if len(generator.Resources) != 2 {
+		t.Fatalf("resource count = %d, want 2", len(generator.Resources))
+	}
+	if got := generator.Resources[0].InstanceState.Meta["import_id"]; got != "account-123/route-1" {
+		t.Fatalf("first import_id = %q, want account-123/route-1", got)
+	}
+	if got := generator.Resources[1].InstanceState.Meta["import_id"]; got != "account-123/route-2" {
+		t.Fatalf("second import_id = %q, want account-123/route-2", got)
+	}
+}

--- a/providers/cloudflare/unsupported_resources.json
+++ b/providers/cloudflare/unsupported_resources.json
@@ -57,6 +57,18 @@
       ]
     },
     {
+      "resource": "cloudflare_ai_gateway_dynamic_routing",
+      "service_family": "ai",
+      "reason": "AI Gateway dynamic routing needs a dedicated discovery design before broad import.",
+      "evidence": "Terraform provider v5.19.1 imports by account_id/gateway_id/id and reads an individual dynamic route, but the provider does not expose a list data source for dynamic routes. The resource also has required nested elements/outputs plus computed route and success fields, while the parent cloudflare_ai_gateway resource remains deferred for nullable nested-state drift and credential-bearing integrations.",
+      "status": "deferred",
+      "references": [
+        "https://github.com/chenrui333/terraformer/issues/335",
+        "https://registry.terraform.io/providers/cloudflare/cloudflare/latest/docs/resources/ai_gateway_dynamic_routing",
+        "https://registry.terraform.io/providers/cloudflare/cloudflare/latest/docs/resources/ai_gateway"
+      ]
+    },
+    {
       "resource": "cloudflare_ai_search_instance",
       "service_family": "ai",
       "reason": "AI Search instances are not importable through the Terraform provider.",
@@ -938,6 +950,18 @@
       "references": [
         "https://github.com/chenrui333/terraformer/issues/335",
         "https://registry.terraform.io/providers/cloudflare/cloudflare/latest/docs/resources/zero_trust_risk_scoring_integration"
+      ]
+    },
+    {
+      "resource": "cloudflare_zero_trust_tunnel_cloudflared_config",
+      "service_family": "zero_trust_tunnel",
+      "reason": "Cloudflared tunnel configuration is deferred to avoid broad duplicate ownership of tunnel config bodies.",
+      "evidence": "Terraform provider v5.19.1 imports by account_id/tunnel_id and reads the remote configuration body, but the resource owns the full cloudflared ingress/origin_request configuration while cloudflare_zero_trust_tunnel_cloudflared already owns the tunnel and config_src. The provider delete path is intentionally a no-op that only removes state, and local YAML-managed tunnel configs are not reconstructible from the remote configuration endpoint.",
+      "status": "deferred",
+      "references": [
+        "https://github.com/chenrui333/terraformer/issues/335",
+        "https://registry.terraform.io/providers/cloudflare/cloudflare/latest/docs/resources/zero_trust_tunnel_cloudflared_config",
+        "https://registry.terraform.io/providers/cloudflare/cloudflare/latest/docs/resources/zero_trust_tunnel_cloudflared"
       ]
     },
     {


### PR DESCRIPTION
## Summary

Handle the final four unclassified Cloudflare provider resources for #335.

## Resources

Implemented:

- `cloudflare_connectivity_directory_service`
- `cloudflare_zero_trust_tunnel_cloudflared_route`

## Deferred / Unsupported

Added deferred metadata for:

- `cloudflare_ai_gateway_dynamic_routing` - no provider list data source for dynamic routes, required nested route elements, and parent AI Gateway remains deferred for refresh drift/credential-bearing integrations.
- `cloudflare_zero_trust_tunnel_cloudflared_config` - full tunnel config body ownership overlaps with the tunnel resource, provider delete is state-only, and local YAML configs are not reconstructible from the remote config endpoint.

## Scope

This PR is limited to:

- `cloudflare_ai_gateway_dynamic_routing`
- `cloudflare_connectivity_directory_service`
- `cloudflare_zero_trust_tunnel_cloudflared_config`
- `cloudflare_zero_trust_tunnel_cloudflared_route`

## Validation

- `go test ./providers/cloudflare/...`
- `go test ./cmd/...`
- `go test ./providers -run 'TestUnsupportedResourcesMetadata|TestUnsupportedResourceStatusesAreDocumented' -count=1`
- `jq . providers/cloudflare/unsupported_resources.json`
- `git diff --check`

Ref: #335

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds discovery and import for `cloudflare_connectivity_directory_service` and `cloudflare_zero_trust_tunnel_cloudflared_route`. Defers `cloudflare_ai_gateway_dynamic_routing` and `cloudflare_zero_trust_tunnel_cloudflared_config`, finishing the last unclassified Cloudflare resources for #335.

- **New Features**
  - Added `connectivity` service generator; lists and imports directory services with pagination.
  - Implemented tunnel routes listing via Teamnet; imports only non-deleted `cfd_tunnel` routes and sets `account_id/route_id` import IDs.

- **Refactors**
  - Consolidated pagination fallback into a shared helper used by Connectivity, Tunnel, and Media Platform; updated docs and tests.

<sup>Written for commit d4e782edc5cea1eec9cb3f5bc1bc4ada02f3c700. Summary will update on new commits. <a href="https://cubic.dev/pr/chenrui333/terraformer/pull/503?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

