### PR TITLE
docs: update provider tracker close-out guidance

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -90,8 +90,9 @@ Rules:
 - Close the tracking issue as completed only after a final audit confirms docs
   and provider registration are aligned, unsupported/deferred metadata
   validates, previously named remaining resources are accounted for, the
-  unclassified count is zero, and validation has passed. Post the close-out
-  summary after that validation, not merely after the last expected lane merges.
+  unclassified count for the tracker is zero, and validation has passed. Post
+  the close-out summary after that validation, not merely after the last
+  expected lane merges.
 - Do not treat literal Terraform provider parity as the goal when resources are request-style, runtime/media output, high-cardinality content, provider-managed, source/body-heavy, or secret-required.
 - For settings and singleton resources, distinguish durable user-owned configuration from effective API values and platform defaults before moving a resource from deferred metadata to supported import.
 - Use close-out audits to reduce repeated search work: update unsupported metadata when evidence is clear, and group remaining importable resources into focused next lanes.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -87,6 +87,11 @@ Rules:
 - For large provider schemas, practical close-out means every reviewed candidate is supported, evidence-backed deferred/unsupported, or assigned to a named focused follow-up lane.
 - Reduce final follow-up lanes to exact resource names whenever possible, so the
   next lane is bounded before implementation starts.
+- Close the tracking issue as completed only after a final audit confirms docs
+  and provider registration are aligned, unsupported/deferred metadata
+  validates, previously named remaining resources are accounted for, the
+  unclassified count is zero, and validation has passed. Post the close-out
+  summary after that validation, not merely after the last expected lane merges.
 - Do not treat literal Terraform provider parity as the goal when resources are request-style, runtime/media output, high-cardinality content, provider-managed, source/body-heavy, or secret-required.
 - For settings and singleton resources, distinguish durable user-owned configuration from effective API values and platform defaults before moving a resource from deferred metadata to supported import.
 - Use close-out audits to reduce repeated search work: update unsupported metadata when evidence is clear, and group remaining importable resources into focused next lanes.

--- a/docs/provider-architecture.md
+++ b/docs/provider-architecture.md
@@ -152,6 +152,11 @@ follow-up lanes to exact resource names whenever possible.
 A lane can close while the broader tracking issue remains open. A large-provider
 issue is closeable only when remaining resources are supported, evidence-backed
 deferred or unsupported, or assigned to focused follow-up lanes.
+Close the tracking issue as completed only after the final audit confirms docs
+and provider registration are aligned, unsupported/deferred metadata validates,
+previously named remaining resources are accounted for, the unclassified count
+is zero, and validation has passed. Post any close-out summary after that final
+validation, not merely after the last expected lane merges.
 
 If a clean audit finds no metadata or documentation corrections, leave the
 worktree unchanged instead of creating a docs-only record of the no-op.

--- a/docs/provider-architecture.md
+++ b/docs/provider-architecture.md
@@ -155,8 +155,8 @@ deferred or unsupported, or assigned to focused follow-up lanes.
 Close the tracking issue as completed only after the final audit confirms docs
 and provider registration are aligned, unsupported/deferred metadata validates,
 previously named remaining resources are accounted for, the unclassified count
-is zero, and validation has passed. Post any close-out summary after that final
-validation, not merely after the last expected lane merges.
+for the tracker is zero, and validation has passed. Post any close-out summary
+after that final validation, not merely after the last expected lane merges.
 
 If a clean audit finds no metadata or documentation corrections, leave the
 worktree unchanged instead of creating a docs-only record of the no-op.


### PR DESCRIPTION
## Summary

Update provider-maintenance guidance with final tracker close-out criteria from the Cloudflare provider work.

## Notes

- Clarifies final tracker closure criteria for large provider gaps.
- No provider behavior changes.

## Validation

- `git diff --check`
- `markdownlint` if available

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Clarifies final close-out criteria and scope for large provider tracking issues, based on the Cloudflare provider audit. Close a tracker only after a final audit confirms docs and provider registration are aligned, unsupported/deferred metadata validates, all named remaining resources are accounted for, unclassified is zero, validation passes, and the summary is posted after that final validation (not just after the last lane merges); no provider behavior changes.

<sup>Written for commit 3511455d91d2a76ddb3b4fe52269a52967a44d6e. Summary will update on new commits. <a href="https://cubic.dev/pr/chenrui333/terraformer/pull/505?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

