### PR TITLE
ci(release): limit Go build parallelism

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -30,6 +30,7 @@ concurrency:
 
 env:
   GOWORK: off
+  GOFLAGS: -p=1
   GORELEASER_VERSION: v2.15.4
   GORELEASER_TIMEOUT: 3h
 


### PR DESCRIPTION
## Summary

Limit Go build parallelism in the release workflow.

## Notes

The v0.13.0 snapshot preflight reached go build -v ./... on GitHub Actions and was terminated with exit code 143. Setting GOFLAGS=-p=1 keeps the release build path within the hosted runner resource envelope and also applies to the GoReleaser build hooks.

## Validation

- env GOFLAGS='-p=1' GOWORK=off go test ./tools/aws-gap-inventory/... -count=1
- env GOFLAGS='-p=1' GOWORK=off goreleaser check
- git diff --check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Limits Go build parallelism in the release workflow to avoid runner resource exhaustion and killed builds. Sets `GOFLAGS=-p=1` so `go build` and `GoReleaser` hooks run serially.

- **Bug Fixes**
  - Stops preflight builds from being killed on GitHub Actions (exit 143).
  - Applies to all steps that honor `GOFLAGS`, including `go test` and `GoReleaser` hooks.

<sup>Written for commit 756414bb2bf736d8762700f4c980f2a966b547cd. Summary will update on new commits. <a href="https://cubic.dev/pr/chenrui333/terraformer/pull/508?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated release workflow build configuration.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/chenrui333/terraformer/pull/508?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->