### PR TITLE
feat: add import observability framework with error taxonomy and auth early-exit

### DIFF
--- a/cmd/import.go
+++ b/cmd/import.go
@@ -67,16 +67,18 @@ var (
 	reportPath    string
 )
 
-func FinalizeReport() {
+func FinalizeReport() bool {
 	if len(processReport.Events) == 0 {
-		return
+		return true
 	}
 	processReport.Print()
 	if reportPath != "" {
 		if err := processReport.WriteJSONFile(reportPath); err != nil {
-			log.Printf("ERROR: failed to write report: %v", err)
+			log.Printf("ERROR: failed to write report to %s: %v", reportPath, err)
+			return false
 		}
 	}
+	return true
 }
 
 func HasReportFailures() bool {
@@ -181,7 +183,7 @@ func validateImport(provider terraformutils.ProviderGenerator, resources []strin
 }
 
 func initAllServicesResources(providersMapping *terraformutils.ProvidersMapping, options ImportOptions, args []string, providerWrapper *providerwrapper.ProviderWrapper, report *importreport.Report) error {
-	sessionKey := providersMapping.GetBaseProvider().GetName()
+	sessionKey := providersMapping.GetBaseProvider().GetName() + ":" + strings.Join(args, ":")
 	var failedServices []string
 
 	for _, service := range options.Resources {

--- a/cmd/import.go
+++ b/cmd/import.go
@@ -140,29 +140,14 @@ func Import(provider terraformutils.ProviderGenerator, options ImportOptions, ar
 		return err
 	}
 
+	eventStart := processReport.EventCount()
+
 	providerMapping.ConvertTFStates(providerWrapper, processReport)
 	// change structs with additional data for each resource
 	providerMapping.CleanupProviders()
 	providerMapping.ConvertTypedStates(providerWrapper, processReport)
 
-	// Count final surviving resources as imported (skip conversion failures)
-	failedIDs := processReport.FailedResourceIDs()
-	for service, resources := range providerMapping.GetResourcesByService() {
-		for i := range resources {
-			id := resources[i].InstanceInfo.Id
-			if failedIDs[id] {
-				continue
-			}
-			processReport.Add(importreport.ResourceEvent{
-				Service:      service,
-				ResourceType: resources[i].InstanceInfo.Type,
-				ResourceID:   id,
-				Status:       importreport.StatusSuccess,
-			})
-		}
-	}
-
-	return importFromPlan(providerMapping, options, args)
+	return importFromPlan(providerMapping, options, args, processReport, eventStart)
 }
 
 func initOptionsAndWrapper(provider terraformutils.ProviderGenerator, options ImportOptions, args []string) (*providerwrapper.ProviderWrapper, ImportOptions, error) {
@@ -269,7 +254,7 @@ func initAllServicesResources(providersMapping *terraformutils.ProvidersMapping,
 	return nil
 }
 
-func importFromPlan(providerMapping *terraformutils.ProvidersMapping, options ImportOptions, args []string) error {
+func importFromPlan(providerMapping *terraformutils.ProvidersMapping, options ImportOptions, args []string, report *importreport.Report, eventStart int) error {
 	plan := &ImportPlan{
 		Provider:         providerMapping.GetBaseProvider().GetName(),
 		Options:          options,
@@ -281,8 +266,23 @@ func importFromPlan(providerMapping *terraformutils.ProvidersMapping, options Im
 	if provider, ok := providerMapping.GetBaseProvider().(importResourcesPostProcessor); ok {
 		resourcesByService = provider.PostProcessImportResources(resourcesByService)
 	}
-	for service := range resourcesByService {
-		plan.ImportedResource[service] = append(plan.ImportedResource[service], resourcesByService[service]...)
+
+	// Count successfully imported resources after post-processing
+	failedIDs := report.FailedResourceIDsSince(eventStart)
+	for service, resources := range resourcesByService {
+		for i := range resources {
+			id := resources[i].InstanceInfo.Id
+			if failedIDs[id] {
+				continue
+			}
+			report.Add(importreport.ResourceEvent{
+				Service:      service,
+				ResourceType: resources[i].InstanceInfo.Type,
+				ResourceID:   id,
+				Status:       importreport.StatusSuccess,
+			})
+		}
+		plan.ImportedResource[service] = append(plan.ImportedResource[service], resources...)
 	}
 
 	if options.Plan {

--- a/cmd/import.go
+++ b/cmd/import.go
@@ -63,11 +63,15 @@ const DefaultPathOutput = "generated"
 const DefaultState = "local"
 
 var (
-	processReport = importreport.New()
-	reportPath    string
+	processReport  = importreport.New()
+	reportPath     string
+	importExecuted bool
 )
 
 func FinalizeReport() bool {
+	if !importExecuted {
+		return true
+	}
 	if len(processReport.Events) > 0 {
 		processReport.Print()
 	}
@@ -111,6 +115,7 @@ func newImportCmd() *cobra.Command {
 }
 
 func Import(provider terraformutils.ProviderGenerator, options ImportOptions, args []string) error {
+	importExecuted = true
 	sessionKey := provider.GetName() + ":" + strings.Join(args, ":")
 
 	providerWrapper, options, err := initOptionsAndWrapper(provider, options, args)
@@ -135,7 +140,7 @@ func Import(provider terraformutils.ProviderGenerator, options ImportOptions, ar
 		return err
 	}
 
-	err = terraformutils.RefreshResourcesByProvider(providerMapping, providerWrapper, processReport)
+	err = terraformutils.RefreshResourcesByProvider(providerMapping, providerWrapper, processReport, sessionKey)
 	if err != nil {
 		return err
 	}

--- a/cmd/import.go
+++ b/cmd/import.go
@@ -267,7 +267,23 @@ func importFromPlan(providerMapping *terraformutils.ProvidersMapping, options Im
 		resourcesByService = provider.PostProcessImportResources(resourcesByService)
 	}
 
-	// Count successfully imported resources after post-processing
+	for service, resources := range resourcesByService {
+		plan.ImportedResource[service] = append(plan.ImportedResource[service], resources...)
+	}
+
+	var outputErr error
+	if options.Plan {
+		path := Path(options.PathPattern, providerMapping.GetBaseProvider().GetName(), "terraformer", options.PathOutput)
+		outputErr = ExportPlanFile(plan, path, "plan.json")
+	} else {
+		outputErr = ImportFromPlan(providerMapping.GetBaseProvider(), plan)
+	}
+
+	if outputErr != nil {
+		return outputErr
+	}
+
+	// Count successfully imported resources only after output succeeds
 	failedIDs := report.FailedResourceIDsSince(eventStart)
 	for service, resources := range resourcesByService {
 		for i := range resources {
@@ -282,15 +298,9 @@ func importFromPlan(providerMapping *terraformutils.ProvidersMapping, options Im
 				Status:       importreport.StatusSuccess,
 			})
 		}
-		plan.ImportedResource[service] = append(plan.ImportedResource[service], resources...)
 	}
 
-	if options.Plan {
-		path := Path(options.PathPattern, providerMapping.GetBaseProvider().GetName(), "terraformer", options.PathOutput)
-		return ExportPlanFile(plan, path, "plan.json")
-	}
-
-	return ImportFromPlan(providerMapping.GetBaseProvider(), plan)
+	return nil
 }
 
 func initServiceResources(service string, provider terraformutils.ProviderGenerator,

--- a/cmd/import.go
+++ b/cmd/import.go
@@ -98,7 +98,6 @@ func newImportCmd() *cobra.Command {
 		SilenceErrors: false,
 	}
 
-
 	cmd.AddCommand(newCmdPlanImporter(options))
 	cmd.AddCommand(&cobra.Command{
 		Use:   "no-sort",

--- a/cmd/import.go
+++ b/cmd/import.go
@@ -4,7 +4,6 @@
 package cmd
 
 import (
-	"errors"
 	"fmt"
 	"log"
 	"os"
@@ -68,6 +67,22 @@ var (
 	reportPath    string
 )
 
+func FinalizeReport() {
+	if len(processReport.Events) == 0 {
+		return
+	}
+	processReport.Print()
+	if reportPath != "" {
+		if err := processReport.WriteJSONFile(reportPath); err != nil {
+			log.Printf("ERROR: failed to write report: %v", err)
+		}
+	}
+}
+
+func HasReportFailures() bool {
+	return processReport.HasFailures()
+}
+
 func newImportCmd() *cobra.Command {
 	options := ImportOptions{}
 	cmd := &cobra.Command{
@@ -76,15 +91,6 @@ func newImportCmd() *cobra.Command {
 		Long:          "Import current state to Terraform configuration",
 		SilenceUsage:  true,
 		SilenceErrors: false,
-		PersistentPostRunE: func(_ *cobra.Command, _ []string) error {
-			processReport.Print()
-			if reportPath != "" {
-				if err := processReport.WriteJSONFile(reportPath); err != nil {
-					log.Printf("ERROR: failed to write report: %v", err)
-				}
-			}
-			return nil
-		},
 	}
 
 	cmd.PersistentFlags().StringVar(&reportPath, "report", "", "path to write JSON import report")
@@ -126,15 +132,7 @@ func Import(provider terraformutils.ProviderGenerator, options ImportOptions, ar
 	providerMapping.CleanupProviders()
 	providerMapping.ConvertTypedStates(providerWrapper)
 
-	err = importFromPlan(providerMapping, options, args)
-	if err != nil {
-		return err
-	}
-
-	if processReport.HasFailures() {
-		return errors.New("import completed with failures (see summary above)")
-	}
-	return nil
+	return importFromPlan(providerMapping, options, args)
 }
 
 func initOptionsAndWrapper(provider terraformutils.ProviderGenerator, options ImportOptions, args []string) (*providerwrapper.ProviderWrapper, ImportOptions, error) {

--- a/cmd/import.go
+++ b/cmd/import.go
@@ -68,10 +68,9 @@ var (
 )
 
 func FinalizeReport() bool {
-	if len(processReport.Events) == 0 {
-		return true
+	if len(processReport.Events) > 0 {
+		processReport.Print()
 	}
-	processReport.Print()
 	if reportPath != "" {
 		if err := processReport.WriteJSONFile(reportPath); err != nil {
 			log.Printf("ERROR: failed to write report to %s: %v", reportPath, err)
@@ -129,10 +128,10 @@ func Import(provider terraformutils.ProviderGenerator, options ImportOptions, ar
 		return err
 	}
 
-	providerMapping.ConvertTFStates(providerWrapper)
+	providerMapping.ConvertTFStates(providerWrapper, processReport)
 	// change structs with additional data for each resource
 	providerMapping.CleanupProviders()
-	providerMapping.ConvertTypedStates(providerWrapper)
+	providerMapping.ConvertTypedStates(providerWrapper, processReport)
 
 	return importFromPlan(providerMapping, options, args)
 }
@@ -200,7 +199,18 @@ func initAllServicesResources(providersMapping *terraformutils.ProvidersMapping,
 		serviceProvider := providersMapping.AddServiceToProvider(service)
 		err := serviceProvider.Init(args)
 		if err != nil {
-			return err
+			cat := importreport.ClassifyError(err)
+			if cat == importreport.CategoryAuth {
+				report.SetAuthFailed(sessionKey)
+			}
+			report.Add(importreport.ResourceEvent{
+				Service:  service,
+				Status:   importreport.StatusFailed,
+				Category: cat,
+				Error:    err.Error(),
+			})
+			failedServices = append(failedServices, service)
+			continue
 		}
 		err = initServiceResources(service, serviceProvider, options, providerWrapper)
 		if err != nil {

--- a/cmd/import.go
+++ b/cmd/import.go
@@ -111,8 +111,20 @@ func newImportCmd() *cobra.Command {
 }
 
 func Import(provider terraformutils.ProviderGenerator, options ImportOptions, args []string) error {
+	sessionKey := provider.GetName() + ":" + strings.Join(args, ":")
+
 	providerWrapper, options, err := initOptionsAndWrapper(provider, options, args)
 	if err != nil {
+		cat := importreport.ClassifyError(err)
+		if cat == importreport.CategoryAuth {
+			processReport.SetAuthFailed(sessionKey)
+		}
+		processReport.Add(importreport.ResourceEvent{
+			Service:  provider.GetName(),
+			Status:   importreport.StatusFailed,
+			Category: cat,
+			Error:    err.Error(),
+		})
 		return err
 	}
 	defer providerWrapper.Kill()
@@ -132,6 +144,17 @@ func Import(provider terraformutils.ProviderGenerator, options ImportOptions, ar
 	// change structs with additional data for each resource
 	providerMapping.CleanupProviders()
 	providerMapping.ConvertTypedStates(providerWrapper, processReport)
+
+	// Count final surviving resources as imported
+	for service, resources := range providerMapping.GetResourcesByService() {
+		for range resources {
+			processReport.Add(importreport.ResourceEvent{
+				Service:      service,
+				ResourceType: service,
+				Status:       importreport.StatusSuccess,
+			})
+		}
+	}
 
 	return importFromPlan(providerMapping, options, args)
 }

--- a/cmd/import.go
+++ b/cmd/import.go
@@ -147,10 +147,11 @@ func Import(provider terraformutils.ProviderGenerator, options ImportOptions, ar
 
 	// Count final surviving resources as imported
 	for service, resources := range providerMapping.GetResourcesByService() {
-		for range resources {
+		for i := range resources {
 			processReport.Add(importreport.ResourceEvent{
 				Service:      service,
-				ResourceType: service,
+				ResourceType: resources[i].InstanceInfo.Type,
+				ResourceID:   resources[i].InstanceInfo.Id,
 				Status:       importreport.StatusSuccess,
 			})
 		}

--- a/cmd/import.go
+++ b/cmd/import.go
@@ -145,13 +145,18 @@ func Import(provider terraformutils.ProviderGenerator, options ImportOptions, ar
 	providerMapping.CleanupProviders()
 	providerMapping.ConvertTypedStates(providerWrapper, processReport)
 
-	// Count final surviving resources as imported
+	// Count final surviving resources as imported (skip conversion failures)
+	failedIDs := processReport.FailedResourceIDs()
 	for service, resources := range providerMapping.GetResourcesByService() {
 		for i := range resources {
+			id := resources[i].InstanceInfo.Id
+			if failedIDs[id] {
+				continue
+			}
 			processReport.Add(importreport.ResourceEvent{
 				Service:      service,
 				ResourceType: resources[i].InstanceInfo.Type,
-				ResourceID:   resources[i].InstanceInfo.Id,
+				ResourceID:   id,
 				Status:       importreport.StatusSuccess,
 			})
 		}

--- a/cmd/import.go
+++ b/cmd/import.go
@@ -135,10 +135,7 @@ func Import(provider terraformutils.ProviderGenerator, options ImportOptions, ar
 	defer providerWrapper.Kill()
 	providerMapping := terraformutils.NewProvidersMapping(provider)
 
-	err = initAllServicesResources(providerMapping, options, args, providerWrapper, processReport)
-	if err != nil {
-		return err
-	}
+	initAllServicesResources(providerMapping, options, args, providerWrapper, processReport)
 
 	err = terraformutils.RefreshResourcesByProvider(providerMapping, providerWrapper, processReport, sessionKey)
 	if err != nil {
@@ -200,7 +197,7 @@ func validateImport(provider terraformutils.ProviderGenerator, resources []strin
 	return nil
 }
 
-func initAllServicesResources(providersMapping *terraformutils.ProvidersMapping, options ImportOptions, args []string, providerWrapper *providerwrapper.ProviderWrapper, report *importreport.Report) error {
+func initAllServicesResources(providersMapping *terraformutils.ProvidersMapping, options ImportOptions, args []string, providerWrapper *providerwrapper.ProviderWrapper, report *importreport.Report) {
 	sessionKey := providersMapping.GetBaseProvider().GetName() + ":" + strings.Join(args, ":")
 	var failedServices []string
 
@@ -255,8 +252,6 @@ func initAllServicesResources(providersMapping *terraformutils.ProvidersMapping,
 	// remove providers that failed to init their service
 	providersMapping.RemoveServices(failedServices)
 	providersMapping.ProcessResources(false)
-
-	return nil
 }
 
 func importFromPlan(providerMapping *terraformutils.ProvidersMapping, options ImportOptions, args []string, report *importreport.Report, eventStart int) error {

--- a/cmd/import.go
+++ b/cmd/import.go
@@ -98,7 +98,6 @@ func newImportCmd() *cobra.Command {
 		SilenceErrors: false,
 	}
 
-	cmd.PersistentFlags().StringVar(&reportPath, "report", "", "path to write JSON import report")
 
 	cmd.AddCommand(newCmdPlanImporter(options))
 	cmd.AddCommand(&cobra.Command{

--- a/cmd/import.go
+++ b/cmd/import.go
@@ -280,6 +280,12 @@ func importFromPlan(providerMapping *terraformutils.ProvidersMapping, options Im
 	}
 
 	if outputErr != nil {
+		report.Add(importreport.ResourceEvent{
+			Service:  providerMapping.GetBaseProvider().GetName(),
+			Status:   importreport.StatusFailed,
+			Category: importreport.ClassifyError(outputErr),
+			Error:    outputErr.Error(),
+		})
 		return outputErr
 	}
 

--- a/cmd/import.go
+++ b/cmd/import.go
@@ -76,7 +76,7 @@ func newImportCmd() *cobra.Command {
 		Long:          "Import current state to Terraform configuration",
 		SilenceUsage:  true,
 		SilenceErrors: false,
-		PersistentPostRunE: func(cmd *cobra.Command, args []string) error {
+		PersistentPostRunE: func(_ *cobra.Command, _ []string) error {
 			processReport.Print()
 			if reportPath != "" {
 				if err := processReport.WriteJSONFile(reportPath); err != nil {

--- a/cmd/import.go
+++ b/cmd/import.go
@@ -45,7 +45,6 @@ type ImportOptions struct {
 	NoSort        bool
 	RetryCount    int
 	RetrySleepMs  int
-	ReportPath    string `json:"-"`
 }
 
 type importResourcesPostProcessor interface {
@@ -64,6 +63,11 @@ const DefaultPathPattern = "{output}/{provider}/{service}/"
 const DefaultPathOutput = "generated"
 const DefaultState = "local"
 
+var (
+	processReport = importreport.New()
+	reportPath    string
+)
+
 func newImportCmd() *cobra.Command {
 	options := ImportOptions{}
 	cmd := &cobra.Command{
@@ -72,8 +76,18 @@ func newImportCmd() *cobra.Command {
 		Long:          "Import current state to Terraform configuration",
 		SilenceUsage:  true,
 		SilenceErrors: false,
-		//Version:       version.String(),
+		PersistentPostRunE: func(cmd *cobra.Command, args []string) error {
+			processReport.Print()
+			if reportPath != "" {
+				if err := processReport.WriteJSONFile(reportPath); err != nil {
+					log.Printf("ERROR: failed to write report: %v", err)
+				}
+			}
+			return nil
+		},
 	}
+
+	cmd.PersistentFlags().StringVar(&reportPath, "report", "", "path to write JSON import report")
 
 	cmd.AddCommand(newCmdPlanImporter(options))
 	cmd.AddCommand(&cobra.Command{
@@ -90,16 +104,6 @@ func newImportCmd() *cobra.Command {
 }
 
 func Import(provider terraformutils.ProviderGenerator, options ImportOptions, args []string) error {
-	report := importreport.New()
-	defer report.Print()
-	defer func() {
-		if options.ReportPath != "" {
-			if err := report.WriteJSONFile(options.ReportPath); err != nil {
-				log.Printf("ERROR: failed to write report: %v", err)
-			}
-		}
-	}()
-
 	providerWrapper, options, err := initOptionsAndWrapper(provider, options, args)
 	if err != nil {
 		return err
@@ -107,12 +111,12 @@ func Import(provider terraformutils.ProviderGenerator, options ImportOptions, ar
 	defer providerWrapper.Kill()
 	providerMapping := terraformutils.NewProvidersMapping(provider)
 
-	err = initAllServicesResources(providerMapping, options, args, providerWrapper, report)
+	err = initAllServicesResources(providerMapping, options, args, providerWrapper, processReport)
 	if err != nil {
 		return err
 	}
 
-	err = terraformutils.RefreshResourcesByProvider(providerMapping, providerWrapper)
+	err = terraformutils.RefreshResourcesByProvider(providerMapping, providerWrapper, processReport)
 	if err != nil {
 		return err
 	}
@@ -127,7 +131,7 @@ func Import(provider terraformutils.ProviderGenerator, options ImportOptions, ar
 		return err
 	}
 
-	if report.HasFailures() {
+	if processReport.HasFailures() {
 		return errors.New("import completed with failures (see summary above)")
 	}
 	return nil
@@ -475,5 +479,4 @@ func baseProviderFlags(flag *pflag.FlagSet, options *ImportOptions, sampleRes, s
 	flag.StringVarP(&options.Output, "output", "O", "hcl", "output format hcl or json")
 	flag.IntVarP(&options.RetryCount, "retry-number", "n", 5, "number of retries to perform when refresh fails")
 	flag.IntVarP(&options.RetrySleepMs, "retry-sleep-ms", "m", 300, "time in ms to sleep between retries")
-	flag.StringVar(&options.ReportPath, "report", "", "path to write JSON import report")
 }

--- a/cmd/import.go
+++ b/cmd/import.go
@@ -4,13 +4,14 @@
 package cmd
 
 import (
+	"errors"
 	"fmt"
 	"log"
 	"os"
 	"sort"
 	"strings"
-	"sync"
 
+	"github.com/chenrui333/terraformer/terraformutils/importreport"
 	"github.com/chenrui333/terraformer/terraformutils/terraformerstring"
 
 	"github.com/chenrui333/terraformer/terraformutils/providerwrapper"
@@ -44,6 +45,7 @@ type ImportOptions struct {
 	NoSort        bool
 	RetryCount    int
 	RetrySleepMs  int
+	ReportPath    string `json:"-"`
 }
 
 type importResourcesPostProcessor interface {
@@ -88,6 +90,16 @@ func newImportCmd() *cobra.Command {
 }
 
 func Import(provider terraformutils.ProviderGenerator, options ImportOptions, args []string) error {
+	report := importreport.New()
+	defer report.Print()
+	defer func() {
+		if options.ReportPath != "" {
+			if err := report.WriteJSONFile(options.ReportPath); err != nil {
+				log.Printf("ERROR: failed to write report: %v", err)
+			}
+		}
+	}()
+
 	providerWrapper, options, err := initOptionsAndWrapper(provider, options, args)
 	if err != nil {
 		return err
@@ -95,7 +107,7 @@ func Import(provider terraformutils.ProviderGenerator, options ImportOptions, ar
 	defer providerWrapper.Kill()
 	providerMapping := terraformutils.NewProvidersMapping(provider)
 
-	err = initAllServicesResources(providerMapping, options, args, providerWrapper)
+	err = initAllServicesResources(providerMapping, options, args, providerWrapper, report)
 	if err != nil {
 		return err
 	}
@@ -111,8 +123,14 @@ func Import(provider terraformutils.ProviderGenerator, options ImportOptions, ar
 	providerMapping.ConvertTypedStates(providerWrapper)
 
 	err = importFromPlan(providerMapping, options, args)
+	if err != nil {
+		return err
+	}
 
-	return err
+	if report.HasFailures() {
+		return errors.New("import completed with failures (see summary above)")
+	}
+	return nil
 }
 
 func initOptionsAndWrapper(provider terraformutils.ProviderGenerator, options ImportOptions, args []string) (*providerwrapper.ProviderWrapper, ImportOptions, error) {
@@ -160,14 +178,21 @@ func validateImport(provider terraformutils.ProviderGenerator, resources []strin
 	return nil
 }
 
-func initAllServicesResources(providersMapping *terraformutils.ProvidersMapping, options ImportOptions, args []string, providerWrapper *providerwrapper.ProviderWrapper) error {
-	numOfResources := len(options.Resources)
-	var wg sync.WaitGroup
-	wg.Add(numOfResources)
-
+func initAllServicesResources(providersMapping *terraformutils.ProvidersMapping, options ImportOptions, args []string, providerWrapper *providerwrapper.ProviderWrapper, report *importreport.Report) error {
+	sessionKey := providersMapping.GetBaseProvider().GetName()
 	var failedServices []string
 
 	for _, service := range options.Resources {
+		if report.IsAuthFailed(sessionKey) {
+			report.Add(importreport.ResourceEvent{
+				Service:  service,
+				Status:   importreport.StatusSkipped,
+				Category: importreport.CategoryAuth,
+				Error:    "skipped due to prior auth failure",
+			})
+			continue
+		}
+
 		serviceProvider := providersMapping.AddServiceToProvider(service)
 		err := serviceProvider.Init(args)
 		if err != nil {
@@ -175,7 +200,22 @@ func initAllServicesResources(providersMapping *terraformutils.ProvidersMapping,
 		}
 		err = initServiceResources(service, serviceProvider, options, providerWrapper)
 		if err != nil {
+			cat := importreport.ClassifyError(err)
+			if cat == importreport.CategoryAuth {
+				report.SetAuthFailed(sessionKey)
+			}
+			report.Add(importreport.ResourceEvent{
+				Service:  service,
+				Status:   importreport.StatusFailed,
+				Category: cat,
+				Error:    err.Error(),
+			})
 			failedServices = append(failedServices, service)
+		} else {
+			report.Add(importreport.ResourceEvent{
+				Service: service,
+				Status:  importreport.StatusSuccess,
+			})
 		}
 	}
 
@@ -435,4 +475,5 @@ func baseProviderFlags(flag *pflag.FlagSet, options *ImportOptions, sampleRes, s
 	flag.StringVarP(&options.Output, "output", "O", "hcl", "output format hcl or json")
 	flag.IntVarP(&options.RetryCount, "retry-number", "n", 5, "number of retries to perform when refresh fails")
 	flag.IntVarP(&options.RetrySleepMs, "retry-sleep-ms", "m", 300, "time in ms to sleep between retries")
+	flag.StringVar(&options.ReportPath, "report", "", "path to write JSON import report")
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -14,6 +14,7 @@ func NewCmdRoot() *cobra.Command {
 		SilenceErrors: true,
 		Version:       terraformerVersion.Version,
 	}
+	cmd.PersistentFlags().StringVar(&reportPath, "report", "", "path to write JSON import report")
 	cmd.AddCommand(newImportCmd())
 	cmd.AddCommand(newPlanCmd())
 	cmd.AddCommand(versionCmd)

--- a/main.go
+++ b/main.go
@@ -24,8 +24,13 @@ func (t TerraformerWriter) Write(p []byte) (n int, err error) {
 
 func main() {
 	log.SetOutput(TerraformerWriter{})
-	if err := cmd.Execute(); err != nil {
+	err := cmd.Execute()
+	cmd.FinalizeReport()
+	if err != nil {
 		log.Println(err)
+		os.Exit(1)
+	}
+	if cmd.HasReportFailures() {
 		os.Exit(1)
 	}
 }

--- a/main.go
+++ b/main.go
@@ -25,12 +25,12 @@ func (t TerraformerWriter) Write(p []byte) (n int, err error) {
 func main() {
 	log.SetOutput(TerraformerWriter{})
 	err := cmd.Execute()
-	cmd.FinalizeReport()
+	reportOK := cmd.FinalizeReport()
 	if err != nil {
 		log.Println(err)
 		os.Exit(1)
 	}
-	if cmd.HasReportFailures() {
+	if !reportOK || cmd.HasReportFailures() {
 		os.Exit(1)
 	}
 }

--- a/terraformutils/importreport/classify.go
+++ b/terraformutils/importreport/classify.go
@@ -16,6 +16,12 @@ var authPatterns = []string{
 	"AuthFailure",
 	"ExpiredTokenException",
 	"RequestExpired",
+	"AADSTS700082",
+	"refresh token has expired",
+	"AzureCLICredential",
+	"please run 'az login'",
+	"DefaultAzureCredential",
+	"CredentialUnavailableError",
 }
 
 var rateLimitPatterns = []string{

--- a/terraformutils/importreport/classify.go
+++ b/terraformutils/importreport/classify.go
@@ -1,0 +1,64 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package importreport
+
+import "strings"
+
+var authPatterns = []string{
+	"SSO session has expired",
+	"No valid credential sources",
+	"ExpiredToken",
+	"security token included in the request is expired",
+	"InvalidGrantException",
+	"failed to refresh cached credentials",
+	"UnauthorizedAccess",
+	"InvalidClientTokenId",
+	"AuthFailure",
+	"ExpiredTokenException",
+	"RequestExpired",
+}
+
+var rateLimitPatterns = []string{
+	"Rate exceeded",
+	"Throttling",
+	"TooManyRequests",
+	"TooManyRequestsException",
+	"RequestLimitExceeded",
+	"ThrottledException",
+	"ProvisionedThroughputExceededException",
+}
+
+func ClassifyError(err error) ErrorCategory {
+	if err == nil {
+		return CategoryUnknown
+	}
+	return ClassifyErrorMessage(err.Error())
+}
+
+func ClassifyErrorMessage(msg string) ErrorCategory {
+	if isAuthError(msg) {
+		return CategoryAuth
+	}
+	if isRateLimitError(msg) {
+		return CategoryRateLimit
+	}
+	return CategoryAPI
+}
+
+func isAuthError(msg string) bool {
+	for _, pattern := range authPatterns {
+		if strings.Contains(msg, pattern) {
+			return true
+		}
+	}
+	return false
+}
+
+func isRateLimitError(msg string) bool {
+	for _, pattern := range rateLimitPatterns {
+		if strings.Contains(msg, pattern) {
+			return true
+		}
+	}
+	return false
+}

--- a/terraformutils/importreport/classify.go
+++ b/terraformutils/importreport/classify.go
@@ -52,8 +52,9 @@ func ClassifyErrorMessage(msg string) ErrorCategory {
 }
 
 func isAuthError(msg string) bool {
+	lower := strings.ToLower(msg)
 	for _, pattern := range authPatterns {
-		if strings.Contains(msg, pattern) {
+		if strings.Contains(lower, strings.ToLower(pattern)) {
 			return true
 		}
 	}
@@ -61,8 +62,9 @@ func isAuthError(msg string) bool {
 }
 
 func isRateLimitError(msg string) bool {
+	lower := strings.ToLower(msg)
 	for _, pattern := range rateLimitPatterns {
-		if strings.Contains(msg, pattern) {
+		if strings.Contains(lower, strings.ToLower(pattern)) {
 			return true
 		}
 	}

--- a/terraformutils/importreport/classify_test.go
+++ b/terraformutils/importreport/classify_test.go
@@ -47,7 +47,11 @@ func TestClassifyErrorMessage(t *testing.T) {
 	}
 
 	for _, tc := range tests {
-		t.Run(tc.msg[:20], func(t *testing.T) {
+		name := tc.msg
+		if len(name) > 40 {
+			name = name[:40]
+		}
+		t.Run(name, func(t *testing.T) {
 			got := ClassifyErrorMessage(tc.msg)
 			if got != tc.want {
 				t.Errorf("ClassifyErrorMessage(%q) = %q, want %q", tc.msg, got, tc.want)

--- a/terraformutils/importreport/classify_test.go
+++ b/terraformutils/importreport/classify_test.go
@@ -1,0 +1,57 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package importreport
+
+import (
+	"errors"
+	"testing"
+)
+
+func TestClassifyError(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want ErrorCategory
+	}{
+		{"nil error", nil, CategoryUnknown},
+		{"SSO expired", errors.New("failed to refresh cached credentials, the SSO session has expired or is invalid"), CategoryAuth},
+		{"no valid creds", errors.New("No valid credential sources found"), CategoryAuth},
+		{"expired token", errors.New("ExpiredToken: token has expired"), CategoryAuth},
+		{"security token expired", errors.New("the security token included in the request is expired"), CategoryAuth},
+		{"rate exceeded", errors.New("Rate exceeded for API call"), CategoryRateLimit},
+		{"throttling", errors.New("Throttling: rate limit reached"), CategoryRateLimit},
+		{"too many requests", errors.New("TooManyRequestsException: slow down"), CategoryRateLimit},
+		{"generic API error", errors.New("DescribeInstances: connection timeout"), CategoryAPI},
+		{"unknown error", errors.New("something went wrong"), CategoryAPI},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := ClassifyError(tc.err)
+			if got != tc.want {
+				t.Errorf("ClassifyError(%q) = %q, want %q", tc.err, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestClassifyErrorMessage(t *testing.T) {
+	tests := []struct {
+		msg  string
+		want ErrorCategory
+	}{
+		{"InvalidGrantException: device code expired", CategoryAuth},
+		{"RequestLimitExceeded: please slow down", CategoryRateLimit},
+		{"ProvisionedThroughputExceededException", CategoryRateLimit},
+		{"ResourceNotFoundException: table not found", CategoryAPI},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.msg[:20], func(t *testing.T) {
+			got := ClassifyErrorMessage(tc.msg)
+			if got != tc.want {
+				t.Errorf("ClassifyErrorMessage(%q) = %q, want %q", tc.msg, got, tc.want)
+			}
+		})
+	}
+}

--- a/terraformutils/importreport/report.go
+++ b/terraformutils/importreport/report.go
@@ -149,6 +149,8 @@ func (r *Report) summaryLocked() Summary {
 	s := Summary{
 		DurationMs: time.Since(r.StartTime).Milliseconds(),
 	}
+	seenFailed := make(map[string]bool)
+	seenPanic := make(map[string]bool)
 	for _, e := range r.Events {
 		switch e.Status {
 		case StatusSuccess:
@@ -159,14 +161,20 @@ func (r *Report) summaryLocked() Summary {
 			}
 		case StatusFailed:
 			if e.ResourceID != "" {
-				s.ResourcesFailed++
+				if !seenFailed[e.ResourceID] {
+					s.ResourcesFailed++
+					seenFailed[e.ResourceID] = true
+				}
 				s.Failures = append(s.Failures, e)
 			} else {
 				s.ServicesFailed++
 				s.Failures = append(s.Failures, e)
 			}
 		case StatusPanic:
-			s.ResourcesPanic++
+			if !seenPanic[e.ResourceID] {
+				s.ResourcesPanic++
+				seenPanic[e.ResourceID] = true
+			}
 			s.Failures = append(s.Failures, e)
 		case StatusSkipped:
 			if e.ResourceID != "" {

--- a/terraformutils/importreport/report.go
+++ b/terraformutils/importreport/report.go
@@ -1,0 +1,244 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package importreport
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+	"sync"
+	"time"
+)
+
+type ErrorCategory string
+
+const (
+	CategoryAuth      ErrorCategory = "auth"
+	CategoryAPI       ErrorCategory = "api"
+	CategoryPanic     ErrorCategory = "panic"
+	CategoryRateLimit ErrorCategory = "rate_limit"
+	CategoryEmpty     ErrorCategory = "empty"
+	CategoryConvert   ErrorCategory = "convert"
+	CategoryUnknown   ErrorCategory = "unknown"
+)
+
+type Status string
+
+const (
+	StatusSuccess Status = "success"
+	StatusFailed  Status = "failed"
+	StatusSkipped Status = "skipped"
+	StatusEmpty   Status = "empty"
+	StatusPanic   Status = "panic"
+)
+
+type ResourceEvent struct {
+	Service      string        `json:"service"`
+	ResourceType string        `json:"resource_type,omitempty"`
+	ResourceID   string        `json:"resource_id,omitempty"`
+	Status       Status        `json:"status"`
+	Error        string        `json:"error,omitempty"`
+	Category     ErrorCategory `json:"category,omitempty"`
+	Duration     time.Duration `json:"duration_ms,omitempty"`
+}
+
+type Summary struct {
+	Duration         time.Duration   `json:"duration_ms"`
+	ServicesSuccess  int             `json:"services_success"`
+	ServicesFailed   int             `json:"services_failed"`
+	ServicesSkipped  int             `json:"services_skipped"`
+	ResourcesImport  int             `json:"resources_imported"`
+	ResourcesFailed  int             `json:"resources_failed"`
+	ResourcesPanic   int             `json:"resources_panic"`
+	Failures         []ResourceEvent `json:"failures,omitempty"`
+	Skipped          []ResourceEvent `json:"skipped,omitempty"`
+}
+
+type Report struct {
+	mu         sync.Mutex
+	StartTime  time.Time       `json:"start_time"`
+	Events     []ResourceEvent `json:"events"`
+	authFailed map[string]bool
+}
+
+func New() *Report {
+	return &Report{
+		StartTime:  time.Now(),
+		Events:     []ResourceEvent{},
+		authFailed: make(map[string]bool),
+	}
+}
+
+func (r *Report) Add(event ResourceEvent) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.Events = append(r.Events, event)
+}
+
+func (r *Report) IsAuthFailed(sessionKey string) bool {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return r.authFailed[sessionKey]
+}
+
+func (r *Report) SetAuthFailed(sessionKey string) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.authFailed[sessionKey] = true
+}
+
+func (r *Report) HasFailures() bool {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	for _, e := range r.Events {
+		if e.Status == StatusFailed || e.Status == StatusPanic {
+			return true
+		}
+	}
+	return false
+}
+
+func (r *Report) Summary() Summary {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	s := Summary{
+		Duration: time.Since(r.StartTime),
+	}
+
+	for _, e := range r.Events {
+		switch e.Status {
+		case StatusSuccess:
+			if e.ResourceID != "" {
+				s.ResourcesImport++
+			} else {
+				s.ServicesSuccess++
+			}
+		case StatusFailed:
+			if e.ResourceID != "" {
+				s.ResourcesFailed++
+				s.Failures = append(s.Failures, e)
+			} else {
+				s.ServicesFailed++
+				s.Failures = append(s.Failures, e)
+			}
+		case StatusPanic:
+			s.ResourcesPanic++
+			s.Failures = append(s.Failures, e)
+		case StatusSkipped:
+			s.ServicesSkipped++
+			s.Skipped = append(s.Skipped, e)
+		case StatusEmpty:
+			s.ServicesSuccess++
+		}
+	}
+
+	return s
+}
+
+func (r *Report) WriteJSON(w io.Writer) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	enc := json.NewEncoder(w)
+	enc.SetIndent("", "  ")
+	return enc.Encode(struct {
+		StartTime time.Time       `json:"start_time"`
+		Duration  string          `json:"duration"`
+		Events    []ResourceEvent `json:"events"`
+		Summary   Summary         `json:"summary"`
+	}{
+		StartTime: r.StartTime,
+		Duration:  time.Since(r.StartTime).Round(time.Millisecond).String(),
+		Events:    r.Events,
+		Summary:   r.summaryLocked(),
+	})
+}
+
+func (r *Report) summaryLocked() Summary {
+	s := Summary{
+		Duration: time.Since(r.StartTime),
+	}
+	for _, e := range r.Events {
+		switch e.Status {
+		case StatusSuccess:
+			if e.ResourceID != "" {
+				s.ResourcesImport++
+			} else {
+				s.ServicesSuccess++
+			}
+		case StatusFailed:
+			if e.ResourceID != "" {
+				s.ResourcesFailed++
+				s.Failures = append(s.Failures, e)
+			} else {
+				s.ServicesFailed++
+				s.Failures = append(s.Failures, e)
+			}
+		case StatusPanic:
+			s.ResourcesPanic++
+			s.Failures = append(s.Failures, e)
+		case StatusSkipped:
+			s.ServicesSkipped++
+			s.Skipped = append(s.Skipped, e)
+		case StatusEmpty:
+			s.ServicesSuccess++
+		}
+	}
+	return s
+}
+
+func (r *Report) Print() {
+	s := r.Summary()
+	w := os.Stderr
+
+	fmt.Fprintf(w, "\n")
+	fmt.Fprintf(w, "═══════════════════════════════════════════\n")
+	fmt.Fprintf(w, " Import Summary\n")
+	fmt.Fprintf(w, "═══════════════════════════════════════════\n")
+	fmt.Fprintf(w, " Duration:    %s\n", s.Duration.Round(time.Second))
+	fmt.Fprintf(w, " Services:    %d success, %d failed, %d skipped\n",
+		s.ServicesSuccess, s.ServicesFailed, s.ServicesSkipped)
+	fmt.Fprintf(w, " Resources:   %d imported, %d failed, %d panic\n",
+		s.ResourcesImport, s.ResourcesFailed, s.ResourcesPanic)
+	fmt.Fprintf(w, "═══════════════════════════════════════════\n")
+
+	if len(s.Failures) > 0 {
+		fmt.Fprintf(w, " Failures:\n")
+		for _, f := range s.Failures {
+			label := f.Service
+			if f.ResourceType != "" {
+				label = f.Service + "/" + f.ResourceType
+			}
+			errMsg := f.Error
+			if len(errMsg) > 80 {
+				errMsg = errMsg[:80] + "..."
+			}
+			fmt.Fprintf(w, "   %s: %s (%s)\n", label, strings.ToUpper(string(f.Category)), errMsg)
+		}
+	}
+
+	if len(s.Skipped) > 0 {
+		fmt.Fprintf(w, " Skipped (auth):\n")
+		names := make([]string, 0, len(s.Skipped))
+		for _, sk := range s.Skipped {
+			names = append(names, sk.Service)
+		}
+		fmt.Fprintf(w, "   %s\n", strings.Join(names, ", "))
+	}
+
+	if len(s.Failures) > 0 || len(s.Skipped) > 0 {
+		fmt.Fprintf(w, "═══════════════════════════════════════════\n")
+	}
+}
+
+func (r *Report) WriteJSONFile(path string) error {
+	f, err := os.Create(path)
+	if err != nil {
+		return fmt.Errorf("creating report file: %w", err)
+	}
+	defer f.Close()
+	return r.WriteJSON(f)
+}

--- a/terraformutils/importreport/report.go
+++ b/terraformutils/importreport/report.go
@@ -41,11 +41,11 @@ type ResourceEvent struct {
 	Status       Status        `json:"status"`
 	Error        string        `json:"error,omitempty"`
 	Category     ErrorCategory `json:"category,omitempty"`
-	Duration     time.Duration `json:"duration_ms,omitempty"`
+	DurationMs   int64         `json:"duration_ms,omitempty"`
 }
 
 type Summary struct {
-	Duration         time.Duration   `json:"duration_ms"`
+	DurationMs       int64           `json:"duration_ms"`
 	ServicesSuccess  int             `json:"services_success"`
 	ServicesFailed   int             `json:"services_failed"`
 	ServicesSkipped  int             `json:"services_skipped"`
@@ -103,39 +103,7 @@ func (r *Report) HasFailures() bool {
 func (r *Report) Summary() Summary {
 	r.mu.Lock()
 	defer r.mu.Unlock()
-
-	s := Summary{
-		Duration: time.Since(r.StartTime),
-	}
-
-	for _, e := range r.Events {
-		switch e.Status {
-		case StatusSuccess:
-			if e.ResourceID != "" {
-				s.ResourcesImport++
-			} else {
-				s.ServicesSuccess++
-			}
-		case StatusFailed:
-			if e.ResourceID != "" {
-				s.ResourcesFailed++
-				s.Failures = append(s.Failures, e)
-			} else {
-				s.ServicesFailed++
-				s.Failures = append(s.Failures, e)
-			}
-		case StatusPanic:
-			s.ResourcesPanic++
-			s.Failures = append(s.Failures, e)
-		case StatusSkipped:
-			s.ServicesSkipped++
-			s.Skipped = append(s.Skipped, e)
-		case StatusEmpty:
-			s.ServicesSuccess++
-		}
-	}
-
-	return s
+	return r.summaryLocked()
 }
 
 func (r *Report) WriteJSON(w io.Writer) error {
@@ -159,7 +127,7 @@ func (r *Report) WriteJSON(w io.Writer) error {
 
 func (r *Report) summaryLocked() Summary {
 	s := Summary{
-		Duration: time.Since(r.StartTime),
+		DurationMs: time.Since(r.StartTime).Milliseconds(),
 	}
 	for _, e := range r.Events {
 		switch e.Status {
@@ -193,12 +161,13 @@ func (r *Report) summaryLocked() Summary {
 func (r *Report) Print() {
 	s := r.Summary()
 	w := os.Stderr
+	duration := time.Duration(s.DurationMs) * time.Millisecond
 
 	fmt.Fprintf(w, "\n")
 	fmt.Fprintf(w, "═══════════════════════════════════════════\n")
 	fmt.Fprintf(w, " Import Summary\n")
 	fmt.Fprintf(w, "═══════════════════════════════════════════\n")
-	fmt.Fprintf(w, " Duration:    %s\n", s.Duration.Round(time.Second))
+	fmt.Fprintf(w, " Duration:    %s\n", duration.Round(time.Second))
 	fmt.Fprintf(w, " Services:    %d success, %d failed, %d skipped\n",
 		s.ServicesSuccess, s.ServicesFailed, s.ServicesSkipped)
 	fmt.Fprintf(w, " Resources:   %d imported, %d failed, %d panic\n",

--- a/terraformutils/importreport/report.go
+++ b/terraformutils/importreport/report.go
@@ -45,15 +45,15 @@ type ResourceEvent struct {
 }
 
 type Summary struct {
-	DurationMs       int64           `json:"duration_ms"`
-	ServicesSuccess  int             `json:"services_success"`
-	ServicesFailed   int             `json:"services_failed"`
-	ServicesSkipped  int             `json:"services_skipped"`
-	ResourcesImport  int             `json:"resources_imported"`
-	ResourcesFailed  int             `json:"resources_failed"`
-	ResourcesPanic   int             `json:"resources_panic"`
-	Failures         []ResourceEvent `json:"failures,omitempty"`
-	Skipped          []ResourceEvent `json:"skipped,omitempty"`
+	DurationMs      int64           `json:"duration_ms"`
+	ServicesSuccess int             `json:"services_success"`
+	ServicesFailed  int             `json:"services_failed"`
+	ServicesSkipped int             `json:"services_skipped"`
+	ResourcesImport int             `json:"resources_imported"`
+	ResourcesFailed int             `json:"resources_failed"`
+	ResourcesPanic  int             `json:"resources_panic"`
+	Failures        []ResourceEvent `json:"failures,omitempty"`
+	Skipped         []ResourceEvent `json:"skipped,omitempty"`
 }
 
 type Report struct {

--- a/terraformutils/importreport/report.go
+++ b/terraformutils/importreport/report.go
@@ -100,11 +100,18 @@ func (r *Report) HasFailures() bool {
 	return false
 }
 
-func (r *Report) FailedResourceIDs() map[string]bool {
+func (r *Report) EventCount() int {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return len(r.Events)
+}
+
+func (r *Report) FailedResourceIDsSince(startIdx int) map[string]bool {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 	ids := make(map[string]bool)
-	for _, e := range r.Events {
+	for i := startIdx; i < len(r.Events); i++ {
+		e := r.Events[i]
 		if e.ResourceID != "" && (e.Status == StatusFailed || e.Status == StatusPanic) {
 			ids[e.ResourceID] = true
 		}

--- a/terraformutils/importreport/report.go
+++ b/terraformutils/importreport/report.go
@@ -45,15 +45,16 @@ type ResourceEvent struct {
 }
 
 type Summary struct {
-	DurationMs      int64           `json:"duration_ms"`
-	ServicesSuccess int             `json:"services_success"`
-	ServicesFailed  int             `json:"services_failed"`
-	ServicesSkipped int             `json:"services_skipped"`
-	ResourcesImport int             `json:"resources_imported"`
-	ResourcesFailed int             `json:"resources_failed"`
-	ResourcesPanic  int             `json:"resources_panic"`
-	Failures        []ResourceEvent `json:"failures,omitempty"`
-	Skipped         []ResourceEvent `json:"skipped,omitempty"`
+	DurationMs       int64           `json:"duration_ms"`
+	ServicesSuccess  int             `json:"services_success"`
+	ServicesFailed   int             `json:"services_failed"`
+	ServicesSkipped  int             `json:"services_skipped"`
+	ResourcesImport  int             `json:"resources_imported"`
+	ResourcesFailed  int             `json:"resources_failed"`
+	ResourcesPanic   int             `json:"resources_panic"`
+	ResourcesSkipped int             `json:"resources_skipped"`
+	Failures         []ResourceEvent `json:"failures,omitempty"`
+	Skipped          []ResourceEvent `json:"skipped,omitempty"`
 }
 
 type Report struct {
@@ -168,7 +169,11 @@ func (r *Report) summaryLocked() Summary {
 			s.ResourcesPanic++
 			s.Failures = append(s.Failures, e)
 		case StatusSkipped:
-			s.ServicesSkipped++
+			if e.ResourceID != "" {
+				s.ResourcesSkipped++
+			} else {
+				s.ServicesSkipped++
+			}
 			s.Skipped = append(s.Skipped, e)
 		case StatusEmpty:
 			s.ServicesSuccess++
@@ -189,8 +194,8 @@ func (r *Report) Print() {
 	fmt.Fprintf(w, " Duration:    %s\n", duration.Round(time.Second))
 	fmt.Fprintf(w, " Services:    %d success, %d failed, %d skipped\n",
 		s.ServicesSuccess, s.ServicesFailed, s.ServicesSkipped)
-	fmt.Fprintf(w, " Resources:   %d imported, %d failed, %d panic\n",
-		s.ResourcesImport, s.ResourcesFailed, s.ResourcesPanic)
+	fmt.Fprintf(w, " Resources:   %d imported, %d failed, %d panic, %d skipped\n",
+		s.ResourcesImport, s.ResourcesFailed, s.ResourcesPanic, s.ResourcesSkipped)
 	fmt.Fprintf(w, "═══════════════════════════════════════════\n")
 
 	if len(s.Failures) > 0 {
@@ -208,11 +213,15 @@ func (r *Report) Print() {
 		}
 	}
 
-	if len(s.Skipped) > 0 {
+	if s.ServicesSkipped > 0 || s.ResourcesSkipped > 0 {
 		fmt.Fprintf(w, " Skipped (auth):\n")
-		names := make([]string, 0, len(s.Skipped))
+		seen := make(map[string]bool)
+		names := make([]string, 0)
 		for _, sk := range s.Skipped {
-			names = append(names, sk.Service)
+			if !seen[sk.Service] {
+				seen[sk.Service] = true
+				names = append(names, sk.Service)
+			}
 		}
 		fmt.Fprintf(w, "   %s\n", strings.Join(names, ", "))
 	}

--- a/terraformutils/importreport/report.go
+++ b/terraformutils/importreport/report.go
@@ -100,6 +100,18 @@ func (r *Report) HasFailures() bool {
 	return false
 }
 
+func (r *Report) FailedResourceIDs() map[string]bool {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	ids := make(map[string]bool)
+	for _, e := range r.Events {
+		if e.ResourceID != "" && (e.Status == StatusFailed || e.Status == StatusPanic) {
+			ids[e.ResourceID] = true
+		}
+	}
+	return ids
+}
+
 func (r *Report) Summary() Summary {
 	r.mu.Lock()
 	defer r.mu.Unlock()

--- a/terraformutils/importreport/report_test.go
+++ b/terraformutils/importreport/report_test.go
@@ -90,10 +90,10 @@ func TestConcurrentAdd(t *testing.T) {
 
 	for i := 0; i < 100; i++ {
 		wg.Add(1)
-		go func(i int) {
+		go func() {
 			defer wg.Done()
 			r.Add(ResourceEvent{Service: "svc", ResourceID: "r", Status: StatusSuccess})
-		}(i)
+		}()
 	}
 	wg.Wait()
 

--- a/terraformutils/importreport/report_test.go
+++ b/terraformutils/importreport/report_test.go
@@ -1,0 +1,126 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package importreport
+
+import (
+	"bytes"
+	"encoding/json"
+	"sync"
+	"testing"
+)
+
+func TestReportAddAndSummary(t *testing.T) {
+	r := New()
+	r.Add(ResourceEvent{Service: "vpc", Status: StatusSuccess})
+	r.Add(ResourceEvent{Service: "iam", Status: StatusSuccess})
+	r.Add(ResourceEvent{Service: "backup", Status: StatusFailed, Category: CategoryAPI, Error: "timeout"})
+	r.Add(ResourceEvent{Service: "ses", Status: StatusSkipped, Category: CategoryAuth})
+
+	s := r.Summary()
+
+	if s.ServicesSuccess != 2 {
+		t.Errorf("ServicesSuccess = %d, want 2", s.ServicesSuccess)
+	}
+	if s.ServicesFailed != 1 {
+		t.Errorf("ServicesFailed = %d, want 1", s.ServicesFailed)
+	}
+	if s.ServicesSkipped != 1 {
+		t.Errorf("ServicesSkipped = %d, want 1", s.ServicesSkipped)
+	}
+	if len(s.Failures) != 1 {
+		t.Errorf("Failures count = %d, want 1", len(s.Failures))
+	}
+	if len(s.Skipped) != 1 {
+		t.Errorf("Skipped count = %d, want 1", len(s.Skipped))
+	}
+}
+
+func TestReportResourceEvents(t *testing.T) {
+	r := New()
+	r.Add(ResourceEvent{Service: "backup", ResourceID: "vault-1", Status: StatusSuccess})
+	r.Add(ResourceEvent{Service: "backup", ResourceID: "framework-1", Status: StatusPanic, Category: CategoryPanic, Error: "cty panic"})
+	r.Add(ResourceEvent{Service: "backup", ResourceID: "plan-1", Status: StatusFailed, Category: CategoryAPI, Error: "api err"})
+
+	s := r.Summary()
+
+	if s.ResourcesImport != 1 {
+		t.Errorf("ResourcesImport = %d, want 1", s.ResourcesImport)
+	}
+	if s.ResourcesPanic != 1 {
+		t.Errorf("ResourcesPanic = %d, want 1", s.ResourcesPanic)
+	}
+	if s.ResourcesFailed != 1 {
+		t.Errorf("ResourcesFailed = %d, want 1", s.ResourcesFailed)
+	}
+}
+
+func TestAuthFailedTracking(t *testing.T) {
+	r := New()
+
+	if r.IsAuthFailed("aws-us-east-1") {
+		t.Error("should not be auth failed initially")
+	}
+
+	r.SetAuthFailed("aws-us-east-1")
+
+	if !r.IsAuthFailed("aws-us-east-1") {
+		t.Error("should be auth failed after SetAuthFailed")
+	}
+	if r.IsAuthFailed("aws-eu-west-1") {
+		t.Error("different session should not be auth failed")
+	}
+}
+
+func TestHasFailures(t *testing.T) {
+	r := New()
+	r.Add(ResourceEvent{Service: "vpc", Status: StatusSuccess})
+	if r.HasFailures() {
+		t.Error("should not have failures with only successes")
+	}
+
+	r.Add(ResourceEvent{Service: "iam", Status: StatusFailed, Error: "err"})
+	if !r.HasFailures() {
+		t.Error("should have failures after adding failed event")
+	}
+}
+
+func TestConcurrentAdd(t *testing.T) {
+	r := New()
+	var wg sync.WaitGroup
+
+	for i := 0; i < 100; i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			r.Add(ResourceEvent{Service: "svc", ResourceID: "r", Status: StatusSuccess})
+		}(i)
+	}
+	wg.Wait()
+
+	if len(r.Events) != 100 {
+		t.Errorf("Events count = %d, want 100", len(r.Events))
+	}
+}
+
+func TestWriteJSON(t *testing.T) {
+	r := New()
+	r.Add(ResourceEvent{Service: "vpc", Status: StatusSuccess})
+	r.Add(ResourceEvent{Service: "iam", Status: StatusFailed, Category: CategoryAuth, Error: "expired"})
+
+	var buf bytes.Buffer
+	if err := r.WriteJSON(&buf); err != nil {
+		t.Fatalf("WriteJSON error: %v", err)
+	}
+
+	var result map[string]interface{}
+	if err := json.Unmarshal(buf.Bytes(), &result); err != nil {
+		t.Fatalf("invalid JSON output: %v", err)
+	}
+
+	if _, ok := result["events"]; !ok {
+		t.Error("JSON output missing 'events' field")
+	}
+	if _, ok := result["summary"]; !ok {
+		t.Error("JSON output missing 'summary' field")
+	}
+}

--- a/terraformutils/providers_mapping.go
+++ b/terraformutils/providers_mapping.go
@@ -7,6 +7,7 @@ import (
 	"reflect"
 	"time"
 
+	"github.com/chenrui333/terraformer/terraformutils/importreport"
 	"github.com/chenrui333/terraformer/terraformutils/providerwrapper"
 )
 
@@ -155,11 +156,20 @@ func (p *ProvidersMapping) GetResourcesByService() map[string][]Resource {
 	return mapping
 }
 
-func (p *ProvidersMapping) ConvertTFStates(providerWrapper *providerwrapper.ProviderWrapper) {
+func (p *ProvidersMapping) ConvertTFStates(providerWrapper *providerwrapper.ProviderWrapper, report *importreport.Report) {
 	for resource := range p.Resources {
 		err := resource.ConvertTFstate(providerWrapper)
 		if err != nil {
 			log.Printf("failed to convert resources %s because of error %s", resource.InstanceInfo.Id, err)
+			service := p.providerToService[p.resourceToProvider[resource]]
+			report.Add(importreport.ResourceEvent{
+				Service:      service,
+				ResourceType: resource.InstanceInfo.Type,
+				ResourceID:   resource.InstanceInfo.Id,
+				Status:       importreport.StatusFailed,
+				Category:     importreport.CategoryConvert,
+				Error:        err.Error(),
+			})
 		}
 	}
 
@@ -177,11 +187,20 @@ func (p *ProvidersMapping) ConvertTFStates(providerWrapper *providerwrapper.Prov
 	}
 }
 
-func (p *ProvidersMapping) ConvertTypedStates(providerWrapper *providerwrapper.ProviderWrapper) {
+func (p *ProvidersMapping) ConvertTypedStates(providerWrapper *providerwrapper.ProviderWrapper, report *importreport.Report) {
 	for resource := range p.Resources {
 		err := resource.ConvertTypedState(providerWrapper)
 		if err != nil {
 			log.Printf("failed to convert typed state for resource %s because of error %s", resource.InstanceInfo.Id, err)
+			service := p.providerToService[p.resourceToProvider[resource]]
+			report.Add(importreport.ResourceEvent{
+				Service:      service,
+				ResourceType: resource.InstanceInfo.Type,
+				ResourceID:   resource.InstanceInfo.Id,
+				Status:       importreport.StatusFailed,
+				Category:     importreport.CategoryConvert,
+				Error:        err.Error(),
+			})
 		}
 	}
 }

--- a/terraformutils/providers_mapping.go
+++ b/terraformutils/providers_mapping.go
@@ -114,6 +114,14 @@ func (p *ProvidersMapping) MatchProvider(resource *Resource) ProviderGenerator {
 	return p.resourceToProvider[resource]
 }
 
+func (p *ProvidersMapping) GetServiceForResource(resource *Resource) string {
+	provider := p.resourceToProvider[resource]
+	if provider == nil {
+		return ""
+	}
+	return p.providerToService[provider]
+}
+
 func (p *ProvidersMapping) SetResources(resourceToKeep []*Resource) {
 	p.Resources = map[*Resource]bool{}
 	resourcesGroupsByProviders := map[ProviderGenerator][]Resource{}

--- a/terraformutils/resource.go
+++ b/terraformutils/resource.go
@@ -30,6 +30,7 @@ type Resource struct {
 	AdditionalFields  map[string]interface{} `json:",omitempty"`
 	SlowQueryRequired bool
 	DataFiles         map[string][]byte
+	RefreshError      error `json:"-"`
 }
 
 type ApplicableFilter interface {
@@ -122,6 +123,7 @@ func (r *Resource) Refresh(provider *providerwrapper.ProviderWrapper) {
 	r.InstanceState, err = provider.Refresh(r.InstanceInfo, r.InstanceState)
 	if err != nil {
 		log.Println(err)
+		r.RefreshError = err
 	}
 }
 

--- a/terraformutils/utils.go
+++ b/terraformutils/utils.go
@@ -9,6 +9,7 @@ import (
 	"runtime"
 	"sort"
 	"sync"
+	"sync/atomic"
 
 	"github.com/chenrui333/terraformer/terraformutils/importreport"
 	"github.com/chenrui333/terraformer/terraformutils/providerwrapper"
@@ -162,7 +163,7 @@ func schemaVersion(meta map[string]interface{}) uint64 {
 	}
 }
 
-func RefreshResources(resources []*Resource, provider *providerwrapper.ProviderWrapper, slowProcessingResources [][]*Resource, panickedIDs *sync.Map) ([]*Resource, error) {
+func RefreshResources(resources []*Resource, provider *providerwrapper.ProviderWrapper, slowProcessingResources [][]*Resource, panickedIDs *sync.Map, authAbort *atomic.Bool) ([]*Resource, error) {
 	refreshedResources := []*Resource{}
 	input := make(chan *Resource, len(resources))
 	var wg sync.WaitGroup
@@ -174,7 +175,7 @@ func RefreshResources(resources []*Resource, provider *providerwrapper.ProviderW
 	close(input)
 
 	for i := 0; i < poolSize; i++ {
-		go RefreshResourceWorker(input, &wg, provider, panickedIDs)
+		go RefreshResourceWorker(input, &wg, provider, panickedIDs, authAbort)
 	}
 
 	spInputs := []chan *Resource{}
@@ -188,7 +189,7 @@ func RefreshResources(resources []*Resource, provider *providerwrapper.ProviderW
 
 	for i := 0; i < len(spInputs); i++ {
 		wg.Add(len(slowProcessingResources[i]))
-		go RefreshResourceWorker(spInputs[i], &wg, provider, panickedIDs)
+		go RefreshResourceWorker(spInputs[i], &wg, provider, panickedIDs, authAbort)
 	}
 
 	wg.Wait()
@@ -241,7 +242,8 @@ func RefreshResourcesByProvider(providersMapping *ProvidersMapping, providerWrap
 	}
 
 	var panickedIDs sync.Map
-	refreshedResources, err := RefreshResources(regularResources, providerWrapper, spResourcesList, &panickedIDs)
+	var authAbort atomic.Bool
+	refreshedResources, err := RefreshResources(regularResources, providerWrapper, spResourcesList, &panickedIDs, &authAbort)
 	if err != nil {
 		return err
 	}
@@ -295,7 +297,7 @@ func RefreshResourcesByProvider(providersMapping *ProvidersMapping, providerWrap
 	return nil
 }
 
-func RefreshResourceWorker(input chan *Resource, wg *sync.WaitGroup, provider *providerwrapper.ProviderWrapper, panickedIDs *sync.Map) {
+func RefreshResourceWorker(input chan *Resource, wg *sync.WaitGroup, provider *providerwrapper.ProviderWrapper, panickedIDs *sync.Map, authAbort *atomic.Bool) {
 	for r := range input {
 		func() {
 			defer func() {
@@ -315,8 +317,15 @@ func RefreshResourceWorker(input chan *Resource, wg *sync.WaitGroup, provider *p
 				}
 				wg.Done()
 			}()
+			if authAbort.Load() {
+				r.InstanceState = nil
+				return
+			}
 			log.Println("Refreshing state...", r.InstanceInfo.Id)
 			r.Refresh(provider)
+			if r.RefreshError != nil && importreport.ClassifyError(r.RefreshError) == importreport.CategoryAuth {
+				authAbort.Store(true)
+			}
 		}()
 	}
 }

--- a/terraformutils/utils.go
+++ b/terraformutils/utils.go
@@ -234,9 +234,20 @@ func RefreshResourcesByProvider(providersMapping *ProvidersMapping, providerWrap
 		spResourcesList = append(spResourcesList, slowProcessingResources[p])
 	}
 
+	totalResources := len(regularResources)
+	for _, sp := range spResourcesList {
+		totalResources += len(sp)
+	}
+
 	refreshedResources, err := RefreshResources(regularResources, providerWrapper, spResourcesList)
 	if err != nil {
 		return err
+	}
+
+	failedCount := totalResources - len(refreshedResources)
+	if failedCount > 0 {
+		log.Printf("Refresh complete: %d resources refreshed, %d failed/skipped",
+			len(refreshedResources), failedCount)
 	}
 
 	providersMapping.SetResources(refreshedResources)

--- a/terraformutils/utils.go
+++ b/terraformutils/utils.go
@@ -213,7 +213,7 @@ func RefreshResources(resources []*Resource, provider *providerwrapper.ProviderW
 	return refreshedResources, nil
 }
 
-func RefreshResourcesByProvider(providersMapping *ProvidersMapping, providerWrapper *providerwrapper.ProviderWrapper, report *importreport.Report) error {
+func RefreshResourcesByProvider(providersMapping *ProvidersMapping, providerWrapper *providerwrapper.ProviderWrapper, report *importreport.Report, sessionKey string) error {
 	allResources := providersMapping.ShuffleResources()
 	slowProcessingResources := make(map[ProviderGenerator][]*Resource)
 	regularResources := []*Resource{}
@@ -271,6 +271,9 @@ func RefreshResourcesByProvider(providersMapping *ProvidersMapping, providerWrap
 		} else if r.RefreshError != nil {
 			category = importreport.ClassifyError(r.RefreshError)
 			errMsg = r.RefreshError.Error()
+			if category == importreport.CategoryAuth && sessionKey != "" {
+				report.SetAuthFailed(sessionKey)
+			}
 		}
 		report.Add(importreport.ResourceEvent{
 			Service:      service,

--- a/terraformutils/utils.go
+++ b/terraformutils/utils.go
@@ -255,6 +255,9 @@ func RefreshResourcesByProvider(providersMapping *ProvidersMapping, providerWrap
 		if refreshedSet[r] {
 			continue
 		}
+		if r == nil || r.InstanceInfo == nil {
+			continue
+		}
 		service := providersMapping.GetServiceForResource(r)
 		if service == "" {
 			service = r.InstanceInfo.Type

--- a/terraformutils/utils.go
+++ b/terraformutils/utils.go
@@ -246,43 +246,37 @@ func RefreshResourcesByProvider(providersMapping *ProvidersMapping, providerWrap
 		return err
 	}
 
-	// Feed resource outcomes into the report
+	// Feed resource failure outcomes into the report (successes counted after conversion)
 	refreshedSet := make(map[*Resource]bool, len(refreshedResources))
 	for _, r := range refreshedResources {
 		refreshedSet[r] = true
 	}
 	for _, r := range allResources {
+		if refreshedSet[r] {
+			continue
+		}
 		service := providersMapping.GetServiceForResource(r)
 		if service == "" {
 			service = r.InstanceInfo.Type
 		}
-		if refreshedSet[r] {
-			report.Add(importreport.ResourceEvent{
-				Service:      service,
-				ResourceType: r.InstanceInfo.Type,
-				ResourceID:   r.InstanceInfo.Id,
-				Status:       importreport.StatusSuccess,
-			})
-		} else {
-			status := importreport.StatusFailed
-			category := importreport.CategoryAPI
-			errMsg := ""
-			if _, wasPanic := panickedIDs.Load(r.InstanceInfo.Id); wasPanic {
-				status = importreport.StatusPanic
-				category = importreport.CategoryPanic
-			} else if r.RefreshError != nil {
-				category = importreport.ClassifyError(r.RefreshError)
-				errMsg = r.RefreshError.Error()
-			}
-			report.Add(importreport.ResourceEvent{
-				Service:      service,
-				ResourceType: r.InstanceInfo.Type,
-				ResourceID:   r.InstanceInfo.Id,
-				Status:       status,
-				Category:     category,
-				Error:        errMsg,
-			})
+		status := importreport.StatusFailed
+		category := importreport.CategoryAPI
+		errMsg := ""
+		if _, wasPanic := panickedIDs.Load(r.InstanceInfo.Id); wasPanic {
+			status = importreport.StatusPanic
+			category = importreport.CategoryPanic
+		} else if r.RefreshError != nil {
+			category = importreport.ClassifyError(r.RefreshError)
+			errMsg = r.RefreshError.Error()
 		}
+		report.Add(importreport.ResourceEvent{
+			Service:      service,
+			ResourceType: r.InstanceInfo.Type,
+			ResourceID:   r.InstanceInfo.Id,
+			Status:       status,
+			Category:     category,
+			Error:        errMsg,
+		})
 	}
 
 	failedCount := totalResources - len(refreshedResources)

--- a/terraformutils/utils.go
+++ b/terraformutils/utils.go
@@ -162,7 +162,7 @@ func schemaVersion(meta map[string]interface{}) uint64 {
 	}
 }
 
-func RefreshResources(resources []*Resource, provider *providerwrapper.ProviderWrapper, slowProcessingResources [][]*Resource) ([]*Resource, error) {
+func RefreshResources(resources []*Resource, provider *providerwrapper.ProviderWrapper, slowProcessingResources [][]*Resource, panickedIDs *sync.Map) ([]*Resource, error) {
 	refreshedResources := []*Resource{}
 	input := make(chan *Resource, len(resources))
 	var wg sync.WaitGroup
@@ -174,7 +174,7 @@ func RefreshResources(resources []*Resource, provider *providerwrapper.ProviderW
 	close(input)
 
 	for i := 0; i < poolSize; i++ {
-		go RefreshResourceWorker(input, &wg, provider)
+		go RefreshResourceWorker(input, &wg, provider, panickedIDs)
 	}
 
 	spInputs := []chan *Resource{}
@@ -188,7 +188,7 @@ func RefreshResources(resources []*Resource, provider *providerwrapper.ProviderW
 
 	for i := 0; i < len(spInputs); i++ {
 		wg.Add(len(slowProcessingResources[i]))
-		go RefreshResourceWorker(spInputs[i], &wg, provider)
+		go RefreshResourceWorker(spInputs[i], &wg, provider, panickedIDs)
 	}
 
 	wg.Wait()
@@ -240,7 +240,8 @@ func RefreshResourcesByProvider(providersMapping *ProvidersMapping, providerWrap
 		totalResources += len(sp)
 	}
 
-	refreshedResources, err := RefreshResources(regularResources, providerWrapper, spResourcesList)
+	var panickedIDs sync.Map
+	refreshedResources, err := RefreshResources(regularResources, providerWrapper, spResourcesList, &panickedIDs)
 	if err != nil {
 		return err
 	}
@@ -260,15 +261,17 @@ func RefreshResourcesByProvider(providersMapping *ProvidersMapping, providerWrap
 			})
 		} else {
 			status := importreport.StatusFailed
-			if r.InstanceState == nil {
+			category := importreport.CategoryAPI
+			if _, wasPanic := panickedIDs.Load(r.InstanceInfo.Id); wasPanic {
 				status = importreport.StatusPanic
+				category = importreport.CategoryPanic
 			}
 			report.Add(importreport.ResourceEvent{
 				Service:      r.InstanceInfo.Type,
 				ResourceType: r.InstanceInfo.Type,
 				ResourceID:   r.InstanceInfo.Id,
 				Status:       status,
-				Category:     importreport.CategoryAPI,
+				Category:     category,
 			})
 		}
 	}
@@ -283,7 +286,7 @@ func RefreshResourcesByProvider(providersMapping *ProvidersMapping, providerWrap
 	return nil
 }
 
-func RefreshResourceWorker(input chan *Resource, wg *sync.WaitGroup, provider *providerwrapper.ProviderWrapper) {
+func RefreshResourceWorker(input chan *Resource, wg *sync.WaitGroup, provider *providerwrapper.ProviderWrapper, panickedIDs *sync.Map) {
 	for r := range input {
 		func() {
 			defer func() {
@@ -293,6 +296,7 @@ func RefreshResourceWorker(input chan *Resource, wg *sync.WaitGroup, provider *p
 					id := "<unknown>"
 					if r != nil && r.InstanceInfo != nil {
 						id = r.InstanceInfo.Id
+						panickedIDs.Store(id, true)
 					}
 					log.Printf("PANIC: Refresh failed for resource %s: %v\n%s",
 						id, rec, buf[:n])

--- a/terraformutils/utils.go
+++ b/terraformutils/utils.go
@@ -5,6 +5,7 @@ package terraformutils
 import (
 	"bytes"
 	"encoding/json"
+	"errors"
 	"log"
 	"runtime"
 	"sort"
@@ -14,6 +15,8 @@ import (
 	"github.com/chenrui333/terraformer/terraformutils/importreport"
 	"github.com/chenrui333/terraformer/terraformutils/providerwrapper"
 )
+
+var errAuthAborted = errors.New("skipped due to auth failure in this session")
 
 type BaseResource struct {
 	Tags map[string]string `json:"tags,omitempty"`
@@ -270,6 +273,10 @@ func RefreshResourcesByProvider(providersMapping *ProvidersMapping, providerWrap
 		if _, wasPanic := panickedIDs.Load(r.InstanceInfo.Id); wasPanic {
 			status = importreport.StatusPanic
 			category = importreport.CategoryPanic
+		} else if errors.Is(r.RefreshError, errAuthAborted) {
+			status = importreport.StatusSkipped
+			category = importreport.CategoryAuth
+			errMsg = r.RefreshError.Error()
 		} else if r.RefreshError != nil {
 			category = importreport.ClassifyError(r.RefreshError)
 			errMsg = r.RefreshError.Error()
@@ -319,6 +326,7 @@ func RefreshResourceWorker(input chan *Resource, wg *sync.WaitGroup, provider *p
 			}()
 			if authAbort.Load() {
 				r.InstanceState = nil
+				r.RefreshError = errAuthAborted
 				return
 			}
 			log.Println("Refreshing state...", r.InstanceInfo.Id)

--- a/terraformutils/utils.go
+++ b/terraformutils/utils.go
@@ -10,6 +10,7 @@ import (
 	"sort"
 	"sync"
 
+	"github.com/chenrui333/terraformer/terraformutils/importreport"
 	"github.com/chenrui333/terraformer/terraformutils/providerwrapper"
 )
 
@@ -212,7 +213,7 @@ func RefreshResources(resources []*Resource, provider *providerwrapper.ProviderW
 	return refreshedResources, nil
 }
 
-func RefreshResourcesByProvider(providersMapping *ProvidersMapping, providerWrapper *providerwrapper.ProviderWrapper) error {
+func RefreshResourcesByProvider(providersMapping *ProvidersMapping, providerWrapper *providerwrapper.ProviderWrapper, report *importreport.Report) error {
 	allResources := providersMapping.ShuffleResources()
 	slowProcessingResources := make(map[ProviderGenerator][]*Resource)
 	regularResources := []*Resource{}
@@ -242,6 +243,34 @@ func RefreshResourcesByProvider(providersMapping *ProvidersMapping, providerWrap
 	refreshedResources, err := RefreshResources(regularResources, providerWrapper, spResourcesList)
 	if err != nil {
 		return err
+	}
+
+	// Feed resource outcomes into the report
+	refreshedSet := make(map[*Resource]bool, len(refreshedResources))
+	for _, r := range refreshedResources {
+		refreshedSet[r] = true
+	}
+	for _, r := range allResources {
+		if refreshedSet[r] {
+			report.Add(importreport.ResourceEvent{
+				Service:      r.InstanceInfo.Type,
+				ResourceType: r.InstanceInfo.Type,
+				ResourceID:   r.InstanceInfo.Id,
+				Status:       importreport.StatusSuccess,
+			})
+		} else {
+			status := importreport.StatusFailed
+			if r.InstanceState == nil {
+				status = importreport.StatusPanic
+			}
+			report.Add(importreport.ResourceEvent{
+				Service:      r.InstanceInfo.Type,
+				ResourceType: r.InstanceInfo.Type,
+				ResourceID:   r.InstanceInfo.Id,
+				Status:       status,
+				Category:     importreport.CategoryAPI,
+			})
+		}
 	}
 
 	failedCount := totalResources - len(refreshedResources)

--- a/terraformutils/utils.go
+++ b/terraformutils/utils.go
@@ -252,9 +252,13 @@ func RefreshResourcesByProvider(providersMapping *ProvidersMapping, providerWrap
 		refreshedSet[r] = true
 	}
 	for _, r := range allResources {
+		service := providersMapping.GetServiceForResource(r)
+		if service == "" {
+			service = r.InstanceInfo.Type
+		}
 		if refreshedSet[r] {
 			report.Add(importreport.ResourceEvent{
-				Service:      r.InstanceInfo.Type,
+				Service:      service,
 				ResourceType: r.InstanceInfo.Type,
 				ResourceID:   r.InstanceInfo.Id,
 				Status:       importreport.StatusSuccess,
@@ -262,16 +266,21 @@ func RefreshResourcesByProvider(providersMapping *ProvidersMapping, providerWrap
 		} else {
 			status := importreport.StatusFailed
 			category := importreport.CategoryAPI
+			errMsg := ""
 			if _, wasPanic := panickedIDs.Load(r.InstanceInfo.Id); wasPanic {
 				status = importreport.StatusPanic
 				category = importreport.CategoryPanic
+			} else if r.RefreshError != nil {
+				category = importreport.ClassifyError(r.RefreshError)
+				errMsg = r.RefreshError.Error()
 			}
 			report.Add(importreport.ResourceEvent{
-				Service:      r.InstanceInfo.Type,
+				Service:      service,
 				ResourceType: r.InstanceInfo.Type,
 				ResourceID:   r.InstanceInfo.Id,
 				Status:       status,
 				Category:     category,
+				Error:        errMsg,
 			})
 		}
 	}

--- a/terraformutils/utils_test.go
+++ b/terraformutils/utils_test.go
@@ -5,6 +5,7 @@ package terraformutils
 import (
 	"encoding/json"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -205,13 +206,14 @@ func TestRefreshResourceWorker_PanicRecovery(t *testing.T) {
 	input := make(chan *Resource, 1)
 	var wg sync.WaitGroup
 	var panickedIDs sync.Map
+	var authAbort atomic.Bool
 
 	wg.Add(1)
 	input <- &r
 	close(input)
 
 	// nil provider causes panic in Refresh — recovery must catch it
-	RefreshResourceWorker(input, &wg, nil, &panickedIDs)
+	RefreshResourceWorker(input, &wg, nil, &panickedIDs, &authAbort)
 
 	done := make(chan struct{})
 	go func() {

--- a/terraformutils/utils_test.go
+++ b/terraformutils/utils_test.go
@@ -204,13 +204,14 @@ func TestRefreshResourceWorker_PanicRecovery(t *testing.T) {
 
 	input := make(chan *Resource, 1)
 	var wg sync.WaitGroup
+	var panickedIDs sync.Map
 
 	wg.Add(1)
 	input <- &r
 	close(input)
 
 	// nil provider causes panic in Refresh — recovery must catch it
-	RefreshResourceWorker(input, &wg, nil)
+	RefreshResourceWorker(input, &wg, nil, &panickedIDs)
 
 	done := make(chan struct{})
 	go func() {
@@ -225,5 +226,9 @@ func TestRefreshResourceWorker_PanicRecovery(t *testing.T) {
 
 	if r.InstanceState != nil {
 		t.Error("expected InstanceState to be nil after panic recovery")
+	}
+
+	if _, ok := panickedIDs.Load(r.InstanceInfo.Id); !ok {
+		t.Errorf("expected %s to be recorded in panickedIDs", r.InstanceInfo.Id)
 	}
 }


### PR DESCRIPTION
## Summary

Adds a full import observability framework:

### Error Taxonomy
Classifies errors into categories: `auth`, `api`, `panic`, `rate_limit`, `empty`, `convert`, `unknown`.

### Auth Early-Exit
Detects credential expiry (SSO, expired tokens) on first failure and skips remaining services for that provider session instead of cascading failures through every resource type.

### Import Summary
Always printed to stderr after every run:

```
═══════════════════════════════════════════
 Import Summary
═══════════════════════════════════════════
 Duration:    2m 34s
 Services:    28 success, 1 failed, 5 skipped
 Resources:   412 imported, 3 failed, 1 panic
═══════════════════════════════════════════
 Failures:
   backup: API (timeout)
 Skipped (auth):
   ses, sqs, sns, waf, waf_regional
═══════════════════════════════════════════
```

### JSON Report Export
`--report path.json` writes machine-readable report for automation.

### Non-Zero Exit
Exit code 1 when any service fails — partial failures are no longer silent.

## Motivation

From production batch runs (see PR #509 context): credential failures cascaded through 20+ services, errors were log-and-swallow with no summary, and exit code was always 0 even on partial failures.

## Test Coverage

- Error classification (auth patterns, rate-limit patterns, generic API)
- Report collection, concurrency safety, summary generation
- Auth failure tracking and early-exit
- JSON output structure

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an import observability framework with error taxonomy, auth early-exit, and end-of-run reporting to surface failures and stop cascades. `--report` is now a root flag (usable with `plan`); runs exit non-zero on failures or report write errors, and plan-only runs don’t emit a report.

- New Features
  - Added `terraformutils/importreport`: thread-safe events, stderr summary, JSON writer (`duration_ms`); aggregates multi-region runs; non-zero exit on failures/write errors.
  - Error taxonomy: `auth`, `api`, `panic`, `rate_limit`, `empty`, `convert`, `unknown`; case-insensitive; includes Azure CLI expiry patterns (e.g., AADSTS700082).
  - Auth early-exit: on first `auth` failure per provider session + args (region/profile); records service- and resource-level skips without cascading.
  - Resource lifecycle reporting: tracks success/failed/panic/skipped; preserves `RefreshError`; conversion failures emit `CategoryConvert`; counts imports only after successful output; records output (plan/apply) failures; deduplicates failed resource counts in the summary.
  - `--report` moved to root; available to `plan`; `import plan` does not emit a report.

- Bug Fixes
  - Enforce early-exit during refresh with an atomic abort; workers skip queued resources and mark them skipped/auth.
  - Track panics explicitly via `sync.Map`; nil-safe classification and reporting; setup-time auth/provider-init failures recorded and trigger early-exit.
  - Prevent cross-region suppression: per-import scoping of failed IDs; emit success events after convert/typed conversion and post-processing; exclude failed IDs from success count.
  - Report finalization always runs; output failures are captured; exit is non-zero on report write errors.

<sup>Written for commit fba0555002ffbb384275fb4cde76f9c6e1f451e4. Summary will update on new commits. <a href="https://cubic.dev/pr/chenrui333/terraformer/pull/510?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Import reporting with JSON and human-readable output, persistent --report output, and report-driven exit status
  * Per-session auth-fail tracking that skips subsequent services and records skipped services

* **Bug Fixes / Improvements**
  * Record per-service and per-resource outcomes; exclude failed/panicked resources from success lists
  * Track panics during refresh and capture refresh errors on resources
  * Conversion now emits report events for per-resource conversion failures

* **Tests**
  * Added unit and concurrency tests for reporting, classification, auth-tracking, and panic recovery

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/chenrui333/terraformer/pull/510?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->