### PR TITLE
chore(renovate): group provider dependency updates

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -10,7 +10,7 @@
   "dependencyDashboard": true,
   "enabledManagers": ["github-actions", "gomod"],
   "internalChecksFilter": "strict",
-  "labels": ["dependencies"],
+  "labels": ["dependencies", "renovate"],
   "minimumReleaseAge": "7 days",
   "semanticCommitType": "chore",
   "platformAutomerge": true,
@@ -132,6 +132,25 @@
       "groupSlug": "go-ibm-provider"
     },
     {
+      "description": "TencentCloud provider dependency family.",
+      "matchManagers": ["gomod"],
+      "matchPackageNames": [
+        "/^github\\.com/tencentcloud/tencentcloud-sdk-go($|\\/)/",
+        "/^github\\.com/tencentyun\\//"
+      ],
+      "groupName": "tencentcloud provider dependencies",
+      "groupSlug": "go-tencentcloud-provider"
+    },
+    {
+      "description": "Yandex provider dependency family.",
+      "matchManagers": ["gomod"],
+      "matchPackageNames": [
+        "/^github\\.com/yandex-cloud\\//"
+      ],
+      "groupName": "yandex provider dependencies",
+      "groupSlug": "go-yandex-provider"
+    },
+    {
       "description": "Kubernetes provider dependency family.",
       "matchManagers": ["gomod"],
       "matchPackageNames": [
@@ -147,7 +166,8 @@
       "matchPackageNames": [
         "/^github\\.com/bradleyfalzon/ghinstallation($|\\/)/",
         "/^github\\.com/google/go-github($|\\/)/",
-        "/^github\\.com/xanzy/go-gitlab($|\\/)/"
+        "/^github\\.com/xanzy/go-gitlab($|\\/)/",
+        "/^gitlab\\.com/gitlab-org/api/client-go($|\\/)/"
       ],
       "groupName": "vcs provider dependencies",
       "groupSlug": "go-vcs-provider"


### PR DESCRIPTION
Summary:
- add the `renovate` label to Renovate-created PRs
- group TencentCloud and Yandex Go module updates by provider family
- include the GitLab API client in the existing VCS provider dependency group

Notes:
- Keeps grouping targeted to provider families where overlapping Renovate PRs have already caused churn.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Group provider dependency updates in Renovate to reduce PR churn, and add the `renovate` label to Renovate PRs. Also include the GitLab API client in the VCS provider group.

- **Dependencies**
  - Add `renovate` label to Renovate-created PRs.
  - Group TencentCloud modules: `github.com/tencentcloud/tencentcloud-sdk-go` and `github.com/tencentyun/*`.
  - Group Yandex modules: `github.com/yandex-cloud/*`.
  - Expand VCS provider group to include `gitlab.com/gitlab-org/api/client-go`.

<sup>Written for commit 547bfbf8251e07620b5939f60d3267a7000080a1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/chenrui333/terraformer/pull/596?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced organization of dependency update pull requests with improved grouping for cloud provider-related dependencies.
  * Refined dependency management configuration with better labeling and categorization of third-party library updates.
  * Extended version control provider dependency tracking for more comprehensive update coverage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->