### PR TITLE
fix(aws): harden importer refresh edge cases

### DIFF
--- a/providers/aws/alb.go
+++ b/providers/aws/alb.go
@@ -5,6 +5,8 @@ package aws
 import (
 	"context"
 	"fmt"
+	"strconv"
+	"strings"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/elasticloadbalancingv2"
@@ -173,21 +175,49 @@ func (g *AlbGenerator) loadTargetGroupTargets(svc *elasticloadbalancingv2.Client
 		return err
 	}
 	for _, tgh := range targetHealths.TargetHealthDescriptions {
-		id := fmt.Sprintf("%s-%s", *targetGroupArn, *tgh.Target.Id)
-		g.Resources = append(g.Resources, terraformutils.NewResource(
-			id,
-			id,
-			"aws_lb_target_group_attachment",
-			"aws",
-			map[string]string{
-				"target_id":        *tgh.Target.Id,
-				"target_group_arn": *targetGroupArn,
-			},
-			AlbAllowEmptyValues,
-			map[string]interface{}{},
-		))
+		resource, ok := newALBTargetGroupAttachmentResource(StringValue(targetGroupArn), tgh.Target)
+		if ok {
+			g.Resources = append(g.Resources, resource)
+		}
 	}
 	return nil
+}
+
+func newALBTargetGroupAttachmentResource(targetGroupArn string, target *types.TargetDescription) (terraformutils.Resource, bool) {
+	if target == nil {
+		return terraformutils.Resource{}, false
+	}
+	targetID := StringValue(target.Id)
+	if targetGroupArn == "" || targetID == "" {
+		return terraformutils.Resource{}, false
+	}
+	attributes := map[string]string{
+		"target_id":        targetID,
+		"target_group_arn": targetGroupArn,
+	}
+	idParts := []string{targetGroupArn, targetID}
+	if target.Port != nil {
+		port := strconv.FormatInt(int64(*target.Port), 10)
+		attributes["port"] = port
+		idParts = append(idParts, port)
+	}
+	if availabilityZone := StringValue(target.AvailabilityZone); availabilityZone != "" {
+		attributes["availability_zone"] = availabilityZone
+		if target.Port == nil {
+			idParts = append(idParts, "")
+		}
+		idParts = append(idParts, availabilityZone)
+	}
+	resourceName := strings.Join(idParts, ",")
+	return terraformutils.NewResource(
+		resourceName,
+		resourceName,
+		"aws_lb_target_group_attachment",
+		"aws",
+		attributes,
+		AlbAllowEmptyValues,
+		map[string]interface{}{},
+	), true
 }
 
 // Generate TerraformResources from AWS API,

--- a/providers/aws/alb_test.go
+++ b/providers/aws/alb_test.go
@@ -80,6 +80,35 @@ func TestNewALBTargetGroupAttachmentResourceWithAvailabilityZoneOnly(t *testing.
 	}
 }
 
+func TestNewALBTargetGroupAttachmentResourcePortOnly(t *testing.T) {
+	targetGroupARN := "arn:aws:elasticloadbalancing:us-east-1:123456789012:targetgroup/app/abc"
+	resource, ok := newALBTargetGroupAttachmentResource(targetGroupARN, &types.TargetDescription{
+		Id:   aws.String("10.0.0.12"),
+		Port: aws.Int32(8080),
+	})
+	if !ok {
+		t.Fatal("newALBTargetGroupAttachmentResource() ok = false, want true")
+	}
+	wantID := targetGroupARN + ",10.0.0.12,8080"
+	if got := resource.InstanceState.ID; got != wantID {
+		t.Fatalf("state ID = %q, want %q", got, wantID)
+	}
+}
+
+func TestNewALBTargetGroupAttachmentResourceMinimal(t *testing.T) {
+	targetGroupARN := "arn:aws:elasticloadbalancing:us-east-1:123456789012:targetgroup/app/abc"
+	resource, ok := newALBTargetGroupAttachmentResource(targetGroupARN, &types.TargetDescription{
+		Id: aws.String("i-123"),
+	})
+	if !ok {
+		t.Fatal("newALBTargetGroupAttachmentResource() ok = false, want true")
+	}
+	wantID := targetGroupARN + ",i-123"
+	if got := resource.InstanceState.ID; got != wantID {
+		t.Fatalf("state ID = %q, want %q", got, wantID)
+	}
+}
+
 func TestNewALBTargetGroupAttachmentResourceSkipsIncompleteTargets(t *testing.T) {
 	if _, ok := newALBTargetGroupAttachmentResource("", &types.TargetDescription{Id: aws.String("i-123")}); ok {
 		t.Fatal("target without target group ARN should be skipped")

--- a/providers/aws/alb_test.go
+++ b/providers/aws/alb_test.go
@@ -5,6 +5,7 @@ package aws
 import (
 	"testing"
 
+	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/elasticloadbalancingv2/types"
 )
 
@@ -29,5 +30,64 @@ func TestListenerSupportsCertificates(t *testing.T) {
 				t.Fatalf("listenerSupportsCertificates(%q) = %t, want %t", tt.protocol, got, tt.want)
 			}
 		})
