### PR TITLE
build: make provider release builds use isolated temp workspaces

### DIFF
--- a/build/multi-build/main.go
+++ b/build/multi-build/main.go
@@ -4,16 +4,43 @@ package main
 import (
 	"bytes"
 	"fmt"
+	"io"
+	"io/fs"
 	"log"
 	"os"
 	"os/exec"
 	"path/filepath"
+	"sort"
 	"strings"
+	"time"
 )
 
 const filePrefix = "provider_cmd_"
 const fileSuffix = ".go"
 const packageCmdPath = "cmd"
+
+type providerCommand struct {
+	Name string
+	File string
+}
+
+type buildTarget struct {
+	Provider   providerCommand
+	GOOS       string
+	GOARCH     string
+	BinaryName string
+	OutputPath string
+}
+
+type buildOptions struct {
+	RepoRoot       string
+	OutputDir      string
+	Arches         []string
+	OSes           []string
+	ProviderFilter []string
+	LDFlags        string
+	DryRun         bool
+}
 
 func envList(name string, defaults []string) []string {
 	value := strings.TrimSpace(os.Getenv(name))
@@ -33,146 +60,418 @@ func envList(name string, defaults []string) []string {
 	return items
 }
 
-func main() {
-	// provider := os.Args[1]
+func envBool(name string) bool {
+	switch strings.ToLower(strings.TrimSpace(os.Getenv(name))) {
+	case "1", "true", "yes", "y":
+		return true
+	default:
+		return false
+	}
+}
+
+func loadOptions() (buildOptions, error) {
+	repoRoot, err := os.Getwd()
+	if err != nil {
+		return buildOptions{}, fmt.Errorf("get working directory: %w", err)
+	}
+
 	outputDir := os.Getenv("TERRAFORMER_BUILD_OUTPUT_DIR")
 	if outputDir == "" {
 		outputDir = "."
 	}
-	if err := os.MkdirAll(outputDir, os.ModePerm); err != nil {
+	outputDir, err = filepath.Abs(outputDir)
+	if err != nil {
+		return buildOptions{}, fmt.Errorf("resolve output directory: %w", err)
+	}
+
+	return buildOptions{
+		RepoRoot:       repoRoot,
+		OutputDir:      outputDir,
+		Arches:         envList("TERRAFORMER_BUILD_GOARCH", []string{"amd64", "arm64"}),
+		OSes:           envList("TERRAFORMER_BUILD_GOOS", []string{"linux", "windows", "mac"}),
+		ProviderFilter: envList("TERRAFORMER_BUILD_PROVIDERS", nil),
+		LDFlags:        os.Getenv("TERRAFORMER_LDFLAGS"),
+		DryRun:         envBool("TERRAFORMER_BUILD_DRY_RUN"),
+	}, nil
+}
+
+func main() {
+	options, err := loadOptions()
+	if err != nil {
 		log.Fatal("err:", err)
 	}
-
-	allProviders := []string{}
-	files, err := os.ReadDir(packageCmdPath)
-	if err != nil {
-		log.Println(err)
+	if err := run(options); err != nil {
+		log.Fatal("err:", err)
 	}
-	for _, f := range files {
-		if strings.HasPrefix(f.Name(), filePrefix) {
-			providerName := strings.ReplaceAll(f.Name(), filePrefix, "")
-			providerName = strings.ReplaceAll(providerName, fileSuffix, "")
-			allProviders = append(allProviders, providerName)
+}
+
+func run(options buildOptions) (err error) {
+	if err := os.MkdirAll(options.OutputDir, os.ModePerm); err != nil {
+		return fmt.Errorf("create output directory %s: %w", options.OutputDir, err)
+	}
+
+	var providers []providerCommand
+	if err := timed("provider enumeration", func() error {
+		var enumerateErr error
+		providers, enumerateErr = enumerateProviders(filepath.Join(options.RepoRoot, packageCmdPath))
+		return enumerateErr
+	}); err != nil {
+		return err
+	}
+
+	selectedProviders, err := selectProviders(providers, options.ProviderFilter)
+	if err != nil {
+		return err
+	}
+
+	targets, err := buildTargets(selectedProviders, options.OSes, options.Arches, options.OutputDir)
+	if err != nil {
+		return err
+	}
+	log.Printf("Selected %d provider command(s), %d build target(s)", len(selectedProviders), len(targets))
+
+	if options.DryRun {
+		for _, target := range targets {
+			log.Printf("dry-run target provider=%s GOOS=%s GOARCH=%s output=%s", target.Provider.Name, target.GOOS, target.GOARCH, target.OutputPath)
+		}
+		return nil
+	}
+
+	var workspace string
+	if err := timed("setup temp source tree", func() error {
+		var setupErr error
+		workspace, setupErr = createSourceWorkspace(options.RepoRoot)
+		return setupErr
+	}); err != nil {
+		return err
+	}
+	defer func() {
+		cleanupErr := timed("cleanup temp source tree", func() error {
+			return os.RemoveAll(workspace)
+		})
+		if err == nil && cleanupErr != nil {
+			err = cleanupErr
+		}
+	}()
+
+	for _, target := range targets {
+		target := target
+		phase := fmt.Sprintf("provider build %s %s/%s", target.Provider.Name, target.GOOS, target.GOARCH)
+		if err := timed(phase, func() error {
+			return buildProviderBinary(workspace, providers, target, options.LDFlags)
+		}); err != nil {
+			return err
 		}
 	}
-	arches := envList("TERRAFORMER_BUILD_GOARCH", []string{"amd64", "arm64"})
-	oses := envList("TERRAFORMER_BUILD_GOOS", []string{"linux", "windows", "mac"})
-	providerFilter := map[string]bool{}
-	for _, provider := range envList("TERRAFORMER_BUILD_PROVIDERS", nil) {
-		providerFilter[provider] = true
+
+	return nil
+}
+
+func timed(name string, fn func() error) error {
+	start := time.Now()
+	err := fn()
+	duration := time.Since(start).Round(time.Millisecond)
+	if err != nil {
+		log.Printf("timing phase=%q status=failed duration=%s", name, duration)
+		return err
 	}
+	log.Printf("timing phase=%q status=success duration=%s", name, duration)
+	return nil
+}
+
+func enumerateProviders(cmdDir string) ([]providerCommand, error) {
+	files, err := os.ReadDir(cmdDir)
+	if err != nil {
+		return nil, fmt.Errorf("read command directory %s: %w", cmdDir, err)
+	}
+
+	providers := make([]providerCommand, 0, len(files))
+	for _, f := range files {
+		if !strings.HasPrefix(f.Name(), filePrefix) {
+			continue
+		}
+		providerName := strings.ReplaceAll(f.Name(), filePrefix, "")
+		providerName = strings.ReplaceAll(providerName, fileSuffix, "")
+		providers = append(providers, providerCommand{Name: providerName, File: f.Name()})
+	}
+	if len(providers) == 0 {
+		return nil, fmt.Errorf("no provider command files found in %s", cmdDir)
+	}
+	return providers, nil
+}
+
+func selectProviders(providers []providerCommand, filter []string) ([]providerCommand, error) {
+	if len(filter) == 0 {
+		return providers, nil
+	}
+
+	requested := make(map[string]bool, len(filter))
+	for _, provider := range filter {
+		requested[provider] = true
+	}
+
+	selected := make([]providerCommand, 0, len(filter))
+	found := make(map[string]bool, len(filter))
+	for _, provider := range providers {
+		if requested[provider.Name] {
+			selected = append(selected, provider)
+			found[provider.Name] = true
+		}
+	}
+
+	missing := make([]string, 0)
+	for provider := range requested {
+		if !found[provider] {
+			missing = append(missing, provider)
+		}
+	}
+	if len(missing) > 0 {
+		sort.Strings(missing)
+		return nil, fmt.Errorf("provider command filter includes unknown provider(s): %s", strings.Join(missing, ", "))
+	}
+
+	return selected, nil
+}
+
+func buildTargets(providers []providerCommand, oses []string, arches []string, outputDir string) ([]buildTarget, error) {
+	targets := make([]buildTarget, 0, len(providers)*len(oses)*len(arches))
 	for _, arch := range arches {
-		for _, OS := range oses {
-			for _, provider := range allProviders {
-				if len(providerFilter) > 0 && !providerFilter[provider] {
-					continue
-				}
-				GOOS := ""
-				binaryName := ""
-				switch OS {
-				case "linux":
-					GOOS = "linux"
-					binaryName = "terraformer-" + provider + "-linux-" + arch
-				case "windows":
-					GOOS = "windows"
-					binaryName = "terraformer-" + provider + "-windows-" + arch + ".exe"
-				case "darwin", "mac":
-					GOOS = "darwin"
-					binaryName = "terraformer-" + provider + "-darwin-" + arch
-				default:
-					log.Fatal("err: unsupported TERRAFORMER_BUILD_GOOS value: ", OS)
-				}
-				log.Println("Build terraformer with "+provider+" provider...", "GOOS=", GOOS, " for GOARCH=", arch)
-				deletedProvider := []string{}
-				for _, f := range files {
-					if strings.HasPrefix(f.Name(), filePrefix) {
-						if !strings.HasPrefix(f.Name(), filePrefix+provider+fileSuffix) {
-							providerName := strings.ReplaceAll(f.Name(), filePrefix, "")
-							providerName = strings.ReplaceAll(providerName, fileSuffix, "")
-							deletedProvider = append(deletedProvider, providerName)
-						}
-					}
-				}
-				// move files for deleted providers
-				err := os.MkdirAll(packageCmdPath+"/tmp", os.ModePerm)
+		for _, osName := range oses {
+			for _, provider := range providers {
+				target, err := newBuildTarget(provider, osName, arch, outputDir)
 				if err != nil {
-					log.Fatal("err:", err)
+					return nil, err
 				}
-				for _, provider := range deletedProvider {
-					err := os.Rename(packageCmdPath+"/"+filePrefix+provider+fileSuffix, packageCmdPath+"/tmp/"+filePrefix+provider+fileSuffix)
-					if err != nil {
-						log.Println(err)
-					}
-				}
-				restoreProviderFiles := func() {
-					for _, provider := range deletedProvider {
-						err := os.Rename(packageCmdPath+"/tmp/"+filePrefix+provider+fileSuffix, packageCmdPath+"/"+filePrefix+provider+fileSuffix)
-						if err != nil {
-							log.Println(err)
-						}
-					}
-				}
-
-				// comment deleted providers in code
-				rootCode, err := os.ReadFile(packageCmdPath + "/root.go")
-				if err != nil {
-					restoreProviderFiles()
-					log.Fatal("err:", err)
-				}
-				cleanupCodeAndFiles := func() {
-					if err := os.WriteFile(packageCmdPath+"/root.go", rootCode, os.ModePerm); err != nil {
-						log.Println(err)
-					}
-					restoreProviderFiles()
-				}
-				lines := strings.Split(string(rootCode), "\n")
-				newRootCodeLines := make([]string, len(lines))
-				for i, line := range lines {
-					for _, provider := range deletedProvider {
-						if strings.Contains(strings.ToLower(line), "newcmd"+provider+"importer") {
-							line = "// " + line
-						}
-						if strings.Contains(strings.ToLower(line), "new"+provider+"provider") {
-							line = "// " + line
-						}
-					}
-					newRootCodeLines[i] = line
-				}
-				newRootCode := strings.Join(newRootCodeLines, "\n")
-				err = os.WriteFile(packageCmdPath+"/root.go", []byte(newRootCode), os.ModePerm)
-				if err != nil {
-					cleanupCodeAndFiles()
-					log.Fatal("err:", err)
-				}
-
-				// build....
-				binaryPath := filepath.Join(outputDir, binaryName)
-				args := []string{"build", "-v", "-o", binaryPath}
-				if ldflags := os.Getenv("TERRAFORMER_LDFLAGS"); ldflags != "" {
-					args = append(args, "-ldflags", ldflags)
-				}
-				cmd := exec.Command("go", args...)
-				cmd.Env = os.Environ()
-				cmd.Env = append(cmd.Env, "GOOS="+GOOS)
-				cmd.Env = append(cmd.Env, "GOARCH="+arch)
-				var outb, errb bytes.Buffer
-				cmd.Stdout = &outb
-				cmd.Stderr = &errb
-				err = cmd.Run()
-				if err != nil {
-					cleanupCodeAndFiles()
-					log.Fatal("err:", errb.String())
-				}
-				fmt.Println(outb.String())
-
-				// revert code and files
-				err = os.WriteFile(packageCmdPath+"/root.go", rootCode, os.ModePerm)
-				if err != nil {
-					restoreProviderFiles()
-					log.Fatal("err:", err)
-				}
-				restoreProviderFiles()
+				targets = append(targets, target)
 			}
 		}
 	}
+	return targets, nil
+}
+
+func newBuildTarget(provider providerCommand, osName string, arch string, outputDir string) (buildTarget, error) {
+	goos := ""
+	binaryName := ""
+	switch osName {
+	case "linux":
+		goos = "linux"
+		binaryName = "terraformer-" + provider.Name + "-linux-" + arch
+	case "windows":
+		goos = "windows"
+		binaryName = "terraformer-" + provider.Name + "-windows-" + arch + ".exe"
+	case "darwin", "mac":
+		goos = "darwin"
+		binaryName = "terraformer-" + provider.Name + "-darwin-" + arch
+	default:
+		return buildTarget{}, fmt.Errorf("unsupported TERRAFORMER_BUILD_GOOS value: %s", osName)
+	}
+
+	return buildTarget{
+		Provider:   provider,
+		GOOS:       goos,
+		GOARCH:     arch,
+		BinaryName: binaryName,
+		OutputPath: filepath.Join(outputDir, binaryName),
+	}, nil
+}
+
+func createSourceWorkspace(repoRoot string) (string, error) {
+	workspace, err := os.MkdirTemp("", "terraformer-provider-build-*")
+	if err != nil {
+		return "", fmt.Errorf("create temp source tree: %w", err)
+	}
+	if err := copySourceTree(repoRoot, workspace); err != nil {
+		_ = os.RemoveAll(workspace)
+		return "", err
+	}
+	return workspace, nil
+}
+
+func copySourceTree(srcRoot string, dstRoot string) error {
+	return filepath.WalkDir(srcRoot, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+
+		rel, err := filepath.Rel(srcRoot, path)
+		if err != nil {
+			return err
+		}
+		if rel == "." {
+			return nil
+		}
+
+		if d.IsDir() && skipSourceDir(rel) {
+			return filepath.SkipDir
+		}
+
+		dst := filepath.Join(dstRoot, rel)
+		info, err := d.Info()
+		if err != nil {
+			return fmt.Errorf("stat %s: %w", path, err)
+		}
+
+		switch {
+		case d.IsDir():
+			return os.MkdirAll(dst, info.Mode().Perm())
+		case info.Mode().Type() == 0:
+			return copyFile(path, dst, info.Mode().Perm())
+		case info.Mode()&os.ModeSymlink != 0:
+			target, err := os.Readlink(path)
+			if err != nil {
+				return fmt.Errorf("read symlink %s: %w", path, err)
+			}
+			if err := os.MkdirAll(filepath.Dir(dst), os.ModePerm); err != nil {
+				return err
+			}
+			return os.Symlink(target, dst)
+		default:
+			return nil
+		}
+	})
+}
+
+func skipSourceDir(rel string) bool {
+	switch rel {
+	case ".git", ".goreleaser-extra", "dist", filepath.Join(packageCmdPath, "tmp"):
+		return true
+	default:
+		return false
+	}
+}
+
+func copyFile(src string, dst string, mode fs.FileMode) error {
+	if err := os.MkdirAll(filepath.Dir(dst), os.ModePerm); err != nil {
+		return err
+	}
+
+	in, err := os.Open(src)
+	if err != nil {
+		return fmt.Errorf("open %s: %w", src, err)
+	}
+	defer in.Close()
+
+	out, err := os.OpenFile(dst, os.O_CREATE|os.O_TRUNC|os.O_WRONLY, mode)
+	if err != nil {
+		return fmt.Errorf("create %s: %w", dst, err)
+	}
+	if _, err := io.Copy(out, in); err != nil {
+		_ = out.Close()
+		return fmt.Errorf("copy %s to %s: %w", src, dst, err)
+	}
+	if err := out.Close(); err != nil {
+		return fmt.Errorf("close %s: %w", dst, err)
+	}
+	return nil
+}
+
+func buildProviderBinary(workspace string, providers []providerCommand, target buildTarget, ldflags string) (err error) {
+	cleanup, err := prepareProviderWorkspace(workspace, target.Provider, providers)
+	if err != nil {
+		return err
+	}
+	defer func() {
+		cleanupErr := cleanup()
+		if err == nil && cleanupErr != nil {
+			err = cleanupErr
+		}
+	}()
+
+	log.Println("Build terraformer with "+target.Provider.Name+" provider...", "GOOS=", target.GOOS, " for GOARCH=", target.GOARCH)
+	args := []string{"build", "-v", "-o", target.OutputPath}
+	if ldflags != "" {
+		args = append(args, "-ldflags", ldflags)
+	}
+	cmd := exec.Command("go", args...)
+	cmd.Dir = workspace
+	cmd.Env = os.Environ()
+	cmd.Env = append(cmd.Env, "GOOS="+target.GOOS, "GOARCH="+target.GOARCH)
+	var outb, errb bytes.Buffer
+	cmd.Stdout = &outb
+	cmd.Stderr = &errb
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("build %s: %w: %s", target.BinaryName, err, errb.String())
+	}
+	fmt.Print(outb.String())
+	return nil
+}
+
+func prepareProviderWorkspace(workspace string, selected providerCommand, providers []providerCommand) (func() error, error) {
+	cmdDir := filepath.Join(workspace, packageCmdPath)
+	selectedPath := filepath.Join(cmdDir, selected.File)
+	if _, err := os.Stat(selectedPath); err != nil {
+		return nil, fmt.Errorf("selected provider command %s is missing at %s: %w", selected.Name, selectedPath, err)
+	}
+
+	tmpDir := filepath.Join(cmdDir, "tmp")
+	if err := os.MkdirAll(tmpDir, os.ModePerm); err != nil {
+		return nil, fmt.Errorf("create provider temp dir: %w", err)
+	}
+
+	movedProviders := make([]providerCommand, 0, len(providers)-1)
+	for _, provider := range providers {
+		if provider.Name == selected.Name {
+			continue
+		}
+		src := filepath.Join(cmdDir, provider.File)
+		dst := filepath.Join(tmpDir, provider.File)
+		if err := os.Rename(src, dst); err != nil {
+			return nil, fmt.Errorf("move provider command %s out of build package: %w", provider.File, err)
+		}
+		movedProviders = append(movedProviders, provider)
+	}
+
+	rootPath := filepath.Join(cmdDir, "root.go")
+	rootCode, err := os.ReadFile(rootPath)
+	if err != nil {
+		return nil, fmt.Errorf("read %s: %w", rootPath, err)
+	}
+	rootMode := fs.FileMode(0o644)
+	if info, err := os.Stat(rootPath); err == nil {
+		rootMode = info.Mode().Perm()
+	}
+
+	newRootCode := pruneRootProviderRegistrations(string(rootCode), movedProviders)
+	if err := os.WriteFile(rootPath, []byte(newRootCode), rootMode); err != nil {
+		return nil, fmt.Errorf("write pruned root.go: %w", err)
+	}
+
+	cleanup := func() error {
+		var errs []string
+		if err := os.WriteFile(rootPath, rootCode, rootMode); err != nil {
+			errs = append(errs, err.Error())
+		}
+		for _, provider := range movedProviders {
+			src := filepath.Join(tmpDir, provider.File)
+			dst := filepath.Join(cmdDir, provider.File)
+			if err := os.Rename(src, dst); err != nil {
+				errs = append(errs, err.Error())
+			}
+		}
+		if err := os.Remove(tmpDir); err != nil && !os.IsNotExist(err) {
+			errs = append(errs, err.Error())
+		}
+		if len(errs) > 0 {
+			return fmt.Errorf("cleanup provider workspace: %s", strings.Join(errs, "; "))
+		}
+		return nil
+	}
+
+	return cleanup, nil
+}
+
+func pruneRootProviderRegistrations(rootCode string, removedProviders []providerCommand) string {
+	lines := strings.Split(rootCode, "\n")
+	newRootCodeLines := make([]string, len(lines))
+	for i, line := range lines {
+		lowerLine := strings.ToLower(line)
+		for _, provider := range removedProviders {
+			if strings.Contains(lowerLine, "newcmd"+provider.Name+"importer") || strings.Contains(lowerLine, "new"+provider.Name+"provider") {
+				line = "// " + line
+				break
+			}
+		}
+		newRootCodeLines[i] = line
+	}
+	return strings.Join(newRootCodeLines, "\n")
 }

--- a/build/multi-build/main.go
+++ b/build/multi-build/main.go
@@ -155,7 +155,6 @@ func run(options buildOptions) (err error) {
 	}()
 
 	for _, target := range targets {
-		target := target
 		phase := fmt.Sprintf("provider build %s %s/%s", target.Provider.Name, target.GOOS, target.GOARCH)
 		if err := timed(phase, func() error {
 			return buildProviderBinary(workspace, providers, target, options.LDFlags)

--- a/build/multi-build/main.go
+++ b/build/multi-build/main.go
@@ -186,11 +186,10 @@ func enumerateProviders(cmdDir string) ([]providerCommand, error) {
 
 	providers := make([]providerCommand, 0, len(files))
 	for _, f := range files {
-		if !strings.HasPrefix(f.Name(), filePrefix) {
+		if !f.Type().IsRegular() || !strings.HasPrefix(f.Name(), filePrefix) || !strings.HasSuffix(f.Name(), fileSuffix) {
 			continue
 		}
-		providerName := strings.ReplaceAll(f.Name(), filePrefix, "")
-		providerName = strings.ReplaceAll(providerName, fileSuffix, "")
+		providerName := strings.TrimSuffix(strings.TrimPrefix(f.Name(), filePrefix), fileSuffix)
 		providers = append(providers, providerCommand{Name: providerName, File: f.Name()})
 	}
 	if len(providers) == 0 {

--- a/build/multi-build/main_test.go
+++ b/build/multi-build/main_test.go
@@ -1,0 +1,200 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"testing"
+)
+
+func TestEnumerateProvidersPreservesLegacyNames(t *testing.T) {
+	cmdDir := filepath.Join(t.TempDir(), "cmd")
+	mustMkdir(t, cmdDir)
+	writeFile(t, filepath.Join(cmdDir, "provider_cmd_google.go"), "package cmd\n")
+	writeFile(t, filepath.Join(cmdDir, "provider_cmd_aws.go"), "package cmd\n")
+	writeFile(t, filepath.Join(cmdDir, "provider_cmd_aws_test.go"), "package cmd\n")
+	writeFile(t, filepath.Join(cmdDir, "root.go"), "package cmd\n")
+
+	providers, err := enumerateProviders(cmdDir)
+	if err != nil {
+		t.Fatalf("enumerateProviders() error = %v", err)
+	}
+
+	got := providerNames(providers)
+	want := []string{"aws", "aws_test", "google"}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("provider names = %#v, want %#v", got, want)
+	}
+}
+
+func TestSelectProvidersRejectsUnknownFilter(t *testing.T) {
+	providers := []providerCommand{{Name: "aws", File: "provider_cmd_aws.go"}}
+
+	_, err := selectProviders(providers, []string{"aws", "missing"})
+	if err == nil {
+		t.Fatal("selectProviders() error = nil, want missing provider error")
+	}
+	if !strings.Contains(err.Error(), "missing") {
+		t.Fatalf("selectProviders() error = %q, want missing provider name", err)
+	}
+}
+
+func TestBuildTargetArtifactNames(t *testing.T) {
+	provider := providerCommand{Name: "aws", File: "provider_cmd_aws.go"}
+	outputDir := t.TempDir()
+
+	tests := []struct {
+		osName string
+		arch   string
+		goos   string
+		name   string
+	}{
+		{osName: "linux", arch: "amd64", goos: "linux", name: "terraformer-aws-linux-amd64"},
+		{osName: "windows", arch: "arm64", goos: "windows", name: "terraformer-aws-windows-arm64.exe"},
+		{osName: "darwin", arch: "amd64", goos: "darwin", name: "terraformer-aws-darwin-amd64"},
+		{osName: "mac", arch: "arm64", goos: "darwin", name: "terraformer-aws-darwin-arm64"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.osName+"/"+tt.arch, func(t *testing.T) {
+			target, err := newBuildTarget(provider, tt.osName, tt.arch, outputDir)
+			if err != nil {
+				t.Fatalf("newBuildTarget() error = %v", err)
+			}
+			if target.GOOS != tt.goos {
+				t.Fatalf("GOOS = %q, want %q", target.GOOS, tt.goos)
+			}
+			if target.BinaryName != tt.name {
+				t.Fatalf("BinaryName = %q, want %q", target.BinaryName, tt.name)
+			}
+			if target.OutputPath != filepath.Join(outputDir, tt.name) {
+				t.Fatalf("OutputPath = %q, want %q", target.OutputPath, filepath.Join(outputDir, tt.name))
+			}
+		})
+	}
+}
+
+func TestCopySourceTreeSkipsReleaseOutputs(t *testing.T) {
+	src := t.TempDir()
+	dst := t.TempDir()
+	writeFile(t, filepath.Join(src, "go.mod"), "module example.com/test\n")
+	writeFile(t, filepath.Join(src, "cmd", "root.go"), "package cmd\n")
+	writeFile(t, filepath.Join(src, ".goreleaser-extra", "provider-binaries", "terraformer-aws-linux-amd64"), "binary")
+	writeFile(t, filepath.Join(src, "dist", "old"), "artifact")
+	writeFile(t, filepath.Join(src, "cmd", "tmp", "provider_cmd_google.go"), "package cmd\n")
+
+	if err := copySourceTree(src, dst); err != nil {
+		t.Fatalf("copySourceTree() error = %v", err)
+	}
+
+	assertExists(t, filepath.Join(dst, "go.mod"))
+	assertExists(t, filepath.Join(dst, "cmd", "root.go"))
+	assertNotExists(t, filepath.Join(dst, ".goreleaser-extra"))
+	assertNotExists(t, filepath.Join(dst, "dist"))
+	assertNotExists(t, filepath.Join(dst, "cmd", "tmp"))
+}
+
+func TestPrepareProviderWorkspaceMutatesOnlyWorkspaceAndCleansUp(t *testing.T) {
+	src := t.TempDir()
+	workspace := t.TempDir()
+	rootCode := strings.Join([]string{
+		"package cmd",
+		"newCmdAwsImporter,",
+		"newCmdGoogleImporter,",
+		"newAWSProvider,",
+		"newGoogleProvider,",
+		"",
+	}, "\n")
+	writeFile(t, filepath.Join(src, "cmd", "root.go"), rootCode)
+	writeFile(t, filepath.Join(src, "cmd", "provider_cmd_aws.go"), "package cmd\n")
+	writeFile(t, filepath.Join(src, "cmd", "provider_cmd_google.go"), "package cmd\n")
+
+	if err := copySourceTree(src, workspace); err != nil {
+		t.Fatalf("copySourceTree() error = %v", err)
+	}
+	providers, err := enumerateProviders(filepath.Join(workspace, "cmd"))
+	if err != nil {
+		t.Fatalf("enumerateProviders() error = %v", err)
+	}
+	selected := providerCommand{Name: "aws", File: "provider_cmd_aws.go"}
+
+	cleanup, err := prepareProviderWorkspace(workspace, selected, providers)
+	if err != nil {
+		t.Fatalf("prepareProviderWorkspace() error = %v", err)
+	}
+
+	assertExists(t, filepath.Join(workspace, "cmd", "provider_cmd_aws.go"))
+	assertNotExists(t, filepath.Join(workspace, "cmd", "provider_cmd_google.go"))
+	assertExists(t, filepath.Join(workspace, "cmd", "tmp", "provider_cmd_google.go"))
+
+	prunedRoot := readFile(t, filepath.Join(workspace, "cmd", "root.go"))
+	if strings.Contains(prunedRoot, "// newCmdAwsImporter") || strings.Contains(prunedRoot, "// newAWSProvider") {
+		t.Fatalf("selected provider registrations were commented:\n%s", prunedRoot)
+	}
+	if !strings.Contains(prunedRoot, "// newCmdGoogleImporter") || !strings.Contains(prunedRoot, "// newGoogleProvider") {
+		t.Fatalf("removed provider registrations were not commented:\n%s", prunedRoot)
+	}
+
+	if got := readFile(t, filepath.Join(src, "cmd", "root.go")); got != rootCode {
+		t.Fatalf("source root.go was mutated:\n%s", got)
+	}
+	assertExists(t, filepath.Join(src, "cmd", "provider_cmd_google.go"))
+
+	if err := cleanup(); err != nil {
+		t.Fatalf("cleanup() error = %v", err)
+	}
+	if got := readFile(t, filepath.Join(workspace, "cmd", "root.go")); got != rootCode {
+		t.Fatalf("workspace root.go after cleanup = %q, want original", got)
+	}
+	assertExists(t, filepath.Join(workspace, "cmd", "provider_cmd_google.go"))
+	assertNotExists(t, filepath.Join(workspace, "cmd", "tmp"))
+}
+
+func providerNames(providers []providerCommand) []string {
+	names := make([]string, 0, len(providers))
+	for _, provider := range providers {
+		names = append(names, provider.Name)
+	}
+	return names
+}
+
+func mustMkdir(t *testing.T, path string) {
+	t.Helper()
+	if err := os.MkdirAll(path, os.ModePerm); err != nil {
+		t.Fatalf("MkdirAll(%q) error = %v", path, err)
+	}
+}
+
+func writeFile(t *testing.T, path string, content string) {
+	t.Helper()
+	mustMkdir(t, filepath.Dir(path))
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatalf("WriteFile(%q) error = %v", path, err)
+	}
+}
+
+func readFile(t *testing.T, path string) string {
+	t.Helper()
+	content, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("ReadFile(%q) error = %v", path, err)
+	}
+	return string(content)
+}
+
+func assertExists(t *testing.T, path string) {
+	t.Helper()
+	if _, err := os.Stat(path); err != nil {
+		t.Fatalf("Stat(%q) error = %v", path, err)
+	}
+}
+
+func assertNotExists(t *testing.T, path string) {
+	t.Helper()
+	if _, err := os.Stat(path); err == nil {
+		t.Fatalf("%q exists, want absent", path)
+	} else if !os.IsNotExist(err) {
+		t.Fatalf("Stat(%q) error = %v", path, err)
+	}
+}

--- a/build/multi-build/main_test.go
+++ b/build/multi-build/main_test.go
@@ -14,6 +14,8 @@ func TestEnumerateProvidersPreservesLegacyNames(t *testing.T) {
 	writeFile(t, filepath.Join(cmdDir, "provider_cmd_google.go"), "package cmd\n")
 	writeFile(t, filepath.Join(cmdDir, "provider_cmd_aws.go"), "package cmd\n")
 	writeFile(t, filepath.Join(cmdDir, "provider_cmd_aws_test.go"), "package cmd\n")
+	writeFile(t, filepath.Join(cmdDir, "provider_cmd_notes.txt"), "not a Go file\n")
+	mustMkdir(t, filepath.Join(cmdDir, "provider_cmd_directory.go"))
 	writeFile(t, filepath.Join(cmdDir, "root.go"), "package cmd\n")
 
 	providers, err := enumerateProviders(cmdDir)

--- a/build/multi-build/main_test.go
+++ b/build/multi-build/main_test.go
@@ -169,7 +169,7 @@ func mustMkdir(t *testing.T, path string) {
 func writeFile(t *testing.T, path string, content string) {
 	t.Helper()
 	mustMkdir(t, filepath.Dir(path))
-	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+	if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
 		t.Fatalf("WriteFile(%q) error = %v", path, err)
 	}
 }


### PR DESCRIPTION
## Summary

This refactors provider-specific release binary builds so they no longer mutate the checked-out source tree.

Previously, `build/multi-build/main.go` temporarily moved provider command files and rewrote `cmd/root.go` while building provider-specific binaries. This made the release build path harder to reason about, less cache-friendly, and risky if cleanup failed.

Now provider-specific builds copy the source tree into a temporary workspace and mutate only that copy.

## Changes

- Build provider-specific binaries from an isolated temp workspace.
- Keep the real checkout’s `cmd/provider_cmd_*` files and `cmd/root.go` untouched.
- Preserve existing artifact names and output paths.
- Add structured timing for:
  - provider enumeration
  - temp workspace setup
  - per-provider build
  - cleanup
- Add `TERRAFORMER_BUILD_DRY_RUN=1` list mode.
- Add tests for:
  - provider enumeration
  - artifact naming
  - temp layout
  - no source mutation
  - cleanup behavior

## Validation

Passed:

- `go test ./build/...`
- `go build ./build/multi-build`
- `bash -n .github/scripts/release-prebuilt-assets.sh`
- `bash -n .github/scripts/provider-dependency-preflight.sh`
- `goreleaser check`
- `git diff --check`
- Dry-run single target
- Dry-run all current `linux/amd64` provider targets: 50 targets
- Real single-target builds for `audit_test` and `gmailfilter`

Not completed locally:

- `go test ./cmd/... ./providers/...` was attempted, but duplicate runs remained active after the command interface returned. Those processes were terminated to avoid local machine pressure.
- Full `goreleaser build --snapshot --clean` was skipped because it would build the full release asset set locally.

## Notes

This PR is intended as a build-system foundation change. It should make release builds safer and easier to measure, and it creates a cleaner base for future CI/release performance work.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Provider release builds now run in an isolated temp workspace, avoiding any mutations to the checked-out source. Builds remain safe, with artifact names and output paths unchanged.

- **Refactors**
  - Build provider binaries from a temp workspace copy of the repo; the real `cmd/provider_cmd_*` files and `cmd/root.go` stay untouched, and artifact names/paths are unchanged.
  - Restricted provider command discovery to regular Go files named `provider_cmd_*.go` to avoid picking up non-Go files or directories.
  - Fixed lint blockers and improved validation with clearer errors (for example, unknown provider filters).

- **New Features**
  - Added timing logs for provider enumeration, workspace setup, per-provider build, and cleanup.
  - Added `TERRAFORMER_BUILD_DRY_RUN=1` to list targets without building.
  - Added tests for provider enumeration, artifact naming, workspace layout, and cleanup behavior.

<sup>Written for commit ae4237bd3864ab3a03748d2afbc974f4ca4fc978. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/chenrui333/terraformer/pull/610?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  - Build configuration now supported via environment variables (output directory, architecture, OS, providers, linker flags)
  - Dry-run mode to preview build targets without executing builds

* **Refactor**
  - Build pipeline restructured from in-place code mutations to a workspace-based approach for improved isolation and error handling

* **Tests**
  - Added comprehensive test suite covering provider enumeration, validation, artifact naming, workspace management, and cleanup

<!-- end of auto-generated comment: release notes by coderabbit.ai -->