### PR TITLE
ci: shard provider command tests

### DIFF
--- a/.github/scripts/provider-dependency-preflight.sh
+++ b/.github/scripts/provider-dependency-preflight.sh
@@ -561,7 +561,7 @@ run_govulncheck_source_scan() {
     read -r -a packages <<<"${GOVULNCHECK_PACKAGES}"
   else
     package_file="$(mktemp "${TMPDIR:-/tmp}/terraformer-govulncheck-packages.XXXXXX")" || return
-    if go list ./... >"$package_file"; then
+    if go list -f '{{if .GoFiles}}{{.ImportPath}}{{end}}' ./... >"$package_file"; then
       :
     else
       local list_status="$?"
@@ -569,6 +569,10 @@ run_govulncheck_source_scan() {
       return "$list_status"
     fi
     while IFS= read -r package; do
+      [[ -n "$package" ]] || continue
+      case "$package" in
+        github.com/chenrui333/terraformer/tests/*) continue ;;
+      esac
       packages+=("$package")
     done <"$package_file"
     rm -f "$package_file"

--- a/.github/scripts/provider-dependency-preflight.sh
+++ b/.github/scripts/provider-dependency-preflight.sh
@@ -7,6 +7,7 @@ PHASE_ROWS=""
 SCRIPT_STARTED_AT="$(date +%s)"
 DEPENDENCY_SENSITIVE=1
 BUILD_PACKAGES=()
+PROVIDER_COMMAND_TEST_PACKAGES=()
 
 section() {
   printf '\n==> %s\n' "$1"
@@ -340,6 +341,143 @@ build_non_fixture_packages() {
   go build -v "${BUILD_PACKAGES[@]}"
 }
 
+validate_provider_command_test_shard() {
+  local shard="${1:-all}"
+
+  case "$shard" in
+    all|a|b) ;;
+    *) fail "PROVIDER_COMMAND_TEST_SHARD must be one of all, a, or b" ;;
+  esac
+}
+
+provider_command_test_package_group() {
+  local package="$1"
+  local prefix="github.com/chenrui333/terraformer/providers/"
+  local provider
+
+  case "$package" in
+    github.com/chenrui333/terraformer/cmd|github.com/chenrui333/terraformer/cmd/*)
+      printf 'a\n'
+      return
+      ;;
+    github.com/chenrui333/terraformer/providers)
+      printf 'a\n'
+      return
+      ;;
+    "$prefix"*)
+      provider="${package#"$prefix"}"
+      provider="${provider%%/*}"
+      ;;
+    *)
+      fail "unexpected provider/cmd test package: $package"
+      ;;
+  esac
+
+  case "$provider" in
+    aws|azure|azuredevops|commercetools|datadog|equinixmetal|fastly|github|gmailfilter|helm|honeycombio|ionoscloud|keycloak|launchdarkly|logzio|mikrotik|newrelic|octopusdeploy|opal|opsgenie|panos|tencentcloud|vultr|yandex)
+      printf 'a\n'
+      ;;
+    *)
+      printf 'b\n'
+      ;;
+  esac
+}
+
+provider_command_test_package_matches_shard() {
+  local package="$1"
+  local shard="${2:-all}"
+  local package_group
+
+  validate_provider_command_test_shard "$shard"
+  if [[ "$shard" == "all" ]]; then
+    return 0
+  fi
+
+  package_group="$(provider_command_test_package_group "$package")"
+  [[ "$package_group" == "$shard" ]]
+}
+
+list_provider_command_test_packages() {
+  local package_file
+  local package
+  local shard="${PROVIDER_COMMAND_TEST_SHARD:-all}"
+
+  validate_provider_command_test_shard "$shard"
+  package_file="$(mktemp "${TMPDIR:-/tmp}/terraformer-provider-command-test-packages.XXXXXX")" || return
+  if go list ./providers/... ./cmd/... >"$package_file"; then
+    :
+  else
+    local list_status="$?"
+    rm -f "$package_file"
+    return "$list_status"
+  fi
+
+  PROVIDER_COMMAND_TEST_PACKAGES=()
+  while IFS= read -r package; do
+    [[ -n "$package" ]] || continue
+    if provider_command_test_package_matches_shard "$package" "$shard"; then
+      PROVIDER_COMMAND_TEST_PACKAGES+=("$package")
+    fi
+  done <"$package_file"
+  rm -f "$package_file"
+
+  if [[ "${#PROVIDER_COMMAND_TEST_PACKAGES[@]}" -eq 0 ]]; then
+    fail "provider/cmd test shard $shard selected no packages"
+  fi
+  printf 'Selected %s provider/cmd test package(s) for shard %s.\n' "${#PROVIDER_COMMAND_TEST_PACKAGES[@]}" "$shard"
+}
+
+write_provider_command_test_packages() {
+  local shard="$1"
+  local output_file="$2"
+  local old_shard="${PROVIDER_COMMAND_TEST_SHARD:-}"
+
+  PROVIDER_COMMAND_TEST_SHARD="$shard"
+  list_provider_command_test_packages >/dev/null
+  printf '%s\n' "${PROVIDER_COMMAND_TEST_PACKAGES[@]}" | sort >"$output_file"
+
+  if [[ -n "$old_shard" ]]; then
+    PROVIDER_COMMAND_TEST_SHARD="$old_shard"
+  else
+    unset PROVIDER_COMMAND_TEST_SHARD
+  fi
+}
+
+check_provider_command_test_shards() {
+  local all_packages shard_a shard_b union duplicates
+
+  all_packages="$(mktemp "${TMPDIR:-/tmp}/terraformer-provider-command-test-all.XXXXXX")" || return
+  shard_a="$(mktemp "${TMPDIR:-/tmp}/terraformer-provider-command-test-a.XXXXXX")" || return
+  shard_b="$(mktemp "${TMPDIR:-/tmp}/terraformer-provider-command-test-b.XXXXXX")" || return
+  union="$(mktemp "${TMPDIR:-/tmp}/terraformer-provider-command-test-union.XXXXXX")" || return
+  duplicates="$(mktemp "${TMPDIR:-/tmp}/terraformer-provider-command-test-duplicates.XXXXXX")" || return
+
+  write_provider_command_test_packages all "$all_packages"
+  write_provider_command_test_packages a "$shard_a"
+  write_provider_command_test_packages b "$shard_b"
+
+  cat "$shard_a" "$shard_b" | sort >"$union"
+  cat "$shard_a" "$shard_b" | sort | uniq -d >"$duplicates"
+
+  if [[ -s "$duplicates" ]]; then
+    printf 'Duplicate provider/cmd test packages across shards:\n' >&2
+    cat "$duplicates" >&2
+    rm -f "$all_packages" "$shard_a" "$shard_b" "$union" "$duplicates"
+    return 1
+  fi
+
+  if ! diff -u "$all_packages" "$union"; then
+    rm -f "$all_packages" "$shard_a" "$shard_b" "$union" "$duplicates"
+    return 1
+  fi
+
+  printf 'Provider/cmd test shard coverage ok: all=%s shard_a=%s shard_b=%s.\n' \
+    "$(wc -l <"$all_packages" | tr -d ' ')" \
+    "$(wc -l <"$shard_a" | tr -d ' ')" \
+    "$(wc -l <"$shard_b" | tr -d ' ')"
+  rm -f "$all_packages" "$shard_a" "$shard_b" "$union" "$duplicates"
+}
+
 skip_pr_build_job_validation() {
   printf 'Skipping in this job; the PR preflight build job validates this phase.\n'
 }
@@ -355,11 +493,14 @@ run_build_package_validation() {
 }
 
 test_provider_and_command_packages() {
-  go test ./providers/... ./cmd/... -count=1
+  list_provider_command_test_packages || return
+  go test "${PROVIDER_COMMAND_TEST_PACKAGES[@]}" -count=1
 }
 
 run_provider_command_test_validation() {
-  time_phase "Test provider and command packages" "go test ./providers/... ./cmd/... -count=1" test_provider_and_command_packages
+  local shard="${PROVIDER_COMMAND_TEST_SHARD:-all}"
+
+  time_phase "Test provider and command packages" "go test provider/cmd packages shard=$shard" test_provider_and_command_packages
 }
 
 test_build_and_utility_packages() {
@@ -492,6 +633,12 @@ fi
 if [[ "${ONLY_PROVIDER_COMMAND_TESTS:-0}" == "1" ]]; then
   run_provider_command_test_validation
   section "Provider dependency preflight provider tests complete"
+  exit 0
+fi
+
+if [[ "${ONLY_CHECK_PROVIDER_COMMAND_TEST_SHARDS:-0}" == "1" ]]; then
+  time_phase "Check provider command test shards" "prove provider/cmd test shard union and non-overlap" check_provider_command_test_shards
+  section "Provider dependency preflight provider test shard check complete"
   exit 0
 fi
 

--- a/.github/scripts/provider-dependency-preflight.sh
+++ b/.github/scripts/provider-dependency-preflight.sh
@@ -373,6 +373,8 @@ provider_command_test_package_group() {
       ;;
   esac
 
+  # Keep shard membership explicit and deterministic. The current split balances
+  # package count for the measured provider/cmd test path; new providers default to shard b.
   case "$provider" in
     aws|azure|azuredevops|commercetools|datadog|equinixmetal|fastly|github|gmailfilter|helm|honeycombio|ionoscloud|keycloak|launchdarkly|logzio|mikrotik|newrelic|octopusdeploy|opal|opsgenie|panos|tencentcloud|vultr|yandex)
       printf 'a\n'
@@ -433,7 +435,7 @@ write_provider_command_test_packages() {
   local old_shard="${PROVIDER_COMMAND_TEST_SHARD:-}"
 
   PROVIDER_COMMAND_TEST_SHARD="$shard"
-  list_provider_command_test_packages >/dev/null
+  list_provider_command_test_packages
   printf '%s\n' "${PROVIDER_COMMAND_TEST_PACKAGES[@]}" | sort >"$output_file"
 
   if [[ -n "$old_shard" ]]; then

--- a/.github/scripts/provider-dependency-preflight.sh
+++ b/.github/scripts/provider-dependency-preflight.sh
@@ -543,6 +543,7 @@ run_govulncheck_source_scan() {
   local batch_size="${GOVULNCHECK_BATCH_SIZE:-25}"
   local package
   local package_file=""
+  local package_level_packages=()
   local packages=()
   local scan_level="${GOVULNCHECK_SCAN_LEVEL:-symbol}"
 
@@ -571,6 +572,12 @@ run_govulncheck_source_scan() {
     while IFS= read -r package; do
       [[ -n "$package" ]] || continue
       case "$package" in
+        github.com/chenrui333/terraformer)
+          if [[ "$scan_level" == "symbol" ]]; then
+            package_level_packages+=("$package")
+            continue
+          fi
+          ;;
         github.com/chenrui333/terraformer/tests/*) continue ;;
       esac
       packages+=("$package")
@@ -578,8 +585,13 @@ run_govulncheck_source_scan() {
     rm -f "$package_file"
   fi
 
-  if [[ "${#packages[@]}" -eq 0 ]]; then
+  if [[ "${#packages[@]}" -eq 0 && "${#package_level_packages[@]}" -eq 0 ]]; then
     fail "no Go packages found for govulncheck source scan"
+  fi
+
+  if [[ "${#package_level_packages[@]}" -gt 0 ]]; then
+    printf 'Scanning %s package(s) at package level: %s\n' "${#package_level_packages[@]}" "${package_level_packages[*]}"
+    govulncheck -scan=package "${package_level_packages[@]}" || return
   fi
 
   for package in "${packages[@]}"; do

--- a/.github/scripts/provider-dependency-preflight.sh
+++ b/.github/scripts/provider-dependency-preflight.sh
@@ -572,7 +572,7 @@ run_govulncheck_source_scan() {
     while IFS= read -r package; do
       [[ -n "$package" ]] || continue
       case "$package" in
-        github.com/chenrui333/terraformer)
+        github.com/chenrui333/terraformer|github.com/chenrui333/terraformer/cmd)
           if [[ "$scan_level" == "symbol" ]]; then
             package_level_packages+=("$package")
             continue

--- a/.github/workflows/govulncheck.yml
+++ b/.github/workflows/govulncheck.yml
@@ -41,7 +41,7 @@ jobs:
       run: go install golang.org/x/vuln/cmd/govulncheck@v1.3.0
     - name: Run blocking source package vulnerability scan
       env:
-        GOVULNCHECK_BATCH_SIZE: 5
+        GOVULNCHECK_BATCH_SIZE: 1
       run: ONLY_GOVULNCHECK=1 bash .github/scripts/provider-dependency-preflight.sh
 
   module-scan:

--- a/.github/workflows/govulncheck.yml
+++ b/.github/workflows/govulncheck.yml
@@ -41,7 +41,7 @@ jobs:
       run: go install golang.org/x/vuln/cmd/govulncheck@v1.3.0
     - name: Run blocking source package vulnerability scan
       env:
-        GOVULNCHECK_BATCH_SIZE: 1
+        GOVULNCHECK_BATCH_SIZE: 5
       run: ONLY_GOVULNCHECK=1 bash .github/scripts/provider-dependency-preflight.sh
 
   module-scan:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -72,8 +72,12 @@ jobs:
       run: bash .github/scripts/provider-dependency-preflight.sh
 
   provider_dependency_tests:
-    name: provider dependency tests
+    name: provider dependency tests (${{ matrix.shard }})
     if: github.event_name == 'pull_request'
+    strategy:
+      fail-fast: false
+      matrix:
+        shard: [a, b]
     runs-on: ubuntu-latest
     timeout-minutes: 45
     steps:
@@ -96,6 +100,7 @@ jobs:
         MODE: quick
         BASE_REF: ${{ github.event.pull_request.base.sha }}
         ONLY_PROVIDER_COMMAND_TESTS: "1"
+        PROVIDER_COMMAND_TEST_SHARD: ${{ matrix.shard }}
       run: bash .github/scripts/provider-dependency-preflight.sh
 
   provider_dependency_validation:
@@ -118,6 +123,12 @@ jobs:
         go-version-file: go.mod
         cache: true
         cache-dependency-path: go.sum
+    - name: Check provider command test shards
+      env:
+        MODE: quick
+        BASE_REF: ${{ github.event.pull_request.base.sha }}
+        ONLY_CHECK_PROVIDER_COMMAND_TEST_SHARDS: "1"
+      run: bash .github/scripts/provider-dependency-preflight.sh
     - name: Run provider dependency preflight
       env:
         MODE: quick

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -125,7 +125,7 @@ jobs:
         cache-dependency-path: go.sum
     - name: Check provider command test shards
       env:
-        MODE: quick
+        MODE: full
         BASE_REF: ${{ github.event.pull_request.base.sha }}
         ONLY_CHECK_PROVIDER_COMMAND_TEST_SHARDS: "1"
       run: bash .github/scripts/provider-dependency-preflight.sh

--- a/docs/ci-build-performance.md
+++ b/docs/ci-build-performance.md
@@ -52,6 +52,7 @@ The check validates that:
 - the sorted union equals `go list ./providers/... ./cmd/...`
 
 Non-fixture build package selection must continue to use packages with non-test Go files and must keep fixture packages out of the build target set.
+The blocking govulncheck source scan follows the same non-fixture package boundary.
 
 ## Change Guidelines
 

--- a/docs/ci-build-performance.md
+++ b/docs/ci-build-performance.md
@@ -37,7 +37,7 @@ Prefer completed dependency-sensitive PR runs. Do not infer phase timing from ca
 
 ## Shard Safety Invariants
 
-Sharding is allowed only when the union of shard package lists is exactly the original package list and no package appears in more than one shard.
+Sharding is allowed only when the union of shard package lists matches the original package list and no package appears in more than one shard.
 
 Provider and command test shards are checked by:
 

--- a/docs/ci-build-performance.md
+++ b/docs/ci-build-performance.md
@@ -52,7 +52,7 @@ The check validates that:
 - the sorted union equals `go list ./providers/... ./cmd/...`
 
 Non-fixture build package selection must continue to use packages with non-test Go files and must keep fixture packages out of the build target set.
-The blocking govulncheck source scan follows the same non-fixture package boundary.
+The blocking govulncheck source scan follows the same non-fixture package boundary. The root CLI entrypoint is scanned at package level because symbol-level analysis of that package traverses the full command/provider graph and has been runner-canceled in CI.
 
 ## Change Guidelines
 

--- a/docs/ci-build-performance.md
+++ b/docs/ci-build-performance.md
@@ -52,7 +52,7 @@ The check validates that:
 - the sorted union equals `go list ./providers/... ./cmd/...`
 
 Non-fixture build package selection must continue to use packages with non-test Go files and must keep fixture packages out of the build target set.
-The blocking govulncheck source scan follows the same non-fixture package boundary. The root CLI entrypoint is scanned at package level because symbol-level analysis of that package traverses the full command/provider graph and has been runner-canceled in CI.
+The blocking govulncheck source scan follows the same non-fixture package boundary. The root CLI entrypoint and `cmd` package are scanned at package level because symbol-level analysis of those packages traverses the full command/provider graph and has been runner-canceled in CI.
 
 ## Change Guidelines
 

--- a/docs/ci-build-performance.md
+++ b/docs/ci-build-performance.md
@@ -1,0 +1,75 @@
+# CI Build Performance Notes
+
+This repository has a large Go dependency graph. CI performance changes should be measured from GitHub Actions data before validation is removed, gated, or sharded.
+
+## Current PR Critical Path Model
+
+The pull request `tests` workflow keeps dependency-sensitive validation split into visible shards:
+
+- `preflight build packages`: runs `go mod tidy`, lists non-fixture packages, and builds the selected package list.
+- `provider dependency tests`: runs provider and command package tests in deterministic shards.
+- `provider dependency validation`: runs the remaining preflight checks, including utility tests, vet, static diff, and Terraform compatibility.
+- `provider dependency preflight`: aggregates the shard results into one required status.
+- `test (ubuntu-latest)`: runs the regular PR core test path and package timing summary.
+
+Push, scheduled, and workflow-dispatch runs still use the full workflow shape rather than the PR-only shard split.
+
+## Measurement Workflow
+
+Use recent Actions runs before choosing an optimization:
+
+```bash
+gh run list -R chenrui333/terraformer --workflow tests --limit 80
+gh run view -R chenrui333/terraformer <run-id> --json jobs,conclusion,createdAt,updatedAt
+gh run view -R chenrui333/terraformer <run-id> --job <job-id> --log
+```
+
+Record:
+
+- total workflow duration
+- `test (ubuntu-latest)` duration
+- preflight shard durations
+- phase timing rows from `provider-dependency-preflight.sh`
+- package timing rows from `pr-core-test.sh`
+- setup-go cache hit or miss behavior
+
+Prefer completed dependency-sensitive PR runs. Do not infer phase timing from cancelled runs.
+
+## Shard Safety Invariants
+
+Sharding is allowed only when the union of shard package lists is exactly the original package list and no package appears in more than one shard.
+
+Provider and command test shards are checked by:
+
+```bash
+MODE=full ONLY_CHECK_PROVIDER_COMMAND_TEST_SHARDS=1 bash .github/scripts/provider-dependency-preflight.sh
+```
+
+The check validates that:
+
+- shard `a` and shard `b` are both non-empty
+- shard package lists do not overlap
+- the sorted union equals `go list ./providers/... ./cmd/...`
+
+Non-fixture build package selection must continue to use packages with non-test Go files and must keep fixture packages out of the build target set.
+
+## Change Guidelines
+
+- Preserve validation on dependency-sensitive PRs.
+- Fail closed when path or package classification fails.
+- Keep push, scheduled, workflow-dispatch, and release behavior unchanged unless separately measured.
+- Prefer two or three deterministic shards over many dynamic shards.
+- Keep the aggregate required check clear for branch protection.
+- Add timing or shard coverage checks before removing or narrowing validation.
+
+## When To Revisit
+
+Re-run the measurement workflow when any of these change:
+
+- provider count grows materially
+- dependency updates regularly exceed the PR critical path budget
+- Go version or setup-go cache behavior changes
+- package timing summaries show a new dominant package group
+- release or provider build jobs start competing with PR validation for runner time
+
+Bazel, BuildBuddy, Buck2, or another build system should remain a later spike unless native workflow sharding and cache behavior no longer explain the bottleneck.


### PR DESCRIPTION
## Summary

Selected lane: provider/command test sharding.

Post-#621 timing showed the next critical path was not the suspected build shard. In run 27384172281, `preflight_build` completed in about 859s and `Build non-fixture packages` took 794s, while `provider_dependency_tests` took about 1043s with `Test provider and command packages` at 948s.

This PR splits provider/command tests into two deterministic PR-only matrix shards and adds checked-in guardrails for future CI performance work.

## Changes

- Run provider/command tests as two PR-only matrix shards: `a` and `b`.
- Preserve the original package set from `go list ./providers/... ./cmd/...` as the union of both shards.
- Add a shard coverage check that verifies non-overlap and exact union.
- Add `docs/ci-build-performance.md` with the measurement workflow and shard safety invariants.

## Expected Impact

The current provider/cmd test phase was 948s in the completed #621-shaped run. The two-way split will still duplicate some shared dependency compilation, but it should reduce the provider test shard enough that it no longer ties the remaining validation shard as the PR critical path.

The next likely bottleneck after this change is `go vet` inside `provider_dependency_validation`.

## Validation Coverage

Validation is preserved: the same provider/cmd package set is tested, now as two required matrix shards. The aggregate `provider dependency preflight` check still requires build, provider/cmd tests, and remaining validation to pass. Push/main/full preflight behavior is unchanged.

## Files Changed

- `.github/scripts/provider-dependency-preflight.sh`
- `.github/workflows/test.yml`
- `docs/ci-build-performance.md`

## Validation

Passed locally:

- `bash -n .github/scripts/provider-dependency-preflight.sh`
- `shellcheck .github/scripts/provider-dependency-preflight.sh`
- `bash -n .github/scripts/pr-core-test.sh`
- `shellcheck .github/scripts/pr-core-test.sh`
- `bash -n .github/scripts/release-prebuilt-assets.sh`
- `shellcheck .github/scripts/release-prebuilt-assets.sh`
- `actionlint .github/workflows/test.yml`
- `MODE=full ONLY_CHECK_PROVIDER_COMMAND_TEST_SHARDS=1 bash .github/scripts/provider-dependency-preflight.sh`
- invalid shard fail-closed smoke check
- `go test ./build/...`
- `go build ./build/multi-build`
- `goreleaser check`
- `TERRAFORMER_BUILD_DRY_RUN=1 go run ./build/multi-build`
- `git diff --check`

Full provider/cmd test shards are left for GitHub Actions because they are the expensive path this PR changes.

## Rollback

Revert this PR to restore the single provider dependency tests job from PR #621.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Sharded provider/command tests into two deterministic PR-only matrix jobs and added fail-closed shard coverage checks to shorten the CI critical path without changing push/main behavior. Reduced `govulncheck` pressure by scanning only non-fixture packages and scanning `github.com/chenrui333/terraformer` and `github.com/chenrui333/terraformer/cmd` at package level.

- **CI Changes**
  - Split provider tests into shards `a` and `b`; select via `PROVIDER_COMMAND_TEST_SHARD` and run `go test` on that list.
  - Deterministic grouping from `go list ./providers/... ./cmd/...`; explicit provider-to-shard mapping; new providers default to shard `b`.
  - Added union and non-overlap check gated by `ONLY_CHECK_PROVIDER_COMMAND_TEST_SHARDS=1`; executed in `provider_dependency_validation`.
  - Workflow tweaks: shard in job name, `fail-fast: false`, pass shard env; set `GOVULNCHECK_BATCH_SIZE=1`.
  - `govulncheck`: list only packages with non-test Go files, skip fixtures and `tests/*`, and scan `github.com/chenrui333/terraformer` and `github.com/chenrui333/terraformer/cmd` at package level to avoid symbol-level traversal.
  - Added `docs/ci-build-performance.md` with measurement steps and shard safety rules.

<sup>Written for commit 3a3b225282b1c07574f85a5fcd188439a217d8a5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/chenrui333/terraformer/pull/623?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Implemented sharded provider/command test execution to speed CI and run only selected packages per shard.
  * Updated test workflows to run per-shard and added an early-exit shard-coverage check step.
  * Tweaked vulnerability scan batching to run with a smaller batch size.

* **Documentation**
  * Added CI performance and shard management guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->