### PR TITLE
ci: split provider vet validation

### DIFF
--- a/.github/scripts/provider-dependency-preflight.sh
+++ b/.github/scripts/provider-dependency-preflight.sh
@@ -488,6 +488,10 @@ skip_pr_provider_test_job_validation() {
   printf 'Skipping in this job; the PR provider test job validates this phase.\n'
 }
 
+skip_pr_vet_job_validation() {
+  printf 'Skipping in this job; the PR provider vet job validates this phase.\n'
+}
+
 run_build_package_validation() {
   time_phase "Go module tidy" "go mod tidy and go.mod/go.sum diff check" run_go_mod_tidy_check
   time_phase "Package listing" "go list non-fixture packages for build" list_build_packages
@@ -503,6 +507,10 @@ run_provider_command_test_validation() {
   local shard="${PROVIDER_COMMAND_TEST_SHARD:-all}"
 
   time_phase "Test provider and command packages" "go test provider/cmd packages shard=$shard" test_provider_and_command_packages
+}
+
+run_vet_validation() {
+  time_phase "Vet dependency-sensitive packages" "go vet providers, cmd, build, terraformutils, version" vet_dependency_sensitive_packages
 }
 
 test_build_and_utility_packages() {
@@ -532,7 +540,11 @@ run_provider_validation() {
     run_provider_command_test_validation
   fi
   time_phase "Test build and utility packages" "go test ./build/... ./terraformutils/... ./version -count=1" test_build_and_utility_packages
-  time_phase "Vet dependency-sensitive packages" "go vet providers, cmd, build, terraformutils, version" vet_dependency_sensitive_packages
+  if [[ "${SKIP_VET_DEPENDENCY_PACKAGES:-0}" == "1" ]]; then
+    time_phase "Vet dependency-sensitive packages" "validated by the PR provider vet job" skip_pr_vet_job_validation
+  else
+    run_vet_validation
+  fi
   time_phase "Static diff check" "git diff --check" static_diff_check
   time_phase "Terraform state compatibility" "bash .github/scripts/terraform-state-compat.sh if present" run_compat_script ".github/scripts/terraform-state-compat.sh" "Terraform state compatibility"
   time_phase "Terraform provider compatibility" "bash .github/scripts/terraform-provider-compat.sh if present" run_compat_script ".github/scripts/terraform-provider-compat.sh" "Terraform provider compatibility"
@@ -651,6 +663,12 @@ fi
 if [[ "${ONLY_PROVIDER_COMMAND_TESTS:-0}" == "1" ]]; then
   run_provider_command_test_validation
   section "Provider dependency preflight provider tests complete"
+  exit 0
+fi
+
+if [[ "${ONLY_VET_DEPENDENCY_PACKAGES:-0}" == "1" ]]; then
+  run_vet_validation
+  section "Provider dependency preflight vet complete"
   exit 0
 fi
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -135,6 +135,34 @@ jobs:
         BASE_REF: ${{ github.event.pull_request.base.sha }}
         SKIP_BUILD_NON_FIXTURE: "1"
         SKIP_PROVIDER_COMMAND_TESTS: "1"
+        SKIP_VET_DEPENDENCY_PACKAGES: "1"
+      run: bash .github/scripts/provider-dependency-preflight.sh
+
+  provider_dependency_vet:
+    name: provider dependency vet
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    steps:
+    - name: Free runner disk space
+      if: runner.os == 'Linux'
+      run: |
+        sudo rm -rf /usr/share/dotnet /usr/local/lib/android /opt/ghc
+        df -h
+    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+      with:
+        fetch-depth: 0
+    - name: Install Go
+      uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c
+      with:
+        go-version-file: go.mod
+        cache: true
+        cache-dependency-path: go.sum
+    - name: Vet dependency-sensitive packages
+      env:
+        MODE: quick
+        BASE_REF: ${{ github.event.pull_request.base.sha }}
+        ONLY_VET_DEPENDENCY_PACKAGES: "1"
       run: bash .github/scripts/provider-dependency-preflight.sh
 
   provider-dependency-preflight:
@@ -144,6 +172,7 @@ jobs:
     - preflight_build
     - provider_dependency_tests
     - provider_dependency_validation
+    - provider_dependency_vet
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
@@ -152,11 +181,13 @@ jobs:
         BUILD_RESULT: ${{ needs.preflight_build.result }}
         PROVIDER_TEST_RESULT: ${{ needs.provider_dependency_tests.result }}
         VALIDATION_RESULT: ${{ needs.provider_dependency_validation.result }}
+        VET_RESULT: ${{ needs.provider_dependency_vet.result }}
       run: |
         printf 'preflight build packages: %s\n' "$BUILD_RESULT"
         printf 'provider dependency tests: %s\n' "$PROVIDER_TEST_RESULT"
         printf 'provider dependency validation: %s\n' "$VALIDATION_RESULT"
-        if [[ "$BUILD_RESULT" != "success" || "$PROVIDER_TEST_RESULT" != "success" || "$VALIDATION_RESULT" != "success" ]]; then
+        printf 'provider dependency vet: %s\n' "$VET_RESULT"
+        if [[ "$BUILD_RESULT" != "success" || "$PROVIDER_TEST_RESULT" != "success" || "$VALIDATION_RESULT" != "success" || "$VET_RESULT" != "success" ]]; then
           printf 'provider dependency preflight failed because one or more shards failed.\n' >&2
           exit 1
         fi

--- a/docs/ci-build-performance.md
+++ b/docs/ci-build-performance.md
@@ -8,7 +8,8 @@ The pull request `tests` workflow keeps dependency-sensitive validation split in
 
 - `preflight build packages`: runs `go mod tidy`, lists non-fixture packages, and builds the selected package list.
 - `provider dependency tests`: runs provider and command package tests in deterministic shards.
-- `provider dependency validation`: runs the remaining preflight checks, including utility tests, vet, static diff, and Terraform compatibility.
+- `provider dependency vet`: runs the same dependency-sensitive `go vet` command that the full preflight runs.
+- `provider dependency validation`: runs the remaining preflight checks, including utility tests, static diff, and Terraform compatibility.
 - `provider dependency preflight`: aggregates the shard results into one required status.
 - `test (ubuntu-latest)`: runs the regular PR core test path and package timing summary.
 
@@ -52,6 +53,7 @@ The check validates that:
 - the sorted union equals `go list ./providers/... ./cmd/...`
 
 Non-fixture build package selection must continue to use packages with non-test Go files and must keep fixture packages out of the build target set.
+The PR-only vet shard must keep using `vet_dependency_sensitive_packages` from `.github/scripts/provider-dependency-preflight.sh`; do not duplicate or narrow its package list in workflow YAML.
 The blocking govulncheck source scan follows the same non-fixture package boundary. The root CLI entrypoint and `cmd` package are scanned at package level because symbol-level analysis of those packages traverses the full command/provider graph and has been runner-canceled in CI.
 
 ## Change Guidelines


### PR DESCRIPTION
## Summary

Split the PR-only dependency-sensitive go vet phase into its own validation shard.

Post-#623 timings show provider dependency validation is now the critical path:
- tests run 27390331345: validation 18m23s, with go vet at 833s
- tests run 27431346496: validation 19m08s, with go vet at 817s

The other required PR jobs completed sooner in the post-merge run:
- test (ubuntu-latest): 15m18s
- preflight build packages: 15m03s
- provider tests shard a: 13m20s
- provider tests shard b: 6m12s

## Changes

- Add PR-only provider dependency vet job.
- Keep the same vet_dependency_sensitive_packages function and command.
- Skip only that vet phase from the remaining PR validation shard.
- Keep push/main/full preflight behavior unchanged.
- Update the aggregate provider-dependency-preflight job to require the vet shard.
- Document the vet shard invariant in docs/ci-build-performance.md.

## Validation

Passed locally:
- bash -n .github/scripts/provider-dependency-preflight.sh
- bash -n .github/scripts/pr-core-test.sh
- bash -n .github/scripts/release-prebuilt-assets.sh
- shellcheck .github/scripts/provider-dependency-preflight.sh .github/scripts/pr-core-test.sh .github/scripts/release-prebuilt-assets.sh
- actionlint .github/workflows/test.yml .github/workflows/govulncheck.yml
- MODE=full ONLY_CHECK_PROVIDER_COMMAND_TEST_SHARDS=1 bash .github/scripts/provider-dependency-preflight.sh
- MODE=full ONLY_VET_DEPENDENCY_PACKAGES=1 bash .github/scripts/provider-dependency-preflight.sh
- MODE=full SKIP_BUILD_NON_FIXTURE=1 SKIP_PROVIDER_COMMAND_TESTS=1 SKIP_VET_DEPENDENCY_PACKAGES=1 bash .github/scripts/provider-dependency-preflight.sh
- go test ./build/...
- go build ./build/multi-build
- goreleaser check
- TERRAFORMER_BUILD_DRY_RUN=1 go run ./build/multi-build
- git diff --check

## Rollback

Revert this PR. The preflight script will run vet inline in provider_dependency_validation again, and the aggregate job will stop requiring provider_dependency_vet.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Split the dependency-sensitive `go vet` phase into its own PR-only shard to shorten the CI critical path. Recent post-#623 runs show `go vet` takes ~13–14 minutes and was the bottleneck; sharding removes it from the validation shard without changing main/full preflight behavior.

- **Refactors**
  - Added a PR-only `provider dependency vet` job running `ONLY_VET_DEPENDENCY_PACKAGES=1` via `.github/scripts/provider-dependency-preflight.sh`.
  - Skipped vet in the PR validation shard using `SKIP_VET_DEPENDENCY_PACKAGES=1`.
  - Updated the aggregate preflight job to require the vet shard.
  - Documented the invariant to keep using `vet_dependency_sensitive_packages` (no duplicated or narrowed package lists).

<sup>Written for commit 3164b9575545b731da443890ecf89cb2dc55df24. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/chenrui333/terraformer/pull/624?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

