### PR TITLE
fix(providers): address provider audit gaps

### DIFF
--- a/cmd/provider_cmd_audit_test.go
+++ b/cmd/provider_cmd_audit_test.go
@@ -1,0 +1,93 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package cmd
+
+import (
+	"testing"
+
+	"github.com/spf13/cobra"
+)
+
+func TestLaunchDarklyProviderCommandRegistration(t *testing.T) {
+	provider := newLaunchDarklyProvider()
+	if provider.GetName() != "launchdarkly" {
+		t.Fatalf("provider name = %q, want launchdarkly", provider.GetName())
+	}
+	if _, ok := provider.GetSupportedService()["featureFlag"]; !ok {
+		t.Fatal("LaunchDarkly featureFlag service is not registered")
+	}
+	if _, ok := provider.GetSupportedService()["project"]; !ok {
+		t.Fatal("LaunchDarkly project service is not registered")
+	}
+
+	cmd := importerSubcommand(t, "launchdarkly")
+	if cmd.PersistentFlags().Lookup("resources") == nil {
+		t.Fatal("LaunchDarkly command missing resources flag")
+	}
+	if cmd.PersistentFlags().Lookup("filter") == nil {
+		t.Fatal("LaunchDarkly command missing filter flag")
+	}
+
+	if _, ok := providerGenerators()["launchdarkly"]; !ok {
+		t.Fatal("LaunchDarkly provider generator is not registered")
+	}
+}
+
+func TestCloudflareProviderCommandRegistration(t *testing.T) {
+	provider := newCloudflareProvider()
+	if provider.GetName() != "cloudflare" {
+		t.Fatalf("provider name = %q, want cloudflare", provider.GetName())
+	}
+	if _, ok := provider.GetSupportedService()["access"]; !ok {
+		t.Fatal("Cloudflare access service is not registered")
+	}
+	if _, ok := provider.GetSupportedService()["settings"]; !ok {
+		t.Fatal("Cloudflare settings service is not registered")
+	}
+
+	cmd := importerSubcommand(t, "cloudflare")
+	if cmd.PersistentFlags().Lookup("resources") == nil {
+		t.Fatal("Cloudflare command missing resources flag")
+	}
+	if cmd.PersistentFlags().Lookup("filter") == nil {
+		t.Fatal("Cloudflare command missing filter flag")
+	}
+
+	if _, ok := providerGenerators()["cloudflare"]; !ok {
+		t.Fatal("Cloudflare provider generator is not registered")
+	}
+}
+
+func TestKubernetesProviderCommandRegistration(t *testing.T) {
+	provider := newKubernetesProvider()
+	if provider.GetName() != "kubernetes" {
+		t.Fatalf("provider name = %q, want kubernetes", provider.GetName())
+	}
+
+	cmd := importerSubcommand(t, "kubernetes")
+	if cmd.PersistentFlags().Lookup("resources") == nil {
+		t.Fatal("Kubernetes command missing resources flag")
+	}
+	if cmd.PersistentFlags().Lookup("filter") == nil {
+		t.Fatal("Kubernetes command missing filter flag")
+	}
+	if cmd.PersistentFlags().Lookup("verbose") == nil {
+		t.Fatal("Kubernetes command missing verbose flag")
+	}
+
+	if _, ok := providerGenerators()["kubernetes"]; !ok {
+		t.Fatal("Kubernetes provider generator is not registered")
+	}
+}
+
+func importerSubcommand(t *testing.T, use string) *cobra.Command {
+	t.Helper()
+	for _, importer := range providerImporterSubcommands() {
+		cmd := importer(ImportOptions{})
+		if cmd.Use == use {
+			return cmd
+		}
+	}
+	t.Fatalf("%s import subcommand is not registered", use)
+	return nil
+}

