### PR TITLE
fix: add panic recovery to RefreshResourceWorker

### DIFF
--- a/terraformutils/utils.go
+++ b/terraformutils/utils.go
@@ -6,6 +6,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"log"
+	"runtime"
 	"sort"
 	"sync"
 
@@ -244,9 +245,20 @@ func RefreshResourcesByProvider(providersMapping *ProvidersMapping, providerWrap
 
 func RefreshResourceWorker(input chan *Resource, wg *sync.WaitGroup, provider *providerwrapper.ProviderWrapper) {
 	for r := range input {
-		log.Println("Refreshing state...", r.InstanceInfo.Id)
-		r.Refresh(provider)
-		wg.Done()
+		func() {
+			defer func() {
+				if rec := recover(); rec != nil {
+					buf := make([]byte, 4096)
+					n := runtime.Stack(buf, false)
+					log.Printf("PANIC: Refresh failed for resource %s: %v\n%s",
+						r.InstanceInfo.Id, rec, buf[:n])
+					r.InstanceState = nil
+				}
+				wg.Done()
+			}()
+			log.Println("Refreshing state...", r.InstanceInfo.Id)
+			r.Refresh(provider)
+		}()
 	}
 }
 

--- a/terraformutils/utils.go
+++ b/terraformutils/utils.go
@@ -250,9 +250,15 @@ func RefreshResourceWorker(input chan *Resource, wg *sync.WaitGroup, provider *p
 				if rec := recover(); rec != nil {
 					buf := make([]byte, 4096)
 					n := runtime.Stack(buf, false)
+					id := "<unknown>"
+					if r != nil && r.InstanceInfo != nil {
+						id = r.InstanceInfo.Id
+					}
 					log.Printf("PANIC: Refresh failed for resource %s: %v\n%s",
-						r.InstanceInfo.Id, rec, buf[:n])
-					r.InstanceState = nil
+						id, rec, buf[:n])
+					if r != nil {
+						r.InstanceState = nil
+					}
 				}
 				wg.Done()
 			}()

--- a/terraformutils/utils_test.go
+++ b/terraformutils/utils_test.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"sync"
 	"testing"
+	"time"
 
 	"github.com/chenrui333/terraformer/terraformutils/tfcompat"
 )
@@ -211,7 +212,16 @@ func TestRefreshResourceWorker_PanicRecovery(t *testing.T) {
 	// nil provider causes panic in Refresh — recovery must catch it
 	RefreshResourceWorker(input, &wg, nil)
 
-	wg.Wait()
+	done := make(chan struct{})
+	go func() {
+		wg.Wait()
+		close(done)
+	}()
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("wg.Wait() hung — wg.Done() was not called after panic")
+	}
 
 	if r.InstanceState != nil {
 		t.Error("expected InstanceState to be nil after panic recovery")

--- a/terraformutils/utils_test.go
+++ b/terraformutils/utils_test.go
@@ -4,6 +4,7 @@ package terraformutils
 
 import (
 	"encoding/json"
+	"sync"
 	"testing"
 
 	"github.com/chenrui333/terraformer/terraformutils/tfcompat"
@@ -193,5 +194,26 @@ func TestContainsResource(t *testing.T) {
 	}
 	if ContainsResource(list, r2) {
 		t.Error("should not contain r2")
+	}
+}
+
+func TestRefreshResourceWorker_PanicRecovery(t *testing.T) {
+	r := NewResource("panic-id", "panic-resource", "aws_backup_framework", "aws",
+		map[string]string{}, nil, nil)
+
+	input := make(chan *Resource, 1)
+	var wg sync.WaitGroup
+
+	wg.Add(1)
+	input <- &r
+	close(input)
+
+	// nil provider causes panic in Refresh — recovery must catch it
+	RefreshResourceWorker(input, &wg, nil)
+
+	wg.Wait()
+
+	if r.InstanceState != nil {
+		t.Error("expected InstanceState to be nil after panic recovery")
 	}
 }


### PR DESCRIPTION
## Summary

`RefreshResourceWorker` runs in goroutines with no panic recovery. Provider schema inconsistencies (e.g., `aws_backup_framework` returning mixed cty `Object`/`ObjectWithOptionalAttrs` in sets) cause `go-cty` to panic during state refresh, crashing the entire process.

## Fix

Add `defer/recover` so panicking resources are logged with a stack trace and skipped gracefully. The existing post-refresh logic already handles nil-state resources, so recovered panics integrate cleanly.

## Panic reproduced with

```
panic: inconsistent set element types (cty.Object(..."input_parameter":cty.Set(cty.Object(...))...)
  then cty.Object(..."input_parameter":cty.Set(cty.ObjectWithOptionalAttrs(...))...))
```

Triggered by `aws_backup_framework` resource during `terraformer import aws --resources=backup`.

## Test

`TestRefreshResourceWorker_PanicRecovery` — verifies panic is caught, `wg.Done()` fires (no deadlock), and resource state is nil'd for skip.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add panic recovery to `RefreshResourceWorker` to prevent crashes during state refresh. Panicking resources (e.g., `aws_backup_framework` via `go-cty` inconsistencies) are logged with a stack trace and skipped safely.

- **Bug Fixes**
  - Wrap refresh in `defer`/`recover`; on panic, log stack via `runtime.Stack` and continue.
  - Add nil guards for `r`/`r.InstanceInfo` when logging; set `InstanceState` to nil safely.
  - Always call `wg.Done()` to avoid deadlocks; test adds a timeout to catch hangs.
  - Add `TestRefreshResourceWorker_PanicRecovery` to verify recovery, no deadlock, and nil state.

<sup>Written for commit 002d4942542a02e52d69bd5eaba22d45d5f299fc. Summary will update on new commits. <a href="https://cubic.dev/pr/chenrui333/terraformer/pull/509?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resource refresh operations now gracefully recover from unexpected errors, preventing application crashes while ensuring automatic error logging and proper resource cleanup.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/chenrui333/terraformer/pull/509?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->