### PR TITLE
fix(aws): preserve provider import state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,22 @@
 # Changelog
 
+## 0.13.2
+
+`0.13.2` is a focused AWS import correctness patch. It fixes refresh-stable
+state seeding for selected AWS resources whose Terraform provider import/read
+contracts differ from the raw AWS discovery identifiers.
+
+### Highlights
+
+* Preserve provider-readable state for Lambda runtime/recursion configuration
+  and ECR account setting imports.
+* Fix SSM maintenance window target/task filtering while keeping provider state
+  IDs compatible with refresh.
+* Keep GuardDuty organization-admin discovery and ACM validation-timeout
+  handling narrowly scoped to provider/API semantics.
+
+**Full Changelog**: <https://github.com/chenrui333/terraformer/compare/v0.13.1...v0.13.2>
+
 ## 0.13.1
 
 `0.13.1` is a focused import-observability release. It makes partial import

--- a/providers/aws/acm.go
+++ b/providers/aws/acm.go
@@ -7,9 +7,10 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/chenrui333/terraformer/terraformutils"
-
+	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/acm"
+	acmtypes "github.com/aws/aws-sdk-go-v2/service/acm/types"
+	"github.com/chenrui333/terraformer/terraformutils"
 )
 
 var acmAllowEmptyValues = []string{}
@@ -29,15 +30,31 @@ func (g *ACMGenerator) createCertificatesResources(svc *acm.Client) ([]terraform
 			return nil, fmt.Errorf("list ACM certificates: %w", err)
 		}
 		for _, cert := range page.CertificateSummaryList {
-			certArn := *cert.CertificateArn
+			certArn := StringValue(cert.CertificateArn)
+			domainName := strings.TrimSuffix(StringValue(cert.DomainName), ".")
+			if certArn == "" || domainName == "" {
+				continue
+			}
+			describeOutput, err := svc.DescribeCertificate(context.TODO(), &acm.DescribeCertificateInput{
+				CertificateArn: aws.String(certArn),
+			})
+			if err != nil {
+				return nil, fmt.Errorf("describe ACM certificate %s: %w", certArn, err)
+			}
+			if describeOutput == nil || describeOutput.Certificate == nil {
+				return nil, fmt.Errorf("describe ACM certificate %s: empty certificate", certArn)
+			}
+			if !acmCertificateStatusImportable(describeOutput.Certificate.Status) {
+				continue
+			}
 			certID := extractCertificateUUID(certArn)
 			resources = append(resources, terraformutils.NewResource(
 				certArn,
-				certID+"_"+strings.TrimSuffix(*cert.DomainName, "."),
+				certID+"_"+domainName,
 				"aws_acm_certificate",
 				"aws",
 				map[string]string{
-					"domain_name": *cert.DomainName,
+					"domain_name": domainName,
 				},
 				acmAllowEmptyValues,
 				acmAdditionalFields,
@@ -45,6 +62,10 @@ func (g *ACMGenerator) createCertificatesResources(svc *acm.Client) ([]terraform
 		}
 	}
 	return resources, nil
+}
+
+func acmCertificateStatusImportable(status acmtypes.CertificateStatus) bool {
+	return status != acmtypes.CertificateStatusValidationTimedOut
 }
 
 // Generate TerraformResources from AWS API,

--- a/providers/aws/acm.go
+++ b/providers/aws/acm.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/acm"
 	acmtypes "github.com/aws/aws-sdk-go-v2/service/acm/types"
 	"github.com/chenrui333/terraformer/terraformutils"
@@ -30,38 +29,34 @@ func (g *ACMGenerator) createCertificatesResources(svc *acm.Client) ([]terraform
 			return nil, fmt.Errorf("list ACM certificates: %w", err)
 		}
 		for _, cert := range page.CertificateSummaryList {
-			certArn := StringValue(cert.CertificateArn)
-			domainName := strings.TrimSuffix(StringValue(cert.DomainName), ".")
-			if certArn == "" || domainName == "" {
+			resource, ok := newACMCertificateResource(cert)
+			if !ok {
 				continue
 			}
-			describeOutput, err := svc.DescribeCertificate(context.TODO(), &acm.DescribeCertificateInput{
-				CertificateArn: aws.String(certArn),
-			})
-			if err != nil {
-				return nil, fmt.Errorf("describe ACM certificate %s: %w", certArn, err)
-			}
-			if describeOutput == nil || describeOutput.Certificate == nil {
-				return nil, fmt.Errorf("describe ACM certificate %s: empty certificate", certArn)
-			}
-			if !acmCertificateStatusImportable(describeOutput.Certificate.Status) {
-				continue
-			}
-			certID := extractCertificateUUID(certArn)
-			resources = append(resources, terraformutils.NewResource(
-				certArn,
-				certID+"_"+domainName,
-				"aws_acm_certificate",
-				"aws",
-				map[string]string{
-					"domain_name": domainName,
-				},
-				acmAllowEmptyValues,
-				acmAdditionalFields,
-			))
+			resources = append(resources, resource)
 		}
 	}
 	return resources, nil
+}
+
+func newACMCertificateResource(cert acmtypes.CertificateSummary) (terraformutils.Resource, bool) {
+	certArn := StringValue(cert.CertificateArn)
+	domainName := strings.TrimSuffix(StringValue(cert.DomainName), ".")
+	if certArn == "" || domainName == "" || !acmCertificateStatusImportable(cert.Status) {
+		return terraformutils.Resource{}, false
+	}
+	certID := extractCertificateUUID(certArn)
+	return terraformutils.NewResource(
+		certArn,
+		certID+"_"+domainName,
+		"aws_acm_certificate",
+		"aws",
+		map[string]string{
+			"domain_name": domainName,
+		},
+		acmAllowEmptyValues,
+		acmAdditionalFields,
+	), true
 }
 
 func acmCertificateStatusImportable(status acmtypes.CertificateStatus) bool {

--- a/providers/aws/acm_test.go
+++ b/providers/aws/acm_test.go
@@ -5,6 +5,7 @@ package aws
 import (
 	"testing"
 
+	"github.com/aws/aws-sdk-go-v2/aws"
 	acmtypes "github.com/aws/aws-sdk-go-v2/service/acm/types"
 )
 
@@ -28,5 +29,34 @@ func TestACMCertificateStatusImportable(t *testing.T) {
 				t.Fatalf("acmCertificateStatusImportable(%q) = %t, want %t", tt.status, got, tt.want)
 			}
 		})