+	}
+}
+
+func TestNewALBTargetGroupAttachmentResource(t *testing.T) {
+	targetGroupARN := "arn:aws:elasticloadbalancing:us-east-1:123456789012:targetgroup/app/abc"
+	resource, ok := newALBTargetGroupAttachmentResource(targetGroupARN, &types.TargetDescription{
+		Id:               aws.String("10.0.0.12"),
+		Port:             aws.Int32(8080),
+		AvailabilityZone: aws.String("us-east-1a"),
+	})
+	if !ok {
+		t.Fatal("newALBTargetGroupAttachmentResource() ok = false, want true")
+	}
+	if got := resource.InstanceInfo.Type; got != "aws_lb_target_group_attachment" {
+		t.Fatalf("resource type = %q, want aws_lb_target_group_attachment", got)
+	}
+	wantID := targetGroupARN + ",10.0.0.12,8080,us-east-1a"
+	if got := resource.InstanceState.ID; got != wantID {
+		t.Fatalf("state ID = %q, want %q", got, wantID)
+	}
+	attrs := resource.InstanceState.Attributes
+	if attrs["target_group_arn"] != targetGroupARN {
+		t.Fatalf("target_group_arn = %q, want %q", attrs["target_group_arn"], targetGroupARN)
+	}
+	if attrs["target_id"] != "10.0.0.12" {
+		t.Fatalf("target_id = %q, want 10.0.0.12", attrs["target_id"])
+	}
+	if attrs["port"] != "8080" {
+		t.Fatalf("port = %q, want 8080", attrs["port"])
+	}
+	if attrs["availability_zone"] != "us-east-1a" {
+		t.Fatalf("availability_zone = %q, want us-east-1a", attrs["availability_zone"])
+	}
+}
+
+func TestNewALBTargetGroupAttachmentResourceWithAvailabilityZoneOnly(t *testing.T) {
+	targetGroupARN := "arn:aws:elasticloadbalancing:us-east-1:123456789012:targetgroup/app/abc"
+	resource, ok := newALBTargetGroupAttachmentResource(targetGroupARN, &types.TargetDescription{
+		Id:               aws.String("i-123"),
+		AvailabilityZone: aws.String("all"),
+	})
+	if !ok {
+		t.Fatal("newALBTargetGroupAttachmentResource() ok = false, want true")
+	}
+	wantID := targetGroupARN + ",i-123,,all"
+	if got := resource.InstanceState.ID; got != wantID {
+		t.Fatalf("state ID = %q, want %q", got, wantID)
+	}
+}
+
+func TestNewALBTargetGroupAttachmentResourceSkipsIncompleteTargets(t *testing.T) {
+	if _, ok := newALBTargetGroupAttachmentResource("", &types.TargetDescription{Id: aws.String("i-123")}); ok {
+		t.Fatal("target without target group ARN should be skipped")
+	}
+	if _, ok := newALBTargetGroupAttachmentResource("target-group", &types.TargetDescription{}); ok {
+		t.Fatal("target without ID should be skipped")
+	}
+	if _, ok := newALBTargetGroupAttachmentResource("target-group", nil); ok {
+		t.Fatal("nil target should be skipped")
 	}
 }

