### PR TITLE
docs: prepare v0.13.13 release notes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,19 @@
 
 ## Unreleased
 
+## 0.13.13
+
+`0.13.13` is an AWS provider fix and dependency refresh patch.
+
+### Highlights
+
+* Harden AWS provider importer refresh edge cases.
+* Refresh provider and client dependencies across AWS, Azure, GCP, IBM,
+  TencentCloud, Yandex, Cloudflare, Auth0, DigitalOcean, GitLab, and HashiCorp
+  Azure SDK families.
+
+**Full Changelog**: <https://github.com/chenrui333/terraformer/compare/v0.13.12...v0.13.13>
+
 ## 0.13.12
 
 `0.13.12` is a Kubernetes compatibility and provider dependency patch. It


### PR DESCRIPTION
Summary:
- prepare the v0.13.13 changelog entry
- keep the release notes focused on the AWS provider fix and dependency refreshes

Notes:
- Previewed generated GitHub release notes for comparison.
- Ran `git diff --check`.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add v0.13.13 release notes focused on an AWS provider importer refresh fix and dependency updates across AWS, Azure, GCP, IBM, TencentCloud, Yandex, Cloudflare, Auth0, DigitalOcean, GitLab, and HashiCorp Azure SDK families.

<sup>Written for commit c8a80b24552e447fc4f2a68e774485eb4ecd7bc4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/chenrui333/terraformer/pull/597?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

