### PR TITLE
ci: split command package test shard

### DIFF
--- a/.github/scripts/provider-dependency-preflight.sh
+++ b/.github/scripts/provider-dependency-preflight.sh
@@ -345,8 +345,8 @@ validate_provider_command_test_shard() {
   local shard="${1:-all}"
 
   case "$shard" in
-    all|a|b) ;;
-    *) fail "PROVIDER_COMMAND_TEST_SHARD must be one of all, a, or b" ;;
+    all|a|b|cmd) ;;
+    *) fail "PROVIDER_COMMAND_TEST_SHARD must be one of all, a, b, or cmd" ;;
   esac
 }
 
@@ -357,7 +357,7 @@ provider_command_test_package_group() {
 
   case "$package" in
     github.com/chenrui333/terraformer/cmd|github.com/chenrui333/terraformer/cmd/*)
-      printf 'a\n'
+      printf 'cmd\n'
       return
       ;;
     github.com/chenrui333/terraformer/providers)
@@ -373,8 +373,9 @@ provider_command_test_package_group() {
       ;;
   esac
 
-  # Keep shard membership explicit and deterministic. The current split balances
-  # package count for the measured provider/cmd test path; new providers default to shard b.
+  # Keep shard membership explicit and deterministic. The cmd package is its own
+  # shard because it compiles the command/provider graph and dominated shard a.
+  # New providers default to shard b.
   case "$provider" in
     aws|azure|azuredevops|commercetools|datadog|equinixmetal|fastly|github|gmailfilter|helm|honeycombio|ionoscloud|keycloak|launchdarkly|logzio|mikrotik|newrelic|octopusdeploy|opal|opsgenie|panos|tencentcloud|vultr|yandex)
       printf 'a\n'
@@ -446,38 +447,41 @@ write_provider_command_test_packages() {
 }
 
 check_provider_command_test_shards() {
-  local all_packages shard_a shard_b union duplicates
+  local all_packages shard_a shard_b shard_cmd union duplicates
 
   all_packages="$(mktemp "${TMPDIR:-/tmp}/terraformer-provider-command-test-all.XXXXXX")" || return
   shard_a="$(mktemp "${TMPDIR:-/tmp}/terraformer-provider-command-test-a.XXXXXX")" || return
   shard_b="$(mktemp "${TMPDIR:-/tmp}/terraformer-provider-command-test-b.XXXXXX")" || return
+  shard_cmd="$(mktemp "${TMPDIR:-/tmp}/terraformer-provider-command-test-cmd.XXXXXX")" || return
   union="$(mktemp "${TMPDIR:-/tmp}/terraformer-provider-command-test-union.XXXXXX")" || return
   duplicates="$(mktemp "${TMPDIR:-/tmp}/terraformer-provider-command-test-duplicates.XXXXXX")" || return
 
   write_provider_command_test_packages all "$all_packages"
   write_provider_command_test_packages a "$shard_a"
   write_provider_command_test_packages b "$shard_b"
+  write_provider_command_test_packages cmd "$shard_cmd"
 
-  cat "$shard_a" "$shard_b" | sort >"$union"
-  cat "$shard_a" "$shard_b" | sort | uniq -d >"$duplicates"
+  cat "$shard_a" "$shard_b" "$shard_cmd" | sort >"$union"
+  cat "$shard_a" "$shard_b" "$shard_cmd" | sort | uniq -d >"$duplicates"
 
   if [[ -s "$duplicates" ]]; then
     printf 'Duplicate provider/cmd test packages across shards:\n' >&2
     cat "$duplicates" >&2
-    rm -f "$all_packages" "$shard_a" "$shard_b" "$union" "$duplicates"
+    rm -f "$all_packages" "$shard_a" "$shard_b" "$shard_cmd" "$union" "$duplicates"
     return 1
   fi
 
   if ! diff -u "$all_packages" "$union"; then
-    rm -f "$all_packages" "$shard_a" "$shard_b" "$union" "$duplicates"
+    rm -f "$all_packages" "$shard_a" "$shard_b" "$shard_cmd" "$union" "$duplicates"
     return 1
   fi
 
-  printf 'Provider/cmd test shard coverage ok: all=%s shard_a=%s shard_b=%s.\n' \
+  printf 'Provider/cmd test shard coverage ok: all=%s shard_a=%s shard_b=%s shard_cmd=%s.\n' \
     "$(wc -l <"$all_packages" | tr -d ' ')" \
     "$(wc -l <"$shard_a" | tr -d ' ')" \
-    "$(wc -l <"$shard_b" | tr -d ' ')"
-  rm -f "$all_packages" "$shard_a" "$shard_b" "$union" "$duplicates"
+    "$(wc -l <"$shard_b" | tr -d ' ')" \
+    "$(wc -l <"$shard_cmd" | tr -d ' ')"
+  rm -f "$all_packages" "$shard_a" "$shard_b" "$shard_cmd" "$union" "$duplicates"
 }
 
 skip_pr_build_job_validation() {

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -77,7 +77,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        shard: [a, b]
+        shard: [a, b, cmd]
     runs-on: ubuntu-latest
     timeout-minutes: 45
     steps:

--- a/docs/ci-build-performance.md
+++ b/docs/ci-build-performance.md
@@ -7,7 +7,7 @@ This repository has a large Go dependency graph. CI performance changes should b
 The pull request `tests` workflow keeps dependency-sensitive validation split into visible shards:
 
 - `preflight build packages`: runs `go mod tidy`, lists non-fixture packages, and builds the selected package list.
-- `provider dependency tests`: runs provider and command package tests in deterministic shards.
+- `provider dependency tests`: runs provider packages and the command package in deterministic shards.
 - `provider dependency vet`: runs the same dependency-sensitive `go vet` command that the full preflight runs.
 - `provider dependency validation`: runs the remaining preflight checks, including utility tests, static diff, and Terraform compatibility.
 - `provider dependency preflight`: aggregates the shard results into one required status.
@@ -48,10 +48,11 @@ MODE=full ONLY_CHECK_PROVIDER_COMMAND_TEST_SHARDS=1 bash .github/scripts/provide
 
 The check validates that:
 
-- shard `a` and shard `b` are both non-empty
+- shard `a`, shard `b`, and shard `cmd` are non-empty
 - shard package lists do not overlap
 - the sorted union equals `go list ./providers/... ./cmd/...`
 
+Keep the `cmd` package in its own provider dependency test shard unless fresh timing shows another layout is faster. The command package compiles the command/provider graph and was the longest part of shard `a` after PR #624.
 Non-fixture build package selection must continue to use packages with non-test Go files and must keep fixture packages out of the build target set.
 The PR-only vet shard must keep using `vet_dependency_sensitive_packages` from `.github/scripts/provider-dependency-preflight.sh`; do not duplicate or narrow its package list in workflow YAML.
 The blocking govulncheck source scan follows the same non-fixture package boundary. The root CLI entrypoint and `cmd` package are scanned at package level because symbol-level analysis of those packages traverses the full command/provider graph and has been runner-canceled in CI.

--- a/go.sum
+++ b/go.sum
@@ -263,8 +263,8 @@ github.com/aws/aws-sdk-go-v2/service/bedrock v1.63.3 h1:4zoxLg/KlIk+MP7wEJFQ8zrY
 github.com/aws/aws-sdk-go-v2/service/bedrock v1.63.3/go.mod h1:63ve0/t5wlX+XJGhpUec4R2Ig9IsqDwZukYcDIvVYSI=
 github.com/aws/aws-sdk-go-v2/service/bedrockagent v1.54.5 h1:1VwqupN7wD85TLbr/xbCadNQvBT9jL1ZuAdbNfbsmxc=
 github.com/aws/aws-sdk-go-v2/service/bedrockagent v1.54.5/go.mod h1:gR7frvvW5Esh8rn0TeI3X5rAlFiM5tTaliCvak3hUeU=
-github.com/aws/aws-sdk-go-v2/service/budgets v1.44.3 h1:1Hj2HywvS6YribnQBRGGgdfAYPszKiUMTUMcHuho0Xw=
-github.com/aws/aws-sdk-go-v2/service/budgets v1.44.3/go.mod h1:ZGAw/lOxwwQhEFAv3/zc97qdvWjbreHRlj1wchVxyyw=
+github.com/aws/aws-sdk-go-v2/service/budgets v1.44.4 h1:tLpAAp7nz1R1Tw2ykZSz84/rkZFOWr3qAmNlohbG/Io=
+github.com/aws/aws-sdk-go-v2/service/budgets v1.44.4/go.mod h1:ZGAw/lOxwwQhEFAv3/zc97qdvWjbreHRlj1wchVxyyw=
 github.com/aws/aws-sdk-go-v2/service/chatbot v1.15.4 h1:culwm4aTxVpOeIxZhD3Y+j/5X/Fh9k+GzAkySzjEVN8=
 github.com/aws/aws-sdk-go-v2/service/chatbot v1.15.4/go.mod h1:8JvZUE1jyVSu47C+ioKDYAZvBn+4o5+SqIZkLaySOCE=
 github.com/aws/aws-sdk-go-v2/service/chimesdkvoice v1.28.19 h1:Mn3GhtQGaeyWl0jZPtocL4GTF6CxgbZfCswJFCTmg3I=
@@ -335,8 +335,8 @@ github.com/aws/aws-sdk-go-v2/service/elasticache v1.54.2 h1:8PgK/1gT2edn+kbzDji5
 github.com/aws/aws-sdk-go-v2/service/elasticache v1.54.2/go.mod h1:NPrGVBJ+OL1+w6POq+op7C51FQiw2YW6om3lGHI8K4Q=
 github.com/aws/aws-sdk-go-v2/service/elasticbeanstalk v1.35.3 h1:LCIQKvegz9CcBUWHv58BOqt6V4wBLmV1gp021vUXa98=
 github.com/aws/aws-sdk-go-v2/service/elasticbeanstalk v1.35.3/go.mod h1:ouidVmBE65C9U0VfH2+Kg6pEhmanZoaWTiarNuR5bVU=
-github.com/aws/aws-sdk-go-v2/service/elasticloadbalancing v1.34.3 h1:6VzJULpLj7w7GQVpHqMm2UuPXHgfo0Mg259qi970iO8=
-github.com/aws/aws-sdk-go-v2/service/elasticloadbalancing v1.34.3/go.mod h1:qQRGWMXDdy/rLGTzJWFlUM+GMs1KLSq/Uw8GnDLzIbo=
+github.com/aws/aws-sdk-go-v2/service/elasticloadbalancing v1.34.4 h1:KgHEX5K9FrrqNpznvmigWjvnAOSEfy0k+MSPz1C5yBY=
+github.com/aws/aws-sdk-go-v2/service/elasticloadbalancing v1.34.4/go.mod h1:qQRGWMXDdy/rLGTzJWFlUM+GMs1KLSq/Uw8GnDLzIbo=
 github.com/aws/aws-sdk-go-v2/service/elasticloadbalancingv2 v1.55.3 h1:4L++HaxpcF6Hch8tDnYftT607fkKWVuneL4wgCM+Vdk=
 github.com/aws/aws-sdk-go-v2/service/elasticloadbalancingv2 v1.55.3/go.mod h1:jDJ3tH8kX7jFEyJew+tB56SJuatSkpA7iPVn9O80rVQ=
 github.com/aws/aws-sdk-go-v2/service/elasticsearchservice v1.42.3 h1:hhgnuTF60zlFgGQfnTtE3yB4aKjQBjw19EYexHzCNEI=
@@ -411,8 +411,8 @@ github.com/aws/aws-sdk-go-v2/service/notifications v1.8.5 h1:QLvZ282mdUTKYPtln/u
 github.com/aws/aws-sdk-go-v2/service/notifications v1.8.5/go.mod h1:aewhjehOSC9tdKRKsJ83wcSZnKyhQDIsWMi74Fsu/6c=
 github.com/aws/aws-sdk-go-v2/service/notificationscontacts v1.6.5 h1:fLAq6r88jgNHXtYGCYXqlSbJzsrInViyeKXJ1u4MCZo=
 github.com/aws/aws-sdk-go-v2/service/notificationscontacts v1.6.5/go.mod h1:AaxThjoc3poIsMUk41S5219z9HO4tfg+VZZaEiR88DA=
-github.com/aws/aws-sdk-go-v2/service/opensearch v1.70.5 h1:W43usVZkCp/aYNDnJ8M0U4yhcVyWzlH2BAkSssliUsM=
-github.com/aws/aws-sdk-go-v2/service/opensearch v1.70.5/go.mod h1:fvtcPQCRRe0S/W0hqLNiKnjkURzynwv9dNXJcSaYeog=
+github.com/aws/aws-sdk-go-v2/service/opensearch v1.70.6 h1:WnwXHKQtIIlEM+GTeUcZ1xoXeR6uLNO82mhZdTiQcR8=
+github.com/aws/aws-sdk-go-v2/service/opensearch v1.70.6/go.mod h1:fvtcPQCRRe0S/W0hqLNiKnjkURzynwv9dNXJcSaYeog=
 github.com/aws/aws-sdk-go-v2/service/opensearchserverless v1.31.3 h1:8sAHyY60lbBqvXlSpfaeeXxA1ppqX3YT2/jS+3JW0Ok=
 github.com/aws/aws-sdk-go-v2/service/opensearchserverless v1.31.3/go.mod h1:L7ZhckNWXc3shXzkhLrRaOS5zpbNdVFFyAa1Z6/1R+w=
 github.com/aws/aws-sdk-go-v2/service/opsworks v1.31.0 h1:wTMEW5MX0+KDR2twK2UkdZ2AHItnab8/XFrM6bHYvtY=
@@ -421,8 +421,8 @@ github.com/aws/aws-sdk-go-v2/service/organizations v1.51.9 h1:/Yw+ioY/jT1fYyde+J
 github.com/aws/aws-sdk-go-v2/service/organizations v1.51.9/go.mod h1:5izq549KJUAudvAwchpU5Gt2ToeNDtJEd4cvE+d/Tx0=
 github.com/aws/aws-sdk-go-v2/service/pinpoint v1.40.2 h1:sMm0vLLG3zG4aic0AdJ/Zl4I3zAd5AtibcXtON7RqK8=
 github.com/aws/aws-sdk-go-v2/service/pinpoint v1.40.2/go.mod h1:BmVt7lkkpy+17WjbncDXKIGAfcKQKobLatJsZ3TiEws=
-github.com/aws/aws-sdk-go-v2/service/pinpointsmsvoicev2 v1.29.4 h1:A7xTWlS2Mq+/WIP4491W3f06QzMRkgC+13Esm5ZZ1YA=
-github.com/aws/aws-sdk-go-v2/service/pinpointsmsvoicev2 v1.29.4/go.mod h1:j5uSk+GQHL6eaVxEd4WsBZoZ/Zo6SE4YmW6Jcisayv0=
+github.com/aws/aws-sdk-go-v2/service/pinpointsmsvoicev2 v1.29.5 h1:SJgqdGuubpHxA1qyadPJbcM180UzJ/yyNSnLxIIC/VI=
+github.com/aws/aws-sdk-go-v2/service/pinpointsmsvoicev2 v1.29.5/go.mod h1:j5uSk+GQHL6eaVxEd4WsBZoZ/Zo6SE4YmW6Jcisayv0=
 github.com/aws/aws-sdk-go-v2/service/pipes v1.24.5 h1:zVrbhpCtXv5tdrMcD40KlrMIEB1Hqs7tt6Co506kJRc=
 github.com/aws/aws-sdk-go-v2/service/pipes v1.24.5/go.mod h1:AwfcKMXt62aZovyv4ZsKQnZMcQLfUE1ftVlMasCCeR8=
 github.com/aws/aws-sdk-go-v2/service/qldb v1.32.2 h1:tSctQisNHgXnDmyoOdLXkSQmHYo5yPQuvYK+4c4QiNI=
@@ -433,8 +433,8 @@ github.com/aws/aws-sdk-go-v2/service/rds v1.118.6 h1:PCHRNddrE/b1IKx5qdKX9dE0OyD
 github.com/aws/aws-sdk-go-v2/service/rds v1.118.6/go.mod h1:e65cVtBgKsndwx7fCvgWgss9xRbfhWN6DthRKDeu6dI=
 github.com/aws/aws-sdk-go-v2/service/redshift v1.63.2 h1:un+KXR9WhPksPcsppgOxvTfZAeoOgHPoKejnkkfp6kI=
 github.com/aws/aws-sdk-go-v2/service/redshift v1.63.2/go.mod h1:AyfjQy9wJhvaSOvzgmugQ2G5bzo7BAKLTf7d+9+yXB8=
-github.com/aws/aws-sdk-go-v2/service/redshiftserverless v1.35.5 h1:X24JxNZpOt1MAyLT5f0Q0aHHePax0vVa5aDWfrkQZnk=
-github.com/aws/aws-sdk-go-v2/service/redshiftserverless v1.35.5/go.mod h1:IAzrgzMZiDQuNDP4KzzVxl6BcRD/gMlkVAcfH2AJSl8=
+github.com/aws/aws-sdk-go-v2/service/redshiftserverless v1.35.6 h1:ESLqBFYAAqX5NsYlVZ6NiiBC65OW5VKaC2uP2lZa9Wk=
+github.com/aws/aws-sdk-go-v2/service/redshiftserverless v1.35.6/go.mod h1:IAzrgzMZiDQuNDP4KzzVxl6BcRD/gMlkVAcfH2AJSl8=
 github.com/aws/aws-sdk-go-v2/service/rekognition v1.52.2 h1:fupHwX9ofyOs2QFQNAC0UCnxCJJotzcB4Wo7HMKKmnY=
 github.com/aws/aws-sdk-go-v2/service/rekognition v1.52.2/go.mod h1:VtVKQ9l8Nhypimq/ACawQlWMm2EH1MtLtKSAlTsCfCM=
 github.com/aws/aws-sdk-go-v2/service/resourcegroups v1.33.30 h1:IKw+EowuF+y6hT+HwwBHlwA3hO4kv7G658YRoXPE4/s=
@@ -487,8 +487,8 @@ github.com/aws/aws-sdk-go-v2/service/transcribe v1.56.2 h1:rG7HOMoSUi9homqGj9haV
 github.com/aws/aws-sdk-go-v2/service/transcribe v1.56.2/go.mod h1:+/ZzFX+XKRrwCr4XVWg5CJa28CnMM6wTPDMOkDrr2P0=
 github.com/aws/aws-sdk-go-v2/service/vpclattice v1.21.4 h1:AH8/Lt0KyAz1l1S9Kq9tupSBF3RAVYgol64lr6eRC7g=
 github.com/aws/aws-sdk-go-v2/service/vpclattice v1.21.4/go.mod h1:fM7GmghMJv0BzdP425R+fpXPDNZpR7XXsHqCEx6N2kk=
-github.com/aws/aws-sdk-go-v2/service/waf v1.31.2 h1:nFYdUhTJmYs2x29Ofehzlko8fyTyZf9WrtLq6sPT19c=
-github.com/aws/aws-sdk-go-v2/service/waf v1.31.2/go.mod h1:SBjpDD7ivBiBYen/d8Mr6OKP3f5SCAO7d1Ph5QtivFI=
+github.com/aws/aws-sdk-go-v2/service/waf v1.31.3 h1:aCB59E+n3sQ419w8BU9w+jQJbxysu4a1LENOFLNuG8o=
+github.com/aws/aws-sdk-go-v2/service/waf v1.31.3/go.mod h1:SBjpDD7ivBiBYen/d8Mr6OKP3f5SCAO7d1Ph5QtivFI=
 github.com/aws/aws-sdk-go-v2/service/wafregional v1.30.27 h1:988x/sbWMSKdzL7diQJBoysySChCWjLr8nu1pqaj39A=
 github.com/aws/aws-sdk-go-v2/service/wafregional v1.30.27/go.mod h1:QwXeSdwMxH4zEcvBRuhjoS1ixd2ShfqU9YeQ0B9efDo=
 github.com/aws/aws-sdk-go-v2/service/wafv2 v1.72.3 h1:+kDjxyj48ZdOWEIaIzim8UXY4o10R1NmhyQoHnSmg2w=
@@ -497,8 +497,8 @@ github.com/aws/aws-sdk-go-v2/service/workspaces v1.68.5 h1:cm+4Gztlcy0l4E/y5UM+U
 github.com/aws/aws-sdk-go-v2/service/workspaces v1.68.5/go.mod h1:sjaakRCrmRRzVbqSat9xwnMwZ7TbFlqAwHLjJbnuFa0=
 github.com/aws/aws-sdk-go-v2/service/xray v1.37.2 h1:OCVitzEHo5l8N/6KQp/iIkloJgjWMReVLk7TZrNc4ck=
 github.com/aws/aws-sdk-go-v2/service/xray v1.37.2/go.mod h1:JzCwtlMhyVD+Ps3bkAB3wEgpA8FhF9ejZea4Kt1sZAI=
-github.com/aws/smithy-go v1.27.1 h1:4T340VFndXtADGF52gYa1POyL7s9E4Z1OeZ1hCscIw8=
-github.com/aws/smithy-go v1.27.1/go.mod h1:YE2RhdIuDbA5E5bTdciG9KrW3+TiEONeUWCqxX9i1Fc=
+github.com/aws/smithy-go v1.27.2 h1:y9NPmSE6am6LjEFPfqHqG/jJk7AauQvhCJONKh7kpzk=
+github.com/aws/smithy-go v1.27.2/go.mod h1:YE2RhdIuDbA5E5bTdciG9KrW3+TiEONeUWCqxX9i1Fc=
 github.com/aybabtme/iocontrol v0.0.0-20150809002002-ad15bcfc95a0 h1:0NmehRCgyk5rljDQLKUO+cRJCnduDyn11+zGZIc9Z48=
 github.com/aybabtme/iocontrol v0.0.0-20150809002002-ad15bcfc95a0/go.mod h1:6L7zgvqo0idzI7IO8de6ZC051AfXb5ipkIJ7bIA2tGA=
 github.com/beevik/etree v1.6.0 h1:u8Kwy8pp9D9XeITj2Z0XtA5qqZEmtJtuXZRQi+j03eE=


### PR DESCRIPTION
## Summary

Post-#624 timing did not support sharding PR core tests first. In the complete #624 PR run, test (ubuntu-latest) took 15m18s, but provider dependency tests shard a was the long pole at 16m54s.

This splits the command package out of provider dependency test shard a into its own deterministic cmd shard while preserving the existing provider/cmd shard coverage invariant.

## Evidence

Tests run 27432457059:
- provider dependency tests a: 16m54s, test phase 925s
- preflight build packages: 15m56s
- provider dependency validation: 15m56s
- test (ubuntu-latest): 15m18s
- provider dependency vet: 13m02s
- provider dependency tests b: 7m18s

The command package was in shard a. Moving it into its own shard should bring shard a closer to the next critical-path jobs and give the next run a clearer command-package timing signal.

## Changes

- Add PROVIDER_COMMAND_TEST_SHARD=cmd.
- Move cmd packages from shard a to the cmd shard.
- Extend the provider/cmd shard coverage check to prove a + b + cmd equals the original package list with no duplicates.
- Add cmd to the PR provider dependency test matrix.
- Document the cmd shard invariant in docs/ci-build-performance.md.
- Restore AWS go.sum entries selected by current go.mod; current main govulncheck was already failing on missing AWS sums.

## Validation

Passed locally:
- bash -n .github/scripts/provider-dependency-preflight.sh
- bash -n .github/scripts/pr-core-test.sh
- bash -n .github/scripts/release-prebuilt-assets.sh
- shellcheck .github/scripts/provider-dependency-preflight.sh .github/scripts/pr-core-test.sh .github/scripts/release-prebuilt-assets.sh
- actionlint .github/workflows/test.yml .github/workflows/govulncheck.yml
- MODE=full ONLY_CHECK_PROVIDER_COMMAND_TEST_SHARDS=1 bash .github/scripts/provider-dependency-preflight.sh
- go test ./build/...
- go build ./build/multi-build
- goreleaser check
- TERRAFORMER_BUILD_DRY_RUN=1 go run ./build/multi-build
- git diff --check

## Rollback

Revert this PR. Provider dependency tests return to the two-shard a/b layout with cmd back in shard a.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Split `cmd` package tests into a dedicated CI shard (`cmd`) to reduce the long pole and balance provider dependency test time. Also updates shard validation and workflow matrix, and restores missing AWS `go.sum` entries.

- **Refactors**
  - Add `PROVIDER_COMMAND_TEST_SHARD=cmd` and move `cmd` packages out of shard `a`.
  - Extend shard validation to cover `a` + `b` + `cmd` with no duplicates.
  - Run `cmd` in the provider dependency test matrix and document the invariant.

- **Dependencies**
  - Restore AWS sums in `go.sum` to match current `go.mod`.

<sup>Written for commit cefe0eb40eefdae975ec07b8d3a9b31803139f8b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/chenrui333/terraformer/pull/625?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Expanded test sharding configuration to introduce an additional shard, improving CI pipeline parallelization efficiency.
  * Updated testing infrastructure scripts and validation logic to accommodate the new shard structure and coverage requirements.
  * Enhanced CI build performance documentation with clearer details on sharding distribution and safety invariants.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->