### PR TITLE
ci: report PR core test package timings

### DIFF
--- a/.github/scripts/pr-core-test.sh
+++ b/.github/scripts/pr-core-test.sh
@@ -1,0 +1,80 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_STARTED_AT="$(date +%s)"
+TEST_OUTPUT=""
+
+markdown_escape() {
+  local value="$1"
+  value="${value//\\/\\\\}"
+  value="${value//|/\\|}"
+  value="${value//$'\n'/ }"
+  printf '%s\n' "$value"
+}
+
+write_step_summary() {
+  local exit_code="$1"
+  local total_duration="$2"
+  local package_rows
+
+  [[ -n "${GITHUB_STEP_SUMMARY:-}" ]] || return 0
+
+  package_rows="$(
+    awk '
+      ($1 == "ok" || $1 == "FAIL") && $3 ~ /^[0-9.]+s$/ {
+        duration=$3
+        sub(/s$/, "", duration)
+        printf "%s\t%s\n", $2, duration
+      }
+    ' "$TEST_OUTPUT" | sort -k2,2nr | awk 'NR <= 20 { print }'
+  )"
+
+  {
+    printf '## PR Core Test Timing\n\n'
+    printf -- '- Result: %s\n' "$([[ "$exit_code" -eq 0 ]] && printf success || printf failed)"
+    printf -- '- Total duration seconds: %s\n' "$total_duration"
+    printf -- '- Command: go test ./build/... ./terraformutils/... ./version ./cmd ./providers ./providers/aws ./providers/gcp ./providers/azure -count=1\n\n'
+    printf '| Package | Duration seconds |\n'
+    printf '| --- | ---: |\n'
+    if [[ -n "$package_rows" ]]; then
+      while IFS=$'\t' read -r package seconds; do
+        printf '| %s | %s |\n' "$(markdown_escape "$package")" "$seconds"
+      done <<<"$package_rows"
+    else
+      printf '| _No package timing rows found_ | 0 |\n'
+    fi
+  } >>"$GITHUB_STEP_SUMMARY"
+}
+
+trap 'rm -f "$TEST_OUTPUT"' EXIT
+
+TEST_OUTPUT="$(mktemp "${TMPDIR:-/tmp}/terraformer-pr-core-test.XXXXXX")"
+
+packages=(
+  ./build/...
+  ./terraformutils/...
+  ./version
+  ./cmd
+  ./providers
+  ./providers/aws
+  ./providers/gcp
+  ./providers/azure
+)
+
+set +e
+go test "${packages[@]}" -count=1 2>&1 | tee "$TEST_OUTPUT"
+test_status="${PIPESTATUS[0]}"
+set -e
+
+total_duration="$(($(date +%s) - SCRIPT_STARTED_AT))"
+if [[ "$test_status" -eq 0 ]]; then
+  status="success"
+else
+  status="failed"
+fi
+
+printf 'pr-core-test: timing phase=%q status=%s duration=%ss notes=%q\n' \
+  "Test core packages" "$status" "$total_duration" "go test selected PR packages"
+write_step_summary "$test_status" "$total_duration"
+
+exit "$test_status"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -37,7 +37,7 @@ jobs:
     - name: Check go.mod and go.sum
       run: git diff --exit-code -- go.mod go.sum
     - name: Test core packages
-      run: go test ./build/... ./terraformutils/... ./version ./cmd ./providers ./providers/aws ./providers/gcp ./providers/azure -count=1
+      run: bash .github/scripts/pr-core-test.sh
 
   provider-dependency-preflight:
     name: provider dependency preflight


### PR DESCRIPTION
## Summary

Adds package-level timing reporting to the PR-only core test step.

The current post-#617 data shows `provider-dependency-preflight` remains the critical path, while `test (ubuntu-latest)` still spends most of its time inside one opaque `go test` step. This keeps the same package list and exit semantics, but writes the slowest package timings to the GitHub Step Summary for future overlap/sharding decisions.

## Notes

- No validation is skipped or reordered.
- The existing `go test` console output is preserved.
- The helper preserves the `go test` exit status through `PIPESTATUS`.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add per-package timing reporting to the PR core test job to surface slow packages and guide future sharding. The workflow now runs `bash .github/scripts/pr-core-test.sh` instead of a raw `go test`.

- **New Features**
  - Writes a GitHub Step Summary with total duration, the exact test command, and the top 20 slowest packages.
  - Keeps `go test` console output and exit status unchanged.
  - Uses the same package set: `./build/... ./terraformutils/... ./version ./cmd ./providers ./providers/aws ./providers/gcp ./providers/azure`.

<sup>Written for commit d124ecacd0b31159cd8f4a398655738ec8c4bc01. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/chenrui333/terraformer/pull/618?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

