### PR TITLE
ci: add release asset timing summary

### DIFF
--- a/.github/scripts/release-prebuilt-assets.sh
+++ b/.github/scripts/release-prebuilt-assets.sh
@@ -5,14 +5,136 @@ MODE="${MODE:-snapshot}"
 PROVIDER_DIR="${PROVIDER_DIR:-.goreleaser-extra/provider-binaries}"
 ALL_DIR="${ALL_DIR:-.goreleaser-extra/all-binaries}"
 ASSET_DIR="${ASSET_DIR:-.goreleaser-extra/release-assets}"
+PHASE_ROWS=""
+SCRIPT_STARTED_AT="$(date +%s)"
 
 fail() {
   printf 'release-prebuilt-assets: %s\n' "$*" >&2
   exit 1
 }
 
+phase_error() {
+  printf 'release-prebuilt-assets: %s\n' "$*" >&2
+  return 1
+}
+
 section() {
   printf '\n==> %s\n' "$*"
+}
+
+markdown_escape() {
+  local value="$1"
+  value="${value//\\/\\\\}"
+  value="${value//|/\\|}"
+  value="${value//$'\n'/ }"
+  printf '%s\n' "$value"
+}
+
+asset_count() {
+  [[ -d "$ASSET_DIR" ]] || {
+    printf '0\n'
+    return 0
+  }
+
+  find "$ASSET_DIR" -maxdepth 1 -type f | wc -l | tr -d ' '
+}
+
+file_size_bytes() {
+  local file="$1"
+
+  if stat -c %s "$file" >/dev/null 2>&1; then
+    stat -c %s "$file"
+  else
+    stat -f %z "$file"
+  fi
+}
+
+asset_bytes() {
+  local file size total
+  total=0
+
+  [[ -d "$ASSET_DIR" ]] || {
+    printf '0\n'
+    return 0
+  }
+
+  while IFS= read -r -d '' file; do
+    size="$(file_size_bytes "$file")" || return 1
+    total="$((total + size))"
+  done < <(find "$ASSET_DIR" -maxdepth 1 -type f -print0)
+
+  printf '%s\n' "$total"
+}
+
+record_phase() {
+  local phase="$1"
+  local status="$2"
+  local duration="$3"
+  local count="$4"
+  local bytes="$5"
+  local notes="$6"
+
+  PHASE_ROWS+="| $(markdown_escape "$phase") | $status | $duration | $count | $bytes | $(markdown_escape "$notes") |"$'\n'
+}
+
+write_step_summary() {
+  local exit_code="$1"
+  local total_duration
+  total_duration="$(($(date +%s) - SCRIPT_STARTED_AT))"
+
+  [[ -n "${GITHUB_STEP_SUMMARY:-}" ]] || return 0
+
+  {
+    printf '## Release Asset Timing\n\n'
+    printf -- '- Mode: %s\n' "$MODE"
+    printf -- '- Result: %s\n' "$([[ "$exit_code" -eq 0 ]] && printf success || printf failed)"
+    printf -- '- Total duration seconds: %s\n' "$total_duration"
+    printf -- '- Final artifact count: %s\n' "$(asset_count)"
+    printf -- '- Final artifact bytes: %s\n\n' "$(asset_bytes)"
+    printf '| Phase | Status | Duration seconds | Artifact count | Total bytes | Notes |\n'
+    printf '| --- | --- | ---: | ---: | ---: | --- |\n'
+    if [[ -n "$PHASE_ROWS" ]]; then
+      printf '%s' "$PHASE_ROWS"
+    else
+      printf '| script startup | failed | 0 | 0 | 0 | no phases completed |\n'
+    fi
+  } >>"$GITHUB_STEP_SUMMARY"
+}
+
+on_exit() {
+  local exit_code="$?"
+  write_step_summary "$exit_code" || true
+  exit "$exit_code"
+}
+
+time_phase() {
+  local phase="$1"
+  local notes="$2"
+  shift 2
+
+  section "$phase"
+  local started_at ended_at duration status rc count bytes
+  started_at="$(date +%s)"
+  set +e
+  "$@"
+  rc="$?"
+  set -e
+  ended_at="$(date +%s)"
+  duration="$((ended_at - started_at))"
+  count="$(asset_count)"
+  bytes="$(asset_bytes)"
+
+  if [[ "$rc" -eq 0 ]]; then
+    status="success"
+  else
+    status="failed"
+  fi
+
+  printf 'release-prebuilt-assets: timing phase=%q status=%s duration=%ss artifacts=%s bytes=%s notes=%q\n' \
+    "$phase" "$status" "$duration" "$count" "$bytes" "$notes"
+  record_phase "$phase" "$status" "$duration" "$count" "$bytes" "$notes"
+
+  return "$rc"
 }
 
 version_from_ref() {
@@ -34,37 +156,82 @@ checksum_assets() {
   fi
 }
 
-stage_assets() {
-  [[ -d "$PROVIDER_DIR" ]] || fail "missing provider binary directory: $PROVIDER_DIR"
-  [[ -d "$ALL_DIR" ]] || fail "missing all-in-one binary directory: $ALL_DIR"
+prepare_asset_dir() {
+  rm -rf "$ASSET_DIR" && mkdir -p "$ASSET_DIR"
+}
 
-  rm -rf "$ASSET_DIR"
-  mkdir -p "$ASSET_DIR"
+stage_provider_assets() {
+  [[ -d "$PROVIDER_DIR" ]] || {
+    phase_error "missing provider binary directory: $PROVIDER_DIR"
+    return 1
+  }
 
   find "$PROVIDER_DIR" -type f -name 'terraformer-*' -exec cp '{}' "$ASSET_DIR/" \;
-  find "$ALL_DIR" -type f -name 'terraformer-all-*' -exec cp '{}' "$ASSET_DIR/" \;
+}
 
+stage_all_assets() {
+  [[ -d "$ALL_DIR" ]] || {
+    phase_error "missing all-in-one binary directory: $ALL_DIR"
+    return 1
+  }
+
+  find "$ALL_DIR" -type f -name 'terraformer-all-*' -exec cp '{}' "$ASSET_DIR/" \;
+}
+
+verify_expected_counts() {
   local provider_count all_count
   provider_count="$(find "$ASSET_DIR" -type f -name 'terraformer-*' ! -name 'terraformer-all-*' | wc -l | tr -d ' ')"
   all_count="$(find "$ASSET_DIR" -type f -name 'terraformer-all-*' | wc -l | tr -d ' ')"
 
-  [[ "$provider_count" -gt 0 ]] || fail "no provider binaries staged"
-  [[ "$all_count" -eq 4 ]] || fail "expected 4 all-in-one binaries, found $all_count"
+  [[ "$provider_count" -gt 0 ]] || {
+    phase_error "no provider binaries staged"
+    return 1
+  }
+  [[ "$all_count" -eq 4 ]] || {
+    phase_error "expected 4 all-in-one binaries, found $all_count"
+    return 1
+  }
 
-  section "Staged assets"
+  printf 'Staged %s provider binaries and %s all-in-one binaries\n' "$provider_count" "$all_count"
+}
+
+list_staged_assets() {
   find "$ASSET_DIR" -maxdepth 1 -type f -print | sort
+}
+
+print_checksums() {
+  local checksum_name="$1"
+
+  cat "$ASSET_DIR/$checksum_name"
+}
+
+print_asset_size() {
+  if command -v du >/dev/null 2>&1; then
+    du -sh "$ASSET_DIR"
+  else
+    printf 'du is unavailable; skipped asset size summary\n'
+  fi
 }
 
 publish_release() {
   local tag="${RELEASE_REF:-${GITHUB_REF_NAME:-}}"
-  [[ -n "$tag" ]] || fail "RELEASE_REF or GITHUB_REF_NAME is required for release mode"
-  [[ "$tag" == v* ]] || fail "release mode requires a v-prefixed tag, got: $tag"
+  [[ -n "$tag" ]] || {
+    phase_error "RELEASE_REF or GITHUB_REF_NAME is required for release mode"
+    return 1
+  }
+  [[ "$tag" == v* ]] || {
+    phase_error "release mode requires a v-prefixed tag, got: $tag"
+    return 1
+  }
 
   if gh release view "$tag" >/dev/null 2>&1; then
     local is_draft
-    is_draft="$(gh release view "$tag" --json isDraft --jq '.isDraft')"
-    [[ "$is_draft" == "true" ]] || fail "release $tag already exists and is not a draft"
-    gh release delete "$tag" --yes
+    is_draft="$(gh release view "$tag" --json isDraft --jq '.isDraft')" || return 1
+    [[ "$is_draft" == "true" ]] || {
+      phase_error "release $tag already exists and is not a draft"
+      return 1
+    }
+    gh release delete "$tag" --yes || return 1
   fi
 
   gh release create "$tag" "$ASSET_DIR"/terraformer-* "$ASSET_DIR"/terraformer_*_checksums.txt \
@@ -78,21 +245,20 @@ case "$MODE" in
   *) fail "unsupported MODE=$MODE; expected snapshot or release" ;;
 esac
 
+trap on_exit EXIT
+
 version="$(version_from_ref)"
 checksum_name="terraformer_${version}_checksums.txt"
 
-stage_assets
-
-section "Checksums"
-checksum_assets "$checksum_name"
-cat "$ASSET_DIR/$checksum_name"
-
-if command -v du >/dev/null 2>&1; then
-  section "Asset size"
-  du -sh "$ASSET_DIR"
-fi
+time_phase "Prepare asset directory" "reset $ASSET_DIR" prepare_asset_dir
+time_phase "Stage provider binaries" "copy terraformer-* from $PROVIDER_DIR" stage_provider_assets
+time_phase "Stage all-in-one binaries" "copy terraformer-all-* from $ALL_DIR" stage_all_assets
+time_phase "Verify expected counts" "require provider binaries and 4 all-in-one binaries" verify_expected_counts
+time_phase "Staged assets" "list staged release assets" list_staged_assets
+time_phase "Checksum generation" "write $checksum_name" checksum_assets "$checksum_name"
+time_phase "Checksums" "print $checksum_name" print_checksums "$checksum_name"
+time_phase "Asset size" "du -sh $ASSET_DIR" print_asset_size
 
 if [[ "$MODE" == "release" ]]; then
-  section "Publish draft release"
-  publish_release
+  time_phase "Publish draft release" "gh release create draft for ${RELEASE_REF:-${GITHUB_REF_NAME:-}}" publish_release
 fi


### PR DESCRIPTION
## Summary

- Add structured phase timing around release asset staging, verification, checksum generation, size accounting, and draft release publication.
- Emit a GitHub Step Summary table when GITHUB_STEP_SUMMARY is available.
- Preserve existing release asset names, checksum format, staged file selection, and gh release create behavior.

## Notes

No post-PR #610 full release run exists yet, so this keeps the next release-path optimization data-backed instead of changing compression, grouping, or matrix structure from stale timing.

Byte totals use stat metadata rather than reading asset contents, so the summary should remain cheap on the full multi-GiB release asset set.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add phase-level timing and artifact stats to the release asset script and emit a GitHub Step Summary for staging, checksums, and draft publishing. Existing asset names, checksum format, staged files, and `gh release create` behavior remain unchanged.

- **New Features**
  - Time and log phases: prepare dir, stage provider/all-in-one, verify counts, list assets, checksum, asset size, publish draft (release mode).
  - Write a GitHub Step Summary (when `GITHUB_STEP_SUMMARY` is set) with totals and a per‑phase table; summary is written on exit.
  - Use `stat` for byte totals to keep measurement lightweight on large artifacts.

<sup>Written for commit dd61e02b238fb10ec285853c1e9613e6fc8b531c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/chenrui333/terraformer/pull/612?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