--- a/providers/aws/autoscaling.go
+++ b/providers/aws/autoscaling.go
@@ -119,19 +119,17 @@ func (g *AutoScalingGenerator) InitResources() error {
 }
 
 func (g *AutoScalingGenerator) PostConvertHook() error {
-	for i, r := range g.Resources {
-		if r.InstanceInfo.Type != "aws_autoscaling_group" {
+	for i := range g.Resources {
+		resource := &g.Resources[i]
+		if resource.InstanceInfo == nil || resource.InstanceInfo.Type != "aws_autoscaling_group" || resource.InstanceState == nil {
 			continue
 		}
-		if lcName, exist := r.InstanceState.Attributes["launch_configuration"]; exist {
-			for _, lc := range g.Resources {
-				if lc.InstanceInfo.Type != "aws_launch_configuration" {
-					continue
+		if lcName, exist := resource.InstanceState.Attributes["launch_configuration"]; exist {
+			if reference, ok := g.launchConfigurationReference(lcName); ok {
+				if resource.Item == nil {
+					resource.Item = map[string]interface{}{}
 				}
-				if lcName == lc.InstanceState.Attributes["name"] {
-					g.Resources[i].Item["launch_configuration"] = "${aws_launch_configuration." + lc.ResourceName + ".name}"
-					continue
-				}
+				resource.Item["launch_configuration"] = reference
 			}
 		}
 		// TODO add LaunchTemplate and mix policy connection naming
@@ -175,4 +173,19 @@ func (g *AutoScalingGenerator) PostConvertHook() error {
 		g.Resources = append(g.Resources, templateFiles...)
 	*/
 	return nil
+}
+
+func (g *AutoScalingGenerator) launchConfigurationReference(name string) (string, bool) {
+	if name == "" {
+		return "", false
+	}
+	for _, resource := range g.Resources {
+		if resource.InstanceInfo == nil || resource.InstanceInfo.Type != "aws_launch_configuration" || resource.InstanceState == nil {
+			continue
+		}
+		if name == resource.InstanceState.Attributes["name"] {
+			return "${aws_launch_configuration." + resource.ResourceName + ".name}", true
+		}
+	}
+	return "", false
 }

--- a/providers/aws/autoscaling_test.go
+++ b/providers/aws/autoscaling_test.go
@@ -1,0 +1,85 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package aws
+
+import (
+	"testing"
+
+	"github.com/chenrui333/terraformer/terraformutils"
+)
+
+func TestAutoScalingPostConvertHookLinksLaunchConfiguration(t *testing.T) {
+	autoscalingGroup := terraformutils.NewResource(
+		"app-asg",
+		"app-asg",
+		"aws_autoscaling_group",
+		"aws",
+		map[string]string{"launch_configuration": "app-lc"},
+		AsgAllowEmptyValues,
+		map[string]interface{}{},
+	)
+	launchConfiguration := terraformutils.NewResource(
+		"app-lc",
+		"app-lc",
+		"aws_launch_configuration",
+		"aws",
+		map[string]string{"name": "app-lc"},
+		AsgAllowEmptyValues,
+		map[string]interface{}{},
+	)
+	generator := AutoScalingGenerator{
+		AWSService: AWSService{
+			Service: terraformutils.Service{
+				Resources: []terraformutils.Resource{autoscalingGroup, launchConfiguration},
+			},
+		},
+	}
+
+	if err := generator.PostConvertHook(); err != nil {
+		t.Fatalf("PostConvertHook() error = %v", err)
+	}
+
+	want := "${aws_launch_configuration." + launchConfiguration.ResourceName + ".name}"
+	if got := generator.Resources[0].Item["launch_configuration"]; got != want {
+		t.Fatalf("launch_configuration = %q, want %q", got, want)
+	}
+}
+
+func TestAutoScalingPostConvertHookSkipsMalformedResources(t *testing.T) {
+	autoscalingGroup := terraformutils.NewResource(
+		"app-asg",
+		"app-asg",
+		"aws_autoscaling_group",
+		"aws",
+		map[string]string{"launch_configuration": "missing-lc"},
+		AsgAllowEmptyValues,
+		map[string]interface{}{},
+	)
+	launchConfiguration := terraformutils.NewResource(
+		"app-lc",
+		"app-lc",
+		"aws_launch_configuration",
+		"aws",
+		map[string]string{},
+		AsgAllowEmptyValues,
+		map[string]interface{}{},
+	)
+	generator := AutoScalingGenerator{
+		AWSService: AWSService{
+			Service: terraformutils.Service{
+				Resources: []terraformutils.Resource{
+					{},
+					autoscalingGroup,
+					launchConfiguration,
+				},
+			},
+		},
+	}
+
+	if err := generator.PostConvertHook(); err != nil {
+		t.Fatalf("PostConvertHook() error = %v", err)
+	}
+	if generator.Resources[1].Item != nil {
+		t.Fatalf("unmatched autoscaling group item = %#v, want nil", generator.Resources[1].Item)
+	}
+}

--- a/providers/aws/unsupported_resources_test.go
+++ b/providers/aws/unsupported_resources_test.go
@@ -1,0 +1,98 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package aws
+
+import (
+	"encoding/json"
+	"os"
+	"strings"
+	"testing"
+)
+
+const awsUnsupportedIssue = "https://github.com/chenrui333/terraformer/issues/338"
+
+func TestAWSUnsupportedResourcesMetadata(t *testing.T) {
+	data, err := os.ReadFile("unsupported_resources.json")
+	if err != nil {
+		t.Fatalf("read unsupported resources: %v", err)
+	}
+
+	var metadata map[string]interface{}
+	if err := json.Unmarshal(data, &metadata); err != nil {
+		t.Fatalf("decode unsupported resources: %v", err)
+	}
+	if version, ok := metadata["version"].(float64); !ok || int(version) != 1 {
+		t.Fatalf("unsupported resources version = %v, want 1", metadata["version"])
+	}
+	rawResources, ok := metadata["resources"].([]interface{})
+	if !ok || len(rawResources) == 0 {
+		t.Fatal("unsupported resources file is missing resources list")
+	}
+
+	allowedStatuses := map[string]bool{
+		"deferred":       true,
+		"not-importable": true,
+		"runtime-data":   true,
+		"unsupported":    true,
+	}
+	seen := map[string]bool{}
+	previousResource := ""
+	for _, rawResource := range rawResources {
+		resource, ok := rawResource.(map[string]interface{})
+		if !ok {
+			t.Fatalf("unsupported resource entry has unexpected type %T", rawResource)
+		}
+		name, _ := resource["resource"].(string)
+		serviceFamily, _ := resource["service_family"].(string)
+		reason, _ := resource["reason"].(string)
+		evidence, _ := resource["evidence"].(string)
+		status, _ := resource["status"].(string)
+		references, _ := resource["references"].([]interface{})
+
+		if name == "" {
+			t.Fatal("unsupported resource entry is missing resource")
+		}
+		if !strings.HasPrefix(name, "aws_") {
+			t.Fatalf("unsupported resource %q does not use aws_ prefix", name)
+		}
+		if seen[name] {
+			t.Fatalf("unsupported resource %q is duplicated", name)
+		}
+		seen[name] = true
+		if previousResource != "" && previousResource > name {
+			t.Fatalf("unsupported resources are not sorted by resource: %q before %q", previousResource, name)
+		}
+		previousResource = name
+
+		if serviceFamily == "" {
+			t.Fatalf("unsupported resource %q is missing service_family", name)
+		}
+		if reason == "" {
+			t.Fatalf("unsupported resource %q is missing reason", name)
+		}
+		if evidence == "" {
+			t.Fatalf("unsupported resource %q is missing evidence", name)
+		}
+		if !allowedStatuses[status] {
+			t.Fatalf("unsupported resource %q has unknown status %q", name, status)
+		}
+		if !hasUnsupportedResourceReference(references, awsUnsupportedIssue) {
+			t.Fatalf("unsupported resource %q is missing issue #338 reference", name)
+		}
+		for _, rawReference := range references {
+			reference, _ := rawReference.(string)
+			if strings.TrimSpace(reference) == "" {
+				t.Fatalf("unsupported resource %q has an empty reference", name)
+			}
+		}
+	}
+}
+
+func hasUnsupportedResourceReference(references []interface{}, expected string) bool {
+	for _, rawReference := range references {
+		if reference, _ := rawReference.(string); reference == expected {
+			return true
+		}
+	}
+	return false
+}

--- a/providers/aws/unsupported_resources_test.go
+++ b/providers/aws/unsupported_resources_test.go
@@ -21,7 +21,7 @@ func TestAWSUnsupportedResourcesMetadata(t *testing.T) {
 	if err := json.Unmarshal(data, &metadata); err != nil {
 		t.Fatalf("decode unsupported resources: %v", err)
 	}
-	if version, ok := metadata["version"].(float64); !ok || int(version) != 1 {
+	if version, ok := metadata["version"].(float64); !ok || version != 1 {
 		t.Fatalf("unsupported resources version = %v, want 1", metadata["version"])
 	}
 	rawResources, ok := metadata["resources"].([]interface{})

--- a/providers/cloudflare/cloudflare_provider_test.go
+++ b/providers/cloudflare/cloudflare_provider_test.go
@@ -1,0 +1,184 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package cloudflare
+
+import (
+	"net/url"
+	"reflect"
+	"sort"
+	"testing"
+
+	"github.com/chenrui333/terraformer/terraformutils"
+	cf "github.com/cloudflare/cloudflare-go"
+)
+
+func TestCloudflareProviderSupportedServices(t *testing.T) {
+	services := (&CloudflareProvider{}).GetSupportedService()
+	got := make([]string, 0, len(services))
+	for service := range services {
+		got = append(got, service)
+	}
+	sort.Strings(got)
+
+	want := []string{
+		"access",
+		"account_member",
+		"certificates",
+		"connectivity",
+		"dns",
+		"email_routing",
+		"firewall",
+		"lists",
+		"load_balancing",
+		"logpush",
+		"magic_wan",
+		"media_platform",
+		"network_edge",
+		"notifications",
+		"page_rule",
+		"pages",
+		"ruleset",
+		"security",
+		"settings",
+		"storage",
+		"tunnel",
+		"turnstile",
+		"waiting_room",
+		"web_analytics",
+		"workers",
+		"zero_trust_device_dlp",
+		"zero_trust_gateway",
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("supported services = %#v, want %#v", got, want)
+	}
+}
+
+func TestCloudflareProviderInitServiceConfiguresService(t *testing.T) {
+	provider := &CloudflareProvider{}
+
+	if err := provider.InitService("settings", true); err != nil {
+		t.Fatalf("InitService() error = %v", err)
+	}
+	if provider.Service.GetName() != "settings" {
+		t.Fatalf("service name = %q, want settings", provider.Service.GetName())
+	}
+	if provider.Service.GetProviderName() != "cloudflare" {
+		t.Fatalf("provider name = %q, want cloudflare", provider.Service.GetProviderName())
+	}
+}
+
+func TestCloudflareProviderInitServiceRejectsUnsupportedService(t *testing.T) {
+	provider := &CloudflareProvider{}
+
+	err := provider.InitService("missing", false)
+	if err == nil {
+		t.Fatal("expected unsupported service error")
+	}
+	if got, want := err.Error(), "cloudflare: missing not supported service"; got != want {
+		t.Fatalf("error = %q, want %q", got, want)
+	}
+	if provider.Service != nil {
+		t.Fatalf("service = %#v, want nil", provider.Service)
+	}
+}
+
+func TestCloudflareAuthHelpersRequireCredentials(t *testing.T) {
+	t.Setenv("CLOUDFLARE_API_KEY", "")
+	t.Setenv("CLOUDFLARE_EMAIL", "")
+	t.Setenv("CLOUDFLARE_API_TOKEN", "")
+	service := &CloudflareService{}
+
+	if _, err := service.initializeAPI(); err == nil {
+		t.Fatal("expected initializeAPI to require credentials")
+	}
+	if _, err := service.cloudflareV7Options(); err == nil {
+		t.Fatal("expected cloudflareV7Options to require credentials")
+	}
+
+	t.Setenv("CLOUDFLARE_API_TOKEN", "token")
+	if _, err := service.initializeAPI(); err != nil {
+		t.Fatalf("initializeAPI() error = %v", err)
+	}
+	if options, err := service.cloudflareV7Options(); err != nil {
+		t.Fatalf("cloudflareV7Options() error = %v", err)
+	} else if len(options) != 1 {
+		t.Fatalf("cloudflareV7Options() returned %d options, want 1", len(options))
+	}
+}
+
+func TestCloudflareAccountIDRequired(t *testing.T) {
+	service := &CloudflareService{}
+	t.Setenv("CLOUDFLARE_ACCOUNT_ID", "")
+
+	if _, err := service.accountIDRequired(); err == nil {
+		t.Fatal("expected account ID error")
+	}
+
+	t.Setenv("CLOUDFLARE_ACCOUNT_ID", "account-123")
+	if accountID, err := service.accountIDRequired(); err != nil {
+		t.Fatalf("accountIDRequired() error = %v", err)
+	} else if accountID != "account-123" {
+		t.Fatalf("account ID = %q, want account-123", accountID)
+	}
+}
+
+func TestCloudflareResourceAndImportIDHelpers(t *testing.T) {
+	if got, want := cloudflareResourceName("account", "", "resource"), "account_resource"; got != want {
+		t.Fatalf("cloudflareResourceName() = %q, want %q", got, want)
+	}
+
+	resource := terraformutils.NewSimpleResource("id", "name", "cloudflare_test", "cloudflare", nil)
+	setCloudflareImportID(&resource, "account/id")
+	if got := resource.InstanceState.Meta["import_id"]; got != "account/id" {
+		t.Fatalf("import_id = %q, want account/id", got)
+	}
+}
+
+func TestCloudflarePaginationHelpers(t *testing.T) {
+	query, err := url.ParseQuery(cloudflarePaginationQuery(2, ""))
+	if err != nil {
+		t.Fatalf("parse page query: %v", err)
+	}
+	if query.Get("page") != "2" {
+		t.Fatalf("page query = %q, want 2", query.Get("page"))
+	}
+	if query.Get("per_page") != "50" {
+		t.Fatalf("per_page query = %q, want 50", query.Get("per_page"))
+	}
+
+	query, err = url.ParseQuery(cloudflarePaginationQuery(1, "cursor-123"))
+	if err != nil {
+		t.Fatalf("parse cursor query: %v", err)
+	}
+	if query.Get("cursor") != "cursor-123" {
+		t.Fatalf("cursor query = %q, want cursor-123", query.Get("cursor"))
+	}
+	if query.Get("page") != "" {
+		t.Fatalf("page query with cursor = %q, want empty", query.Get("page"))
+	}
+
+	page := 1
+	cursor := ""
+	if !cloudflareAdvancePagination(&cf.ResultInfo{Cursor: "next"}, &page, &cursor) {
+		t.Fatal("expected cursor pagination to advance")
+	}
+	if cursor != "next" {
+		t.Fatalf("cursor = %q, want next", cursor)
+	}
+	if cloudflareAdvancePagination(&cf.ResultInfo{Cursor: "next"}, &page, &cursor) {
+		t.Fatal("expected repeated cursor to stop pagination")
+	}
+
+	page = 1
+	cursor = ""
+	if !cloudflareAdvancePaginationWithItemCount(&cf.ResultInfo{Page: 1, PerPage: 10}, &page, &cursor, 10) {
+		t.Fatal("expected full page item count to advance pagination")
+	}
+	if page != 2 {
+		t.Fatalf("page = %d, want 2", page)
+	}
+	if cloudflareAdvancePaginationWithItemCount(&cf.ResultInfo{Page: 2, PerPage: 10}, &page, &cursor, 9) {
+		t.Fatal("expected short page item count to stop pagination")
+	}
+}

--- a/providers/launchdarkly/launchdarkly_provider.go
+++ b/providers/launchdarkly/launchdarkly_provider.go
@@ -49,13 +49,7 @@ func (p *LaunchDarklyProvider) GetName() string {
 }
 
 func (p *LaunchDarklyProvider) GetProviderData(_ ...string) map[string]interface{} {
-	return map[string]interface{}{
-		"provider": map[string]interface{}{
-			"launchdarkly": map[string]interface{}{
-				"access_token": p.apiKey,
-			},
-		},
-	}
+	return map[string]interface{}{}
 }
 
 func (LaunchDarklyProvider) GetResourceConnections() map[string]map[string][]string {

--- a/providers/launchdarkly/launchdarkly_provider_test.go
+++ b/providers/launchdarkly/launchdarkly_provider_test.go
@@ -2,7 +2,13 @@
 
 package launchdarkly
 
-import "testing"
+import (
+	"encoding/json"
+	"reflect"
+	"sort"
+	"strings"
+	"testing"
+)
 
 func TestLaunchDarklyProviderInitClearsStateOnMissingToken(t *testing.T) {
 	provider := &LaunchDarklyProvider{}
@@ -21,5 +27,101 @@ func TestLaunchDarklyProviderInitClearsStateOnMissingToken(t *testing.T) {
 	}
 	if provider.apiKey != "" || provider.client != nil || provider.ctx != nil {
 		t.Fatalf("expected stale provider state to be cleared, got apiKey=%q client=%v ctx=%v", provider.apiKey, provider.client, provider.ctx)
+	}
+}
+
+func TestLaunchDarklyProviderDataDoesNotExportAccessToken(t *testing.T) {
+	provider := &LaunchDarklyProvider{apiKey: "secret-token"}
+
+	data := provider.GetProviderData()
+	encoded, err := json.Marshal(data)
+	if err != nil {
+		t.Fatalf("marshal provider data: %v", err)
+	}
+	if strings.Contains(string(encoded), "secret-token") {
+		t.Fatalf("provider data exported access token: %s", encoded)
+	}
+	if len(data) != 0 {
+		t.Fatalf("provider data = %#v, want empty map", data)
+	}
+}
+
+func TestLaunchDarklyProviderSupportedServices(t *testing.T) {
+	services := (&LaunchDarklyProvider{}).GetSupportedService()
+	got := make([]string, 0, len(services))
+	for service := range services {
+		got = append(got, service)
+	}
+	sort.Strings(got)
+
+	want := []string{
+		"accessToken",
+		"aiConfig",
+		"aiConfigVariation",
+		"aiTool",
+		"auditLogSubscription",
+		"customRole",
+		"destination",
+		"environment",
+		"featureFlag",
+		"flagTemplates",
+		"flagTrigger",
+		"metric",
+		"modelConfig",
+		"project",
+		"relayProxyConfiguration",
+		"segment",
+		"team",
+		"teamMember",
+		"view",
+		"viewLinks",
+		"webhook",
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("supported services = %#v, want %#v", got, want)
+	}
+}
+
+func TestLaunchDarklyProviderInitServiceSeedsDiscoveryArgs(t *testing.T) {
+	t.Setenv("LAUNCHDARKLY_ACCESS_TOKEN", "access-token")
+
+	provider := &LaunchDarklyProvider{}
+	if err := provider.Init(nil); err != nil {
+		t.Fatalf("Init() error = %v", err)
+	}
+	if err := provider.InitService("webhook", true); err != nil {
+		t.Fatalf("InitService() error = %v", err)
+	}
+
+	if provider.Service.GetName() != "webhook" {
+		t.Fatalf("service name = %q, want webhook", provider.Service.GetName())
+	}
+	if provider.Service.GetProviderName() != "launchdarkly" {
+		t.Fatalf("provider name = %q, want launchdarkly", provider.Service.GetProviderName())
+	}
+	args := provider.Service.GetArgs()
+	if args["api_key"] != "access-token" {
+		t.Fatalf("api_key arg = %q, want access-token", args["api_key"])
+	}
+	if args["client"] == nil {
+		t.Fatal("client arg was not set")
+	}
+	if args["ctx"] == nil {
+		t.Fatal("ctx arg was not set")
+	}
+}
+
+func TestLaunchDarklyProviderInitServiceRejectsUnsupportedService(t *testing.T) {
+	provider := &LaunchDarklyProvider{}
+
+	err := provider.InitService("missing", false)
+	if err == nil {
+		t.Fatal("expected unsupported service error")
+	}
+	if got, want := err.Error(), "launchdarkly: missing not supported service"; got != want {
+		t.Fatalf("error = %q, want %q", got, want)
+	}
+	if provider.Service != nil {
+		t.Fatalf("service = %#v, want nil", provider.Service)
 	}
 }

--- a/providers/launchdarkly/unsupported_resources_test.go
+++ b/providers/launchdarkly/unsupported_resources_test.go
@@ -19,7 +19,7 @@ func TestLaunchDarklyUnsupportedResourcesMetadata(t *testing.T) {
 	if err := json.Unmarshal(data, &metadata); err != nil {
 		t.Fatalf("decode unsupported resources: %v", err)
 	}
-	if version, ok := metadata["version"].(float64); !ok || int(version) != 1 {
+	if version, ok := metadata["version"].(float64); !ok || version != 1 {
 		t.Fatalf("unsupported resources version = %v, want 1", metadata["version"])
 	}
 	rawResources, ok := metadata["resources"].([]interface{})

--- a/providers/launchdarkly/unsupported_resources_test.go
+++ b/providers/launchdarkly/unsupported_resources_test.go
@@ -1,0 +1,85 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package launchdarkly
+
+import (
+	"encoding/json"
+	"os"
+	"strings"
+	"testing"
+)
+
+func TestLaunchDarklyUnsupportedResourcesMetadata(t *testing.T) {
+	data, err := os.ReadFile("unsupported_resources.json")
+	if err != nil {
+		t.Fatalf("read unsupported resources: %v", err)
+	}
+
+	var metadata map[string]interface{}
+	if err := json.Unmarshal(data, &metadata); err != nil {
+		t.Fatalf("decode unsupported resources: %v", err)
+	}
+	if version, ok := metadata["version"].(float64); !ok || int(version) != 1 {
+		t.Fatalf("unsupported resources version = %v, want 1", metadata["version"])
+	}
+	rawResources, ok := metadata["resources"].([]interface{})
+	if !ok || len(rawResources) == 0 {
+		t.Fatal("unsupported resources file is missing resources list")
+	}
+
+	allowedStatuses := map[string]bool{
+		"deferred":    true,
+		"unsupported": true,
+	}
+	seen := map[string]bool{}
+	previousResource := ""
+	for _, rawResource := range rawResources {
+		resource, ok := rawResource.(map[string]interface{})
+		if !ok {
+			t.Fatalf("unsupported resource entry has unexpected type %T", rawResource)
+		}
+		name, _ := resource["resource"].(string)
+		serviceFamily, _ := resource["service_family"].(string)
+		reason, _ := resource["reason"].(string)
+		evidence, _ := resource["evidence"].(string)
+		status, _ := resource["status"].(string)
+		references, _ := resource["references"].([]interface{})
+
+		if name == "" {
+			t.Fatal("unsupported resource entry is missing resource")
+		}
+		if !strings.HasPrefix(name, "launchdarkly_") {
+			t.Fatalf("unsupported resource %q does not use launchdarkly_ prefix", name)
+		}
+		if seen[name] {
+			t.Fatalf("unsupported resource %q is duplicated", name)
+		}
+		seen[name] = true
+		if previousResource != "" && previousResource > name {
+			t.Fatalf("unsupported resources are not sorted by resource: %q before %q", previousResource, name)
+		}
+		previousResource = name
+
+		if serviceFamily == "" {
+			t.Fatalf("unsupported resource %q is missing service_family", name)
+		}
+		if reason == "" {
+			t.Fatalf("unsupported resource %q is missing reason", name)
+		}
+		if evidence == "" {
+			t.Fatalf("unsupported resource %q is missing evidence", name)
+		}
+		if !allowedStatuses[status] {
+			t.Fatalf("unsupported resource %q has unknown status %q", name, status)
+		}
+		if len(references) == 0 {
+			t.Fatalf("unsupported resource %q is missing references", name)
+		}
+		for _, rawReference := range references {
+			reference, _ := rawReference.(string)
+			if strings.TrimSpace(reference) == "" {
+				t.Fatalf("unsupported resource %q has an empty reference", name)
+			}
+		}
+	}
+}


### PR DESCRIPTION
## Summary

- Stop LaunchDarkly provider data from embedding access tokens.
- Harden AWS autoscaling post-convert launch configuration linking against malformed resources.
- Add audit coverage for AWS and LaunchDarkly unsupported metadata, Cloudflare helpers, and provider command registration for LaunchDarkly, Cloudflare, and Kubernetes.

## Checklist

- [x] For provider resource changes, I updated the provider's `unsupported_resources.json` with any evidence-backed unsupported resources discovered, or confirmed no metadata update is needed.
- [x] I ran the relevant validation for this change.

## Notes

- Helm and Kubernetes package tests were run individually after clearing stale Go temp build directories.
- The prior `golangci-lint` GitHub Actions failure was runner disk exhaustion while writing diagnostic logs, not a lint finding.
