### PR TITLE
ci: split Terraform provider compatibility validation

### DIFF
--- a/.github/scripts/provider-dependency-preflight.sh
+++ b/.github/scripts/provider-dependency-preflight.sh
@@ -496,6 +496,10 @@ skip_pr_vet_job_validation() {
   printf 'Skipping in this job; the PR provider vet job validates this phase.\n'
 }
 
+skip_pr_terraform_provider_compatibility_validation() {
+  printf 'Skipping in this job; the PR Terraform provider compatibility job validates this phase.\n'
+}
+
 run_build_package_validation() {
   time_phase "Go module tidy" "go mod tidy and go.mod/go.sum diff check" run_go_mod_tidy_check
   time_phase "Package listing" "go list non-fixture packages for build" list_build_packages
@@ -529,6 +533,10 @@ static_diff_check() {
   git diff --check
 }
 
+run_terraform_provider_compatibility_validation() {
+  time_phase "Terraform provider compatibility" "bash .github/scripts/terraform-provider-compat.sh if present" run_compat_script ".github/scripts/terraform-provider-compat.sh" "Terraform provider compatibility"
+}
+
 run_provider_validation() {
   time_phase "Environment diagnostics" "go version, go env, package counts, cache usage, filesystem space" environment_diagnostics
   if [[ "${SKIP_BUILD_NON_FIXTURE:-0}" == "1" ]]; then
@@ -551,7 +559,11 @@ run_provider_validation() {
   fi
   time_phase "Static diff check" "git diff --check" static_diff_check
   time_phase "Terraform state compatibility" "bash .github/scripts/terraform-state-compat.sh if present" run_compat_script ".github/scripts/terraform-state-compat.sh" "Terraform state compatibility"
-  time_phase "Terraform provider compatibility" "bash .github/scripts/terraform-provider-compat.sh if present" run_compat_script ".github/scripts/terraform-provider-compat.sh" "Terraform provider compatibility"
+  if [[ "${SKIP_TERRAFORM_PROVIDER_COMPATIBILITY:-0}" == "1" ]]; then
+    time_phase "Terraform provider compatibility" "validated by the PR Terraform provider compatibility job" skip_pr_terraform_provider_compatibility_validation
+  else
+    run_terraform_provider_compatibility_validation
+  fi
 }
 
 run_govulncheck_source_scan() {
@@ -673,6 +685,12 @@ fi
 if [[ "${ONLY_VET_DEPENDENCY_PACKAGES:-0}" == "1" ]]; then
   run_vet_validation
   section "Provider dependency preflight vet complete"
+  exit 0
+fi
+
+if [[ "${ONLY_TERRAFORM_PROVIDER_COMPATIBILITY:-0}" == "1" ]]; then
+  run_terraform_provider_compatibility_validation
+  section "Provider dependency preflight Terraform provider compatibility complete"
   exit 0
 fi
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -136,6 +136,34 @@ jobs:
         SKIP_BUILD_NON_FIXTURE: "1"
         SKIP_PROVIDER_COMMAND_TESTS: "1"
         SKIP_VET_DEPENDENCY_PACKAGES: "1"
+        SKIP_TERRAFORM_PROVIDER_COMPATIBILITY: "1"
+      run: bash .github/scripts/provider-dependency-preflight.sh
+
+  provider_dependency_terraform_provider_compatibility:
+    name: provider dependency Terraform provider compatibility
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    steps:
+    - name: Free runner disk space
+      if: runner.os == 'Linux'
+      run: |
+        sudo rm -rf /usr/share/dotnet /usr/local/lib/android /opt/ghc
+        df -h
+    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+      with:
+        fetch-depth: 0
+    - name: Install Go
+      uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c
+      with:
+        go-version-file: go.mod
+        cache: true
+        cache-dependency-path: go.sum
+    - name: Check Terraform provider compatibility
+      env:
+        MODE: quick
+        BASE_REF: ${{ github.event.pull_request.base.sha }}
+        ONLY_TERRAFORM_PROVIDER_COMPATIBILITY: "1"
       run: bash .github/scripts/provider-dependency-preflight.sh
 
   provider_dependency_vet:
@@ -172,6 +200,7 @@ jobs:
     - preflight_build
     - provider_dependency_tests
     - provider_dependency_validation
+    - provider_dependency_terraform_provider_compatibility
     - provider_dependency_vet
     runs-on: ubuntu-latest
     timeout-minutes: 5
@@ -181,13 +210,15 @@ jobs:
         BUILD_RESULT: ${{ needs.preflight_build.result }}
         PROVIDER_TEST_RESULT: ${{ needs.provider_dependency_tests.result }}
         VALIDATION_RESULT: ${{ needs.provider_dependency_validation.result }}
+        TERRAFORM_PROVIDER_COMPATIBILITY_RESULT: ${{ needs.provider_dependency_terraform_provider_compatibility.result }}
         VET_RESULT: ${{ needs.provider_dependency_vet.result }}
       run: |
         printf 'preflight build packages: %s\n' "$BUILD_RESULT"
         printf 'provider dependency tests: %s\n' "$PROVIDER_TEST_RESULT"
         printf 'provider dependency validation: %s\n' "$VALIDATION_RESULT"
+        printf 'provider dependency Terraform provider compatibility: %s\n' "$TERRAFORM_PROVIDER_COMPATIBILITY_RESULT"
         printf 'provider dependency vet: %s\n' "$VET_RESULT"
-        if [[ "$BUILD_RESULT" != "success" || "$PROVIDER_TEST_RESULT" != "success" || "$VALIDATION_RESULT" != "success" || "$VET_RESULT" != "success" ]]; then
+        if [[ "$BUILD_RESULT" != "success" || "$PROVIDER_TEST_RESULT" != "success" || "$VALIDATION_RESULT" != "success" || "$TERRAFORM_PROVIDER_COMPATIBILITY_RESULT" != "success" || "$VET_RESULT" != "success" ]]; then
           printf 'provider dependency preflight failed because one or more shards failed.\n' >&2
           exit 1
         fi

--- a/docs/ci-build-performance.md
+++ b/docs/ci-build-performance.md
@@ -9,7 +9,8 @@ The pull request `tests` workflow keeps dependency-sensitive validation split in
 - `preflight build packages`: runs `go mod tidy`, lists non-fixture packages, and builds the selected package list.
 - `provider dependency tests`: runs provider packages and the command package in deterministic shards.
 - `provider dependency vet`: runs the same dependency-sensitive `go vet` command that the full preflight runs.
-- `provider dependency validation`: runs the remaining preflight checks, including utility tests, static diff, and Terraform compatibility.
+- `provider dependency Terraform provider compatibility`: runs the provider registry compatibility test that exercises the command/provider graph.
+- `provider dependency validation`: runs the remaining preflight checks, including utility tests, static diff, and Terraform state compatibility.
 - `provider dependency preflight`: aggregates the shard results into one required status.
 - `test (ubuntu-latest)`: runs the regular PR core test path and package timing summary.
 
@@ -55,6 +56,7 @@ The check validates that:
 Keep the `cmd` package in its own provider dependency test shard unless fresh timing shows another layout is faster. The command package compiles the command/provider graph and was the longest part of shard `a` after PR #624.
 Non-fixture build package selection must continue to use packages with non-test Go files and must keep fixture packages out of the build target set.
 The PR-only vet shard must keep using `vet_dependency_sensitive_packages` from `.github/scripts/provider-dependency-preflight.sh`; do not duplicate or narrow its package list in workflow YAML.
+The Terraform provider compatibility shard must keep using `.github/scripts/terraform-provider-compat.sh` through `.github/scripts/provider-dependency-preflight.sh`. Keep it as a PR-only shard unless new timing shows it is no longer material; push, scheduled, and workflow-dispatch runs should continue using the full preflight path.
 The blocking govulncheck source scan follows the same non-fixture package boundary. The root CLI entrypoint and `cmd` package are scanned at package level because symbol-level analysis of those packages traverses the full command/provider graph and has been runner-canceled in CI.
 
 ## Change Guidelines


### PR DESCRIPTION
## Summary

Splits Terraform provider compatibility out of the remaining provider dependency validation shard into its own PR-only shard.

Post-#625 run `27438330695` showed `provider dependency validation` as the longest required job at 958s, with `Terraform provider compatibility` taking 791s inside it. Moving that independent phase into its own required shard should shift the critical path to the existing near-tie group around 913-914s (`provider dependency tests (cmd)` and `preflight build packages`).

## Changes

- Add `ONLY_TERRAFORM_PROVIDER_COMPATIBILITY` and `SKIP_TERRAFORM_PROVIDER_COMPATIBILITY` to the provider preflight script.
- Add PR-only `provider dependency Terraform provider compatibility` to `tests`.
- Keep push, scheduled, and workflow-dispatch full preflight behavior unchanged.
- Update the CI performance notes with the new shard invariant.

## Evidence

- Post-#625 workflow-shape run inspected: `27438330695`
- Newer post-merge PR run inspected while in progress: `27439761737`
- Selected lane: split remaining provider dependency validation
- Expected impact: roughly 45-60s off dependency-sensitive PR critical path, subject to setup/cache variance

## Validation

- `bash -n .github/scripts/provider-dependency-preflight.sh`
- `shellcheck .github/scripts/provider-dependency-preflight.sh`
- `bash -n .github/scripts/pr-core-test.sh`
- `shellcheck .github/scripts/pr-core-test.sh`
- `bash -n .github/scripts/release-prebuilt-assets.sh`
- `shellcheck .github/scripts/release-prebuilt-assets.sh`
- `actionlint .github/workflows/test.yml .github/workflows/govulncheck.yml`
- `go test ./build/...`
- `go build ./build/multi-build`
- `goreleaser check`
- `TERRAFORMER_BUILD_DRY_RUN=1 go run ./build/multi-build`
- `git diff --check`

## Rollback

Revert this PR. The full preflight path remains intact; rollback only removes the PR-only compatibility shard and its skip flag.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Splits the Terraform provider compatibility check into its own PR-only CI shard to shorten the dependency-sensitive critical path. Push, scheduled, and manual runs keep the full preflight path unchanged.

- **Performance**
  - Expected ~45–60s reduction on PR critical path.

- **Refactors**
  - Added `ONLY_TERRAFORM_PROVIDER_COMPATIBILITY` and `SKIP_TERRAFORM_PROVIDER_COMPATIBILITY` to `provider-dependency-preflight.sh`.
  - Introduced `provider dependency Terraform provider compatibility` PR-only job in `tests` and made the aggregator require it.
  - Kept `provider dependency validation` but skip the compatibility phase there when the dedicated shard runs.
  - Updated `docs/ci-build-performance.md` to document the new shard and invariants.

<sup>Written for commit 3ba005e1a6e460676f1d6fb55abdf1e5c91965d7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/chenrui333/terraformer/pull/627?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

