### PR TITLE
ci: split provider preflight build check

### DIFF
--- a/.github/scripts/provider-dependency-preflight.sh
+++ b/.github/scripts/provider-dependency-preflight.sh
@@ -340,8 +340,8 @@ build_non_fixture_packages() {
   go build -v "${BUILD_PACKAGES[@]}"
 }
 
-skip_build_non_fixture_packages() {
-  printf 'Skipping non-fixture package build in this job; the PR preflight build job validates the same package list.\n'
+skip_pr_build_job_validation() {
+  printf 'Skipping in this job; the PR preflight build job validates this phase.\n'
 }
 
 run_build_package_validation() {
@@ -368,11 +368,12 @@ static_diff_check() {
 
 run_provider_validation() {
   time_phase "Environment diagnostics" "go version, go env, package counts, cache usage, filesystem space" environment_diagnostics
-  time_phase "Go module tidy" "go mod tidy and go.mod/go.sum diff check" run_go_mod_tidy_check
   if [[ "${SKIP_BUILD_NON_FIXTURE:-0}" == "1" ]]; then
-    time_phase "Package listing" "skipped; PR preflight build job lists and builds packages" skip_build_non_fixture_packages
-    time_phase "Build non-fixture packages" "validated by the PR preflight build job" skip_build_non_fixture_packages
+    time_phase "Go module tidy" "validated by the PR preflight build job" skip_pr_build_job_validation
+    time_phase "Package listing" "validated by the PR preflight build job" skip_pr_build_job_validation
+    time_phase "Build non-fixture packages" "validated by the PR preflight build job" skip_pr_build_job_validation
   else
+    time_phase "Go module tidy" "go mod tidy and go.mod/go.sum diff check" run_go_mod_tidy_check
     time_phase "Package listing" "go list non-fixture packages for build" list_build_packages
     time_phase "Build non-fixture packages" "go build selected non-fixture packages" build_non_fixture_packages
   fi

--- a/.github/scripts/provider-dependency-preflight.sh
+++ b/.github/scripts/provider-dependency-preflight.sh
@@ -373,9 +373,7 @@ run_provider_validation() {
     time_phase "Package listing" "validated by the PR preflight build job" skip_pr_build_job_validation
     time_phase "Build non-fixture packages" "validated by the PR preflight build job" skip_pr_build_job_validation
   else
-    time_phase "Go module tidy" "go mod tidy and go.mod/go.sum diff check" run_go_mod_tidy_check
-    time_phase "Package listing" "go list non-fixture packages for build" list_build_packages
-    time_phase "Build non-fixture packages" "go build selected non-fixture packages" build_non_fixture_packages
+    run_build_package_validation
   fi
   time_phase "Test provider and command packages" "go test ./providers/... ./cmd/... -count=1" test_provider_and_command_packages
   time_phase "Test build and utility packages" "go test ./build/... ./terraformutils/... ./version -count=1" test_build_and_utility_packages

--- a/.github/scripts/provider-dependency-preflight.sh
+++ b/.github/scripts/provider-dependency-preflight.sh
@@ -340,6 +340,16 @@ build_non_fixture_packages() {
   go build -v "${BUILD_PACKAGES[@]}"
 }
 
+skip_build_non_fixture_packages() {
+  printf 'Skipping non-fixture package build in this job; the PR preflight build job validates the same package list.\n'
+}
+
+run_build_package_validation() {
+  time_phase "Go module tidy" "go mod tidy and go.mod/go.sum diff check" run_go_mod_tidy_check
+  time_phase "Package listing" "go list non-fixture packages for build" list_build_packages
+  time_phase "Build non-fixture packages" "go build selected non-fixture packages" build_non_fixture_packages
+}
+
 test_provider_and_command_packages() {
   go test ./providers/... ./cmd/... -count=1
 }
@@ -359,8 +369,13 @@ static_diff_check() {
 run_provider_validation() {
   time_phase "Environment diagnostics" "go version, go env, package counts, cache usage, filesystem space" environment_diagnostics
   time_phase "Go module tidy" "go mod tidy and go.mod/go.sum diff check" run_go_mod_tidy_check
-  time_phase "Package listing" "go list non-fixture packages for build" list_build_packages
-  time_phase "Build non-fixture packages" "go build selected non-fixture packages" build_non_fixture_packages
+  if [[ "${SKIP_BUILD_NON_FIXTURE:-0}" == "1" ]]; then
+    time_phase "Package listing" "skipped; PR preflight build job lists and builds packages" skip_build_non_fixture_packages
+    time_phase "Build non-fixture packages" "validated by the PR preflight build job" skip_build_non_fixture_packages
+  else
+    time_phase "Package listing" "go list non-fixture packages for build" list_build_packages
+    time_phase "Build non-fixture packages" "go build selected non-fixture packages" build_non_fixture_packages
+  fi
   time_phase "Test provider and command packages" "go test ./providers/... ./cmd/... -count=1" test_provider_and_command_packages
   time_phase "Test build and utility packages" "go test ./build/... ./terraformutils/... ./version -count=1" test_build_and_utility_packages
   time_phase "Vet dependency-sensitive packages" "go vet providers, cmd, build, terraformutils, version" vet_dependency_sensitive_packages
@@ -454,6 +469,12 @@ fi
 if [[ "${ONLY_GOVULNCHECK:-0}" == "1" ]]; then
   time_phase "govulncheck source scan" "install govulncheck if needed and scan source packages" run_govulncheck_source_scan
   section "Provider dependency preflight complete"
+  exit 0
+fi
+
+if [[ "${ONLY_BUILD_NON_FIXTURE:-0}" == "1" ]]; then
+  run_build_package_validation
+  section "Provider dependency preflight build complete"
   exit 0
 fi
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -39,6 +39,33 @@ jobs:
     - name: Test core packages
       run: bash .github/scripts/pr-core-test.sh
 
+  preflight-build:
+    name: preflight build packages
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    steps:
+    - name: Free runner disk space
+      if: runner.os == 'Linux'
+      run: |
+        sudo rm -rf /usr/share/dotnet /usr/local/lib/android /opt/ghc
+        df -h
+    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+      with:
+        fetch-depth: 0
+    - name: Install Go
+      uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c
+      with:
+        go-version-file: go.mod
+        cache: true
+        cache-dependency-path: go.sum
+    - name: Build non-fixture packages
+      env:
+        MODE: quick
+        BASE_REF: ${{ github.event.pull_request.base.sha }}
+        ONLY_BUILD_NON_FIXTURE: "1"
+      run: bash .github/scripts/provider-dependency-preflight.sh
+
   provider-dependency-preflight:
     name: provider dependency preflight
     runs-on: ubuntu-latest
@@ -62,6 +89,7 @@ jobs:
       env:
         MODE: ${{ github.event_name == 'pull_request' && 'quick' || 'full' }}
         BASE_REF: ${{ github.event_name == 'pull_request' && github.event.pull_request.base.sha || 'origin/main' }}
+        SKIP_BUILD_NON_FIXTURE: ${{ github.event_name == 'pull_request' && '1' || '0' }}
       run: bash .github/scripts/provider-dependency-preflight.sh
 
   full:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -39,7 +39,7 @@ jobs:
     - name: Test core packages
       run: bash .github/scripts/pr-core-test.sh
 
-  preflight-build:
+  preflight_build:
     name: preflight build packages
     if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
@@ -66,8 +66,9 @@ jobs:
         ONLY_BUILD_NON_FIXTURE: "1"
       run: bash .github/scripts/provider-dependency-preflight.sh
 
-  provider-dependency-preflight:
-    name: provider dependency preflight
+  provider_dependency_validation:
+    name: provider dependency validation
+    if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
     timeout-minutes: 60
     steps:
@@ -87,9 +88,56 @@ jobs:
         cache-dependency-path: go.sum
     - name: Run provider dependency preflight
       env:
-        MODE: ${{ github.event_name == 'pull_request' && 'quick' || 'full' }}
-        BASE_REF: ${{ github.event_name == 'pull_request' && github.event.pull_request.base.sha || 'origin/main' }}
-        SKIP_BUILD_NON_FIXTURE: ${{ github.event_name == 'pull_request' && '1' || '0' }}
+        MODE: quick
+        BASE_REF: ${{ github.event.pull_request.base.sha }}
+        SKIP_BUILD_NON_FIXTURE: "1"
+      run: bash .github/scripts/provider-dependency-preflight.sh
+
+  provider-dependency-preflight:
+    name: provider dependency preflight
+    if: ${{ always() && github.event_name == 'pull_request' }}
+    needs:
+    - preflight_build
+    - provider_dependency_validation
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+    - name: Check provider preflight shards
+      env:
+        BUILD_RESULT: ${{ needs.preflight_build.result }}
+        VALIDATION_RESULT: ${{ needs.provider_dependency_validation.result }}
+      run: |
+        printf 'preflight build packages: %s\n' "$BUILD_RESULT"
+        printf 'provider dependency validation: %s\n' "$VALIDATION_RESULT"
+        if [[ "$BUILD_RESULT" != "success" || "$VALIDATION_RESULT" != "success" ]]; then
+          printf 'provider dependency preflight failed because one or more shards failed.\n' >&2
+          exit 1
+        fi
+
+  provider-dependency-preflight-full:
+    name: provider dependency preflight (full)
+    if: github.event_name != 'pull_request'
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    steps:
+    - name: Free runner disk space
+      if: runner.os == 'Linux'
+      run: |
+        sudo rm -rf /usr/share/dotnet /usr/local/lib/android /opt/ghc
+        df -h
+    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+      with:
+        fetch-depth: 0
+    - name: Install Go
+      uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c
+      with:
+        go-version-file: go.mod
+        cache: true
+        cache-dependency-path: go.sum
+    - name: Run provider dependency preflight
+      env:
+        MODE: full
+        BASE_REF: origin/main
       run: bash .github/scripts/provider-dependency-preflight.sh
 
   full:


### PR DESCRIPTION
## Summary

Splits the slow PR provider preflight build phase into a separate parallel job.

Recent timing shows `Build non-fixture packages` is the dominant provider-preflight phase, taking roughly 760-790 seconds inside an 1168-1196 second critical-path job. This keeps the same package-listing and `go build` validation, but moves that work into a PR-only `preflight build packages` job so the remaining provider preflight checks can run in parallel.

## Notes

- Pull requests still run quick classification before build validation.
- The non-fixture package list and `go build` command are unchanged.
- Push, workflow_dispatch, and scheduled full preflight behavior are unchanged.
- Detailed report: `/tmp/terraformer-preflight-build-phase-optimization-report.md`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Splits the slow non‑fixture package build out of provider preflight into a PR‑only parallel job and adds a small aggregator to fail the PR if any shard fails. Push and scheduled runs still execute the full preflight.

- **Refactors**
  - Adds PR‑only `preflight_build` job to list and build non‑fixture packages via `ONLY_BUILD_NON_FIXTURE=1`.
  - Adds PR‑only `provider_dependency_validation` job that runs `go mod tidy`, tests, and vet, skipping the build via `SKIP_BUILD_NON_FIXTURE=1` with clear skip logs.
  - Reuses a shared build‑validation wrapper so both shards (and full runs) execute identical tidy/list/build steps.
  - Adds lightweight `provider-dependency-preflight` aggregator that requires both shards to succeed; non‑PR workflows continue to run the full preflight unchanged.

<sup>Written for commit 3170dd5476a38e36cfecf8210176af2012d71622. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/chenrui333/terraformer/pull/619?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Restructured pull request validation workflow to separate build validation into dedicated jobs.
  * Updated preflight script to support conditional execution of build validation phases via environment variables.
  * Added parallel job aggregation for improved CI/CD efficiency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->