### PR TITLE
ci: hardlink staged release assets when possible

### DIFF
--- a/.github/scripts/release-prebuilt-assets.sh
+++ b/.github/scripts/release-prebuilt-assets.sh
@@ -177,11 +177,30 @@ stage_asset_file() {
 stage_matching_assets() {
   local source_dir="$1"
   local pattern="$2"
+  local file_list
   local file
+  local stage_status
 
+  file_list="$(mktemp "${TMPDIR:-/tmp}/terraformer-release-assets.XXXXXX")" || return 1
+
+  if find "$source_dir" -type f -name "$pattern" -print0 >"$file_list"; then
+    :
+  else
+    local find_status="$?"
+    rm -f "$file_list"
+    return "$find_status"
+  fi
+
+  stage_status=0
   while IFS= read -r -d '' file; do
-    stage_asset_file "$file" || return 1
-  done < <(find "$source_dir" -type f -name "$pattern" -print0)
+    if ! stage_asset_file "$file"; then
+      stage_status=1
+      break
+    fi
+  done <"$file_list"
+
+  rm -f "$file_list"
+  return "$stage_status"
 }
 
 stage_provider_assets() {

--- a/.github/scripts/release-prebuilt-assets.sh
+++ b/.github/scripts/release-prebuilt-assets.sh
@@ -160,13 +160,37 @@ prepare_asset_dir() {
   rm -rf "$ASSET_DIR" && mkdir -p "$ASSET_DIR"
 }
 
+stage_asset_file() {
+  local source="$1"
+  local destination
+
+  destination="$ASSET_DIR/$(basename "$source")"
+
+  rm -f "$destination"
+  if ln "$source" "$destination" 2>/dev/null; then
+    return 0
+  fi
+
+  cp "$source" "$destination"
+}
+
+stage_matching_assets() {
+  local source_dir="$1"
+  local pattern="$2"
+  local file
+
+  while IFS= read -r -d '' file; do
+    stage_asset_file "$file" || return 1
+  done < <(find "$source_dir" -type f -name "$pattern" -print0)
+}
+
 stage_provider_assets() {
   [[ -d "$PROVIDER_DIR" ]] || {
     phase_error "missing provider binary directory: $PROVIDER_DIR"
     return 1
   }
 
-  find "$PROVIDER_DIR" -type f -name 'terraformer-*' -exec cp '{}' "$ASSET_DIR/" \;
+  stage_matching_assets "$PROVIDER_DIR" 'terraformer-*'
 }
 
 stage_all_assets() {
@@ -175,7 +199,7 @@ stage_all_assets() {
     return 1
   }
 
-  find "$ALL_DIR" -type f -name 'terraformer-all-*' -exec cp '{}' "$ASSET_DIR/" \;
+  stage_matching_assets "$ALL_DIR" 'terraformer-all-*'
 }
 
 verify_expected_counts() {
@@ -251,8 +275,8 @@ version="$(version_from_ref)"
 checksum_name="terraformer_${version}_checksums.txt"
 
 time_phase "Prepare asset directory" "reset $ASSET_DIR" prepare_asset_dir
-time_phase "Stage provider binaries" "copy terraformer-* from $PROVIDER_DIR" stage_provider_assets
-time_phase "Stage all-in-one binaries" "copy terraformer-all-* from $ALL_DIR" stage_all_assets
+time_phase "Stage provider binaries" "hardlink/copy terraformer-* from $PROVIDER_DIR" stage_provider_assets
+time_phase "Stage all-in-one binaries" "hardlink/copy terraformer-all-* from $ALL_DIR" stage_all_assets
 time_phase "Verify expected counts" "require provider binaries and 4 all-in-one binaries" verify_expected_counts
 time_phase "Staged assets" "list staged release assets" list_staged_assets
 time_phase "Checksum generation" "write $checksum_name" checksum_assets "$checksum_name"


### PR DESCRIPTION
## Summary

Hardlink release assets into the staging directory when possible, with a copy fallback for cross-device or unsupported filesystems.

The post-#612 snapshot run showed release asset staging copied 17.26 GB and spent 74 seconds across provider and all-in-one staging before checksum generation. This keeps the same staged filenames, counts, checksum inputs, and release upload paths while avoiding the second local data copy when the downloaded artifacts and staging directory share a filesystem.

## Notes

- Evidence run: https://github.com/chenrui333/terraformer/actions/runs/27371862871
- Provider staging: 61s for 300 assets / 14.74 GB
- All-in-one staging: 13s for 4 additional assets / 17.26 GB total staged
- Falls back to the previous copy behavior if hardlinking fails

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Use hardlinks for staging release assets in CI when possible, falling back to copy. Preserves asset discovery failures so CI surfaces them; staging is faster with unchanged filenames, counts, checksums, and upload paths.

- **Refactors**
  - Added staging helpers that hardlink-first, copy on failure, and propagate `find`/copy errors.
  - Replaced `find ... -exec cp` with reusable functions for provider and all-in-one assets; updated phase labels to note hardlink/copy.

<sup>Written for commit 13f2c01769d0527ffc6644d3f78396ccf9abdbf0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/chenrui333/terraformer/pull/616?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

