### PR TITLE
ci: add provider preflight timing summary

### DIFF
--- a/.github/scripts/provider-dependency-preflight.sh
+++ b/.github/scripts/provider-dependency-preflight.sh
@@ -182,9 +182,15 @@ has_dependency_sensitive_changes() {
   local path
   local diff_args=("$base_ref...HEAD")
 
-  if ! changed_paths="$(git diff --name-only "${diff_args[@]}" 2>/dev/null)"; then
+  if changed_paths="$(git diff --name-only "${diff_args[@]}" 2>/dev/null)"; then
+    :
+  else
     warn "could not diff $base_ref...HEAD; falling back to $base_ref HEAD"
-    changed_paths="$(git diff --name-only "$base_ref" HEAD)" || return
+    if changed_paths="$(git diff --name-only "$base_ref" HEAD)"; then
+      :
+    else
+      return 2
+    fi
   fi
 
   while IFS= read -r path; do
@@ -278,16 +284,25 @@ environment_diagnostics() {
 
 detect_dependency_sensitive_changes() {
   local base_ref
+  local sensitive_status
 
   base_ref="$(resolve_base_ref)" || return
   printf 'Using base ref: %s\n' "$base_ref"
-  if ! has_dependency_sensitive_changes "$base_ref"; then
+  if has_dependency_sensitive_changes "$base_ref"; then
+    DEPENDENCY_SENSITIVE=1
+    printf 'Dependency-sensitive changes detected; running provider dependency preflight.\n'
+    return
+  else
+    sensitive_status="$?"
+  fi
+
+  if [[ "$sensitive_status" -eq 1 ]]; then
     DEPENDENCY_SENSITIVE=0
     printf 'No dependency-sensitive changes detected; skipping provider dependency preflight.\n'
     return
   fi
-  DEPENDENCY_SENSITIVE=1
-  printf 'Dependency-sensitive changes detected; running provider dependency preflight.\n'
+
+  return "$sensitive_status"
 }
 
 run_go_mod_tidy_check() {

--- a/.github/scripts/provider-dependency-preflight.sh
+++ b/.github/scripts/provider-dependency-preflight.sh
@@ -3,6 +3,10 @@ set -euo pipefail
 
 MODE="${MODE:-full}"
 export GOWORK=off
+PHASE_ROWS=""
+SCRIPT_STARTED_AT="$(date +%s)"
+DEPENDENCY_SENSITIVE=1
+BUILD_PACKAGES=()
 
 section() {
   printf '\n==> %s\n' "$1"
@@ -53,6 +57,82 @@ restore_release_outputs() {
   rm -rf "$release_backup_dir"
 }
 
+markdown_escape() {
+  local value="$1"
+  value="${value//\\/\\\\}"
+  value="${value//|/\\|}"
+  value="${value//$'\n'/ }"
+  printf '%s\n' "$value"
+}
+
+record_phase() {
+  local phase="$1"
+  local status="$2"
+  local duration="$3"
+  local notes="$4"
+
+  PHASE_ROWS+="| $(markdown_escape "$phase") | $status | $duration | $(markdown_escape "$notes") |"$'\n'
+}
+
+write_step_summary() {
+  local exit_code="$1"
+  local total_duration
+  total_duration="$(($(date +%s) - SCRIPT_STARTED_AT))"
+
+  [[ -n "${GITHUB_STEP_SUMMARY:-}" ]] || return 0
+
+  {
+    printf '## Provider Dependency Preflight Timing\n\n'
+    printf -- '- Mode: %s\n' "$MODE"
+    printf -- '- Result: %s\n' "$([[ "$exit_code" -eq 0 ]] && printf success || printf failed)"
+    printf -- '- Total duration seconds: %s\n\n' "$total_duration"
+    printf '| Phase | Status | Duration seconds | Notes |\n'
+    printf '| --- | --- | ---: | --- |\n'
+    if [[ -n "$PHASE_ROWS" ]]; then
+      printf '%s' "$PHASE_ROWS"
+    else
+      printf '| script startup | failed | 0 | no phases completed |\n'
+    fi
+  } >>"$GITHUB_STEP_SUMMARY"
+}
+
+on_exit() {
+  local exit_code="$?"
+  restore_release_outputs || true
+  write_step_summary "$exit_code" || true
+  exit "$exit_code"
+}
+
+time_phase() {
+  local phase="$1"
+  local notes="$2"
+  shift 2
+
+  section "$phase"
+  local started_at ended_at duration status rc
+  started_at="$(date +%s)"
+  set +e
+  "$@"
+  rc="$?"
+  set -e
+  ended_at="$(date +%s)"
+  duration="$((ended_at - started_at))"
+
+  if [[ "$rc" -eq 0 ]]; then
+    status="success"
+  else
+    status="failed"
+  fi
+
+  printf 'provider-dependency-preflight: timing phase=%q status=%s duration=%ss notes=%q\n' \
+    "$phase" "$status" "$duration" "$notes"
+  record_phase "$phase" "$status" "$duration" "$notes"
+
+  return "$rc"
+}
+
+trap on_exit EXIT
+
 prepare_release_output_cleanup() {
   for path in dist .goreleaser-extra; do
     if git ls-files --error-unmatch "$path" >/dev/null 2>&1; then
@@ -61,7 +141,6 @@ prepare_release_output_cleanup() {
   done
 
   release_backup_dir="$(mktemp -d "${TMPDIR:-/tmp}/terraformer-release-preflight.XXXXXX")"
-  trap restore_release_outputs EXIT
   if [[ -e dist ]]; then
     mv dist "$release_backup_dir/dist"
   fi
@@ -105,7 +184,7 @@ has_dependency_sensitive_changes() {
 
   if ! changed_paths="$(git diff --name-only "${diff_args[@]}" 2>/dev/null)"; then
     warn "could not diff $base_ref...HEAD; falling back to $base_ref HEAD"
-    changed_paths="$(git diff --name-only "$base_ref" HEAD)"
+    changed_paths="$(git diff --name-only "$base_ref" HEAD)" || return
   fi
 
   while IFS= read -r path; do
@@ -122,9 +201,9 @@ has_dependency_sensitive_changes() {
 
 ensure_govulncheck() {
   local gobin
-  gobin="$(go env GOBIN)"
+  gobin="$(go env GOBIN)" || return
   if [[ -z "$gobin" ]]; then
-    gobin="$(go env GOPATH)/bin"
+    gobin="$(go env GOPATH)/bin" || return
   fi
   export PATH="$gobin:$PATH"
 
@@ -141,7 +220,6 @@ run_compat_script() {
   local name="$2"
 
   if [[ -f "$script" && -r "$script" ]]; then
-    section "$name"
     bash "$script"
     return
   fi
@@ -149,48 +227,142 @@ run_compat_script() {
   printf 'Skipping %s; %s is not present/readable.\n' "$name" "$script"
 }
 
-run_provider_validation() {
-  local build_packages=()
+go_list_count() {
+  local label="$1"
+  shift
+  local output
+  local count
+
+  if output="$("$@" 2>/dev/null)"; then
+    if [[ -n "$output" ]]; then
+      count="$(printf '%s\n' "$output" | wc -l | tr -d ' ')"
+    else
+      count=0
+    fi
+    printf '%s: %s\n' "$label" "$count"
+  else
+    printf '%s: unavailable (%s failed)\n' "$label" "$*"
+  fi
+}
+
+environment_diagnostics() {
+  local gocache gomodcache gotmpdir tmpfs
+
+  printf 'go version: '
+  go version || true
+
+  printf 'go env GOCACHE GOMODCACHE GOTMPDIR GOFLAGS:\n'
+  go env -json GOCACHE GOMODCACHE GOTMPDIR GOFLAGS || true
+
+  go_list_count "local packages" go list ./...
+  go_list_count "transitive packages" go list -deps ./...
+
+  gocache="$(go env GOCACHE 2>/dev/null || true)"
+  gomodcache="$(go env GOMODCACHE 2>/dev/null || true)"
+  gotmpdir="$(go env GOTMPDIR 2>/dev/null || true)"
+
+  for cache_dir in "$gocache" "$gomodcache"; do
+    if [[ -n "$cache_dir" && -e "$cache_dir" ]]; then
+      du -sh "$cache_dir" 2>/dev/null || true
+    fi
+  done
+
+  printf 'workspace filesystem:\n'
+  df -h "$PWD" || true
+  tmpfs="${gotmpdir:-${TMPDIR:-/tmp}}"
+  if [[ -e "$tmpfs" ]]; then
+    printf 'temporary filesystem:\n'
+    df -h "$tmpfs" || true
+  fi
+}
+
+detect_dependency_sensitive_changes() {
+  local base_ref
+
+  base_ref="$(resolve_base_ref)" || return
+  printf 'Using base ref: %s\n' "$base_ref"
+  if ! has_dependency_sensitive_changes "$base_ref"; then
+    DEPENDENCY_SENSITIVE=0
+    printf 'No dependency-sensitive changes detected; skipping provider dependency preflight.\n'
+    return
+  fi
+  DEPENDENCY_SENSITIVE=1
+  printf 'Dependency-sensitive changes detected; running provider dependency preflight.\n'
+}
+
+run_go_mod_tidy_check() {
+  go mod tidy || return
+  git diff --exit-code -- go.mod go.sum
+}
+
+list_build_packages() {
+  local package_file
   local package
 
-  section "Go module tidy"
-  go mod tidy
-  git diff --exit-code -- go.mod go.sum
+  package_file="$(mktemp "${TMPDIR:-/tmp}/terraformer-build-packages.XXXXXX")" || return
+  if go list -f '{{if .GoFiles}}{{.ImportPath}}{{end}}' ./... >"$package_file"; then
+    :
+  else
+    local list_status="$?"
+    rm -f "$package_file"
+    return "$list_status"
+  fi
 
-  section "Build non-fixture packages"
+  BUILD_PACKAGES=()
   while IFS= read -r package; do
     [[ -n "$package" ]] || continue
     case "$package" in
       github.com/chenrui333/terraformer/tests/*) continue ;;
     esac
-    build_packages+=("$package")
-  done < <(go list -f '{{if .GoFiles}}{{.ImportPath}}{{end}}' ./...)
-  go build -v "${build_packages[@]}"
+    BUILD_PACKAGES+=("$package")
+  done <"$package_file"
+  rm -f "$package_file"
 
-  section "Test provider and command packages"
+  printf 'Selected %s package(s) for build.\n' "${#BUILD_PACKAGES[@]}"
+}
+
+build_non_fixture_packages() {
+  go build -v "${BUILD_PACKAGES[@]}"
+}
+
+test_provider_and_command_packages() {
   go test ./providers/... ./cmd/... -count=1
+}
 
-  section "Test build and utility packages"
+test_build_and_utility_packages() {
   go test ./build/... ./terraformutils/... ./version -count=1
+}
 
-  section "Vet dependency-sensitive packages"
+vet_dependency_sensitive_packages() {
   go vet ./providers/... ./cmd/... ./build/... ./terraformutils/... ./version
+}
 
-  section "Static diff check"
+static_diff_check() {
   git diff --check
+}
 
-  run_compat_script ".github/scripts/terraform-state-compat.sh" "Terraform state compatibility"
-  run_compat_script ".github/scripts/terraform-provider-compat.sh" "Terraform provider compatibility"
+run_provider_validation() {
+  time_phase "Environment diagnostics" "go version, go env, package counts, cache usage, filesystem space" environment_diagnostics
+  time_phase "Go module tidy" "go mod tidy and go.mod/go.sum diff check" run_go_mod_tidy_check
+  time_phase "Package listing" "go list non-fixture packages for build" list_build_packages
+  time_phase "Build non-fixture packages" "go build selected non-fixture packages" build_non_fixture_packages
+  time_phase "Test provider and command packages" "go test ./providers/... ./cmd/... -count=1" test_provider_and_command_packages
+  time_phase "Test build and utility packages" "go test ./build/... ./terraformutils/... ./version -count=1" test_build_and_utility_packages
+  time_phase "Vet dependency-sensitive packages" "go vet providers, cmd, build, terraformutils, version" vet_dependency_sensitive_packages
+  time_phase "Static diff check" "git diff --check" static_diff_check
+  time_phase "Terraform state compatibility" "bash .github/scripts/terraform-state-compat.sh if present" run_compat_script ".github/scripts/terraform-state-compat.sh" "Terraform state compatibility"
+  time_phase "Terraform provider compatibility" "bash .github/scripts/terraform-provider-compat.sh if present" run_compat_script ".github/scripts/terraform-provider-compat.sh" "Terraform provider compatibility"
 }
 
 run_govulncheck_source_scan() {
   local batch=()
   local batch_size="${GOVULNCHECK_BATCH_SIZE:-25}"
   local package
+  local package_file=""
   local packages=()
   local scan_level="${GOVULNCHECK_SCAN_LEVEL:-symbol}"
 
-  ensure_govulncheck
+  ensure_govulncheck || return
 
   case "$scan_level" in
     package|symbol) ;;
@@ -204,9 +376,18 @@ run_govulncheck_source_scan() {
   if [[ -n "${GOVULNCHECK_PACKAGES:-}" ]]; then
     read -r -a packages <<<"${GOVULNCHECK_PACKAGES}"
   else
+    package_file="$(mktemp "${TMPDIR:-/tmp}/terraformer-govulncheck-packages.XXXXXX")" || return
+    if go list ./... >"$package_file"; then
+      :
+    else
+      local list_status="$?"
+      rm -f "$package_file"
+      return "$list_status"
+    fi
     while IFS= read -r package; do
       packages+=("$package")
-    done < <(go list ./...)
+    done <"$package_file"
+    rm -f "$package_file"
   fi
 
   if [[ "${#packages[@]}" -eq 0 ]]; then
@@ -217,7 +398,7 @@ run_govulncheck_source_scan() {
     batch+=("$package")
     if [[ "${#batch[@]}" -ge "$batch_size" ]]; then
       printf 'Scanning %s package(s) at %s level: %s\n' "${#batch[@]}" "$scan_level" "${batch[*]}"
-      govulncheck -scan="$scan_level" "${batch[@]}"
+      govulncheck -scan="$scan_level" "${batch[@]}" || return
       batch=()
     fi
   done
@@ -233,33 +414,30 @@ run_release_validation() {
     fail "goreleaser is required for MODE=release; install GoReleaser or run through the release workflow"
   fi
 
-  section "GoReleaser check"
-  goreleaser check
+  time_phase "GoReleaser check" "goreleaser check" goreleaser check
 
   if [[ "${RUN_GORELEASER_SNAPSHOT:-0}" == "1" ]]; then
-    section "GoReleaser snapshot preflight"
     prepare_release_output_cleanup
-    goreleaser release --snapshot --clean --skip=publish --timeout=3h --parallelism=1
+    time_phase "GoReleaser snapshot preflight" "goreleaser release --snapshot --clean --skip=publish" goreleaser release --snapshot --clean --skip=publish --timeout=3h --parallelism=1
   else
-    section "GoReleaser snapshot preflight"
-    printf 'Skipping local GoReleaser snapshot by default; the release workflow runs fanout/fanin snapshot validation with prebuilt assets.\n'
-    printf 'Set RUN_GORELEASER_SNAPSHOT=1 to run the monolithic local snapshot anyway.\n'
+    time_phase "GoReleaser snapshot preflight" "skip unless RUN_GORELEASER_SNAPSHOT=1" skip_goreleaser_snapshot_preflight
   fi
 }
 
+skip_goreleaser_snapshot_preflight() {
+  printf 'Skipping local GoReleaser snapshot by default; the release workflow runs fanout/fanin snapshot validation with prebuilt assets.\n'
+  printf 'Set RUN_GORELEASER_SNAPSHOT=1 to run the monolithic local snapshot anyway.\n'
+}
+
 if [[ "$MODE" == "quick" ]]; then
-  section "Detect dependency-sensitive changes"
-  base_ref="$(resolve_base_ref)"
-  printf 'Using base ref: %s\n' "$base_ref"
-  if ! has_dependency_sensitive_changes "$base_ref"; then
-    printf 'No dependency-sensitive changes detected; skipping provider dependency preflight.\n'
+  time_phase "Detect dependency-sensitive changes" "diff BASE_REF against HEAD and classify paths" detect_dependency_sensitive_changes
+  if [[ "$DEPENDENCY_SENSITIVE" -eq 0 ]]; then
     exit 0
   fi
-  printf 'Dependency-sensitive changes detected; running provider dependency preflight.\n'
 fi
 
 if [[ "${ONLY_GOVULNCHECK:-0}" == "1" ]]; then
-  run_govulncheck_source_scan
+  time_phase "govulncheck source scan" "install govulncheck if needed and scan source packages" run_govulncheck_source_scan
   section "Provider dependency preflight complete"
   exit 0
 fi
@@ -267,7 +445,7 @@ fi
 run_provider_validation
 
 if [[ "$MODE" == "release" || "${RUN_GOVULNCHECK:-0}" == "1" ]]; then
-  run_govulncheck_source_scan
+  time_phase "govulncheck source scan" "install govulncheck if needed and scan source packages" run_govulncheck_source_scan
 fi
 
 if [[ "$MODE" == "release" ]]; then


### PR DESCRIPTION
## Summary

Adds structured phase timing to `provider-dependency-preflight.sh` so dependency-sensitive PR latency can be optimized from phase-level data instead of job-level guesses.

Recent `tests` workflow runs show `provider dependency preflight` is usually the dependency-sensitive PR critical path, while `test (ubuntu-latest)` is also expensive. `origin/main` did not expose enough preflight phase timing to safely remove duplicated tidy/test work yet, so this PR is instrumentation-only.

## Notes

- Adds a reusable timing helper and console timing lines.
- Emits a GitHub Step Summary table when `GITHUB_STEP_SUMMARY` is set.
- Adds Go/cache/package/filesystem diagnostics.
- Times tidy, package listing/build, provider/cmd tests, core tests, vet, static diff, Terraform compatibility, govulncheck, and release-only checks.
- Preserves quick-skip behavior and validation order.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add phase-level timing and a GitHub Step Summary to `provider-dependency-preflight.sh` to pinpoint slow phases and optimize dependency-sensitive PR latency. Also preserves diff errors so preflight fails when Git cannot diff.

- **New Features**
  - Introduced `time_phase` to record status, duration, and notes; prints console timing lines.
  - Writes a Markdown timing table to `GITHUB_STEP_SUMMARY` with mode, result, and total duration.
  - Times major phases: tidy, package list/build, provider/cmd and build/util tests, vet, diff, Terraform compat scripts, `govulncheck`, and `goreleaser` checks.
  - Adds diagnostics (Go env, `go list` counts, cache sizes, filesystem space); ensures `govulncheck`; better temp-file handling; always writes a summary on exit.

- **Bug Fixes**
  - Preserve preflight diff failures in dependency change detection: try `BASE_REF...HEAD`, then `BASE_REF HEAD`; if both fail, propagate the error and fail the job (visible in the timing summary).

<sup>Written for commit 0a7b923ef137e84c38183e051abc3810ce8e7e80. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/chenrui333/terraformer/pull/617?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced CI/CD build process with execution phase tracking and timing summaries reported to GitHub Actions.
  * Improved error handling and resilience in build validation steps.
  * Refactored build workflow for better modularity and consistency across validation checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->