### PR TITLE
chore(renovate): force chore dependency commits

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -3,7 +3,8 @@
   "extends": [
     "config:recommended",
     "helpers:pinGitHubActionDigests",
-    ":semanticCommits"
+    ":semanticCommits",
+    ":semanticCommitTypeAll(chore)"
   ],
   "baseBranchPatterns": ["main"],
   "dependencyDashboard": true,


### PR DESCRIPTION
Summary
- Add Renovate's `:semanticCommitTypeAll(chore)` preset so dependency PR titles and commits use `chore(deps)` consistently.

References
- https://docs.renovatebot.com/semantic-commits/#changing-the-semantic-commit-type


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Force all Renovate dependency updates to use `chore(deps)` in PR titles and commits. Adds `:semanticCommitTypeAll(chore)` to `renovate.json` for consistent semantic commits and cleaner changelogs.

<sup>Written for commit a05b26da104e8631ff79d90d690b9c476bd9b61c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/chenrui333/terraformer/pull/591?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

