### PR TITLE
ci: split provider dependency test shard

### DIFF
--- a/.github/scripts/provider-dependency-preflight.sh
+++ b/.github/scripts/provider-dependency-preflight.sh
@@ -344,6 +344,10 @@ skip_pr_build_job_validation() {
   printf 'Skipping in this job; the PR preflight build job validates this phase.\n'
 }
 
+skip_pr_provider_test_job_validation() {
+  printf 'Skipping in this job; the PR provider test job validates this phase.\n'
+}
+
 run_build_package_validation() {
   time_phase "Go module tidy" "go mod tidy and go.mod/go.sum diff check" run_go_mod_tidy_check
   time_phase "Package listing" "go list non-fixture packages for build" list_build_packages
@@ -352,6 +356,10 @@ run_build_package_validation() {
 
 test_provider_and_command_packages() {
   go test ./providers/... ./cmd/... -count=1
+}
+
+run_provider_command_test_validation() {
+  time_phase "Test provider and command packages" "go test ./providers/... ./cmd/... -count=1" test_provider_and_command_packages
 }
 
 test_build_and_utility_packages() {
@@ -375,7 +383,11 @@ run_provider_validation() {
   else
     run_build_package_validation
   fi
-  time_phase "Test provider and command packages" "go test ./providers/... ./cmd/... -count=1" test_provider_and_command_packages
+  if [[ "${SKIP_PROVIDER_COMMAND_TESTS:-0}" == "1" ]]; then
+    time_phase "Test provider and command packages" "validated by the PR provider test job" skip_pr_provider_test_job_validation
+  else
+    run_provider_command_test_validation
+  fi
   time_phase "Test build and utility packages" "go test ./build/... ./terraformutils/... ./version -count=1" test_build_and_utility_packages
   time_phase "Vet dependency-sensitive packages" "go vet providers, cmd, build, terraformutils, version" vet_dependency_sensitive_packages
   time_phase "Static diff check" "git diff --check" static_diff_check
@@ -474,6 +486,12 @@ fi
 if [[ "${ONLY_BUILD_NON_FIXTURE:-0}" == "1" ]]; then
   run_build_package_validation
   section "Provider dependency preflight build complete"
+  exit 0
+fi
+
+if [[ "${ONLY_PROVIDER_COMMAND_TESTS:-0}" == "1" ]]; then
+  run_provider_command_test_validation
+  section "Provider dependency preflight provider tests complete"
   exit 0
 fi
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -71,6 +71,33 @@ jobs:
         ONLY_BUILD_NON_FIXTURE: "1"
       run: bash .github/scripts/provider-dependency-preflight.sh
 
+  provider_dependency_tests:
+    name: provider dependency tests
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    steps:
+    - name: Free runner disk space
+      if: runner.os == 'Linux'
+      run: |
+        sudo rm -rf /usr/share/dotnet /usr/local/lib/android /opt/ghc
+        df -h
+    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+      with:
+        fetch-depth: 0
+    - name: Install Go
+      uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c
+      with:
+        go-version-file: go.mod
+        cache: true
+        cache-dependency-path: go.sum
+    - name: Test provider and command packages
+      env:
+        MODE: quick
+        BASE_REF: ${{ github.event.pull_request.base.sha }}
+        ONLY_PROVIDER_COMMAND_TESTS: "1"
+      run: bash .github/scripts/provider-dependency-preflight.sh
+
   provider_dependency_validation:
     name: provider dependency validation
     if: github.event_name == 'pull_request'
@@ -96,6 +123,7 @@ jobs:
         MODE: quick
         BASE_REF: ${{ github.event.pull_request.base.sha }}
         SKIP_BUILD_NON_FIXTURE: "1"
+        SKIP_PROVIDER_COMMAND_TESTS: "1"
       run: bash .github/scripts/provider-dependency-preflight.sh
 
   provider-dependency-preflight:
@@ -103,6 +131,7 @@ jobs:
     if: ${{ always() && github.event_name == 'pull_request' }}
     needs:
     - preflight_build
+    - provider_dependency_tests
     - provider_dependency_validation
     runs-on: ubuntu-latest
     timeout-minutes: 5
@@ -110,11 +139,13 @@ jobs:
     - name: Check provider preflight shards
       env:
         BUILD_RESULT: ${{ needs.preflight_build.result }}
+        PROVIDER_TEST_RESULT: ${{ needs.provider_dependency_tests.result }}
         VALIDATION_RESULT: ${{ needs.provider_dependency_validation.result }}
       run: |
         printf 'preflight build packages: %s\n' "$BUILD_RESULT"
+        printf 'provider dependency tests: %s\n' "$PROVIDER_TEST_RESULT"
         printf 'provider dependency validation: %s\n' "$VALIDATION_RESULT"
-        if [[ "$BUILD_RESULT" != "success" || "$VALIDATION_RESULT" != "success" ]]; then
+        if [[ "$BUILD_RESULT" != "success" || "$PROVIDER_TEST_RESULT" != "success" || "$VALIDATION_RESULT" != "success" ]]; then
           printf 'provider dependency preflight failed because one or more shards failed.\n' >&2
           exit 1
         fi


### PR DESCRIPTION
## Summary

Selected lane: split or narrow the provider validation shard.

Post-#619 timing moved the bottleneck out of the build phase and into the provider validation shard. In completed run 27381861252, provider dependency preflight took 1096s and its Test provider and command packages phase took 834s. test (ubuntu-latest) was also 834s, while the separate build shard took 997s with Build non-fixture packages at 776s.

This PR splits go test ./providers/... ./cmd/... -count=1 into its own PR-only shard so provider/cmd tests can run in parallel with the remaining provider validation phases.

## Impact

Expected critical path changes from the observed run:

- Before: provider validation serialized provider/cmd tests, utility tests, vet, static diff, and Terraform compatibility for about 1096s.
- After: provider/cmd tests run as a sibling shard, while the validation shard keeps tidy/build skips plus utility tests, vet, static diff, and Terraform compatibility.
- The build shard and test (ubuntu-latest) remain unchanged.

Validation coverage is preserved: the same provider/cmd test command still runs for dependency-sensitive PRs, just in a separate required shard. Push/main behavior is unchanged.

## Files Changed

- .github/scripts/provider-dependency-preflight.sh
- .github/workflows/test.yml

## Validation

Passed locally:

- bash -n .github/scripts/provider-dependency-preflight.sh
- shellcheck .github/scripts/provider-dependency-preflight.sh
- bash -n .github/scripts/pr-core-test.sh
- shellcheck .github/scripts/pr-core-test.sh
- bash -n .github/scripts/release-prebuilt-assets.sh
- shellcheck .github/scripts/release-prebuilt-assets.sh
- actionlint .github/workflows/test.yml
- MODE=quick BASE_REF=HEAD ONLY_PROVIDER_COMMAND_TESTS=1 bash .github/scripts/provider-dependency-preflight.sh
- MODE=quick BASE_REF=HEAD~1 SKIP_BUILD_NON_FIXTURE=1 SKIP_PROVIDER_COMMAND_TESTS=1 bash .github/scripts/provider-dependency-preflight.sh
- go test ./build/...
- go build ./build/multi-build
- goreleaser check
- TERRAFORMER_BUILD_DRY_RUN=1 go run ./build/multi-build
- git diff --check

## Rollback

Revert this PR to restore the post-#619 two-shard preflight shape.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Split provider dependency tests into a dedicated PR-only CI shard so `go test ./providers/... ./cmd/...` runs in parallel with validation, shortening the preflight critical path. Validation coverage and push/main behavior are unchanged.

- **Refactors**
  - Added `provider_dependency_tests` job in `.github/workflows/test.yml` to run `./providers/...` and `./cmd/...` only.
  - Updated `provider_dependency_validation` to skip provider/command tests; aggregator now checks build, tests, and validation shards.
  - Extended `.github/scripts/provider-dependency-preflight.sh` to run/skip provider/command tests and support an only-tests mode.

<sup>Written for commit 433f8bbf83c7e2028983045b12a71f5dd3fd425a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/chenrui333/terraformer/pull/621?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

