### PR TITLE
docs: update AWS provider maintenance guidance

### DIFF
--- a/docs/provider-architecture.md
+++ b/docs/provider-architecture.md
@@ -68,9 +68,9 @@ filter decisions aligned with both naming layers:
 
 - Normalize typed filters between Terraformer service keys and Terraform
   resource names before deciding which loaders to run.
-- Treat typed filters for other requested services as unrelated; they should not
-  suppress this service's broad discovery when cleanup would otherwise ignore
-  them.
+- Treat typed filters for other service families as unrelated to the current
+  service; they should not disable this service's normal discovery path after
+  service-local filter cleanup.
 - Gate child, add-on, and association discovery behind matching parent or
   resource filters and known parent scope so filtered imports do not call
   unrelated APIs or emit helper resources.
@@ -78,9 +78,9 @@ filter decisions aligned with both naming layers:
   one control-plane scope and de-duplicate output across requested regions.
 - Keep gap inventory tooling aligned with service aliases or override mappings
   when new service families group resources under non-obvious names.
-- Provider docs for service-family generators must list the emitted Terraform
-  resource types, grouped discovery buckets, and any aliases or override
-  mappings used to connect service keys to those groups.
+- Provider docs for multi-resource service-family generators should list the
+  emitted Terraform resource types, grouped discovery buckets, and any aliases
+  or override mappings used to connect service keys to those groups.
 
 For resources that cross accounts, regions, or ownership roles, model ownership
 separately from visibility:

--- a/docs/provider-architecture.md
+++ b/docs/provider-architecture.md
@@ -78,6 +78,9 @@ filter decisions aligned with both naming layers:
   one control-plane scope and de-duplicate output across requested regions.
 - Keep gap inventory tooling aligned with service aliases or override mappings
   when new service families group resources under non-obvious names.
+- Provider docs for service-family generators must list the emitted Terraform
+  resource types, grouped discovery buckets, and any aliases or override
+  mappings used to connect service keys to those groups.
 
 For resources that cross accounts, regions, or ownership roles, model ownership
 separately from visibility:
@@ -89,6 +92,10 @@ separately from visibility:
   reconstructed.
 - Preserve ARNs, canonical state IDs, or other globally unique identities when
   the Terraform provider importer or read path requires them.
+- When a supported import intentionally omits authored fields that the provider
+  importer or read path cannot recover, document the omitted fields and the
+  operator follow-up needed to restore them. Skip or defer the resource when
+  those values are required for refreshable, valid HCL.
 
 ## Importability decision model
 

--- a/docs/provider-architecture.md
+++ b/docs/provider-architecture.md
@@ -63,6 +63,33 @@ permission-sensitive reads when the API supports scoped reads. Filters should
 select or narrow the discovered resources; they should not rewrite global IDs or
 normalize provider-facing import IDs destructively.
 
+When a service key covers multiple Terraform resource types, keep discovery and
+filter decisions aligned with both naming layers:
+
+- Normalize typed filters between Terraformer service keys and Terraform
+  resource names before deciding which loaders to run.
+- Treat typed filters for other requested services as unrelated; they should not
+  suppress this service's broad discovery when cleanup would otherwise ignore
+  them.
+- Gate child, add-on, and association discovery behind matching parent or
+  resource filters and known parent scope so filtered imports do not call
+  unrelated APIs or emit helper resources.
+- Route global, account-scoped, and effectively regional-once resources through
+  one control-plane scope and de-duplicate output across requested regions.
+- Keep gap inventory tooling aligned with service aliases or override mappings
+  when new service families group resources under non-obvious names.
+
+For resources that cross accounts, regions, or ownership roles, model ownership
+separately from visibility:
+
+- Do not infer accepter, handshake, proposal, or action-resource ownership from
+  discovered accepted relationships.
+- Distinguish owner-side and accepter-side resources, and skip or defer cases
+  where proposal IDs, acceptance context, or owner identity cannot be
+  reconstructed.
+- Preserve ARNs, canonical state IDs, or other globally unique identities when
+  the Terraform provider importer or read path requires them.
+
 ## Importability decision model
 
 - Full-list import: use when safe list and read APIs exist and Terraformer can


### PR DESCRIPTION
## Summary

Update provider-maintenance guidance with durable lessons from the AWS release-critical provider wave.

## Notes

- Covers regional-once/global discovery, typed-filter normalization, owner/accepter lifecycle boundaries, child discovery gating, and high-cardinality content/resource classification where not already documented.
- No provider behavior changes.

## Validation

- `git diff --check`
- `markdownlint` if available

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updates AWS provider maintenance docs: normalize typed filters (service keys ↔ Terraform resource names), gate child/association discovery, model owner vs accepter cleanly, and de-dup global/account-scoped/regional-once resources via one control-plane scope. Adds guidance to list emitted resource types and discovery buckets for service-family generators, align aliases/inventory, preserve ARNs/canonical IDs, document omitted import fields and operator follow-ups, and skip/defer when needed values can’t be recovered; docs only, no behavior changes.

<sup>Written for commit 3658ab04a4e1c41b705188ef0398db4a37caff41. Summary will update on new commits. <a href="https://cubic.dev/pr/chenrui333/terraformer/pull/506?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated provider architecture guidance with new patterns for resource discovery, filtering, scoping, and ownership modeling across services and regions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/chenrui333/terraformer/pull/506?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->