--- a/providers/aws/s3.go
+++ b/providers/aws/s3.go
@@ -61,7 +61,11 @@ func (g *S3Generator) createResources(config aws.Config, buckets *s3.ListBuckets
 		resourceName := StringValue(bucket.Name)
 		location, err := svc.GetBucketLocation(context.TODO(), &s3.GetBucketLocationInput{Bucket: bucket.Name})
 		if err != nil {
-			log.Println(err)
+			if s3BucketAccessDenied(err) {
+				log.Printf("skipping S3 bucket %s location discovery: access denied", resourceName)
+			} else {
+				log.Printf("skipping S3 bucket %s location discovery: %v", resourceName, err)
+			}
 			continue
 		}
 		// check if bucket in region
@@ -507,6 +511,10 @@ func logS3OptionalBucketConfigurationError(bucketName, resourceType string, err 
 	if s3BucketConfigurationMissing(err) {
 		return
 	}
+	if s3BucketAccessDenied(err) {
+		log.Printf("skipping %s discovery for S3 bucket %s: access denied", resourceType, bucketName)
+		return
+	}
 	log.Printf("skipping %s discovery for S3 bucket %s: %v", resourceType, bucketName, err)
 }
 
@@ -535,6 +543,19 @@ func s3BucketConfigurationMissing(err error) bool {
 		"OwnershipControlsNotFoundError",
 		"ReplicationConfigurationNotFoundError",
 		"ServerSideEncryptionConfigurationNotFoundError":
+		return true
+	default:
+		return false
+	}
+}
+
+func s3BucketAccessDenied(err error) bool {
+	var apiErr smithy.APIError
+	if !errors.As(err, &apiErr) {
+		return false
+	}
+	switch apiErr.ErrorCode() {
+	case "AccessDenied", "AccessDeniedException":
 		return true
 	default:
 		return false

--- a/providers/aws/s3_test.go
+++ b/providers/aws/s3_test.go
@@ -339,6 +339,28 @@ func TestS3BucketConfigurationMissing(t *testing.T) {
 	}
 }
 
+func TestS3BucketAccessDenied(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{name: "access denied", err: &smithy.GenericAPIError{Code: "AccessDenied"}, want: true},
+		{name: "access denied exception", err: &smithy.GenericAPIError{Code: "AccessDeniedException"}, want: true},
+		{name: "missing config", err: &smithy.GenericAPIError{Code: "NoSuchLifecycleConfiguration"}, want: false},
+		{name: "generic error", err: errors.New("boom"), want: false},
+		{name: "nil", want: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := s3BucketAccessDenied(tt.err); got != tt.want {
+				t.Fatalf("s3BucketAccessDenied() = %t, want %t", got, tt.want)
+			}
+		})
+	}
+}
+
 func TestS3BucketInlineFieldsByBucket(t *testing.T) {
 	versioning := terraformutils.NewResource(
 		"versioned-bucket",

--- a/providers/aws/securityhub.go
+++ b/providers/aws/securityhub.go
@@ -587,7 +587,7 @@ func securityHubSkippableAccessMessage(message string) bool {
 		strings.Contains(message, "not a member of an organization") ||
 		strings.Contains(message, "not an administrator account") ||
 		strings.Contains(message, "not an admin account") ||
-		strings.Contains(message, "administrator account") ||
+		strings.Contains(message, "called from an administrator account") ||
 		strings.Contains(message, "securityhub:listorganizationadminaccounts") ||
 		strings.Contains(message, "securityhub:describeorganizationconfiguration") ||
 		strings.Contains(message, "delegated administrator") ||

--- a/providers/aws/securityhub.go
+++ b/providers/aws/securityhub.go
@@ -585,6 +585,11 @@ func securityHubSkippableAccessMessage(message string) bool {
 	return strings.Contains(message, "not subscribed to aws security hub") ||
 		strings.Contains(message, "no such resource found") ||
 		strings.Contains(message, "not a member of an organization") ||
+		strings.Contains(message, "not an administrator account") ||
+		strings.Contains(message, "not an admin account") ||
+		strings.Contains(message, "administrator account") ||
+		strings.Contains(message, "securityhub:listorganizationadminaccounts") ||
+		strings.Contains(message, "securityhub:describeorganizationconfiguration") ||
 		strings.Contains(message, "delegated administrator") ||
 		strings.Contains(message, "central configuration")
 }

--- a/providers/aws/securityhub_test.go
+++ b/providers/aws/securityhub_test.go
@@ -317,6 +317,11 @@ func TestSecurityHubOptionalResourceUnavailable(t *testing.T) {
 			want: true,
 		},
 		{
+			name: "unrelated administrator account access denied",
+			err:  &securityhubtypes.AccessDeniedException{Message: aws.String("administrator account cannot update Security Hub finding")},
+			want: false,
+		},
+		{
 			name: "not subscribed",
 			err:  &securityhubtypes.InvalidAccessException{Message: aws.String("not subscribed to AWS Security Hub")},
 			want: true,

--- a/providers/aws/securityhub_test.go
+++ b/providers/aws/securityhub_test.go
@@ -302,6 +302,21 @@ func TestSecurityHubOptionalResourceUnavailable(t *testing.T) {
 			want: true,
 		},
 		{
+			name: "access denied for org admin list",
+			err:  &securityhubtypes.AccessDeniedException{Message: aws.String("User is not authorized to perform: securityhub:ListOrganizationAdminAccounts")},
+			want: true,
+		},
+		{
+			name: "access denied for org configuration",
+			err:  &securityhubtypes.AccessDeniedException{Message: aws.String("User is not authorized to perform: securityhub:DescribeOrganizationConfiguration")},
+			want: true,
+		},
+		{
+			name: "not administrator account",
+			err:  &securityhubtypes.AccessDeniedException{Message: aws.String("The request must be called from an administrator account")},
+			want: true,
+		},
+		{
 			name: "not subscribed",
 			err:  &securityhubtypes.InvalidAccessException{Message: aws.String("not subscribed to AWS Security Hub")},
 			want: true,

--- a/terraformutils/providerwrapper/provider.go
+++ b/terraformutils/providerwrapper/provider.go
@@ -178,7 +178,12 @@ func (p *ProviderWrapper) Refresh(info *tfcompat.InstanceInfo, state *tfcompat.I
 
 	if resp.NewState.IsNull() {
 		msg := fmt.Sprintf("ERROR: Read resource response is null for resource %s", info.Id)
-		return nil, errors.New(msg)
+		log.Printf("%s, trying import command", msg)
+		importedState, err := p.importResourceState(info, state, schema)
+		if err == nil {
+			return importedState, nil
+		}
+		return nil, fmt.Errorf("%s; import fallback failed: %w", msg, err)
 	}
 
 	refreshedState := tfcompat.NewInstanceStateShimmedFromValue(resp.NewState, int(schema.ResourceTypes[info.Type].Version))

--- a/terraformutils/tfcompat/providerproto/provider.go
+++ b/terraformutils/tfcompat/providerproto/provider.go
@@ -318,12 +318,17 @@ func shouldSendProviderMeta(providerMeta cty.Value, schema configschema.Schema) 
 	return providerMeta.IsWhollyKnown() && !providerMeta.IsNull()
 }
 
-func decodeDynamicValue(v *tfplugin5.DynamicValue, ty cty.Type) (cty.Value, error) {
-	res := cty.NullVal(ty)
+func decodeDynamicValue(v *tfplugin5.DynamicValue, ty cty.Type) (res cty.Value, err error) {
+	res = cty.NullVal(ty)
 	if v == nil {
 		return res, nil
 	}
-	var err error
+	defer func() {
+		if rec := recover(); rec != nil {
+			res = cty.NullVal(ty)
+			err = fmt.Errorf("decode provider dynamic value: %v", rec)
+		}
+	}()
 	switch {
 	case len(v.Msgpack) > 0:
 		res, err = msgpack.Unmarshal(v.Msgpack, ty)

--- a/terraformutils/tfcompat/providerproto/provider6.go
+++ b/terraformutils/tfcompat/providerproto/provider6.go
@@ -161,12 +161,17 @@ func (p provider6Client) ImportResourceState(ctx context.Context, r ImportResour
 	return resp
 }
 
-func decodeDynamicValue6(v *tfplugin6.DynamicValue, ty cty.Type) (cty.Value, error) {
-	res := cty.NullVal(ty)
+func decodeDynamicValue6(v *tfplugin6.DynamicValue, ty cty.Type) (res cty.Value, err error) {
+	res = cty.NullVal(ty)
 	if v == nil {
 		return res, nil
 	}
-	var err error
+	defer func() {
+		if rec := recover(); rec != nil {
+			res = cty.NullVal(ty)
+			err = fmt.Errorf("decode provider dynamic value: %v", rec)
+		}
+	}()
 	switch {
 	case len(v.Msgpack) > 0:
 		res, err = msgpack.Unmarshal(v.Msgpack, ty)

--- a/terraformutils/tfcompat/providerproto/provider_test.go
+++ b/terraformutils/tfcompat/providerproto/provider_test.go
@@ -138,6 +138,24 @@ func TestShouldSendProviderMeta(t *testing.T) {
 	}
 }
 
+func TestDecodeDynamicValueReportsMalformedPayloads(t *testing.T) {
+	value, err := decodeDynamicValue(&tfplugin5.DynamicValue{Msgpack: []byte{0xc1}}, cty.String)
+	if err == nil {
+		t.Fatal("decodeDynamicValue() error = nil, want malformed payload error")
+	}
+	if !value.IsNull() {
+		t.Fatalf("decodeDynamicValue() value = %#v, want null fallback", value)
+	}
+
+	value, err = decodeDynamicValue6(&tfplugin6.DynamicValue{Msgpack: []byte{0xc1}}, cty.String)
+	if err == nil {
+		t.Fatal("decodeDynamicValue6() error = nil, want malformed payload error")
+	}
+	if !value.IsNull() {
+		t.Fatalf("decodeDynamicValue6() value = %#v, want null fallback", value)
+	}
+}
+
 type largeSchemaProvider5 struct {
 	tfplugin5.UnimplementedProviderServer
 


### PR DESCRIPTION
Summary:
- preserve Terraformer refresh progress when provider reads return null by falling back to import state
- handle malformed provider dynamic values as decode errors instead of panics
- make AWS ALB, S3, and SecurityHub inventory paths more tolerant of optional/permission-sensitive API responses

Notes:
- ALB target-group attachment IDs now follow the Terraform AWS provider import identity format, including optional port and availability zone fields.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Strengthens AWS importer/refresh resilience and tolerance for partial permissions, with a safe import fallback on null reads and robust decoding of malformed provider values. Also aligns ALB target group attachment IDs with the Terraform AWS provider import format and adds tests for importer and AWS edge cases.

- **Bug Fixes**
  - Refresh: On null Read, try import and keep progress; return a clear error if import fails.
  - Provider decode: Treat malformed dynamic values as decode errors and return null instead of panicking.
  - ALB: Build `aws_lb_target_group_attachment` IDs using the provider import format (optional port and AZ); skip incomplete targets.
  - S3: On AccessDenied, skip bucket location/config discovery with clear logs; continue without failing.
  - SecurityHub: Recognize more access/role-denied messages as optional to avoid hard failures.

<sup>Written for commit d81d33c7ef2cdd08d6d666aed7eb32931e115fda. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/chenrui333/terraformer/pull/576?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation and error handling for ALB target-group attachments.
  * Enhanced S3 access-denied error messages for clearer diagnostics.
  * Better handling of Security Hub organization-related permission errors.
  * Added fallback recovery when Terraform state refresh fails.
  * Prevented crashes from malformed dynamic value payloads.

* **Tests**
  * Added comprehensive test coverage for ALB attachments, S3 access errors, Security Hub permissions, and malformed payload handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->