+	}
+}
+
+func TestNewACMCertificateResourceUsesSummaryStatus(t *testing.T) {
+	resource, ok := newACMCertificateResource(acmtypes.CertificateSummary{
+		CertificateArn: aws.String("arn:aws:acm:us-east-1:123456789012:certificate/cert-1"),
+		DomainName:     aws.String("example.com."),
+		Status:         acmtypes.CertificateStatusIssued,
+	})
+	if !ok {
+		t.Fatal("newACMCertificateResource() ok = false, want true")
+	}
+	if got := resource.InstanceState.ID; got != "arn:aws:acm:us-east-1:123456789012:certificate/cert-1" {
+		t.Fatalf("InstanceState.ID = %q, want certificate ARN", got)
+	}
+	if got := resource.ResourceName; got != "tfer--cert-1_example-002E-com" {
+		t.Fatalf("ResourceName = %q, want tfer--cert-1_example-002E-com", got)
+	}
+	if got := resource.InstanceState.Attributes["domain_name"]; got != "example.com" {
+		t.Fatalf("domain_name = %q, want example.com", got)
+	}
+
+	_, ok = newACMCertificateResource(acmtypes.CertificateSummary{
+		CertificateArn: aws.String("arn:aws:acm:us-east-1:123456789012:certificate/cert-2"),
+		DomainName:     aws.String("timed-out.example.com"),
+		Status:         acmtypes.CertificateStatusValidationTimedOut,
+	})
+	if ok {
+		t.Fatal("newACMCertificateResource() ok = true for VALIDATION_TIMED_OUT, want false")
 	}
 }

--- a/providers/aws/acm_test.go
+++ b/providers/aws/acm_test.go
@@ -1,0 +1,32 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package aws
+
+import (
+	"testing"
+
+	acmtypes "github.com/aws/aws-sdk-go-v2/service/acm/types"
+)
+
+func TestACMCertificateStatusImportable(t *testing.T) {
+	tests := []struct {
+		name   string
+		status acmtypes.CertificateStatus
+		want   bool
+	}{
+		{name: "validation timed out", status: acmtypes.CertificateStatusValidationTimedOut},
+		{name: "failed", status: acmtypes.CertificateStatusFailed, want: true},
+		{name: "expired", status: acmtypes.CertificateStatusExpired, want: true},
+		{name: "revoked", status: acmtypes.CertificateStatusRevoked, want: true},
+		{name: "pending validation", status: acmtypes.CertificateStatusPendingValidation, want: true},
+		{name: "issued", status: acmtypes.CertificateStatusIssued, want: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := acmCertificateStatusImportable(tt.status); got != tt.want {
+				t.Fatalf("acmCertificateStatusImportable(%q) = %t, want %t", tt.status, got, tt.want)
+			}
+		})
+	}
+}

