### PR TITLE
fix(mikrotik): avoid generated provider config

### DIFF
--- a/cmd/provider_cmd_audit_test.go
+++ b/cmd/provider_cmd_audit_test.go
@@ -80,6 +80,28 @@ func TestKubernetesProviderCommandRegistration(t *testing.T) {
 	}
 }
 
+func TestMikrotikProviderCommandRegistration(t *testing.T) {
+	provider := newMikrotikProvider()
+	if provider.GetName() != "mikrotik" {
+		t.Fatalf("provider name = %q, want mikrotik", provider.GetName())
+	}
+	if _, ok := provider.GetSupportedService()["dhcp_lease"]; !ok {
+		t.Fatal("Mikrotik dhcp_lease service is not registered")
+	}
+
+	cmd := importerSubcommand(t, "mikrotik")
+	if cmd.PersistentFlags().Lookup("resources") == nil {
+		t.Fatal("Mikrotik command missing resources flag")
+	}
+	if cmd.PersistentFlags().Lookup("filter") == nil {
+		t.Fatal("Mikrotik command missing filter flag")
+	}
+
+	if _, ok := providerGenerators()["mikrotik"]; !ok {
+		t.Fatal("Mikrotik provider generator is not registered")
+	}
+}
+
 func importerSubcommand(t *testing.T, use string) *cobra.Command {
 	t.Helper()
 	for _, importer := range providerImporterSubcommands() {

--- a/providers/mikrotik/dhcp_leases_test.go
+++ b/providers/mikrotik/dhcp_leases_test.go
@@ -1,0 +1,39 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package mikrotik
+
+import (
+	"testing"
+
+	"github.com/chenrui333/terraformer/terraformutils"
+	"github.com/ddelnano/terraform-provider-mikrotik/client"
+)
+
+func TestDhcpLeaseGeneratorCreateResources(t *testing.T) {
+	generator := DhcpLeaseGenerator{}
+
+	resources := generator.createResources([]client.DhcpLease{
+		{Id: "*1", Hostname: "laptop"},
+		{Id: "*2"},
+	})
+	if len(resources) != 2 {
+		t.Fatalf("resource count = %d, want 2", len(resources))
+	}
+
+	if got, want := resources[0].InstanceState.ID, "*1"; got != want {
+		t.Fatalf("first resource ID = %q, want %q", got, want)
+	}
+	if got, want := resources[0].ResourceName, terraformutils.TfSanitize("laptop-*1"); got != want {
+		t.Fatalf("first resource name = %q, want %q", got, want)
+	}
+	if got, want := resources[0].InstanceInfo.Type, "mikrotik_dhcp_lease"; got != want {
+		t.Fatalf("first resource type = %q, want %q", got, want)
+	}
+
+	if got, want := resources[1].InstanceState.ID, "*2"; got != want {
+		t.Fatalf("second resource ID = %q, want %q", got, want)
+	}
+	if got, want := resources[1].ResourceName, terraformutils.TfSanitize("*2"); got != want {
+		t.Fatalf("second resource name = %q, want %q", got, want)
+	}
+}

--- a/providers/mikrotik/dhcp_leases_test.go
+++ b/providers/mikrotik/dhcp_leases_test.go
@@ -36,4 +36,7 @@ func TestDhcpLeaseGeneratorCreateResources(t *testing.T) {
 	if got, want := resources[1].ResourceName, terraformutils.TfSanitize("*2"); got != want {
 		t.Fatalf("second resource name = %q, want %q", got, want)
 	}
+	if got, want := resources[1].InstanceInfo.Type, "mikrotik_dhcp_lease"; got != want {
+		t.Fatalf("second resource type = %q, want %q", got, want)
+	}
 }

--- a/providers/mikrotik/mikrotik_provider.go
+++ b/providers/mikrotik/mikrotik_provider.go
@@ -25,14 +25,7 @@ func (p *MikrotikProvider) GetName() string {
 }
 
 func (p *MikrotikProvider) GetProviderData(_ ...string) map[string]interface{} {
-	return map[string]interface{}{
-		"provider": map[string]interface{}{
-			"mikrotik": map[string]interface{}{
-				"host": p.Host,
-				"user": p.Username,
-			},
-		},
-	}
+	return map[string]interface{}{}
 }
 
 func (MikrotikProvider) GetResourceConnections() map[string]map[string][]string {

--- a/providers/mikrotik/mikrotik_provider_test.go
+++ b/providers/mikrotik/mikrotik_provider_test.go
@@ -1,0 +1,102 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package mikrotik
+
+import (
+	"encoding/json"
+	"reflect"
+	"sort"
+	"strings"
+	"testing"
+
+	"github.com/ddelnano/terraform-provider-mikrotik/client"
+)
+
+func TestMikrotikProviderDataDoesNotExportConnectionSettings(t *testing.T) {
+	provider := &MikrotikProvider{
+		Mikrotik: client.Mikrotik{
+			Host:     "router.example.com:8728",
+			Username: "admin",
+			Password: "secret-password",
+		},
+	}
+
+	data := provider.GetProviderData()
+	encoded, err := json.Marshal(data)
+	if err != nil {
+		t.Fatalf("marshal provider data: %v", err)
+	}
+	for _, sensitiveValue := range []string{"router.example.com", "admin", "secret-password"} {
+		if strings.Contains(string(encoded), sensitiveValue) {
+			t.Fatalf("provider data exported %q: %s", sensitiveValue, encoded)
+		}
+	}
+	if len(data) != 0 {
+		t.Fatalf("provider data = %#v, want empty map", data)
+	}
+}
+
+func TestMikrotikProviderSupportedServices(t *testing.T) {
+	services := (&MikrotikProvider{}).GetSupportedService()
+	got := make([]string, 0, len(services))
+	for service := range services {
+		got = append(got, service)
+	}
+	sort.Strings(got)
+
+	want := []string{"dhcp_lease"}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("supported services = %#v, want %#v", got, want)
+	}
+}
+
+func TestMikrotikProviderInitServiceSeedsDiscoveryArgs(t *testing.T) {
+	provider := &MikrotikProvider{
+		Mikrotik: client.Mikrotik{
+			Host:     "router.example.com:8728",
+			Username: "admin",
+			Password: "secret-password",
+			TLS:      true,
+			CA:       "ca-data",
+			Insecure: true,
+		},
+	}
+
+	if err := provider.InitService("dhcp_lease", true); err != nil {
+		t.Fatalf("InitService() error = %v", err)
+	}
+	if provider.Service.GetName() != "dhcp_lease" {
+		t.Fatalf("service name = %q, want dhcp_lease", provider.Service.GetName())
+	}
+	if provider.Service.GetProviderName() != "mikrotik" {
+		t.Fatalf("provider name = %q, want mikrotik", provider.Service.GetProviderName())
+	}
+
+	args := provider.Service.GetArgs()
+	wantArgs := map[string]interface{}{
+		"host":           "router.example.com:8728",
+		"user":           "admin",
+		"password":       "secret-password",
+		"tls":            true,
+		"ca_certificate": "ca-data",
+		"insecure":       true,
+	}
+	if !reflect.DeepEqual(args, wantArgs) {
+		t.Fatalf("service args = %#v, want %#v", args, wantArgs)
+	}
+}
+
+func TestMikrotikProviderInitServiceRejectsUnsupportedService(t *testing.T) {
+	provider := &MikrotikProvider{}
+
+	err := provider.InitService("missing", false)
+	if err == nil {
+		t.Fatal("expected unsupported service error")
+	}
+	if got, want := err.Error(), "mikrotik: missing not supported service"; got != want {
+		t.Fatalf("error = %q, want %q", got, want)
+	}
+	if provider.Service != nil {
+		t.Fatalf("service = %#v, want nil", provider.Service)
+	}
+}


### PR DESCRIPTION
## Summary

- Stop Mikrotik provider output from generating empty provider connection settings.
- Add Mikrotik provider tests for provider data, service registration, service args, unsupported services, and DHCP lease resource naming.
- Extend provider command audit coverage to include Mikrotik registration.

## Notes

- Mikrotik discovery and provider refresh are documented as environment-variable based, so generated provider data should stay empty.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stop emitting `mikrotik` provider config in generated output to avoid leaking connection details and align with env-based setup.
Added tests and provider command audit for registration and generator wiring, flags (`resources`, `filter`), service args (incl. TLS/CA/insecure), unsupported services, and DHCP lease resource names and types.

<sup>Written for commit a667ae762f0ba3d7efdfac2091381df7840ac158. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/chenrui333/terraformer/pull/600?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for the Mikrotik provider with DHCP lease resource management capability.

* **Tests**
  * Added comprehensive test coverage for Mikrotik provider command registration, DHCP lease resource generation, and provider initialization workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->