--- a/providers/aws/ecr.go
+++ b/providers/aws/ecr.go
@@ -112,7 +112,8 @@ func (g *EcrGenerator) getAccountSettings(svc *ecr.Client) error {
 		if err != nil {
 			return err
 		}
-		if StringValue(setting.Value) == "" {
+		value := StringValue(setting.Value)
+		if value == "" {
 			continue
 		}
 
@@ -120,14 +121,33 @@ func (g *EcrGenerator) getAccountSettings(svc *ecr.Client) error {
 		if name == "" {
 			name = settingName
 		}
-		g.Resources = append(g.Resources, terraformutils.NewSimpleResource(
-			name,
-			name,
-			"aws_ecr_account_setting",
-			"aws",
-			ecrAllowEmptyValues))
+		resource, ok := newEcrAccountSettingResource(name, value)
+		if !ok {
+			continue
+		}
+		g.Resources = append(g.Resources, resource)
 	}
 	return nil
+}
+
+func newEcrAccountSettingResource(name, value string) (terraformutils.Resource, bool) {
+	if name == "" || value == "" {
+		return terraformutils.Resource{}, false
+	}
+	resource := terraformutils.NewResource(
+		name,
+		name,
+		"aws_ecr_account_setting",
+		"aws",
+		map[string]string{
+			"name":  name,
+			"value": value,
+		},
+		ecrAllowEmptyValues,
+		map[string]interface{}{},
+	)
+	setAwsFrameworkResourcePreserveIDAfterRefresh(&resource)
+	return resource, true
 }
 
 func (g *EcrGenerator) getRegistryPolicy(svc *ecr.Client) error {

--- a/providers/aws/ecr_test.go
+++ b/providers/aws/ecr_test.go
@@ -85,6 +85,33 @@ func TestEcrOptionalRegistryResourcesContinueAfterError(t *testing.T) {
 	}
 }
 
+func TestNewEcrAccountSettingResource(t *testing.T) {
+	resource, ok := newEcrAccountSettingResource("BASIC_SCAN_TYPE_VERSION", "AWS_NATIVE")
+	if !ok {
+		t.Fatal("newEcrAccountSettingResource() ok = false, want true")
+	}
+	if resource.InstanceInfo.Type != "aws_ecr_account_setting" {
+		t.Fatalf("resource type = %q, want aws_ecr_account_setting", resource.InstanceInfo.Type)
+	}
+	if resource.InstanceState.ID != "BASIC_SCAN_TYPE_VERSION" {
+		t.Fatalf("resource ID = %q, want BASIC_SCAN_TYPE_VERSION", resource.InstanceState.ID)
+	}
+	if got := resource.InstanceState.Attributes["name"]; got != "BASIC_SCAN_TYPE_VERSION" {
+		t.Fatalf("name = %q, want BASIC_SCAN_TYPE_VERSION", got)
+	}
+	if got := resource.InstanceState.Attributes["value"]; got != "AWS_NATIVE" {
+		t.Fatalf("value = %q, want AWS_NATIVE", got)
+	}
+	assertAwsFrameworkResourcePreserveIDAfterRefresh(t, resource)
+
+	if _, ok := newEcrAccountSettingResource("", "AWS_NATIVE"); ok {
+		t.Fatal("newEcrAccountSettingResource() ok = true for empty name, want false")
+	}
+	if _, ok := newEcrAccountSettingResource("BASIC_SCAN_TYPE_VERSION", ""); ok {
+		t.Fatal("newEcrAccountSettingResource() ok = true for empty value, want false")
+	}
+}
+
 func TestEcrPostConvertHookWrapsPolicyFields(t *testing.T) {
 	registryPolicy := terraformutils.NewSimpleResource("123456789012", "registry-policy", "aws_ecr_registry_policy", "aws", ecrAllowEmptyValues)
 	registryPolicy.Item = map[string]interface{}{"policy": "{\"Resource\":\"${aws:ecr}\"}"}

--- a/providers/aws/guardduty.go
+++ b/providers/aws/guardduty.go
@@ -1098,6 +1098,9 @@ func guardDutyOrganizationResourceUnavailable(err error) bool {
 	if strings.Contains(message, "delegated administrator") && strings.Contains(message, "not been enabled") {
 		return true
 	}
+	if strings.Contains(message, "organization") && strings.Contains(message, "not the admin account") {
+		return true
+	}
 	return strings.Contains(message, "organization") &&
 		(strings.Contains(message, "administrator") ||
 			strings.Contains(message, "delegated") ||

--- a/providers/aws/guardduty_test.go
+++ b/providers/aws/guardduty_test.go
@@ -874,6 +874,16 @@ func TestGuardDutyOrganizationResourceUnavailable(t *testing.T) {
 			want: true,
 		},
 		{
+			name: "not organization admin account",
+			err:  &guarddutytypes.BadRequestException{Message: aws.String("The request failed because you are not the admin account for your AWS Organization.")},
+			want: true,
+		},
+		{
+			name: "not admin account outside organization",
+			err:  &guarddutytypes.BadRequestException{Message: aws.String("The request failed because you are not the admin account.")},
+			want: false,
+		},
+		{
 			name: "not organization error",
 			err:  &guarddutytypes.BadRequestException{Message: aws.String("The request is rejected because a parameter is invalid.")},
 			want: false,

--- a/providers/aws/lambda.go
+++ b/providers/aws/lambda.go
@@ -299,7 +299,7 @@ func newLambdaFunctionRecursionConfigResource(functionName string, config *lambd
 	if recursiveLoop == "" {
 		return terraformutils.Resource{}, false
 	}
-	return terraformutils.NewResource(
+	resource := terraformutils.NewResource(
 		lambdaFunctionRecursionConfigImportID(functionName),
 		lambdaResourceNameWithLengths("function_recursion_config", functionName),
 		lambdaFunctionRecursionConfigResourceType,
@@ -310,7 +310,9 @@ func newLambdaFunctionRecursionConfigResource(functionName string, config *lambd
 		},
 		lambdaAllowEmptyValues,
 		map[string]interface{}{},
-	), true
+	)
+	setAwsFrameworkResourcePreserveIDAfterRefresh(&resource)
+	return resource, true
 }
 
 func (g *LambdaGenerator) addRuntimeManagementConfigs(svc *lambda.Client, functions []lambdaFunctionReference) error {
@@ -378,9 +380,10 @@ func newLambdaRuntimeManagementConfigResource(functionName, qualifier string, co
 	if functionName == "" || config == nil {
 		return terraformutils.Resource{}, false
 	}
+	stateQualifier := lambdaRuntimeManagementConfigStateQualifier(qualifier)
 	attributes := map[string]string{
 		"function_name": functionName,
-		"qualifier":     qualifier,
+		"qualifier":     stateQualifier,
 	}
 	if runtimeVersionARN := StringValue(config.RuntimeVersionArn); runtimeVersionARN != "" {
 		attributes["runtime_version_arn"] = runtimeVersionARN
@@ -388,15 +391,17 @@ func newLambdaRuntimeManagementConfigResource(functionName, qualifier string, co
 	if updateRuntimeOn := string(config.UpdateRuntimeOn); updateRuntimeOn != "" {
 		attributes["update_runtime_on"] = updateRuntimeOn
 	}
-	return terraformutils.NewResource(
-		lambdaRuntimeManagementConfigImportID(functionName, qualifier),
+	resource := terraformutils.NewResource(
+		lambdaRuntimeManagementConfigImportID(functionName, stateQualifier),
 		lambdaResourceNameWithLengths("runtime_management_config", functionName, qualifier),
 		lambdaRuntimeManagementConfigResourceType,
 		"aws",
 		attributes,
 		lambdaAllowEmptyValues,
 		map[string]interface{}{},
-	), true
+	)
+	setAwsFrameworkResourcePreserveIDAfterRefresh(&resource)
+	return resource, true
 }
 
 func (g *LambdaGenerator) addProvisionedConcurrencyConfigs(svc *lambda.Client, functions []lambdaFunctionReference) error {
@@ -522,7 +527,14 @@ func lambdaFunctionRecursionConfigImportID(functionName string) string {
 }
 
 func lambdaRuntimeManagementConfigImportID(functionName, qualifier string) string {
-	return functionName + "," + qualifier
+	return functionName + "," + lambdaRuntimeManagementConfigStateQualifier(qualifier)
+}
+
+func lambdaRuntimeManagementConfigStateQualifier(qualifier string) string {
+	if qualifier == "" {
+		return "$LATEST"
+	}
+	return qualifier
 }
 
 func lambdaQualifierFromFunctionARN(functionARN, functionName string) string {

--- a/providers/aws/lambda_test.go
+++ b/providers/aws/lambda_test.go
@@ -57,7 +57,7 @@ func TestLambdaRuntimeManagementConfigImportID(t *testing.T) {
 		qualifier    string
 		want         string
 	}{
-		{name: "unqualified", functionName: "my-function", want: "my-function,"},
+		{name: "unqualified", functionName: "my-function", want: "my-function,$LATEST"},
 		{name: "qualified version", functionName: "my-function", qualifier: "1", want: "my-function,1"},
 	}
 
@@ -91,6 +91,15 @@ func TestLambdaRuntimeManagementConfigQualifier(t *testing.T) {
 				t.Fatalf("lambdaRuntimeManagementConfigQualifier() = %q, %t, want %q, %t", got, ok, tt.want, tt.wantOK)
 			}
 		})
+	}
+}
+
+func TestLambdaRuntimeManagementConfigStateQualifier(t *testing.T) {
+	if got := lambdaRuntimeManagementConfigStateQualifier(""); got != "$LATEST" {
+		t.Fatalf("lambdaRuntimeManagementConfigStateQualifier() = %q, want $LATEST", got)
+	}
+	if got := lambdaRuntimeManagementConfigStateQualifier("1"); got != "1" {
+		t.Fatalf("lambdaRuntimeManagementConfigStateQualifier() = %q, want 1", got)
 	}
 }
 
@@ -220,6 +229,7 @@ func TestNewLambdaFunctionRecursionConfigResource(t *testing.T) {
 			t.Fatalf("attribute %q = %q, want %q", key, got, want)
 		}
 	}
+	assertAwsFrameworkResourcePreserveIDAfterRefresh(t, resource)
 	if _, ok := newLambdaFunctionRecursionConfigResource("", &lambda.GetFunctionRecursionConfigOutput{
 		RecursiveLoop: lambdatypes.RecursiveLoopTerminate,
 	}); ok {
@@ -244,8 +254,8 @@ func TestNewLambdaRuntimeManagementConfigResource(t *testing.T) {
 	if resource.InstanceInfo.Type != lambdaRuntimeManagementConfigResourceType {
 		t.Fatalf("resource type = %q, want %q", resource.InstanceInfo.Type, lambdaRuntimeManagementConfigResourceType)
 	}
-	if resource.InstanceState.ID != "my-function," {
-		t.Fatalf("resource ID = %q, want %q", resource.InstanceState.ID, "my-function,")
+	if resource.InstanceState.ID != "my-function,$LATEST" {
+		t.Fatalf("resource ID = %q, want %q", resource.InstanceState.ID, "my-function,$LATEST")
 	}
 	wantName := terraformutils.TfSanitize(lambdaResourceNameWithLengths("runtime_management_config", "my-function", ""))
 	if resource.ResourceName != wantName {
@@ -253,7 +263,7 @@ func TestNewLambdaRuntimeManagementConfigResource(t *testing.T) {
 	}
 	wantAttributes := map[string]string{
 		"function_name":       "my-function",
-		"qualifier":           "",
+		"qualifier":           "$LATEST",
 		"runtime_version_arn": "arn:aws:lambda:us-east-1::runtime:abcd",
 		"update_runtime_on":   "Manual",
 	}
@@ -262,6 +272,7 @@ func TestNewLambdaRuntimeManagementConfigResource(t *testing.T) {
 			t.Fatalf("attribute %q = %q, want %q", key, got, want)
 		}
 	}
+	assertAwsFrameworkResourcePreserveIDAfterRefresh(t, resource)
 	qualifiedResource, ok := newLambdaRuntimeManagementConfigResource("my-function", "1", &lambda.GetRuntimeManagementConfigOutput{
 		UpdateRuntimeOn: lambdatypes.UpdateRuntimeOnAuto,
 	})
@@ -274,6 +285,7 @@ func TestNewLambdaRuntimeManagementConfigResource(t *testing.T) {
 	if got := qualifiedResource.InstanceState.Attributes["qualifier"]; got != "1" {
 		t.Fatalf("qualified resource qualifier = %q, want %q", got, "1")
 	}
+	assertAwsFrameworkResourcePreserveIDAfterRefresh(t, qualifiedResource)
 	if _, ok := newLambdaRuntimeManagementConfigResource("", "", &lambda.GetRuntimeManagementConfigOutput{
 		UpdateRuntimeOn: lambdatypes.UpdateRuntimeOnAuto,
 	}); ok {

--- a/providers/aws/ssm.go
+++ b/providers/aws/ssm.go
@@ -198,25 +198,34 @@ func (g *SsmGenerator) addMaintenanceWindowTargets(svc *ssm.Client, windowID str
 			return err
 		}
 		for _, target := range page.Targets {
-			targetID := StringValue(target.WindowTargetId)
-			if targetID == "" {
+			resource, ok := newSsmMaintenanceWindowTargetResource(windowID, target)
+			if !ok {
 				continue
 			}
-			g.Resources = append(g.Resources, terraformutils.NewResource(
-				ssmImportID(windowID, targetID),
-				ssmResourceName(windowID, StringValue(target.Name), targetID),
-				"aws_ssm_maintenance_window_target",
-				"aws",
-				map[string]string{
-					"window_id":        windowID,
-					"window_target_id": targetID,
-				},
-				ssmAllowEmptyValues,
-				map[string]interface{}{},
-			))
+			g.Resources = append(g.Resources, resource)
 		}
 	}
 	return nil
+}
+
+func newSsmMaintenanceWindowTargetResource(windowID string, target ssmtypes.MaintenanceWindowTarget) (terraformutils.Resource, bool) {
+	targetID := StringValue(target.WindowTargetId)
+	if windowID == "" || targetID == "" {
+		return terraformutils.Resource{}, false
+	}
+	resource := terraformutils.NewResource(
+		targetID,
+		ssmResourceName(windowID, StringValue(target.Name), targetID),
+		"aws_ssm_maintenance_window_target",
+		"aws",
+		map[string]string{
+			"window_id": windowID,
+		},
+		ssmAllowEmptyValues,
+		map[string]interface{}{},
+	)
+	setSSMImportID(&resource, ssmImportID(windowID, targetID))
+	return resource, true
 }
 
 func (g *SsmGenerator) addMaintenanceWindowTasks(svc *ssm.Client, windowID string) error {
@@ -229,25 +238,34 @@ func (g *SsmGenerator) addMaintenanceWindowTasks(svc *ssm.Client, windowID strin
 			return err
 		}
 		for _, task := range page.Tasks {
-			taskID := StringValue(task.WindowTaskId)
-			if taskID == "" {
+			resource, ok := newSsmMaintenanceWindowTaskResource(windowID, task)
+			if !ok {
 				continue
 			}
-			g.Resources = append(g.Resources, terraformutils.NewResource(
-				ssmImportID(windowID, taskID),
-				ssmResourceName(windowID, StringValue(task.Name), taskID),
-				"aws_ssm_maintenance_window_task",
-				"aws",
-				map[string]string{
-					"window_id":      windowID,
-					"window_task_id": taskID,
-				},
-				ssmAllowEmptyValues,
-				map[string]interface{}{},
-			))
+			g.Resources = append(g.Resources, resource)
 		}
 	}
 	return nil
+}
+
+func newSsmMaintenanceWindowTaskResource(windowID string, task ssmtypes.MaintenanceWindowTask) (terraformutils.Resource, bool) {
+	taskID := StringValue(task.WindowTaskId)
+	if windowID == "" || taskID == "" {
+		return terraformutils.Resource{}, false
+	}
+	resource := terraformutils.NewResource(
+		taskID,
+		ssmResourceName(windowID, StringValue(task.Name), taskID),
+		"aws_ssm_maintenance_window_task",
+		"aws",
+		map[string]string{
+			"window_id": windowID,
+		},
+		ssmAllowEmptyValues,
+		map[string]interface{}{},
+	)
+	setSSMImportID(&resource, ssmImportID(windowID, taskID))
+	return resource, true
 }
 
 func (g *SsmGenerator) addPatchBaselines(svc *ssm.Client) error {
@@ -469,6 +487,16 @@ func (g *SsmGenerator) linkResourceByID(index int, fieldName, resourceType, outp
 
 func ssmImportID(parts ...string) string {
 	return strings.Join(parts, "/")
+}
+
+func setSSMImportID(resource *terraformutils.Resource, importID string) {
+	if resource == nil || resource.InstanceState == nil || importID == "" {
+		return
+	}
+	if resource.InstanceState.Meta == nil {
+		resource.InstanceState.Meta = map[string]interface{}{}
+	}
+	resource.InstanceState.Meta["import_id"] = importID
 }
 
 func ssmPatchGroupImportID(patchGroup, baselineID string) string {

--- a/providers/aws/ssm.go
+++ b/providers/aws/ssm.go
@@ -39,6 +39,26 @@ type ssmOptionalResourceLoader struct {
 	load func() error
 }
 
+func (g *SsmGenerator) InitialCleanup() {
+	if len(g.Filter) == 0 {
+		return
+	}
+	var resources []terraformutils.Resource
+	for _, resource := range g.Resources {
+		allPredicatesTrue := true
+		for _, filter := range g.Filter {
+			if filter.FieldPath != "id" {
+				continue
+			}
+			allPredicatesTrue = allPredicatesTrue && ssmInitialIDFilterMatchesResource(filter, resource)
+		}
+		if allPredicatesTrue && !terraformutils.ContainsResource(resources, resource) {
+			resources = append(resources, resource)
+		}
+	}
+	g.Resources = resources
+}
+
 func (g *SsmGenerator) InitResources() error {
 	config, e := g.generateConfig()
 	if e != nil {
@@ -497,6 +517,30 @@ func setSSMImportID(resource *terraformutils.Resource, importID string) {
 		resource.InstanceState.Meta = map[string]interface{}{}
 	}
 	resource.InstanceState.Meta["import_id"] = importID
+}
+
+func ssmInitialIDFilterMatchesResource(filter terraformutils.ResourceFilter, resource terraformutils.Resource) bool {
+	if filter.Filter(resource) {
+		return true
+	}
+	if resource.InstanceInfo == nil || resource.InstanceState == nil {
+		return false
+	}
+	switch resource.InstanceInfo.Type {
+	case "aws_ssm_maintenance_window_target", "aws_ssm_maintenance_window_task":
+	default:
+		return false
+	}
+	importID, ok := resource.InstanceState.Meta["import_id"].(string)
+	if !ok || importID == "" {
+		return false
+	}
+	for _, acceptableValue := range filter.AcceptableValues {
+		if acceptableValue == importID {
+			return true
+		}
+	}
+	return false
 }
 
 func ssmPatchGroupImportID(patchGroup, baselineID string) string {

--- a/providers/aws/ssm_test.go
+++ b/providers/aws/ssm_test.go
@@ -171,6 +171,68 @@ func TestSsmServiceSettingMissing(t *testing.T) {
 	}
 }
 
+func TestNewSsmMaintenanceWindowTargetResourceUsesChildStateID(t *testing.T) {
+	resource, ok := newSsmMaintenanceWindowTargetResource("mw-123", ssmtypes.MaintenanceWindowTarget{
+		Name:           aws.String("target"),
+		WindowTargetId: aws.String("11111111-2222-3333-4444-555555555555"),
+	})
+	if !ok {
+		t.Fatal("newSsmMaintenanceWindowTargetResource() ok = false, want true")
+	}
+	if resource.InstanceState.ID != "11111111-2222-3333-4444-555555555555" {
+		t.Fatalf("resource ID = %q, want child target ID", resource.InstanceState.ID)
+	}
+	if got := resource.InstanceState.Attributes["window_id"]; got != "mw-123" {
+		t.Fatalf("window_id = %q, want mw-123", got)
+	}
+	if _, ok := resource.InstanceState.Attributes["window_target_id"]; ok {
+		t.Fatalf("window_target_id attribute was set in provider state: %#v", resource.InstanceState.Attributes)
+	}
+	if got := resource.InstanceState.Meta["import_id"]; got != "mw-123/11111111-2222-3333-4444-555555555555" {
+		t.Fatalf("import_id = %#v, want composite import ID", got)
+	}
+
+	if _, ok := newSsmMaintenanceWindowTargetResource("", ssmtypes.MaintenanceWindowTarget{
+		WindowTargetId: aws.String("11111111-2222-3333-4444-555555555555"),
+	}); ok {
+		t.Fatal("newSsmMaintenanceWindowTargetResource() ok = true for empty window ID, want false")
+	}
+	if _, ok := newSsmMaintenanceWindowTargetResource("mw-123", ssmtypes.MaintenanceWindowTarget{}); ok {
+		t.Fatal("newSsmMaintenanceWindowTargetResource() ok = true for empty target ID, want false")
+	}
+}
+
+func TestNewSsmMaintenanceWindowTaskResourceUsesChildStateID(t *testing.T) {
+	resource, ok := newSsmMaintenanceWindowTaskResource("mw-123", ssmtypes.MaintenanceWindowTask{
+		Name:         aws.String("task"),
+		WindowTaskId: aws.String("aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"),
+	})
+	if !ok {
+		t.Fatal("newSsmMaintenanceWindowTaskResource() ok = false, want true")
+	}
+	if resource.InstanceState.ID != "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee" {
+		t.Fatalf("resource ID = %q, want child task ID", resource.InstanceState.ID)
+	}
+	if got := resource.InstanceState.Attributes["window_id"]; got != "mw-123" {
+		t.Fatalf("window_id = %q, want mw-123", got)
+	}
+	if _, ok := resource.InstanceState.Attributes["window_task_id"]; ok {
+		t.Fatalf("window_task_id attribute was set in provider state: %#v", resource.InstanceState.Attributes)
+	}
+	if got := resource.InstanceState.Meta["import_id"]; got != "mw-123/aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee" {
+		t.Fatalf("import_id = %#v, want composite import ID", got)
+	}
+
+	if _, ok := newSsmMaintenanceWindowTaskResource("", ssmtypes.MaintenanceWindowTask{
+		WindowTaskId: aws.String("aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"),
+	}); ok {
+		t.Fatal("newSsmMaintenanceWindowTaskResource() ok = true for empty window ID, want false")
+	}
+	if _, ok := newSsmMaintenanceWindowTaskResource("mw-123", ssmtypes.MaintenanceWindowTask{}); ok {
+		t.Fatal("newSsmMaintenanceWindowTaskResource() ok = true for empty task ID, want false")
+	}
+}
+
 func TestSsmPostConvertHookLinksScopedResources(t *testing.T) {
 	maintenanceWindow := terraformutils.NewSimpleResource("mw-1", "window", "aws_ssm_maintenance_window", "aws", ssmAllowEmptyValues)
 	windowTarget := terraformutils.NewResource(

--- a/providers/aws/ssm_test.go
+++ b/providers/aws/ssm_test.go
@@ -233,6 +233,93 @@ func TestNewSsmMaintenanceWindowTaskResourceUsesChildStateID(t *testing.T) {
 	}
 }
 
+func TestSsmInitialCleanupMatchesMaintenanceWindowChildImportIDs(t *testing.T) {
+	target, ok := newSsmMaintenanceWindowTargetResource("mw-123", ssmtypes.MaintenanceWindowTarget{
+		Name:           aws.String("target"),
+		WindowTargetId: aws.String("target-1"),
+	})
+	if !ok {
+		t.Fatal("target resource ok = false, want true")
+	}
+	otherTarget, ok := newSsmMaintenanceWindowTargetResource("mw-123", ssmtypes.MaintenanceWindowTarget{
+		Name:           aws.String("other-target"),
+		WindowTargetId: aws.String("target-2"),
+	})
+	if !ok {
+		t.Fatal("other target resource ok = false, want true")
+	}
+	task, ok := newSsmMaintenanceWindowTaskResource("mw-123", ssmtypes.MaintenanceWindowTask{
+		Name:         aws.String("task"),
+		WindowTaskId: aws.String("task-1"),
+	})
+	if !ok {
+		t.Fatal("task resource ok = false, want true")
+	}
+	otherTask, ok := newSsmMaintenanceWindowTaskResource("mw-123", ssmtypes.MaintenanceWindowTask{
+		Name:         aws.String("other-task"),
+		WindowTaskId: aws.String("task-2"),
+	})
+	if !ok {
+		t.Fatal("other task resource ok = false, want true")
+	}
+
+	g := SsmGenerator{}
+	g.Resources = []terraformutils.Resource{target, otherTarget, task, otherTask}
+	g.Filter = []terraformutils.ResourceFilter{{
+		FieldPath:        "id",
+		AcceptableValues: []string{"mw-123/target-1", "mw-123/task-1"},
+	}}
+
+	g.InitialCleanup()
+
+	if len(g.Resources) != 2 {
+		t.Fatalf("InitialCleanup() resources len = %d, want 2", len(g.Resources))
+	}
+	got := map[string]bool{}
+	for _, resource := range g.Resources {
+		got[resource.InstanceState.ID] = true
+	}
+	if !got["target-1"] || !got["task-1"] {
+		t.Fatalf("InitialCleanup() kept IDs = %#v, want target-1 and task-1", got)
+	}
+	if got["target-2"] || got["task-2"] {
+		t.Fatalf("InitialCleanup() kept non-matching IDs = %#v", got)
+	}
+}
+
+func TestSsmInitialCleanupStillMatchesMaintenanceWindowChildStateIDs(t *testing.T) {
+	target, ok := newSsmMaintenanceWindowTargetResource("mw-123", ssmtypes.MaintenanceWindowTarget{
+		Name:           aws.String("target"),
+		WindowTargetId: aws.String("target-1"),
+	})
+	if !ok {
+		t.Fatal("target resource ok = false, want true")
+	}
+	task, ok := newSsmMaintenanceWindowTaskResource("mw-123", ssmtypes.MaintenanceWindowTask{
+		Name:         aws.String("task"),
+		WindowTaskId: aws.String("task-1"),
+	})
+	if !ok {
+		t.Fatal("task resource ok = false, want true")
+	}
+
+	g := SsmGenerator{}
+	g.Resources = []terraformutils.Resource{target, task}
+	g.Filter = []terraformutils.ResourceFilter{{
+		FieldPath:        "id",
+		AcceptableValues: []string{"target-1"},
+	}}
+
+	g.InitialCleanup()
+
+	if len(g.Resources) != 1 {
+		t.Fatalf("InitialCleanup() resources len = %d, want 1", len(g.Resources))
+	}
+	if got := g.Resources[0].InstanceState.ID; got != "target-1" {
+		t.Fatalf("InitialCleanup() kept ID = %q, want target-1", got)
+	}
+}
+
 func TestSsmPostConvertHookLinksScopedResources(t *testing.T) {
 	maintenanceWindow := terraformutils.NewSimpleResource("mw-1", "window", "aws_ssm_maintenance_window", "aws", ssmAllowEmptyValues)
 	windowTarget := terraformutils.NewResource(


### PR DESCRIPTION
## Summary

- Preserve provider-readable state for AWS Lambda runtime/recursion config and ECR account settings.
- Use child IDs plus import metadata for SSM maintenance window targets/tasks.
- Keep GuardDuty organization-admin and ACM validation-timeout handling narrowly scoped to provider/API semantics.

## Notes

CloudWatch metric alarm panic handling is intentionally left for a separate repro-driven follow-up.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Preserves Terraform import state across refresh for key AWS resources and respects SSM import filters to avoid drift and missed selections. Aligns ACM, ECR, Lambda, SSM, and GuardDuty behavior with provider/API semantics while avoiding extra ACM pre-describe calls.

- **Bug Fixes**
  - Lambda: Preserve IDs after refresh for recursion and runtime management configs; treat empty qualifier as `$LATEST` and build import IDs with it.
  - ECR: Create `aws_ecr_account_setting` with `name` and `value`; preserve ID after refresh.
  - SSM: For `aws_ssm_maintenance_window_target` and `aws_ssm_maintenance_window_task`, use child IDs as state IDs, store composite `import_id` `<window>/<child>`, and honor initial `id` filters against both state IDs and composite `import_id`.
  - ACM: Skip `ValidationTimedOut` certificates, normalize domain names, and filter by summary status (no pre-describe).
  - GuardDuty: Broaden organization-admin unavailability detection to include “not the admin account” errors.

<sup>Written for commit 342ae4958d29a79204f613441d9a5ff7ea4eb6ec. Summary will update on new commits. <a href="https://cubic.dev/pr/chenrui333/terraformer/pull/513?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved ACM certificate validation before resource generation, filtering out non-importable certificates.
  * Enhanced ECR account setting resource generation with validation for required attributes.
  * Refined Lambda runtime management config handling to properly normalize unqualified versions.
  * Improved SSM maintenance window resource generation with validation for required identifiers.
  * Enhanced GuardDuty error handling for organization-related scenarios.

* **Tests**
  * Added comprehensive test coverage for certificate status filtering, ECR resource creation, Lambda qualifier handling, and SSM maintenance window resources.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/chenrui333/terraformer/pull/513?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->