### PR TITLE
fix(okta): migrate provider to okta sdk v6

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -404,7 +404,6 @@ require (
 	github.com/felixge/httpsnoop v1.0.4 // indirect
 	github.com/fxamacker/cbor/v2 v2.9.1 // indirect
 	github.com/gabriel-vasile/mimetype v1.4.13 // indirect
-	github.com/go-jose/go-jose/v3 v3.0.5 // indirect
 	github.com/go-jose/go-jose/v4 v4.1.4 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect
 	github.com/go-openapi/jsonpointer v0.23.1 // indirect
@@ -554,7 +553,6 @@ require (
 	github.com/linode/linodego/v2 v2.1.0
 	github.com/logzio/logzio_terraform_client v1.30.2
 	github.com/newrelic/newrelic-client-go/v2 v2.86.1
-	github.com/okta/okta-sdk-golang/v2 v2.20.0
 	github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/as v1.3.88
 	github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/cbs v1.3.102
 	github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/cdb v1.3.109

--- a/go.sum
+++ b/go.sum
@@ -636,8 +636,6 @@ github.com/go-errors/errors v1.5.1/go.mod h1:sIVyrIiJhuEF+Pj9Ebtd6P/rEYROXFi3Bop
 github.com/go-gl/glfw v0.0.0-20190409004039-e6da0acd62b1/go.mod h1:vR7hzQXu2zJy9AVAgeJqvqgH9Q5CA+iKCZ2gyEVpxRU=
 github.com/go-gorp/gorp/v3 v3.1.0 h1:ItKF/Vbuj31dmV4jxA1qblpSwkl9g1typ24xoe70IGs=
 github.com/go-gorp/gorp/v3 v3.1.0/go.mod h1:dLEjIyyRNiXvNZ8PSmzpt1GsWAUK8kjVhEpjH8TixEw=
-github.com/go-jose/go-jose/v3 v3.0.5 h1:BLLJWbC4nMZOfuPVxoZIxeYsn6Nl2r1fITaJ78UQlVQ=
-github.com/go-jose/go-jose/v3 v3.0.5/go.mod h1:5b+7YgP7ZICgJDBdfjZaIt+H/9L9T/YQrVfLAMboGkQ=
 github.com/go-jose/go-jose/v4 v4.1.4 h1:moDMcTHmvE6Groj34emNPLs/qtYXRVcd6S7NHbHz3kA=
 github.com/go-jose/go-jose/v4 v4.1.4/go.mod h1:x4oUasVrzR7071A4TnHLGSPpNOm2a21K9Kf04k1rs08=
 github.com/go-logr/logr v1.2.2/go.mod h1:jdQByPbusPIv2/zmleS9BjJVeZ6kBagPoEUsqbVz/1A=
@@ -786,7 +784,6 @@ github.com/google/go-cmp v0.5.2/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/
 github.com/google/go-cmp v0.5.4/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.6/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
-github.com/google/go-cmp v0.5.9/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
 github.com/google/go-cmp v0.6.0/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
 github.com/google/go-cmp v0.7.0 h1:wk8382ETsv4JYUZwIsn6YpYiWiBsYLSJiTsyBybVuN8=
 github.com/google/go-cmp v0.7.0/go.mod h1:pXiqmnSA92OHEEa9HXL2W4E7lf9JzCmGVUdgjX3N/iU=
@@ -1114,8 +1111,6 @@ github.com/oklog/run v1.2.0/go.mod h1:mgDbKRSwPhJfesJ4PntqFUbKQRZ50NgmZTSPlFA0YF
 github.com/oklog/ulid v1.3.1/go.mod h1:CirwcVhetQ6Lv90oh/F+FBtV6XMibvdAFo93nm5qn4U=
 github.com/oklog/ulid/v2 v2.1.1 h1:suPZ4ARWLOJLegGFiZZ1dFAkqzhMjL3J1TzI+5wHz8s=
 github.com/oklog/ulid/v2 v2.1.1/go.mod h1:rcEKHmBBKfef9DhnvX7y1HZBYxjXb0cP5ExxNsTT1QQ=
-github.com/okta/okta-sdk-golang/v2 v2.20.0 h1:EDKM+uOPfihOMNwgHMdno+NAsIfyXkVnoFAYVPay0YU=
-github.com/okta/okta-sdk-golang/v2 v2.20.0/go.mod h1:FMy5hN5G8Rd/VoS0XrfyPPhIfOVo78ZK7lvwiQRS2+U=
 github.com/okta/okta-sdk-golang/v6 v6.1.6 h1:bObKXhkFh1c1tCfjcYoRoTjDJeIPMsEZHrjLasawEpk=
 github.com/okta/okta-sdk-golang/v6 v6.1.6/go.mod h1:hLXAo1HqjsWlMdbop9yLVJ9MWIek9qRsNbkhZQAiXsw=
 github.com/okta/terraform-provider-okta v0.0.0-20260507050055-d8f2f8783a1a h1:GXnol8q65WjOEjULecLEETK4jxcMquuMyv/i0rZjC4g=
@@ -1468,7 +1463,6 @@ golang.org/x/crypto v0.0.0-20201002170205-7f63de1d35b0/go.mod h1:LzIPMQfyMNhhGPh
 golang.org/x/crypto v0.0.0-20201016220609-9e8e0b390897/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/crypto v0.0.0-20210921155107-089bfa567519/go.mod h1:GvvjBRRGRdwPK5ydBHafDWAxML/pGHZbMvKqRZ5+Abc=
 golang.org/x/crypto v0.6.0/go.mod h1:OFC/31mSvZgRz0V1QTNCzfAI1aIRzbiufJtkMIlEp58=
-golang.org/x/crypto v0.19.0/go.mod h1:Iy9bg/ha4yyC70EfRS8jz+B6ybOBKMaSxLj6P6oBDfU=
 golang.org/x/crypto v0.52.0 h1:RMs7fP2rXdep0CftQlK8Uf+kibLm7qkCcradZWYz988=
 golang.org/x/crypto v0.52.0/go.mod h1:1QgfPxDqh0T2M/elOJtp9RvuR95kVjir0e6/BvEmGbc=
 golang.org/x/exp v0.0.0-20180321215751-8460e604b9de/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
@@ -1487,7 +1481,6 @@ golang.org/x/mod v0.0.0-20190513183733-4bf6d317e70e/go.mod h1:mXi4GBBbnImb6dmsKG
 golang.org/x/mod v0.1.0/go.mod h1:0QHyrYULN0/3qlju5TqG8bIK38QM8yzMo5ekMj3DlcY=
 golang.org/x/mod v0.3.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
 golang.org/x/mod v0.6.0-dev.0.20220419223038-86c51ed26bb4/go.mod h1:jJ57K6gSWd91VN4djpZkiMVwK6gcyfeH4XE8wZrZaV4=
-golang.org/x/mod v0.8.0/go.mod h1:iBbtSCu2XBx23ZKBPSOrRkjjQPZFPuis4dIYUhu/chs=
 golang.org/x/mod v0.35.0 h1:Ww1D637e6Pg+Zb2KrWfHQUnH2dQRLBQyAtpr/haaJeM=
 golang.org/x/mod v0.35.0/go.mod h1:+GwiRhIInF8wPm+4AoT6L0FA1QWAad3OMdTRx4tFYlU=
 golang.org/x/net v0.0.0-20180906233101-161cd47e91fd/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
@@ -1508,7 +1501,6 @@ golang.org/x/net v0.0.0-20210610132358-84b48f89b13b/go.mod h1:9nx3DQGgdP8bBQD5qx
 golang.org/x/net v0.0.0-20220722155237-a158d28d115b/go.mod h1:XRhObCWvk6IyKnWLug+ECip1KBveYUHfp+8e9klMJ9c=
 golang.org/x/net v0.6.0/go.mod h1:2Tu9+aMcznHK/AK1HMvgo6xiTLG5rD5rZLDS+rp2Bjs=
 golang.org/x/net v0.7.0/go.mod h1:2Tu9+aMcznHK/AK1HMvgo6xiTLG5rD5rZLDS+rp2Bjs=
-golang.org/x/net v0.10.0/go.mod h1:0qNGK6F8kojg2nk9dLZ2mShWaEBan6FAoqfSigmmuDg=
 golang.org/x/net v0.55.0 h1:bcvxaJn3e1U6InsFWt1JUq1aSjnRxLzT2rtD2KfkDF8=
 golang.org/x/net v0.55.0/go.mod h1:L5U2KuzuOe1lY7Z+aWVIKK6qEeJXnXV9yzGA+WCHJww=
 golang.org/x/oauth2 v0.36.0 h1:peZ/1z27fi9hUOFCAZaHyrpWG5lwe0RJEEEeH0ThlIs=
@@ -1520,7 +1512,6 @@ golang.org/x/sync v0.0.0-20190423024810-112230192c58/go.mod h1:RxMgew5VJxzue5/jJ
 golang.org/x/sync v0.0.0-20190911185100-cd5d95a43a6e/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20201020160332-67f06af15bc9/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20220722155255-886fb9371eb4/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
-golang.org/x/sync v0.1.0/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.20.0 h1:e0PTpb7pjO8GAtTs2dQ6jYa5BWYlMuX047Dco/pItO4=
 golang.org/x/sync v0.20.0/go.mod h1:9xrNwdLfx4jkKbNva9FpL6vEN7evnE43NNNJQ2LF3+0=
 golang.org/x/sys v0.0.0-20180905080454-ebe1bf3edb33/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
@@ -1553,15 +1544,11 @@ golang.org/x/sys v0.0.0-20220520151302-bc2c85ada10a/go.mod h1:oPkhp1MJrh7nUepCBc
 golang.org/x/sys v0.0.0-20220722155257-8c9f86f7a55f/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.1.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.5.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
-golang.org/x/sys v0.8.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
-golang.org/x/sys v0.17.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
 golang.org/x/sys v0.45.0 h1:dO4czNzziLiiXplLQgBCEpCvXQ3dnkn0SdaZSYdQ+FY=
 golang.org/x/sys v0.45.0/go.mod h1:4GL1E5IUh+htKOUEOaiffhrAeqysfVGipDYzABqnCmw=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
 golang.org/x/term v0.0.0-20210927222741-03fcf44c2211/go.mod h1:jbD1KX2456YbFQfuXm/mYQcufACuNUgVhRMnK/tPxf8=
 golang.org/x/term v0.5.0/go.mod h1:jMB1sMXY+tzblOD4FWmEbocvup2/aLOaQEp7JmGp78k=
-golang.org/x/term v0.8.0/go.mod h1:xPskH00ivmX89bAKVGSKKtLOWNx2+17Eiy94tnKShWo=
-golang.org/x/term v0.17.0/go.mod h1:lLRBjIVuehSbZlaOtGMbcMncT+aqLLLmKrsjNrUguwk=
 golang.org/x/term v0.43.0 h1:S4RLU2sB31O/NCl+zFN9Aru9A/Cq2aqKpTZJ6B+DwT4=
 golang.org/x/term v0.43.0/go.mod h1:lrhlHNdQJHO+1qVYiHfFKVuVioJIheAc3fBSMFYEIsk=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
@@ -1572,8 +1559,6 @@ golang.org/x/text v0.3.6/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
 golang.org/x/text v0.3.7/go.mod h1:u+2+/6zg+i71rQMx5EYifcz6MCKuco9NR6JIITiCfzQ=
 golang.org/x/text v0.3.8/go.mod h1:E6s5w1FMmriuDzIBO73fBruAKo1PCIq6d2Q6DHfQ8WQ=
 golang.org/x/text v0.7.0/go.mod h1:mrYo+phRRbMaCq/xk9113O4dZlRixOauAjOtrjsXDZ8=
-golang.org/x/text v0.9.0/go.mod h1:e1OnstbJyHTd6l/uOt8jFFHp6TRDWZR/bV3emEE/zU8=
-golang.org/x/text v0.14.0/go.mod h1:18ZOQIKpY8NJVqYksKHtTdi31H5itFRjB5/qKTNYzSU=
 golang.org/x/text v0.37.0 h1:Cqjiwd9eSg8e0QAkyCaQTNHFIIzWtidPahFWR83rTrc=
 golang.org/x/text v0.37.0/go.mod h1:a5sjxXGs9hsn/AJVwuElvCAo9v8QYLzvavO5z2PiM38=
 golang.org/x/time v0.15.0 h1:bbrp8t3bGUeFOx08pvsMYRTCVSMk89u4tKbNOZbp88U=
@@ -1595,7 +1580,6 @@ golang.org/x/tools v0.0.0-20191029190741-b9c20aec41a5/go.mod h1:b+2E5dAYhXwXZwtn
 golang.org/x/tools v0.0.0-20191119224855-298f0cb1881e/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
 golang.org/x/tools v0.0.0-20201224043029-2b0845dc783e/go.mod h1:emZCQorbCU4vsT4fOWvOPXz4eW1wZW4PmDk9uLelYpA=
 golang.org/x/tools v0.1.12/go.mod h1:hNGJHUnrk76NpqgfD5Aqm5Crs+Hm0VOH/i9J2+nxYbc=
-golang.org/x/tools v0.6.0/go.mod h1:Xwgl3UAJ/d3gWutnCtw505GrjyAbvKui8lOU390QaIU=
 golang.org/x/tools v0.44.0 h1:UP4ajHPIcuMjT1GqzDWRlalUEoY+uzoZKnhOjbIPD2c=
 golang.org/x/tools v0.44.0/go.mod h1:KA0AfVErSdxRZIsOVipbv3rQhVXTnlU6UhKxHd1seDI=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=

--- a/providers/okta/app.go
+++ b/providers/okta/app.go
@@ -5,58 +5,148 @@ package okta
 import (
 	"context"
 
-	"github.com/okta/okta-sdk-golang/v2/okta"
+	"github.com/okta/okta-sdk-golang/v6/okta"
 )
 
-// NOTE: Okta SDK v2.6.1 ListApplications() method does not support applications by type at this time. So
+// NOTE: The Okta SDK ListApplications() method does not support applications by type at this time. So
 //
 //	we have to create the application filter by our self.
-func getApplications(ctx context.Context, client *okta.Client, signOnMode string) ([]*okta.Application, error) {
+type oktaApplicationSummary struct {
+	ID         string
+	Name       string
+	Label      string
+	SignOnMode string
+}
+
+func getApplications(ctx context.Context, client *okta.APIClient, signOnMode string) ([]okta.ListApplications200ResponseInner, error) {
 	supportedApps, err := getAllApplications(ctx, client)
 	if err != nil {
 		return nil, err
 	}
 
-	var filterApps []*okta.Application
+	var filterApps []okta.ListApplications200ResponseInner
 	for _, app := range supportedApps {
-		if app.SignOnMode == signOnMode {
+		summary, ok := getApplicationSummary(app)
+		if ok && summary.SignOnMode == signOnMode {
 			filterApps = append(filterApps, app)
 		}
 	}
 	return filterApps, nil
 }
 
-func getAllApplications(ctx context.Context, client *okta.Client) ([]*okta.Application, error) {
-	var apps []*okta.Application
-	data, resp, err := client.Application.ListApplications(ctx, nil)
+func getAllApplications(ctx context.Context, client *okta.APIClient) ([]okta.ListApplications200ResponseInner, error) {
+	apps, resp, err := client.ApplicationAPI.ListApplications(ctx).Execute()
 	if err != nil {
 		return nil, err
 	}
 
 	for resp.HasNextPage() {
-		var nextAppSet []*okta.Application
-		resp, err = resp.Next(ctx, &nextAppSet)
+		var nextAppSet []okta.ListApplications200ResponseInner
+		resp, err = resp.Next(&nextAppSet)
 		if err != nil {
 			return nil, err
 		}
 		apps = append(apps, nextAppSet...)
 	}
-	for _, a := range data {
-		apps = append(apps, a.(*okta.Application))
-	}
 
-	var supportedApps []*okta.Application
+	var supportedApps []okta.ListApplications200ResponseInner
 	for _, app := range apps {
+		summary, ok := getApplicationSummary(app)
+		if !ok {
+			continue
+		}
 		//NOTE: Okta provider does not support the following app type/name
-		if app.Name == "template_wsfed" ||
-			app.Name == "template_swa_two_page" ||
-			app.Name == "okta_enduser" ||
-			app.Name == "okta_browser_plugin" ||
-			app.Name == "saasure" {
+		if summary.Name == "template_wsfed" ||
+			summary.Name == "template_swa_two_page" ||
+			summary.Name == "okta_enduser" ||
+			summary.Name == "okta_browser_plugin" ||
+			summary.Name == "saasure" {
 			continue
 		}
 		supportedApps = append(supportedApps, app)
 	}
 
 	return supportedApps, nil
+}
+
+func getApplicationSummary(app okta.ListApplications200ResponseInner) (oktaApplicationSummary, bool) {
+	switch {
+	case app.AutoLoginApplication != nil:
+		return applicationSummaryFromFields(
+			app.AutoLoginApplication.GetId(),
+			app.AutoLoginApplication.GetName(),
+			app.AutoLoginApplication.GetLabel(),
+			app.AutoLoginApplication.GetSignOnMode(),
+		)
+	case app.BasicAuthApplication != nil:
+		return applicationSummaryFromFields(
+			app.BasicAuthApplication.GetId(),
+			app.BasicAuthApplication.GetName(),
+			app.BasicAuthApplication.GetLabel(),
+			app.BasicAuthApplication.GetSignOnMode(),
+		)
+	case app.BookmarkApplication != nil:
+		return applicationSummaryFromFields(
+			app.BookmarkApplication.GetId(),
+			app.BookmarkApplication.GetName(),
+			app.BookmarkApplication.GetLabel(),
+			app.BookmarkApplication.GetSignOnMode(),
+		)
+	case app.BrowserPluginApplication != nil:
+		return applicationSummaryFromFields(
+			app.BrowserPluginApplication.GetId(),
+			app.BrowserPluginApplication.GetName(),
+			app.BrowserPluginApplication.GetLabel(),
+			app.BrowserPluginApplication.GetSignOnMode(),
+		)
+	case app.OpenIdConnectApplication != nil:
+		return applicationSummaryFromFields(
+			app.OpenIdConnectApplication.GetId(),
+			app.OpenIdConnectApplication.GetName(),
+			app.OpenIdConnectApplication.GetLabel(),
+			app.OpenIdConnectApplication.GetSignOnMode(),
+		)
+	case app.Saml11Application != nil:
+		return applicationSummaryFromFields(
+			app.Saml11Application.GetId(),
+			app.Saml11Application.GetName(),
+			app.Saml11Application.GetLabel(),
+			app.Saml11Application.GetSignOnMode(),
+		)
+	case app.SamlApplication != nil:
+		return applicationSummaryFromFields(
+			app.SamlApplication.GetId(),
+			app.SamlApplication.GetName(),
+			app.SamlApplication.GetLabel(),
+			app.SamlApplication.GetSignOnMode(),
+		)
+	case app.SecurePasswordStoreApplication != nil:
+		return applicationSummaryFromFields(
+			app.SecurePasswordStoreApplication.GetId(),
+			app.SecurePasswordStoreApplication.GetName(),
+			app.SecurePasswordStoreApplication.GetLabel(),
+			app.SecurePasswordStoreApplication.GetSignOnMode(),
+		)
+	case app.WsFederationApplication != nil:
+		return applicationSummaryFromFields(
+			app.WsFederationApplication.GetId(),
+			app.WsFederationApplication.GetName(),
+			app.WsFederationApplication.GetLabel(),
+			app.WsFederationApplication.GetSignOnMode(),
+		)
+	default:
+		return oktaApplicationSummary{}, false
+	}
+}
+
+func applicationSummaryFromFields(id, name, label, signOnMode string) (oktaApplicationSummary, bool) {
+	if id == "" {
+		return oktaApplicationSummary{}, false
+	}
+	return oktaApplicationSummary{
+		ID:         id,
+		Name:       name,
+		Label:      label,
+		SignOnMode: signOnMode,
+	}, true
 }

--- a/providers/okta/app_auto_login.go
+++ b/providers/okta/app_auto_login.go
@@ -6,19 +6,23 @@ import (
 	"context"
 
 	"github.com/chenrui333/terraformer/terraformutils"
-	"github.com/okta/okta-sdk-golang/v2/okta"
+	"github.com/okta/okta-sdk-golang/v6/okta"
 )
 
 type AppAutoLoginGenerator struct {
 	OktaService
 }
 
-func (g AppAutoLoginGenerator) createResources(appList []*okta.Application) []terraformutils.Resource {
+func (g AppAutoLoginGenerator) createResources(appList []okta.ListApplications200ResponseInner) []terraformutils.Resource {
 	var resources []terraformutils.Resource
 	for _, app := range appList {
+		summary, ok := getApplicationSummary(app)
+		if !ok {
+			continue
+		}
 		resources = append(resources, terraformutils.NewSimpleResource(
-			app.Id,
-			normalizeResourceName(app.Id+"_"+app.Name),
+			summary.ID,
+			normalizeResourceName(summary.ID+"_"+summary.Name),
 			"okta_app_auto_login",
 			"okta",
 			[]string{}))
@@ -41,7 +45,7 @@ func (g *AppAutoLoginGenerator) InitResources() error {
 	return nil
 }
 
-func getAutoLoginApplications(ctx context.Context, client *okta.Client) ([]*okta.Application, error) {
+func getAutoLoginApplications(ctx context.Context, client *okta.APIClient) ([]okta.ListApplications200ResponseInner, error) {
 	signOnMode := "AUTO_LOGIN"
 	apps, err := getApplications(ctx, client, signOnMode)
 	if err != nil {

--- a/providers/okta/app_basic_auth.go
+++ b/providers/okta/app_basic_auth.go
@@ -6,19 +6,23 @@ import (
 	"context"
 
 	"github.com/chenrui333/terraformer/terraformutils"
-	"github.com/okta/okta-sdk-golang/v2/okta"
+	"github.com/okta/okta-sdk-golang/v6/okta"
 )
 
 type AppBasicAuthGenerator struct {
 	OktaService
 }
 
-func (g AppBasicAuthGenerator) createResources(appList []*okta.Application) []terraformutils.Resource {
+func (g AppBasicAuthGenerator) createResources(appList []okta.ListApplications200ResponseInner) []terraformutils.Resource {
 	var resources []terraformutils.Resource
 	for _, app := range appList {
+		summary, ok := getApplicationSummary(app)
+		if !ok {
+			continue
+		}
 		resources = append(resources, terraformutils.NewSimpleResource(
-			app.Id,
-			normalizeResourceName(app.Id+"_"+app.Name),
+			summary.ID,
+			normalizeResourceName(summary.ID+"_"+summary.Name),
 			"okta_app_basic_auth",
 			"okta",
 			[]string{}))
@@ -41,7 +45,7 @@ func (g *AppBasicAuthGenerator) InitResources() error {
 	return nil
 }
 
-func getBasicAuthApplications(ctx context.Context, client *okta.Client) ([]*okta.Application, error) {
+func getBasicAuthApplications(ctx context.Context, client *okta.APIClient) ([]okta.ListApplications200ResponseInner, error) {
 	signOnMode := "BASIC_AUTH"
 	apps, err := getApplications(ctx, client, signOnMode)
 	if err != nil {

--- a/providers/okta/app_secure_password_store.go
+++ b/providers/okta/app_secure_password_store.go
@@ -6,19 +6,23 @@ import (
 	"context"
 
 	"github.com/chenrui333/terraformer/terraformutils"
-	"github.com/okta/okta-sdk-golang/v2/okta"
+	"github.com/okta/okta-sdk-golang/v6/okta"
 )
 
 type AppSecurePasswordStoreGenerator struct {
 	OktaService
 }
 
-func (g AppSecurePasswordStoreGenerator) createResources(appList []*okta.Application) []terraformutils.Resource {
+func (g AppSecurePasswordStoreGenerator) createResources(appList []okta.ListApplications200ResponseInner) []terraformutils.Resource {
 	var resources []terraformutils.Resource
 	for _, app := range appList {
+		summary, ok := getApplicationSummary(app)
+		if !ok {
+			continue
+		}
 		resources = append(resources, terraformutils.NewSimpleResource(
-			app.Id,
-			normalizeResourceName(app.Id+"_"+app.Name),
+			summary.ID,
+			normalizeResourceName(summary.ID+"_"+summary.Name),
 			"okta_app_secure_password_store",
 			"okta",
 			[]string{}))
@@ -41,7 +45,7 @@ func (g *AppSecurePasswordStoreGenerator) InitResources() error {
 	return nil
 }
 
-func getSecurePasswordStoreApplications(ctx context.Context, client *okta.Client) ([]*okta.Application, error) {
+func getSecurePasswordStoreApplications(ctx context.Context, client *okta.APIClient) ([]okta.ListApplications200ResponseInner, error) {
 	signOnMode := "SECURE_PASSWORD_STORE"
 	apps, err := getApplications(ctx, client, signOnMode)
 	if err != nil {

--- a/providers/okta/app_three_field.go
+++ b/providers/okta/app_three_field.go
@@ -6,19 +6,23 @@ import (
 	"context"
 
 	"github.com/chenrui333/terraformer/terraformutils"
-	"github.com/okta/okta-sdk-golang/v2/okta"
+	"github.com/okta/okta-sdk-golang/v6/okta"
 )
 
 type AppThreeFieldGenerator struct {
 	OktaService
 }
 
-func (g AppThreeFieldGenerator) createResources(appList []*okta.Application) []terraformutils.Resource {
+func (g AppThreeFieldGenerator) createResources(appList []okta.ListApplications200ResponseInner) []terraformutils.Resource {
 	var resources []terraformutils.Resource
 	for _, app := range appList {
+		summary, ok := getApplicationSummary(app)
+		if !ok {
+			continue
+		}
 		resources = append(resources, terraformutils.NewSimpleResource(
-			app.Id,
-			normalizeResourceName(app.Id+"_"+app.Name),
+			summary.ID,
+			normalizeResourceName(summary.ID+"_"+summary.Name),
 			"okta_app_three_field",
 			"okta",
 			[]string{}))
@@ -41,16 +45,17 @@ func (g *AppThreeFieldGenerator) InitResources() error {
 	return nil
 }
 
-func getThreeFieldApplications(ctx context.Context, client *okta.Client) ([]*okta.Application, error) {
+func getThreeFieldApplications(ctx context.Context, client *okta.APIClient) ([]okta.ListApplications200ResponseInner, error) {
 	signOnMode := "BROWSER_PLUGIN"
 	apps, err := getApplications(ctx, client, signOnMode)
 	if err != nil {
 		return nil, err
 	}
 
-	threeFieldApps := []*okta.Application{}
+	var threeFieldApps []okta.ListApplications200ResponseInner
 	for _, app := range apps {
-		if app.Name == "template_swa3field" {
+		summary, ok := getApplicationSummary(app)
+		if ok && summary.Name == "template_swa3field" {
 			threeFieldApps = append(threeFieldApps, app)
 		}
 	}

--- a/providers/okta/app_user_schema.go
+++ b/providers/okta/app_user_schema.go
@@ -72,10 +72,7 @@ func (g *AppUserSchemaPropertyGenerator) InitResources() error {
 	}
 
 	for _, app := range apps {
-		appSummary, ok := getApplicationSummary(app)
-		if !ok {
-			continue
-		}
+		appSummary, _ := getApplicationSummary(app)
 		appUserSchema, _, err := client.SchemaAPI.GetApplicationUserSchema(ctx, appSummary.ID).Execute()
 		if err != nil {
 			return err

--- a/providers/okta/app_user_schema.go
+++ b/providers/okta/app_user_schema.go
@@ -3,8 +3,10 @@
 package okta
 
 import (
+	"sort"
+
 	"github.com/chenrui333/terraformer/terraformutils"
-	"github.com/okta/okta-sdk-golang/v2/okta"
+	"github.com/okta/okta-sdk-golang/v6/okta"
 )
 
 type AppUserSchemaPropertyGenerator struct {
@@ -13,7 +15,15 @@ type AppUserSchemaPropertyGenerator struct {
 
 func (g AppUserSchemaPropertyGenerator) createResources(appUserSchema *okta.UserSchema, appID string) []terraformutils.Resource {
 	var resources []terraformutils.Resource
-	for index := range appUserSchema.Definitions.Custom.Properties {
+	definitions := appUserSchema.GetDefinitions()
+	var customPropertyNames []string
+	if custom, ok := definitions.GetCustomOk(); ok {
+		for index := range custom.GetProperties() {
+			customPropertyNames = append(customPropertyNames, index)
+		}
+	}
+	sort.Strings(customPropertyNames)
+	for _, index := range customPropertyNames {
 		resources = append(resources, terraformutils.NewResource(
 			index,
 			normalizeResourceName(appID)+"_property_"+normalizeResourceName(index),
@@ -28,7 +38,11 @@ func (g AppUserSchemaPropertyGenerator) createResources(appUserSchema *okta.User
 		))
 	}
 
-	for index := range appUserSchema.Definitions.Base.Properties {
+	var basePropertyNames []string
+	if base, ok := definitions.GetBaseOk(); ok {
+		basePropertyNames = userSchemaBasePropertyNames(base.GetProperties())
+	}
+	for _, index := range basePropertyNames {
 		resources = append(resources, terraformutils.NewResource(
 			index,
 			normalizeResourceName(appID)+"_property_"+normalizeResourceName(index),
@@ -58,12 +72,16 @@ func (g *AppUserSchemaPropertyGenerator) InitResources() error {
 	}
 
 	for _, app := range apps {
-		appUserSchema, _, err := client.UserSchema.GetApplicationUserSchema(ctx, app.Id)
+		appSummary, ok := getApplicationSummary(app)
+		if !ok {
+			continue
+		}
+		appUserSchema, _, err := client.SchemaAPI.GetApplicationUserSchema(ctx, appSummary.ID).Execute()
 		if err != nil {
 			return err
 		}
 
-		resources = append(resources, g.createResources(appUserSchema, app.Id)...)
+		resources = append(resources, g.createResources(appUserSchema, appSummary.ID)...)
 	}
 	g.Resources = resources
 	return nil

--- a/providers/okta/authorization_server.go
+++ b/providers/okta/authorization_server.go
@@ -6,24 +6,24 @@ import (
 	"context"
 
 	"github.com/chenrui333/terraformer/terraformutils"
-	"github.com/okta/okta-sdk-golang/v2/okta"
+	"github.com/okta/okta-sdk-golang/v6/okta"
 )
 
 type AuthorizationServerGenerator struct {
 	OktaService
 }
 
-func (g AuthorizationServerGenerator) createResources(authorizationServerList []*okta.AuthorizationServer) []terraformutils.Resource {
+func (g AuthorizationServerGenerator) createResources(authorizationServerList []okta.AuthorizationServer) []terraformutils.Resource {
 	var resources []terraformutils.Resource
 	for _, authorizationServer := range authorizationServerList {
 		resourceType := "okta_auth_server"
-		if authorizationServer.Name == "default" {
+		if authorizationServer.GetName() == "default" {
 			resourceType = "okta_auth_server_default"
 		}
 
 		resources = append(resources, terraformutils.NewSimpleResource(
-			authorizationServer.Id,
-			"auth_server_"+authorizationServer.Name,
+			authorizationServer.GetId(),
+			"auth_server_"+authorizationServer.GetName(),
 			resourceType,
 			"okta",
 			[]string{}))
@@ -46,15 +46,15 @@ func (g *AuthorizationServerGenerator) InitResources() error {
 	return nil
 }
 
-func getAuthorizationServers(ctx context.Context, client *okta.Client) ([]*okta.AuthorizationServer, error) {
-	output, resp, err := client.AuthorizationServer.ListAuthorizationServers(ctx, nil)
+func getAuthorizationServers(ctx context.Context, client *okta.APIClient) ([]okta.AuthorizationServer, error) {
+	output, resp, err := client.AuthorizationServerAPI.ListAuthorizationServers(ctx).Execute()
 	if err != nil {
 		return nil, err
 	}
 
 	for resp.HasNextPage() {
-		var nextAuthorizationServerSet []*okta.AuthorizationServer
-		resp, err = resp.Next(ctx, &nextAuthorizationServerSet)
+		var nextAuthorizationServerSet []okta.AuthorizationServer
+		resp, err = resp.Next(&nextAuthorizationServerSet)
 		if err != nil {
 			return nil, err
 		}

--- a/providers/okta/authorization_server_claim.go
+++ b/providers/okta/authorization_server_claim.go
@@ -4,24 +4,24 @@ package okta
 
 import (
 	"github.com/chenrui333/terraformer/terraformutils"
-	"github.com/okta/okta-sdk-golang/v2/okta"
+	"github.com/okta/okta-sdk-golang/v6/okta"
 )
 
 type AuthorizationServerClaimGenerator struct {
 	OktaService
 }
 
-func (g AuthorizationServerClaimGenerator) createResources(authorizationServerClaimList []*okta.OAuth2Claim, authorizationServerID string, authorizationServerName string) []terraformutils.Resource {
+func (g AuthorizationServerClaimGenerator) createResources(authorizationServerClaimList []okta.OAuth2Claim, authorizationServerID string, authorizationServerName string) []terraformutils.Resource {
 	var resources []terraformutils.Resource
 
 	for _, authorizationServerClaim := range authorizationServerClaimList {
 		resourceType := "okta_auth_server_claim"
-		if authorizationServerClaim.Name == "sub" {
+		if authorizationServerClaim.GetName() == "sub" {
 			resourceType = "okta_auth_server_claim_default"
 		}
 		resources = append(resources, terraformutils.NewResource(
-			authorizationServerClaim.Id,
-			normalizeResourceName("auth_server_"+authorizationServerName+"_claim_"+authorizationServerClaim.Id),
+			authorizationServerClaim.GetId(),
+			normalizeResourceName("auth_server_"+authorizationServerName+"_claim_"+authorizationServerClaim.GetId()),
 			resourceType,
 			"okta",
 			map[string]string{
@@ -47,12 +47,12 @@ func (g *AuthorizationServerClaimGenerator) InitResources() error {
 	}
 
 	for _, authorizationServer := range authorizationServers {
-		output, _, err := client.AuthorizationServer.ListOAuth2Claims(ctx, authorizationServer.Id)
+		output, _, err := client.AuthorizationServerClaimsAPI.ListOAuth2Claims(ctx, authorizationServer.GetId()).Execute()
 		if err != nil {
 			return err
 		}
 
-		resources = append(resources, g.createResources(output, authorizationServer.Id, authorizationServer.Name)...)
+		resources = append(resources, g.createResources(output, authorizationServer.GetId(), authorizationServer.GetName())...)
 	}
 
 	g.Resources = resources

--- a/providers/okta/authorization_server_policy.go
+++ b/providers/okta/authorization_server_policy.go
@@ -4,20 +4,20 @@ package okta
 
 import (
 	"github.com/chenrui333/terraformer/terraformutils"
-	"github.com/okta/okta-sdk-golang/v2/okta"
+	"github.com/okta/okta-sdk-golang/v6/okta"
 )
 
 type AuthorizationServerPolicyGenerator struct {
 	OktaService
 }
 
-func (g AuthorizationServerPolicyGenerator) createResources(authorizationServerPolicyList []*okta.AuthorizationServerPolicy, authorizationServerID string, authorizationServerName string) []terraformutils.Resource {
+func (g AuthorizationServerPolicyGenerator) createResources(authorizationServerPolicyList []okta.AuthorizationServerPolicy, authorizationServerID string, authorizationServerName string) []terraformutils.Resource {
 	var resources []terraformutils.Resource
 
 	for _, authorizationServerPolicy := range authorizationServerPolicyList {
 		resources = append(resources, terraformutils.NewResource(
-			authorizationServerPolicy.Id,
-			normalizeResourceName("auth_server_"+authorizationServerName+"_policy_"+authorizationServerPolicy.Name),
+			authorizationServerPolicy.GetId(),
+			normalizeResourceName("auth_server_"+authorizationServerName+"_policy_"+authorizationServerPolicy.GetName()),
 			"okta_auth_server_policy",
 			"okta",
 			map[string]string{
@@ -43,12 +43,12 @@ func (g *AuthorizationServerPolicyGenerator) InitResources() error {
 	}
 
 	for _, authorizationServer := range authorizationServers {
-		output, _, err := client.AuthorizationServer.ListAuthorizationServerPolicies(ctx, authorizationServer.Id)
+		output, _, err := client.AuthorizationServerPoliciesAPI.ListAuthorizationServerPolicies(ctx, authorizationServer.GetId()).Execute()
 		if err != nil {
 			return err
 		}
 
-		resources = append(resources, g.createResources(output, authorizationServer.Id, authorizationServer.Name)...)
+		resources = append(resources, g.createResources(output, authorizationServer.GetId(), authorizationServer.GetName())...)
 	}
 
 	g.Resources = resources

--- a/providers/okta/authorization_server_policy.go
+++ b/providers/okta/authorization_server_policy.go
@@ -3,6 +3,8 @@
 package okta
 
 import (
+	"context"
+
 	"github.com/chenrui333/terraformer/terraformutils"
 	"github.com/okta/okta-sdk-golang/v6/okta"
 )
@@ -43,7 +45,7 @@ func (g *AuthorizationServerPolicyGenerator) InitResources() error {
 	}
 
 	for _, authorizationServer := range authorizationServers {
-		output, _, err := client.AuthorizationServerPoliciesAPI.ListAuthorizationServerPolicies(ctx, authorizationServer.GetId()).Execute()
+		output, err := getAuthorizationServerPolicies(ctx, client, authorizationServer.GetId())
 		if err != nil {
 			return err
 		}
@@ -53,4 +55,22 @@ func (g *AuthorizationServerPolicyGenerator) InitResources() error {
 
 	g.Resources = resources
 	return nil
+}
+
+func getAuthorizationServerPolicies(ctx context.Context, client *okta.APIClient, authorizationServerID string) ([]okta.AuthorizationServerPolicy, error) {
+	output, resp, err := client.AuthorizationServerPoliciesAPI.ListAuthorizationServerPolicies(ctx, authorizationServerID).Execute()
+	if err != nil {
+		return nil, err
+	}
+
+	for resp.HasNextPage() {
+		var nextPolicySet []okta.AuthorizationServerPolicy
+		resp, err = resp.Next(&nextPolicySet)
+		if err != nil {
+			return nil, err
+		}
+		output = append(output, nextPolicySet...)
+	}
+
+	return output, nil
 }

--- a/providers/okta/authorization_server_policy_rule.go
+++ b/providers/okta/authorization_server_policy_rule.go
@@ -4,20 +4,20 @@ package okta
 
 import (
 	"github.com/chenrui333/terraformer/terraformutils"
-	"github.com/okta/okta-sdk-golang/v2/okta"
+	"github.com/okta/okta-sdk-golang/v6/okta"
 )
 
 type AuthorizationServerPolicyRuleGenerator struct {
 	OktaService
 }
 
-func (g AuthorizationServerPolicyRuleGenerator) createResources(authorizationServerPolicyRuleList []*okta.AuthorizationServerPolicyRule, authorizationServerID string, authorizationServerName string, authorizationServerPolicyID string, authorizationServerPolicyName string) []terraformutils.Resource {
+func (g AuthorizationServerPolicyRuleGenerator) createResources(authorizationServerPolicyRuleList []okta.AuthorizationServerPolicyRule, authorizationServerID string, authorizationServerName string, authorizationServerPolicyID string, authorizationServerPolicyName string) []terraformutils.Resource {
 	var resources []terraformutils.Resource
 
 	for _, authorizationServerPolicyRule := range authorizationServerPolicyRuleList {
 		resources = append(resources, terraformutils.NewResource(
-			authorizationServerPolicyRule.Id,
-			normalizeResourceName("auth_server_"+authorizationServerName+"_policy_"+authorizationServerPolicyName+"_rule_"+authorizationServerPolicyRule.Name),
+			authorizationServerPolicyRule.GetId(),
+			normalizeResourceName("auth_server_"+authorizationServerName+"_policy_"+authorizationServerPolicyName+"_rule_"+authorizationServerPolicyRule.GetName()),
 			"okta_auth_server_policy_rule",
 			"okta",
 			map[string]string{
@@ -44,18 +44,18 @@ func (g *AuthorizationServerPolicyRuleGenerator) InitResources() error {
 	}
 
 	for _, authorizationServer := range authorizationServers {
-		authorizationServerPolicies, _, err := client.AuthorizationServer.ListAuthorizationServerPolicies(ctx, authorizationServer.Id)
+		authorizationServerPolicies, _, err := client.AuthorizationServerPoliciesAPI.ListAuthorizationServerPolicies(ctx, authorizationServer.GetId()).Execute()
 		if err != nil {
 			return err
 		}
 
 		for _, authorizationServerPolicy := range authorizationServerPolicies {
-			output, _, err := client.AuthorizationServer.ListAuthorizationServerPolicyRules(ctx, authorizationServer.Id, authorizationServerPolicy.Id)
+			output, _, err := client.AuthorizationServerRulesAPI.ListAuthorizationServerPolicyRules(ctx, authorizationServer.GetId(), authorizationServerPolicy.GetId()).Execute()
 			if err != nil {
 				return err
 			}
 
-			resources = append(resources, g.createResources(output, authorizationServer.Id, authorizationServer.Name, authorizationServerPolicy.Id, authorizationServerPolicy.Name)...)
+			resources = append(resources, g.createResources(output, authorizationServer.GetId(), authorizationServer.GetName(), authorizationServerPolicy.GetId(), authorizationServerPolicy.GetName())...)
 		}
 	}
 

--- a/providers/okta/authorization_server_policy_rule.go
+++ b/providers/okta/authorization_server_policy_rule.go
@@ -44,7 +44,7 @@ func (g *AuthorizationServerPolicyRuleGenerator) InitResources() error {
 	}
 
 	for _, authorizationServer := range authorizationServers {
-		authorizationServerPolicies, _, err := client.AuthorizationServerPoliciesAPI.ListAuthorizationServerPolicies(ctx, authorizationServer.GetId()).Execute()
+		authorizationServerPolicies, err := getAuthorizationServerPolicies(ctx, client, authorizationServer.GetId())
 		if err != nil {
 			return err
 		}

--- a/providers/okta/authorization_server_scope.go
+++ b/providers/okta/authorization_server_scope.go
@@ -4,20 +4,20 @@ package okta
 
 import (
 	"github.com/chenrui333/terraformer/terraformutils"
-	"github.com/okta/okta-sdk-golang/v2/okta"
+	"github.com/okta/okta-sdk-golang/v6/okta"
 )
 
 type AuthorizationServerScopeGenerator struct {
 	OktaService
 }
 
-func (g AuthorizationServerScopeGenerator) createResources(authorizationServerScopeList []*okta.OAuth2Scope, authorizationServerID string, authorizationServerName string) []terraformutils.Resource {
+func (g AuthorizationServerScopeGenerator) createResources(authorizationServerScopeList []okta.OAuth2Scope, authorizationServerID string, authorizationServerName string) []terraformutils.Resource {
 	var resources []terraformutils.Resource
 
 	for _, authorizationServerScope := range authorizationServerScopeList {
 		resources = append(resources, terraformutils.NewResource(
-			authorizationServerScope.Id,
-			normalizeResourceName("auth_server_"+authorizationServerName+"_scope_"+authorizationServerScope.Name),
+			authorizationServerScope.GetId(),
+			normalizeResourceName("auth_server_"+authorizationServerName+"_scope_"+authorizationServerScope.GetName()),
 			"okta_auth_server_scope",
 			"okta",
 			map[string]string{
@@ -43,12 +43,12 @@ func (g *AuthorizationServerScopeGenerator) InitResources() error {
 	}
 
 	for _, authorizationServer := range authorizationServers {
-		output, _, err := client.AuthorizationServer.ListOAuth2Scopes(ctx, authorizationServer.Id, nil)
+		output, _, err := client.AuthorizationServerScopesAPI.ListOAuth2Scopes(ctx, authorizationServer.GetId()).Execute()
 		if err != nil {
 			return err
 		}
 
-		resources = append(resources, g.createResources(output, authorizationServer.Id, authorizationServer.Name)...)
+		resources = append(resources, g.createResources(output, authorizationServer.GetId(), authorizationServer.GetName())...)
 	}
 
 	g.Resources = resources

--- a/providers/okta/event_hook.go
+++ b/providers/okta/event_hook.go
@@ -4,19 +4,19 @@ package okta
 
 import (
 	"github.com/chenrui333/terraformer/terraformutils"
-	"github.com/okta/okta-sdk-golang/v2/okta"
+	"github.com/okta/okta-sdk-golang/v6/okta"
 )
 
 type EventHookGenerator struct {
 	OktaService
 }
 
-func (g EventHookGenerator) createResources(eventHookList []*okta.EventHook) []terraformutils.Resource {
+func (g EventHookGenerator) createResources(eventHookList []okta.EventHook) []terraformutils.Resource {
 	var resources []terraformutils.Resource
 	for _, eventHook := range eventHookList {
 		resources = append(resources, terraformutils.NewSimpleResource(
-			eventHook.Id,
-			"event_hook_"+eventHook.Name,
+			eventHook.GetId(),
+			"event_hook_"+eventHook.GetName(),
 			"okta_event_hook",
 			"okta",
 			[]string{}))
@@ -30,14 +30,14 @@ func (g *EventHookGenerator) InitResources() error {
 		return e
 	}
 
-	output, resp, err := client.EventHook.ListEventHooks(ctx)
+	output, resp, err := client.EventHookAPI.ListEventHooks(ctx).Execute()
 	if err != nil {
 		return err
 	}
 
 	for resp.HasNextPage() {
-		var nextEventHookSet []*okta.EventHook
-		resp, err = resp.Next(ctx, &nextEventHookSet)
+		var nextEventHookSet []okta.EventHook
+		resp, err = resp.Next(&nextEventHookSet)
 		if err != nil {
 			return err
 		}

--- a/providers/okta/factor.go
+++ b/providers/okta/factor.go
@@ -6,7 +6,7 @@ import (
 	"context"
 
 	"github.com/chenrui333/terraformer/terraformutils"
-	"github.com/okta/okta-sdk-golang/v2/okta"
+	"github.com/okta/okta-sdk-golang/v6/okta"
 	"github.com/okta/terraform-provider-okta/sdk"
 )
 
@@ -17,20 +17,20 @@ type FactorGenerator struct {
 func (g FactorGenerator) createResources(ctx context.Context, factorList []*okta.UserFactor, client *sdk.APISupplement) ([]terraformutils.Resource, error) {
 	var resources []terraformutils.Resource
 	for _, factor := range factorList {
-		if factor.Status == "ACTIVE" {
+		if factor.GetStatus() == "ACTIVE" {
 			resources = append(resources, terraformutils.NewResource(
-				factor.Id,
-				"factor_"+normalizeResourceNameWithRandom(factor.Id),
+				factor.GetId(),
+				"factor_"+normalizeResourceNameWithRandom(factor.GetId()),
 				"okta_factor",
 				"okta",
 				map[string]string{
-					"provider_id": factor.Id,
+					"provider_id": factor.GetId(),
 				},
 				[]string{},
 				map[string]interface{}{},
 			))
 
-			if factor.FactorType == "token:hotp" {
+			if factor.GetFactorType() == "token:hotp" {
 				hotpFactorProfiles, _, err := getHotpFactorProfiles(ctx, client)
 				if err != nil {
 					return nil, err

--- a/providers/okta/group.go
+++ b/providers/okta/group.go
@@ -54,8 +54,5 @@ func getGroupName(group okta.Group) string {
 	if profile.OktaUserGroupProfile != nil {
 		return profile.OktaUserGroupProfile.GetName()
 	}
-	if profile.OktaActiveDirectoryGroupProfile != nil {
-		return profile.OktaActiveDirectoryGroupProfile.GetName()
-	}
 	return group.GetId()
 }

--- a/providers/okta/group.go
+++ b/providers/okta/group.go
@@ -54,5 +54,8 @@ func getGroupName(group okta.Group) string {
 	if profile.OktaUserGroupProfile != nil {
 		return profile.OktaUserGroupProfile.GetName()
 	}
+	if profile.OktaActiveDirectoryGroupProfile != nil {
+		return profile.OktaActiveDirectoryGroupProfile.GetName()
+	}
 	return group.GetId()
 }

--- a/providers/okta/group.go
+++ b/providers/okta/group.go
@@ -4,20 +4,20 @@ package okta
 
 import (
 	"github.com/chenrui333/terraformer/terraformutils"
-	"github.com/okta/okta-sdk-golang/v2/okta"
-	"github.com/okta/okta-sdk-golang/v2/okta/query"
+	"github.com/okta/okta-sdk-golang/v6/okta"
 )
 
 type GroupGenerator struct {
 	OktaService
 }
 
-func (g GroupGenerator) createResources(groupList []*okta.Group) []terraformutils.Resource {
+func (g GroupGenerator) createResources(groupList []okta.Group) []terraformutils.Resource {
 	var resources []terraformutils.Resource
 	for _, group := range groupList {
+		groupName := getGroupName(group)
 		resources = append(resources, terraformutils.NewSimpleResource(
-			group.Id,
-			"group_"+group.Profile.Name,
+			group.GetId(),
+			"group_"+groupName,
 			"okta_group",
 			"okta",
 			[]string{}))
@@ -31,15 +31,14 @@ func (g *GroupGenerator) InitResources() error {
 		return e
 	}
 
-	filter := query.NewQueryParams(query.WithFilter("type eq \"OKTA_GROUP\""))
-	output, resp, err := client.Group.ListGroups(ctx, filter)
+	output, resp, err := client.GroupAPI.ListGroups(ctx).Filter("type eq \"OKTA_GROUP\"").Execute()
 	if err != nil {
 		return err
 	}
 
 	for resp.HasNextPage() {
-		var nextGroupSet []*okta.Group
-		resp, err = resp.Next(ctx, &nextGroupSet)
+		var nextGroupSet []okta.Group
+		resp, err = resp.Next(&nextGroupSet)
 		if err != nil {
 			return err
 		}
@@ -48,4 +47,15 @@ func (g *GroupGenerator) InitResources() error {
 
 	g.Resources = g.createResources(output)
 	return nil
+}
+
+func getGroupName(group okta.Group) string {
+	profile := group.GetProfile()
+	if profile.OktaUserGroupProfile != nil {
+		return profile.OktaUserGroupProfile.GetName()
+	}
+	if profile.OktaActiveDirectoryGroupProfile != nil {
+		return profile.OktaActiveDirectoryGroupProfile.GetName()
+	}
+	return group.GetId()
 }

--- a/providers/okta/group_rule.go
+++ b/providers/okta/group_rule.go
@@ -4,19 +4,19 @@ package okta
 
 import (
 	"github.com/chenrui333/terraformer/terraformutils"
-	"github.com/okta/okta-sdk-golang/v2/okta"
+	"github.com/okta/okta-sdk-golang/v6/okta"
 )
 
 type GroupRuleGenerator struct {
 	OktaService
 }
 
-func (g GroupRuleGenerator) createResources(groupRuleList []*okta.GroupRule) []terraformutils.Resource {
+func (g GroupRuleGenerator) createResources(groupRuleList []okta.GroupRule) []terraformutils.Resource {
 	var resources []terraformutils.Resource
 	for _, groupRule := range groupRuleList {
 		resources = append(resources, terraformutils.NewSimpleResource(
-			groupRule.Id,
-			"grouprule_"+groupRule.Name,
+			groupRule.GetId(),
+			"grouprule_"+groupRule.GetName(),
 			"okta_group_rule",
 			"okta",
 			[]string{}))
@@ -30,14 +30,14 @@ func (g *GroupRuleGenerator) InitResources() error {
 		return e
 	}
 
-	output, resp, err := client.Group.ListGroupRules(ctx, nil)
+	output, resp, err := client.GroupRuleAPI.ListGroupRules(ctx).Execute()
 	if err != nil {
 		return err
 	}
 
 	for resp.HasNextPage() {
-		var nextGroupRuleSet []*okta.GroupRule
-		resp, err = resp.Next(ctx, &nextGroupRuleSet)
+		var nextGroupRuleSet []okta.GroupRule
+		resp, err = resp.Next(&nextGroupRuleSet)
 		if err != nil {
 			return err
 		}

--- a/providers/okta/idp_oidc.go
+++ b/providers/okta/idp_oidc.go
@@ -6,20 +6,19 @@ import (
 	"context"
 
 	"github.com/chenrui333/terraformer/terraformutils"
-	"github.com/okta/okta-sdk-golang/v2/okta"
-	"github.com/okta/okta-sdk-golang/v2/okta/query"
+	"github.com/okta/okta-sdk-golang/v6/okta"
 )
 
 type IdpOIDCGenerator struct {
 	OktaService
 }
 
-func (g IdpOIDCGenerator) createResources(idpOIDCList []*okta.IdentityProvider) []terraformutils.Resource {
+func (g IdpOIDCGenerator) createResources(idpOIDCList []okta.IdentityProvider) []terraformutils.Resource {
 	var resources []terraformutils.Resource
 	for _, idp := range idpOIDCList {
 		resources = append(resources, terraformutils.NewSimpleResource(
-			idp.Id,
-			"idp_"+normalizeResourceName(idp.Type+"_"+idp.Name),
+			idp.GetId(),
+			"idp_"+normalizeResourceName(idp.GetType()+"_"+idp.GetName()),
 			"okta_idp_oidc",
 			"okta",
 			[]string{}))
@@ -42,16 +41,15 @@ func (g *IdpOIDCGenerator) InitResources() error {
 	return nil
 }
 
-func getIdpOIDC(ctx context.Context, client *okta.Client) ([]*okta.IdentityProvider, error) {
-	qp := &query.Params{Type: "OIDC", Limit: 1}
-	output, resp, err := client.IdentityProvider.ListIdentityProviders(ctx, qp)
+func getIdpOIDC(ctx context.Context, client *okta.APIClient) ([]okta.IdentityProvider, error) {
+	output, resp, err := client.IdentityProviderAPI.ListIdentityProviders(ctx).Type_("OIDC").Limit(1).Execute()
 	if err != nil {
 		return nil, err
 	}
 
 	for resp.HasNextPage() {
-		var nextIdpOIDCSet []*okta.IdentityProvider
-		resp, err = resp.Next(ctx, &nextIdpOIDCSet)
+		var nextIdpOIDCSet []okta.IdentityProvider
+		resp, err = resp.Next(&nextIdpOIDCSet)
 		if err != nil {
 			return nil, err
 		}

--- a/providers/okta/idp_saml.go
+++ b/providers/okta/idp_saml.go
@@ -6,20 +6,19 @@ import (
 	"context"
 
 	"github.com/chenrui333/terraformer/terraformutils"
-	"github.com/okta/okta-sdk-golang/v2/okta"
-	"github.com/okta/okta-sdk-golang/v2/okta/query"
+	"github.com/okta/okta-sdk-golang/v6/okta"
 )
 
 type IdpSAMLGenerator struct {
 	OktaService
 }
 
-func (g IdpSAMLGenerator) createResources(idpSAMLList []*okta.IdentityProvider) []terraformutils.Resource {
+func (g IdpSAMLGenerator) createResources(idpSAMLList []okta.IdentityProvider) []terraformutils.Resource {
 	var resources []terraformutils.Resource
 	for _, idp := range idpSAMLList {
 		resources = append(resources, terraformutils.NewSimpleResource(
-			idp.Id,
-			"idp_"+normalizeResourceName(idp.Type+"_"+idp.Name),
+			idp.GetId(),
+			"idp_"+normalizeResourceName(idp.GetType()+"_"+idp.GetName()),
 			"okta_idp_saml",
 			"okta",
 			[]string{}))
@@ -42,16 +41,15 @@ func (g *IdpSAMLGenerator) InitResources() error {
 	return nil
 }
 
-func getIdpSAML(ctx context.Context, client *okta.Client) ([]*okta.IdentityProvider, error) {
-	qp := &query.Params{Type: "SAML2", Limit: 1}
-	output, resp, err := client.IdentityProvider.ListIdentityProviders(ctx, qp)
+func getIdpSAML(ctx context.Context, client *okta.APIClient) ([]okta.IdentityProvider, error) {
+	output, resp, err := client.IdentityProviderAPI.ListIdentityProviders(ctx).Type_("SAML2").Limit(1).Execute()
 	if err != nil {
 		return nil, err
 	}
 
 	for resp.HasNextPage() {
-		var nextIdpSAMLSet []*okta.IdentityProvider
-		resp, err = resp.Next(ctx, &nextIdpSAMLSet)
+		var nextIdpSAMLSet []okta.IdentityProvider
+		resp, err = resp.Next(&nextIdpSAMLSet)
 		if err != nil {
 			return nil, err
 		}

--- a/providers/okta/idp_social.go
+++ b/providers/okta/idp_social.go
@@ -6,20 +6,19 @@ import (
 	"context"
 
 	"github.com/chenrui333/terraformer/terraformutils"
-	"github.com/okta/okta-sdk-golang/v2/okta"
-	"github.com/okta/okta-sdk-golang/v2/okta/query"
+	"github.com/okta/okta-sdk-golang/v6/okta"
 )
 
 type IdpSocialGenerator struct {
 	OktaService
 }
 
-func (g IdpSocialGenerator) createResources(idpSocialList []*okta.IdentityProvider) []terraformutils.Resource {
+func (g IdpSocialGenerator) createResources(idpSocialList []okta.IdentityProvider) []terraformutils.Resource {
 	var resources []terraformutils.Resource
 	for _, idp := range idpSocialList {
 		resources = append(resources, terraformutils.NewSimpleResource(
-			idp.Id,
-			"idp_"+normalizeResourceName(idp.Type+"_"+idp.Name),
+			idp.GetId(),
+			"idp_"+normalizeResourceName(idp.GetType()+"_"+idp.GetName()),
 			"okta_idp_social",
 			"okta",
 			[]string{}))
@@ -43,20 +42,19 @@ func (g *IdpSocialGenerator) InitResources() error {
 	return nil
 }
 
-func getIdpSocials(ctx context.Context, client *okta.Client) ([]*okta.IdentityProvider, error) {
+func getIdpSocials(ctx context.Context, client *okta.APIClient) ([]okta.IdentityProvider, error) {
 	idpSocialTypes := []string{"APPLE", "FACEBOOK", "GOOGLE", "LINKEDIN", "MICROSOFT"}
-	var allIDPSocials []*okta.IdentityProvider
+	var allIDPSocials []okta.IdentityProvider
 
 	for _, idpSocialType := range idpSocialTypes {
-		qp := &query.Params{Type: idpSocialType, Limit: 1}
-		output, resp, err := client.IdentityProvider.ListIdentityProviders(ctx, qp)
+		output, resp, err := client.IdentityProviderAPI.ListIdentityProviders(ctx).Type_(idpSocialType).Limit(1).Execute()
 		if err != nil {
 			return nil, err
 		}
 
 		for resp.HasNextPage() {
-			var nextIdpSocialSet []*okta.IdentityProvider
-			resp, err = resp.Next(ctx, &nextIdpSocialSet)
+			var nextIdpSocialSet []okta.IdentityProvider
+			resp, err = resp.Next(&nextIdpSocialSet)
 			if err != nil {
 				return nil, err
 			}

--- a/providers/okta/inline_hook.go
+++ b/providers/okta/inline_hook.go
@@ -4,19 +4,19 @@ package okta
 
 import (
 	"github.com/chenrui333/terraformer/terraformutils"
-	"github.com/okta/okta-sdk-golang/v2/okta"
+	"github.com/okta/okta-sdk-golang/v6/okta"
 )
 
 type InlineHookGenerator struct {
 	OktaService
 }
 
-func (g InlineHookGenerator) createResources(inlineHookList []*okta.InlineHook) []terraformutils.Resource {
+func (g InlineHookGenerator) createResources(inlineHookList []okta.InlineHook) []terraformutils.Resource {
 	var resources []terraformutils.Resource
 	for _, inlineHook := range inlineHookList {
 		resources = append(resources, terraformutils.NewSimpleResource(
-			inlineHook.Id,
-			"inline_hook_"+inlineHook.Name,
+			inlineHook.GetId(),
+			"inline_hook_"+inlineHook.GetName(),
 			"okta_inline_hook",
 			"okta",
 			[]string{}))
@@ -30,14 +30,14 @@ func (g *InlineHookGenerator) InitResources() error {
 		return e
 	}
 
-	output, resp, err := client.InlineHook.ListInlineHooks(ctx, nil)
+	output, resp, err := client.InlineHookAPI.ListInlineHooks(ctx).Execute()
 	if err != nil {
 		return err
 	}
 
 	for resp.HasNextPage() {
-		var nextInlineHookSet []*okta.InlineHook
-		resp, err = resp.Next(ctx, &nextInlineHookSet)
+		var nextInlineHookSet []okta.InlineHook
+		resp, err = resp.Next(&nextInlineHookSet)
 		if err != nil {
 			return err
 		}

--- a/providers/okta/okta_discovery_test.go
+++ b/providers/okta/okta_discovery_test.go
@@ -152,6 +152,44 @@ func TestOktaPolicyCreateResources(t *testing.T) {
 	}
 }
 
+func TestGetAuthorizationServerPoliciesPaginates(t *testing.T) {
+	var requests []string
+	client := newTestOktaClient(t, func(w http.ResponseWriter, r *http.Request) {
+		requests = append(requests, r.URL.String())
+		if r.URL.Path != "/api/v1/authorizationServers/authz-1/policies" {
+			t.Errorf("request path = %q, want /api/v1/authorizationServers/authz-1/policies", r.URL.Path)
+			writeOktaError(t, w, http.StatusNotFound, "unexpected path")
+			return
+		}
+
+		switch r.URL.Query().Get("after") {
+		case "":
+			w.Header().Set("Link", fmt.Sprintf("<%s/api/v1/authorizationServers/authz-1/policies?after=second>; rel=%q", testOktaRequestBaseURL(r), "next"))
+			writeOktaJSON(t, w, []map[string]string{{"id": "policy-1", "type": "RESOURCE_ACCESS", "name": "First Policy"}})
+		case "second":
+			writeOktaJSON(t, w, []map[string]string{{"id": "policy-2", "type": "RESOURCE_ACCESS", "name": "Second Policy"}})
+		default:
+			t.Errorf("after query = %q, want empty or second", r.URL.Query().Get("after"))
+			writeOktaError(t, w, http.StatusBadRequest, "unexpected page")
+		}
+	})
+
+	policies, err := getAuthorizationServerPolicies(context.Background(), client, "authz-1")
+	if err != nil {
+		t.Fatalf("getAuthorizationServerPolicies() returned error: %v", err)
+	}
+	if len(policies) != 2 {
+		t.Fatalf("getAuthorizationServerPolicies() returned %d policies, want 2; requests=%v", len(policies), requests)
+	}
+
+	resources := AuthorizationServerPolicyGenerator{}.createResources(policies, "authz-1", "Authorization Server")
+	if len(resources) != 2 {
+		t.Fatalf("resources length = %d, want 2", len(resources))
+	}
+	assertOktaResource(t, resources[0], "policy-1", normalizeResourceName("auth_server_Authorization Server_policy_First Policy"), "okta_auth_server_policy", map[string]string{"auth_server_id": "authz-1"})
+	assertOktaResource(t, resources[1], "policy-2", normalizeResourceName("auth_server_Authorization Server_policy_Second Policy"), "okta_auth_server_policy", map[string]string{"auth_server_id": "authz-1"})
+}
+
 func TestGetIdpOIDCPaginates(t *testing.T) {
 	var requests []string
 	client := newTestOktaClient(t, func(w http.ResponseWriter, r *http.Request) {

--- a/providers/okta/okta_discovery_test.go
+++ b/providers/okta/okta_discovery_test.go
@@ -152,6 +152,23 @@ func TestOktaPolicyCreateResources(t *testing.T) {
 	}
 }
 
+func TestOktaGroupCreateResourcesPreservesDecodedProfileName(t *testing.T) {
+	var group oktasdk.Group
+	groupJSON := "{\"id\":\"group-1\",\"type\":\"OKTA_GROUP\",\"profile\":{\"name\":\"Engineering\",\"description\":\"Engineering team\"}}"
+	if err := json.Unmarshal([]byte(groupJSON), &group); err != nil {
+		t.Fatalf("unmarshal Okta group: %v", err)
+	}
+	if profile := group.GetProfile(); profile.OktaActiveDirectoryGroupProfile == nil {
+		t.Fatal("expected v6 group profile decoder to use AD profile branch")
+	}
+
+	resources := GroupGenerator{}.createResources([]oktasdk.Group{group})
+	if len(resources) != 1 {
+		t.Fatalf("resources length = %d, want 1", len(resources))
+	}
+	assertOktaResource(t, resources[0], "group-1", "group_Engineering", "okta_group", map[string]string{})
+}
+
 func TestGetAuthorizationServerPoliciesPaginates(t *testing.T) {
 	var requests []string
 	client := newTestOktaClient(t, func(w http.ResponseWriter, r *http.Request) {

--- a/providers/okta/okta_discovery_test.go
+++ b/providers/okta/okta_discovery_test.go
@@ -1,0 +1,352 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package okta
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/chenrui333/terraformer/terraformutils"
+	oktasdk "github.com/okta/okta-sdk-golang/v6/okta"
+)
+
+func TestOktaProviderRegistration(t *testing.T) {
+	provider := &OktaProvider{}
+	t.Setenv("OKTA_ORG_NAME", "dev-123")
+	t.Setenv("OKTA_BASE_URL", "okta.com")
+	t.Setenv("OKTA_API_TOKEN", "api-token")
+
+	if err := provider.Init(nil); err != nil {
+		t.Fatalf("Init returned error: %v", err)
+	}
+	if got := provider.GetName(); got != "okta" {
+		t.Fatalf("GetName() = %q, want okta", got)
+	}
+	if provider.GetConfig().IsNull() {
+		t.Fatal("GetConfig() returned null config")
+	}
+
+	wantServices := map[string]reflect.Type{
+		"okta_idp_oidc":        reflect.TypeOf(&IdpOIDCGenerator{}),
+		"okta_idp_saml":        reflect.TypeOf(&IdpSAMLGenerator{}),
+		"okta_idp_social":      reflect.TypeOf(&IdpSocialGenerator{}),
+		"okta_policy_password": reflect.TypeOf(&PasswordPolicyGenerator{}),
+		"okta_policy_mfa":      reflect.TypeOf(&MFAPolicyGenerator{}),
+		"okta_policy_signon":   reflect.TypeOf(&SignOnPolicyGenerator{}),
+	}
+	services := provider.GetSupportedService()
+	for name, wantType := range wantServices {
+		service, ok := services[name]
+		if !ok {
+			t.Fatalf("supported services missing %q", name)
+		}
+		if gotType := reflect.TypeOf(service); gotType != wantType {
+			t.Fatalf("service %q type = %v, want %v", name, gotType, wantType)
+		}
+	}
+
+	if err := provider.InitService("okta_idp_oidc", true); err != nil {
+		t.Fatalf("InitService(okta_idp_oidc) returned error: %v", err)
+	}
+	if got := provider.GetService().GetArgs()["api_token"]; got != "api-token" {
+		t.Fatalf("selected service api token arg = %#v, want api-token", got)
+	}
+	if err := provider.InitService("missing", false); err == nil {
+		t.Fatal("InitService(missing) returned nil error")
+	}
+}
+
+func TestOktaIDPCreateResources(t *testing.T) {
+	tests := []struct {
+		name     string
+		resource terraformutils.Resource
+		wantName string
+		wantType string
+	}{
+		{
+			name:     "oidc",
+			resource: IdpOIDCGenerator{}.createResources([]oktasdk.IdentityProvider{testIdentityProvider("idp-oidc", "OIDC", "Example IDP")})[0],
+			wantName: "idp_" + normalizeResourceName("OIDC_Example IDP"),
+			wantType: "okta_idp_oidc",
+		},
+		{
+			name:     "saml",
+			resource: IdpSAMLGenerator{}.createResources([]oktasdk.IdentityProvider{testIdentityProvider("idp-saml", "SAML2", "Example IDP")})[0],
+			wantName: "idp_" + normalizeResourceName("SAML2_Example IDP"),
+			wantType: "okta_idp_saml",
+		},
+		{
+			name:     "social",
+			resource: IdpSocialGenerator{}.createResources([]oktasdk.IdentityProvider{testIdentityProvider("idp-social", "SOCIAL", "Example IDP")})[0],
+			wantName: "idp_" + normalizeResourceName("SOCIAL_Example IDP"),
+			wantType: "okta_idp_social",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assertOktaResource(t, tt.resource, tt.resource.InstanceState.ID, tt.wantName, tt.wantType, map[string]string{})
+		})
+	}
+}
+
+func TestOktaPolicyCreateResources(t *testing.T) {
+	passwordDefault := newTestPasswordPolicy("pol-password-default", "Default Policy")
+	passwordCustom := newTestPasswordPolicy("pol-password-custom", "Custom Password")
+	mfaDefault := newTestAuthenticatorEnrollmentPolicy("pol-mfa-default", "Default Policy")
+	signOn := newTestSignOnPolicy("pol-signon", "Sign On")
+
+	tests := []struct {
+		name      string
+		resources []terraformutils.Resource
+		wantIDs   []string
+		wantNames []string
+		wantTypes []string
+	}{
+		{
+			name: "password policies",
+			resources: PasswordPolicyGenerator{}.createResources([]oktasdk.ListPolicies200ResponseInner{
+				oktasdk.PasswordPolicyAsListPolicies200ResponseInner(passwordDefault),
+				oktasdk.PasswordPolicyAsListPolicies200ResponseInner(passwordCustom),
+			}),
+			wantIDs:   []string{"pol-password-default", "pol-password-custom"},
+			wantNames: []string{"policy_password_" + normalizeResourceName("Default Policy"), "policy_password_" + normalizeResourceName("Custom Password")},
+			wantTypes: []string{"okta_policy_password_default", "okta_policy_password"},
+		},
+		{
+			name: "mfa default policy",
+			resources: MFAPolicyGenerator{}.createResources([]oktasdk.ListPolicies200ResponseInner{
+				oktasdk.AuthenticatorEnrollmentPolicyAsListPolicies200ResponseInner(mfaDefault),
+			}),
+			wantIDs:   []string{"pol-mfa-default"},
+			wantNames: []string{"policy_mfa_" + normalizeResourceName("Default Policy")},
+			wantTypes: []string{"okta_policy_mfa_default"},
+		},
+		{
+			name: "signon policy",
+			resources: SignOnPolicyGenerator{}.createResources([]oktasdk.ListPolicies200ResponseInner{
+				oktasdk.OktaSignOnPolicyAsListPolicies200ResponseInner(signOn),
+			}),
+			wantIDs:   []string{"pol-signon"},
+			wantNames: []string{"policy_signon_" + normalizeResourceName("Sign On")},
+			wantTypes: []string{"okta_policy_signon"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if len(tt.resources) != len(tt.wantIDs) {
+				t.Fatalf("resources length = %d, want %d", len(tt.resources), len(tt.wantIDs))
+			}
+			for i, resource := range tt.resources {
+				assertOktaResource(t, resource, tt.wantIDs[i], tt.wantNames[i], tt.wantTypes[i], map[string]string{})
+			}
+		})
+	}
+}
+
+func TestGetIdpOIDCPaginates(t *testing.T) {
+	var requests []string
+	client := newTestOktaClient(t, func(w http.ResponseWriter, r *http.Request) {
+		requests = append(requests, r.URL.String())
+		if r.URL.Path != "/api/v1/idps" {
+			t.Errorf("request path = %q, want /api/v1/idps", r.URL.Path)
+			writeOktaError(t, w, http.StatusNotFound, "unexpected path")
+			return
+		}
+		if got := r.URL.Query().Get("type"); got != "OIDC" {
+			t.Errorf("type query = %q, want OIDC", got)
+		}
+		if got := r.URL.Query().Get("limit"); got != "1" {
+			t.Errorf("limit query = %q, want 1", got)
+		}
+
+		switch r.URL.Query().Get("after") {
+		case "":
+			w.Header().Set("Link", fmt.Sprintf("<%s/api/v1/idps?after=second>; rel=\"next\"", testOktaRequestBaseURL(r)))
+			writeOktaJSON(t, w, []map[string]string{{"id": "idp-1", "type": "OIDC", "name": "First"}})
+		case "second":
+			writeOktaJSON(t, w, []map[string]string{{"id": "idp-2", "type": "OIDC", "name": "Second"}})
+		default:
+			t.Errorf("after query = %q, want empty or second", r.URL.Query().Get("after"))
+			writeOktaError(t, w, http.StatusBadRequest, "unexpected page")
+		}
+	})
+
+	idps, err := getIdpOIDC(context.Background(), client)
+	if err != nil {
+		t.Fatalf("getIdpOIDC() returned error: %v", err)
+	}
+	if len(idps) != 2 {
+		t.Fatalf("getIdpOIDC() returned %d IDPs, want 2; requests=%v", len(idps), requests)
+	}
+	resources := IdpOIDCGenerator{}.createResources(idps)
+	if len(resources) != 2 {
+		t.Fatalf("resources length = %d, want 2", len(resources))
+	}
+	assertOktaResource(t, resources[0], "idp-1", "idp_"+normalizeResourceName("OIDC_First"), "okta_idp_oidc", map[string]string{})
+	assertOktaResource(t, resources[1], "idp-2", "idp_"+normalizeResourceName("OIDC_Second"), "okta_idp_oidc", map[string]string{})
+}
+
+func TestGetIdpOIDCEmptyResponse(t *testing.T) {
+	client := newTestOktaClient(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/v1/idps" {
+			t.Errorf("request path = %q, want /api/v1/idps", r.URL.Path)
+			writeOktaError(t, w, http.StatusNotFound, "unexpected path")
+			return
+		}
+		writeOktaJSON(t, w, []map[string]string{})
+	})
+
+	idps, err := getIdpOIDC(context.Background(), client)
+	if err != nil {
+		t.Fatalf("getIdpOIDC() returned error: %v", err)
+	}
+	if len(idps) != 0 {
+		t.Fatalf("getIdpOIDC() returned %d IDPs, want 0", len(idps))
+	}
+}
+
+func TestGetIdpOIDCPropagatesNextPageError(t *testing.T) {
+	sawSecondPage := false
+	client := newTestOktaClient(t, func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Query().Get("after") {
+		case "":
+			w.Header().Set("Link", fmt.Sprintf("<%s/api/v1/idps?after=second>; rel=\"next\"", testOktaRequestBaseURL(r)))
+			writeOktaJSON(t, w, []map[string]string{{"id": "idp-1", "type": "OIDC", "name": "First"}})
+		case "second":
+			sawSecondPage = true
+			writeOktaError(t, w, http.StatusInternalServerError, "second page failed")
+		default:
+			t.Errorf("after query = %q, want empty or second", r.URL.Query().Get("after"))
+			writeOktaError(t, w, http.StatusBadRequest, "unexpected page")
+		}
+	})
+
+	_, err := getIdpOIDC(context.Background(), client)
+	if err == nil {
+		t.Fatal("getIdpOIDC() returned nil error")
+	}
+	if !sawSecondPage {
+		t.Fatal("getIdpOIDC() did not request the second page")
+	}
+	if !strings.Contains(err.Error(), "500") && !strings.Contains(err.Error(), "unmarshal") {
+		t.Fatalf("getIdpOIDC() error = %q, want propagated second-page failure", err)
+	}
+}
+
+func newTestOktaClient(t *testing.T, handler http.HandlerFunc) *oktasdk.APIClient {
+	t.Helper()
+
+	server := httptest.NewServer(handler)
+	t.Cleanup(server.Close)
+	serverURL, err := url.Parse(server.URL)
+	if err != nil {
+		t.Fatalf("parse test server URL: %v", err)
+	}
+
+	config, err := oktasdk.NewConfiguration(
+		oktasdk.WithOrgUrl("https://example.okta.com"),
+		oktasdk.WithToken("test-token"),
+	)
+	if err != nil {
+		t.Fatalf("okta.NewConfiguration() returned error: %v", err)
+	}
+	config.Servers = oktasdk.ServerConfigurations{{URL: server.URL}}
+	config.HTTPClient = server.Client()
+	config.Host = serverURL.Host
+	config.Scheme = serverURL.Scheme
+	config.Okta.Client.OrgUrl = server.URL
+	config.Okta.Client.AuthorizationMode = "SSWS"
+	config.Okta.Client.Token = "test-token"
+	config.Okta.Client.Proxy.Host = ""
+	config.Okta.Client.Proxy.Port = 0
+	config.Okta.Client.Proxy.Username = ""
+	config.Okta.Client.Proxy.Password = ""
+	return oktasdk.NewAPIClient(config)
+}
+
+func writeOktaJSON(t *testing.T, w http.ResponseWriter, value interface{}) {
+	t.Helper()
+
+	w.Header().Set("Content-Type", "application/json")
+	if err := json.NewEncoder(w).Encode(value); err != nil {
+		t.Errorf("write JSON response: %v", err)
+	}
+}
+
+func writeOktaError(t *testing.T, w http.ResponseWriter, status int, message string) {
+	t.Helper()
+
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	if err := json.NewEncoder(w).Encode(map[string]interface{}{
+		"errorSummary": message,
+	}); err != nil {
+		t.Errorf("write error response: %v", err)
+	}
+}
+
+func testOktaRequestBaseURL(r *http.Request) string {
+	return "http://" + r.Host
+}
+
+func testIdentityProvider(id, idpType, name string) oktasdk.IdentityProvider {
+	idp := oktasdk.IdentityProvider{}
+	idp.SetId(id)
+	idp.SetType(idpType)
+	idp.SetName(name)
+	return idp
+}
+
+func newTestPasswordPolicy(id, name string) *oktasdk.PasswordPolicy {
+	policy := oktasdk.NewPasswordPolicy(name, "PASSWORD")
+	policy.Id = stringPtr(id)
+	return policy
+}
+
+func newTestAuthenticatorEnrollmentPolicy(id, name string) *oktasdk.AuthenticatorEnrollmentPolicy {
+	policy := oktasdk.NewAuthenticatorEnrollmentPolicy(name, "MFA_ENROLL")
+	policy.Id = stringPtr(id)
+	return policy
+}
+
+func newTestSignOnPolicy(id, name string) *oktasdk.OktaSignOnPolicy {
+	policy := oktasdk.NewOktaSignOnPolicy(name, "OKTA_SIGN_ON")
+	policy.Id = stringPtr(id)
+	return policy
+}
+
+func assertOktaResource(t *testing.T, resource terraformutils.Resource, wantID, wantName, wantType string, wantAttrs map[string]string) {
+	t.Helper()
+
+	if resource.InstanceState == nil {
+		t.Fatal("resource InstanceState is nil")
+	}
+	if resource.InstanceInfo == nil {
+		t.Fatal("resource InstanceInfo is nil")
+	}
+	if got := resource.InstanceState.ID; got != wantID {
+		t.Fatalf("resource ID = %q, want %q", got, wantID)
+	}
+	wantResourceName := terraformutils.TfSanitize(wantName)
+	if got := resource.ResourceName; got != wantResourceName {
+		t.Fatalf("resource name = %q, want %q", got, wantResourceName)
+	}
+	if got := resource.InstanceInfo.Type; got != wantType {
+		t.Fatalf("resource type = %q, want %q", got, wantType)
+	}
+	if !reflect.DeepEqual(resource.InstanceState.Attributes, wantAttrs) {
+		t.Fatalf("resource attrs = %#v, want %#v", resource.InstanceState.Attributes, wantAttrs)
+	}
+	if got := resource.Provider; got != "okta" {
+		t.Fatalf("resource provider = %q, want okta", got)
+	}
+}

--- a/providers/okta/okta_provider_test.go
+++ b/providers/okta/okta_provider_test.go
@@ -79,6 +79,38 @@ func TestGetUserTypeName(t *testing.T) {
 	}
 }
 
+func TestGetUserTypeResourceID(t *testing.T) {
+	tests := []struct {
+		name     string
+		userType oktasdk.UserType
+		want     string
+	}{
+		{
+			name:     "default user type uses API name",
+			userType: testOktaUserTypeWithProperties(map[string]interface{}{"name": "user", "displayName": "End User"}),
+			want:     "default",
+		},
+		{
+			name:     "display name alone does not select default",
+			userType: testOktaUserTypeWithProperties(map[string]interface{}{"displayName": "user"}),
+			want:     "custom",
+		},
+		{
+			name:     "custom API name preserves user type id",
+			userType: testOktaUserTypeWithProperties(map[string]interface{}{"name": "custom", "displayName": "user"}),
+			want:     "custom",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := getUserTypeResourceID(tt.userType); got != tt.want {
+				t.Fatalf("getUserTypeResourceID() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
 func TestGetUserTypeSchemaIDAllowsMissingLinkFields(t *testing.T) {
 	tests := []struct {
 		name     string

--- a/providers/okta/okta_provider_test.go
+++ b/providers/okta/okta_provider_test.go
@@ -6,7 +6,7 @@ import (
 	"strings"
 	"testing"
 
-	oktasdk "github.com/okta/okta-sdk-golang/v2/okta"
+	oktasdk "github.com/okta/okta-sdk-golang/v6/okta"
 )
 
 func TestOktaProviderInitClearsStateOnMissingAPIToken(t *testing.T) {
@@ -32,14 +32,11 @@ func TestOktaProviderInitClearsStateOnMissingAPIToken(t *testing.T) {
 }
 
 func TestGetUserTypeSchemaID(t *testing.T) {
-	userType := &oktasdk.UserType{
-		Id: "custom",
-		Links: map[string]interface{}{
-			"schema": map[string]interface{}{
-				"href": "https://example.okta.com/api/v1/meta/schemas/user/custom",
-			},
+	userType := testOktaUserType(map[string]interface{}{
+		"schema": map[string]interface{}{
+			"href": "https://example.okta.com/api/v1/meta/schemas/user/custom",
 		},
-	}
+	})
 
 	schemaID, err := getUserTypeSchemaID(userType)
 	if err != nil {
@@ -50,30 +47,56 @@ func TestGetUserTypeSchemaID(t *testing.T) {
 	}
 }
 
+func TestGetUserTypeName(t *testing.T) {
+	tests := []struct {
+		name     string
+		userType oktasdk.UserType
+		want     string
+	}{
+		{
+			name:     "name metadata",
+			userType: testOktaUserTypeWithProperties(map[string]interface{}{"name": "Custom User"}),
+			want:     "Custom User",
+		},
+		{
+			name:     "display name metadata",
+			userType: testOktaUserTypeWithProperties(map[string]interface{}{"displayName": "Display User"}),
+			want:     "Display User",
+		},
+		{
+			name:     "fallback id",
+			userType: testOktaUserTypeWithProperties(nil),
+			want:     "custom",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := getUserTypeName(tt.userType); got != tt.want {
+				t.Fatalf("getUserTypeName() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
 func TestGetUserTypeSchemaIDAllowsMissingLinkFields(t *testing.T) {
 	tests := []struct {
 		name     string
-		userType *oktasdk.UserType
+		userType oktasdk.UserType
 	}{
 		{
 			name:     "links missing",
-			userType: &oktasdk.UserType{Id: "custom"},
+			userType: testOktaUserTypeWithProperties(nil),
 		},
 		{
-			name: "schema missing",
-			userType: &oktasdk.UserType{
-				Id:    "custom",
-				Links: map[string]interface{}{},
-			},
+			name:     "schema missing",
+			userType: testOktaUserType(map[string]interface{}{}),
 		},
 		{
 			name: "href missing",
-			userType: &oktasdk.UserType{
-				Id: "custom",
-				Links: map[string]interface{}{
-					"schema": map[string]interface{}{},
-				},
-			},
+			userType: testOktaUserType(map[string]interface{}{
+				"schema": map[string]interface{}{},
+			}),
 		},
 	}
 
@@ -93,34 +116,26 @@ func TestGetUserTypeSchemaIDAllowsMissingLinkFields(t *testing.T) {
 func TestGetUserTypeSchemaIDRejectsMalformedLinkFields(t *testing.T) {
 	tests := []struct {
 		name     string
-		userType *oktasdk.UserType
+		userType oktasdk.UserType
 		wantErr  string
 	}{
 		{
 			name:     "links wrong type",
-			userType: &oktasdk.UserType{Id: "custom", Links: "bad-links"},
+			userType: testOktaUserTypeWithProperties(map[string]interface{}{"_links": "bad-links"}),
 			wantErr:  "links has type",
 		},
 		{
-			name: "schema wrong type",
-			userType: &oktasdk.UserType{
-				Id: "custom",
-				Links: map[string]interface{}{
-					"schema": "bad-schema",
-				},
-			},
-			wantErr: "schema has type",
+			name:     "schema wrong type",
+			userType: testOktaUserType(map[string]interface{}{"schema": "bad-schema"}),
+			wantErr:  "schema has type",
 		},
 		{
 			name: "href wrong type",
-			userType: &oktasdk.UserType{
-				Id: "custom",
-				Links: map[string]interface{}{
-					"schema": map[string]interface{}{
-						"href": 123,
-					},
+			userType: testOktaUserType(map[string]interface{}{
+				"schema": map[string]interface{}{
+					"href": 123,
 				},
-			},
+			}),
 			wantErr: "href has type",
 		},
 	}
@@ -139,14 +154,11 @@ func TestGetUserTypeSchemaIDRejectsMalformedLinkFields(t *testing.T) {
 }
 
 func TestGetUserTypeSchemaIDReturnsParseError(t *testing.T) {
-	userType := &oktasdk.UserType{
-		Id: "custom",
-		Links: map[string]interface{}{
-			"schema": map[string]interface{}{
-				"href": "https://example.okta.com/%zz",
-			},
+	userType := testOktaUserType(map[string]interface{}{
+		"schema": map[string]interface{}{
+			"href": "https://example.okta.com/%zz",
 		},
-	}
+	})
 
 	_, err := getUserTypeSchemaID(userType)
 	if err == nil {
@@ -158,14 +170,11 @@ func TestGetUserTypeSchemaIDReturnsParseError(t *testing.T) {
 }
 
 func TestGetUserTypeSchemaIDRejectsUnexpectedPath(t *testing.T) {
-	userType := &oktasdk.UserType{
-		Id: "custom",
-		Links: map[string]interface{}{
-			"schema": map[string]interface{}{
-				"href": "https://example.okta.com/api/v1/users/custom",
-			},
+	userType := testOktaUserType(map[string]interface{}{
+		"schema": map[string]interface{}{
+			"href": "https://example.okta.com/api/v1/users/custom",
 		},
-	}
+	})
 
 	_, err := getUserTypeSchemaID(userType)
 	if err == nil {
@@ -177,14 +186,11 @@ func TestGetUserTypeSchemaIDRejectsUnexpectedPath(t *testing.T) {
 }
 
 func TestGetUserTypeSchemaIDRejectsMissingSchemaID(t *testing.T) {
-	userType := &oktasdk.UserType{
-		Id: "custom",
-		Links: map[string]interface{}{
-			"schema": map[string]interface{}{
-				"href": "https://example.okta.com/api/v1/meta/schemas/user/",
-			},
+	userType := testOktaUserType(map[string]interface{}{
+		"schema": map[string]interface{}{
+			"href": "https://example.okta.com/api/v1/meta/schemas/user/",
 		},
-	}
+	})
 
 	_, err := getUserTypeSchemaID(userType)
 	if err == nil {
@@ -193,4 +199,26 @@ func TestGetUserTypeSchemaIDRejectsMissingSchemaID(t *testing.T) {
 	if !strings.Contains(err.Error(), "missing schema ID") {
 		t.Fatalf("error = %q, want missing schema ID context", err)
 	}
+}
+
+func testOktaUserType(links map[string]interface{}) oktasdk.UserType {
+	props := map[string]interface{}{}
+	if links != nil {
+		props["_links"] = links
+	}
+	return testOktaUserTypeWithProperties(props)
+}
+
+func testOktaUserTypeWithProperties(props map[string]interface{}) oktasdk.UserType {
+	if props == nil {
+		props = map[string]interface{}{}
+	}
+	return oktasdk.UserType{
+		Id:                   stringPtr("custom"),
+		AdditionalProperties: props,
+	}
+}
+
+func stringPtr(value string) *string {
+	return &value
 }

--- a/providers/okta/okta_service.go
+++ b/providers/okta/okta_service.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 
 	"github.com/chenrui333/terraformer/terraformutils"
-	oktaV2 "github.com/okta/okta-sdk-golang/v2/okta"
 	oktaV6 "github.com/okta/okta-sdk-golang/v6/okta"
 	"github.com/okta/terraform-provider-okta/sdk"
 )
@@ -16,26 +15,7 @@ type OktaService struct { //nolint
 	terraformutils.Service
 }
 
-func (s *OktaService) Client() (context.Context, *oktaV2.Client, error) {
-	orgName := s.Args["org_name"].(string)
-	baseURL := s.Args["base_url"].(string)
-	apiToken := s.Args["api_token"].(string)
-
-	orgURL := fmt.Sprintf("https://%v.%v", orgName, baseURL)
-
-	ctx, client, err := oktaV2.NewClient(
-		context.Background(),
-		oktaV2.WithOrgUrl(orgURL),
-		oktaV2.WithToken(apiToken),
-	)
-	if err != nil {
-		return ctx, nil, err
-	}
-
-	return ctx, client, nil
-}
-
-func (s *OktaService) ClientV6() (context.Context, *oktaV6.APIClient, error) {
+func (s *OktaService) Client() (context.Context, *oktaV6.APIClient, error) {
 	orgName := s.Args["org_name"].(string)
 	baseURL := s.Args["base_url"].(string)
 	apiToken := s.Args["api_token"].(string)
@@ -52,6 +32,10 @@ func (s *OktaService) ClientV6() (context.Context, *oktaV6.APIClient, error) {
 	client := oktaV6.NewAPIClient(config)
 
 	return context.Background(), client, nil
+}
+
+func (s *OktaService) ClientV6() (context.Context, *oktaV6.APIClient, error) {
+	return s.Client()
 }
 
 func (s *OktaService) APISupplementClient() (context.Context, *sdk.APISupplement, error) {

--- a/providers/okta/policy_mfa.go
+++ b/providers/okta/policy_mfa.go
@@ -6,24 +6,27 @@ import (
 	"context"
 
 	"github.com/chenrui333/terraformer/terraformutils"
-	"github.com/okta/okta-sdk-golang/v2/okta"
-	"github.com/okta/okta-sdk-golang/v2/okta/query"
+	"github.com/okta/okta-sdk-golang/v6/okta"
 )
 
 type MFAPolicyGenerator struct {
 	OktaService
 }
 
-func (g MFAPolicyGenerator) createResources(mfaPolicyList []*okta.Policy) []terraformutils.Resource {
+func (g MFAPolicyGenerator) createResources(mfaPolicyList []okta.ListPolicies200ResponseInner) []terraformutils.Resource {
 	var resources []terraformutils.Resource
 	for _, mfaPolicy := range mfaPolicyList {
-		resourceName := normalizeResourceName(mfaPolicy.Name)
+		policy, ok := oktaPolicySummaryFromListPolicy(mfaPolicy)
+		if !ok {
+			continue
+		}
+		resourceName := normalizeResourceName(policy.Name)
 		resourceType := "okta_policy_mfa"
-		if mfaPolicy.Name == "Default Policy" {
+		if policy.Name == "Default Policy" {
 			resourceType = "okta_policy_mfa_default"
 		}
 		resources = append(resources, terraformutils.NewSimpleResource(
-			mfaPolicy.Id,
+			policy.ID,
 			"policy_mfa_"+resourceName,
 			resourceType,
 			"okta",
@@ -46,24 +49,19 @@ func (g *MFAPolicyGenerator) InitResources() error {
 	return nil
 }
 
-func getMFAPolicies(ctx context.Context, client *okta.Client) ([]*okta.Policy, error) {
-	qp := query.NewQueryParams(query.WithType("MFA_ENROLL"))
-	var policies []*okta.Policy
-	data, resp, err := client.Policy.ListPolicies(ctx, qp)
+func getMFAPolicies(ctx context.Context, client *okta.APIClient) ([]okta.ListPolicies200ResponseInner, error) {
+	policies, resp, err := client.PolicyAPI.ListPolicies(ctx).Type_("MFA_ENROLL").Execute()
 	if err != nil {
 		return nil, err
 	}
 
 	for resp.HasNextPage() {
-		var nextPolicies []*okta.Policy
-		resp, err = resp.Next(ctx, &nextPolicies)
+		var nextPolicies []okta.ListPolicies200ResponseInner
+		resp, err = resp.Next(&nextPolicies)
 		if err != nil {
 			return nil, err
 		}
 		policies = append(policies, nextPolicies...)
-	}
-	for _, p := range data {
-		policies = append(policies, p.(*okta.Policy))
 	}
 
 	return policies, nil

--- a/providers/okta/policy_password.go
+++ b/providers/okta/policy_password.go
@@ -6,24 +6,27 @@ import (
 	"context"
 
 	"github.com/chenrui333/terraformer/terraformutils"
-	"github.com/okta/okta-sdk-golang/v2/okta"
-	"github.com/okta/okta-sdk-golang/v2/okta/query"
+	"github.com/okta/okta-sdk-golang/v6/okta"
 )
 
 type PasswordPolicyGenerator struct {
 	OktaService
 }
 
-func (g PasswordPolicyGenerator) createResources(passwordPolicyList []*okta.Policy) []terraformutils.Resource {
+func (g PasswordPolicyGenerator) createResources(passwordPolicyList []okta.ListPolicies200ResponseInner) []terraformutils.Resource {
 	var resources []terraformutils.Resource
 	for _, passwordPolicy := range passwordPolicyList {
-		resourceName := normalizeResourceName(passwordPolicy.Name)
+		policy, ok := oktaPolicySummaryFromListPolicy(passwordPolicy)
+		if !ok {
+			continue
+		}
+		resourceName := normalizeResourceName(policy.Name)
 		resourceType := "okta_policy_password"
-		if passwordPolicy.Name == "Default Policy" {
+		if policy.Name == "Default Policy" {
 			resourceType = "okta_policy_password_default"
 		}
 		resources = append(resources, terraformutils.NewSimpleResource(
-			passwordPolicy.Id,
+			policy.ID,
 			"policy_password_"+resourceName,
 			resourceType,
 			"okta",
@@ -46,24 +49,19 @@ func (g *PasswordPolicyGenerator) InitResources() error {
 	return nil
 }
 
-func getPasswordPolicies(ctx context.Context, client *okta.Client) ([]*okta.Policy, error) {
-	qp := query.NewQueryParams(query.WithType("PASSWORD"))
-	var policies []*okta.Policy
-	data, resp, err := client.Policy.ListPolicies(ctx, qp)
+func getPasswordPolicies(ctx context.Context, client *okta.APIClient) ([]okta.ListPolicies200ResponseInner, error) {
+	policies, resp, err := client.PolicyAPI.ListPolicies(ctx).Type_("PASSWORD").Execute()
 	if err != nil {
 		return nil, err
 	}
 
 	for resp.HasNextPage() {
-		var nextPolicies []*okta.Policy
-		resp, err = resp.Next(ctx, &nextPolicies)
+		var nextPolicies []okta.ListPolicies200ResponseInner
+		resp, err = resp.Next(&nextPolicies)
 		if err != nil {
 			return nil, err
 		}
 		policies = append(policies, nextPolicies...)
-	}
-	for _, p := range data {
-		policies = append(policies, p.(*okta.Policy))
 	}
 
 	return policies, nil

--- a/providers/okta/policy_rule_mfa.go
+++ b/providers/okta/policy_rule_mfa.go
@@ -45,12 +45,16 @@ func (g *MFAPolicyRuleGenerator) InitResources() error {
 	}
 
 	for _, policy := range mfaPolicies {
-		output, err := getMFAPolicyRules(g, policy.Id)
+		policySummary, ok := oktaPolicySummaryFromListPolicy(policy)
+		if !ok {
+			continue
+		}
+		output, err := getMFAPolicyRules(g, policySummary.ID)
 		if err != nil {
 			return err
 		}
 
-		resources = append(resources, g.createResources(output, policy.Id, policy.Name)...)
+		resources = append(resources, g.createResources(output, policySummary.ID, policySummary.Name)...)
 	}
 
 	g.Resources = resources

--- a/providers/okta/policy_rule_password.go
+++ b/providers/okta/policy_rule_password.go
@@ -45,12 +45,16 @@ func (g *PasswordPolicyRuleGenerator) InitResources() error {
 	}
 
 	for _, policy := range passwordPolicies {
-		output, err := getPasswordPolicyRules(g, policy.Id)
+		policySummary, ok := oktaPolicySummaryFromListPolicy(policy)
+		if !ok {
+			continue
+		}
+		output, err := getPasswordPolicyRules(g, policySummary.ID)
 		if err != nil {
 			return err
 		}
 
-		resources = append(resources, g.createResources(output, policy.Id, policy.Name)...)
+		resources = append(resources, g.createResources(output, policySummary.ID, policySummary.Name)...)
 	}
 
 	g.Resources = resources

--- a/providers/okta/policy_rule_signon.go
+++ b/providers/okta/policy_rule_signon.go
@@ -45,12 +45,16 @@ func (g *SignOnPolicyRuleGenerator) InitResources() error {
 	}
 
 	for _, policy := range signOnPolicies {
-		output, err := getSignOnPolicyRules(g, policy.Id)
+		policySummary, ok := oktaPolicySummaryFromListPolicy(policy)
+		if !ok {
+			continue
+		}
+		output, err := getSignOnPolicyRules(g, policySummary.ID)
 		if err != nil {
 			return err
 		}
 
-		resources = append(resources, g.createResources(output, policy.Id, policy.Name)...)
+		resources = append(resources, g.createResources(output, policySummary.ID, policySummary.Name)...)
 	}
 
 	g.Resources = resources

--- a/providers/okta/policy_signon.go
+++ b/providers/okta/policy_signon.go
@@ -6,22 +6,30 @@ import (
 	"context"
 
 	"github.com/chenrui333/terraformer/terraformutils"
-	"github.com/okta/okta-sdk-golang/v2/okta"
-	"github.com/okta/okta-sdk-golang/v2/okta/query"
+	"github.com/okta/okta-sdk-golang/v6/okta"
 )
 
 type SignOnPolicyGenerator struct {
 	OktaService
 }
 
-func (g SignOnPolicyGenerator) createResources(signOnPolicyList []*okta.Policy) []terraformutils.Resource {
+type oktaPolicySummary struct {
+	ID   string
+	Name string
+}
+
+func (g SignOnPolicyGenerator) createResources(signOnPolicyList []okta.ListPolicies200ResponseInner) []terraformutils.Resource {
 	var resources []terraformutils.Resource
 	for _, signOnPolicy := range signOnPolicyList {
-		resourceName := normalizeResourceName(signOnPolicy.Name)
+		policy, ok := oktaPolicySummaryFromListPolicy(signOnPolicy)
+		if !ok {
+			continue
+		}
+		resourceName := normalizeResourceName(policy.Name)
 		resourceType := "okta_policy_signon"
 
 		resources = append(resources, terraformutils.NewSimpleResource(
-			signOnPolicy.Id,
+			policy.ID,
 			"policy_signon_"+resourceName,
 			resourceType,
 			"okta",
@@ -44,25 +52,37 @@ func (g *SignOnPolicyGenerator) InitResources() error {
 	return nil
 }
 
-func getSignOnPolicies(ctx context.Context, client *okta.Client) ([]*okta.Policy, error) {
-	qp := query.NewQueryParams(query.WithType("OKTA_SIGN_ON"))
-	var policies []*okta.Policy
-	data, resp, err := client.Policy.ListPolicies(ctx, qp)
+func getSignOnPolicies(ctx context.Context, client *okta.APIClient) ([]okta.ListPolicies200ResponseInner, error) {
+	policies, resp, err := client.PolicyAPI.ListPolicies(ctx).Type_("OKTA_SIGN_ON").Execute()
 	if err != nil {
 		return nil, err
 	}
 
 	for resp.HasNextPage() {
-		var nextPolicies []*okta.Policy
-		resp, err = resp.Next(ctx, &nextPolicies)
+		var nextPolicies []okta.ListPolicies200ResponseInner
+		resp, err = resp.Next(&nextPolicies)
 		if err != nil {
 			return nil, err
 		}
 		policies = append(policies, nextPolicies...)
 	}
-	for _, p := range data {
-		policies = append(policies, p.(*okta.Policy))
-	}
 
 	return policies, nil
+}
+
+func oktaPolicySummaryFromListPolicy(policy okta.ListPolicies200ResponseInner) (oktaPolicySummary, bool) {
+	switch {
+	case policy.AccessPolicy != nil:
+		return oktaPolicySummary{ID: policy.AccessPolicy.GetId(), Name: policy.AccessPolicy.GetName()}, true
+	case policy.AuthenticatorEnrollmentPolicy != nil:
+		return oktaPolicySummary{ID: policy.AuthenticatorEnrollmentPolicy.GetId(), Name: policy.AuthenticatorEnrollmentPolicy.GetName()}, true
+	case policy.OktaSignOnPolicy != nil:
+		return oktaPolicySummary{ID: policy.OktaSignOnPolicy.GetId(), Name: policy.OktaSignOnPolicy.GetName()}, true
+	case policy.PasswordPolicy != nil:
+		return oktaPolicySummary{ID: policy.PasswordPolicy.GetId(), Name: policy.PasswordPolicy.GetName()}, true
+	case policy.ProfileEnrollmentPolicy != nil:
+		return oktaPolicySummary{ID: policy.ProfileEnrollmentPolicy.GetId(), Name: policy.ProfileEnrollmentPolicy.GetName()}, true
+	default:
+		return oktaPolicySummary{}, false
+	}
 }

--- a/providers/okta/template_sms.go
+++ b/providers/okta/template_sms.go
@@ -4,19 +4,19 @@ package okta
 
 import (
 	"github.com/chenrui333/terraformer/terraformutils"
-	"github.com/okta/okta-sdk-golang/v2/okta"
+	"github.com/okta/okta-sdk-golang/v6/okta"
 )
 
 type SMSTemplateGenerator struct {
 	OktaService
 }
 
-func (g SMSTemplateGenerator) createResources(smsTemplateList []*okta.SmsTemplate) []terraformutils.Resource {
+func (g SMSTemplateGenerator) createResources(smsTemplateList []okta.SmsTemplate) []terraformutils.Resource {
 	var resources []terraformutils.Resource
 	for _, smsTemplate := range smsTemplateList {
 		resources = append(resources, terraformutils.NewSimpleResource(
-			smsTemplate.Id,
-			"template_sms_"+smsTemplate.Name,
+			smsTemplate.GetId(),
+			"template_sms_"+smsTemplate.GetName(),
 			"okta_template_sms",
 			"okta",
 			[]string{}))
@@ -30,14 +30,14 @@ func (g *SMSTemplateGenerator) InitResources() error {
 		return e
 	}
 
-	output, resp, err := client.SmsTemplate.ListSmsTemplates(ctx, nil)
+	output, resp, err := client.TemplateAPI.ListSmsTemplates(ctx).Execute()
 	if err != nil {
 		return err
 	}
 
 	for resp.HasNextPage() {
-		var nextSmsTemplateSet []*okta.SmsTemplate
-		resp, err = resp.Next(ctx, &nextSmsTemplateSet)
+		var nextSmsTemplateSet []okta.SmsTemplate
+		resp, err = resp.Next(&nextSmsTemplateSet)
 		if err != nil {
 			return err
 		}

--- a/providers/okta/trusted_origin.go
+++ b/providers/okta/trusted_origin.go
@@ -4,19 +4,19 @@ package okta
 
 import (
 	"github.com/chenrui333/terraformer/terraformutils"
-	"github.com/okta/okta-sdk-golang/v2/okta"
+	"github.com/okta/okta-sdk-golang/v6/okta"
 )
 
 type TrustedOriginGenerator struct {
 	OktaService
 }
 
-func (g TrustedOriginGenerator) createResources(trustedOriginList []*okta.TrustedOrigin) []terraformutils.Resource {
+func (g TrustedOriginGenerator) createResources(trustedOriginList []okta.TrustedOrigin) []terraformutils.Resource {
 	var resources []terraformutils.Resource
 	for _, trustedOrigin := range trustedOriginList {
 		resources = append(resources, terraformutils.NewSimpleResource(
-			trustedOrigin.Id,
-			"trusted_origin_"+trustedOrigin.Id,
+			trustedOrigin.GetId(),
+			"trusted_origin_"+trustedOrigin.GetId(),
 			"okta_trusted_origin",
 			"okta",
 			[]string{}))
@@ -30,14 +30,14 @@ func (g *TrustedOriginGenerator) InitResources() error {
 		return e
 	}
 
-	output, resp, err := client.TrustedOrigin.ListOrigins(ctx, nil)
+	output, resp, err := client.TrustedOriginAPI.ListTrustedOrigins(ctx).Execute()
 	if err != nil {
 		return err
 	}
 
 	for resp.HasNextPage() {
-		var nextTrustedOriginSet []*okta.TrustedOrigin
-		resp, err = resp.Next(ctx, &nextTrustedOriginSet)
+		var nextTrustedOriginSet []okta.TrustedOrigin
+		resp, err = resp.Next(&nextTrustedOriginSet)
 		if err != nil {
 			return err
 		}

--- a/providers/okta/user_schema.go
+++ b/providers/okta/user_schema.go
@@ -6,10 +6,12 @@ import (
 	"context"
 	"fmt"
 	"net/url"
+	"reflect"
+	"sort"
 	"strings"
 
 	"github.com/chenrui333/terraformer/terraformutils"
-	"github.com/okta/okta-sdk-golang/v2/okta"
+	"github.com/okta/okta-sdk-golang/v6/okta"
 )
 
 const oktaUserSchemaPathPrefix = "/api/v1/meta/schemas/user/"
@@ -20,7 +22,15 @@ type UserSchemaPropertyGenerator struct {
 
 func (g UserSchemaPropertyGenerator) createResources(userSchema *okta.UserSchema, userTypeID string, userTypeName string) []terraformutils.Resource {
 	var resources []terraformutils.Resource
-	for index := range userSchema.Definitions.Custom.Properties {
+	definitions := userSchema.GetDefinitions()
+	var customPropertyNames []string
+	if custom, ok := definitions.GetCustomOk(); ok {
+		for index := range custom.GetProperties() {
+			customPropertyNames = append(customPropertyNames, index)
+		}
+	}
+	sort.Strings(customPropertyNames)
+	for _, index := range customPropertyNames {
 		resources = append(resources, terraformutils.NewResource(
 			index,
 			normalizeResourceName(userTypeName)+"_property_"+normalizeResourceName(index),
@@ -35,7 +45,11 @@ func (g UserSchemaPropertyGenerator) createResources(userSchema *okta.UserSchema
 		))
 	}
 
-	for index := range userSchema.Definitions.Base.Properties {
+	var basePropertyNames []string
+	if base, ok := definitions.GetBaseOk(); ok {
+		basePropertyNames = userSchemaBasePropertyNames(base.GetProperties())
+	}
+	for _, index := range basePropertyNames {
 		resources = append(resources, terraformutils.NewResource(
 			index,
 			normalizeResourceName(userTypeName)+"_property_"+normalizeResourceName(index),
@@ -70,17 +84,18 @@ func (g *UserSchemaPropertyGenerator) InitResources() error {
 			return err
 		}
 		if schemaID != "" {
-			schema, _, err := client.UserSchema.GetUserSchema(ctx, schemaID)
+			schema, _, err := client.SchemaAPI.GetUserSchema(ctx, schemaID).Execute()
 			if err != nil {
 				return err
 			}
 
 			userTypeID := "default"
-			if userType.Name != "user" {
-				userTypeID = userType.Id
+			userTypeName := getUserTypeName(userType)
+			if userTypeName != "user" {
+				userTypeID = userType.GetId()
 			}
 
-			resources = append(resources, g.createResources(schema, userTypeID, userType.Name)...)
+			resources = append(resources, g.createResources(schema, userTypeID, userTypeName)...)
 		}
 	}
 
@@ -88,15 +103,15 @@ func (g *UserSchemaPropertyGenerator) InitResources() error {
 	return nil
 }
 
-func getUserTypes(ctx context.Context, client *okta.Client) ([]*okta.UserType, error) {
-	output, resp, err := client.UserType.ListUserTypes(ctx)
+func getUserTypes(ctx context.Context, client *okta.APIClient) ([]okta.UserType, error) {
+	output, resp, err := client.UserTypeAPI.ListUserTypes(ctx).Execute()
 	if err != nil {
 		return nil, err
 	}
 
 	for resp.HasNextPage() {
-		var nextUserTypeSet []*okta.UserType
-		resp, err = resp.Next(ctx, &nextUserTypeSet)
+		var nextUserTypeSet []okta.UserType
+		resp, err = resp.Next(&nextUserTypeSet)
 		if err != nil {
 			return nil, err
 		}
@@ -106,13 +121,24 @@ func getUserTypes(ctx context.Context, client *okta.Client) ([]*okta.UserType, e
 	return output, nil
 }
 
-func getUserTypeSchemaID(ut *okta.UserType) (string, error) {
-	fm, ok := ut.Links.(map[string]interface{})
+func getUserTypeName(ut okta.UserType) string {
+	if name, ok := ut.AdditionalProperties["name"].(string); ok && name != "" {
+		return name
+	}
+	if displayName, ok := ut.AdditionalProperties["displayName"].(string); ok && displayName != "" {
+		return displayName
+	}
+	return ut.GetId()
+}
+
+func getUserTypeSchemaID(ut okta.UserType) (string, error) {
+	links, ok := ut.AdditionalProperties["_links"]
 	if !ok {
-		if ut.Links == nil {
-			return "", nil
-		}
-		return "", fmt.Errorf("parse Okta user type %q schema link: links has type %T, want map[string]interface{}", ut.Id, ut.Links)
+		return "", nil
+	}
+	fm, ok := links.(map[string]interface{})
+	if !ok {
+		return "", fmt.Errorf("parse Okta user type %q schema link: links has type %T, want map[string]interface{}", ut.GetId(), links)
 	}
 	schemaValue, ok := fm["schema"]
 	if !ok {
@@ -120,7 +146,7 @@ func getUserTypeSchemaID(ut *okta.UserType) (string, error) {
 	}
 	sm, ok := schemaValue.(map[string]interface{})
 	if !ok {
-		return "", fmt.Errorf("parse Okta user type %q schema link: schema has type %T, want map[string]interface{}", ut.Id, schemaValue)
+		return "", fmt.Errorf("parse Okta user type %q schema link: schema has type %T, want map[string]interface{}", ut.GetId(), schemaValue)
 	}
 	hrefValue, ok := sm["href"]
 	if !ok {
@@ -128,19 +154,43 @@ func getUserTypeSchemaID(ut *okta.UserType) (string, error) {
 	}
 	href, ok := hrefValue.(string)
 	if !ok {
-		return "", fmt.Errorf("parse Okta user type %q schema link: href has type %T, want string", ut.Id, hrefValue)
+		return "", fmt.Errorf("parse Okta user type %q schema link: href has type %T, want string", ut.GetId(), hrefValue)
 	}
 	u, err := url.Parse(href)
 	if err != nil {
-		return "", fmt.Errorf("parse Okta user type %q schema link: %w", ut.Id, err)
+		return "", fmt.Errorf("parse Okta user type %q schema link: %w", ut.GetId(), err)
 	}
 	path := u.EscapedPath()
 	if !strings.HasPrefix(path, oktaUserSchemaPathPrefix) {
-		return "", fmt.Errorf("parse Okta user type %q schema link %q: unexpected path %q", ut.Id, href, path)
+		return "", fmt.Errorf("parse Okta user type %q schema link %q: unexpected path %q", ut.GetId(), href, path)
 	}
 	schemaID := strings.TrimPrefix(path, oktaUserSchemaPathPrefix)
 	if schemaID == "" {
-		return "", fmt.Errorf("parse Okta user type %q schema link %q: missing schema ID", ut.Id, href)
+		return "", fmt.Errorf("parse Okta user type %q schema link %q: missing schema ID", ut.GetId(), href)
 	}
 	return schemaID, nil
+}
+
+func userSchemaBasePropertyNames(properties okta.UserSchemaBaseProperties) []string {
+	names := make([]string, 0, len(properties.AdditionalProperties))
+	value := reflect.ValueOf(properties)
+	typeOfProperties := value.Type()
+	for i := 0; i < value.NumField(); i++ {
+		field := typeOfProperties.Field(i)
+		if field.Name == "AdditionalProperties" {
+			continue
+		}
+		jsonName := strings.Split(field.Tag.Get("json"), ",")[0]
+		if jsonName == "" || jsonName == "-" {
+			continue
+		}
+		if !value.Field(i).IsNil() {
+			names = append(names, jsonName)
+		}
+	}
+	for index := range properties.AdditionalProperties {
+		names = append(names, index)
+	}
+	sort.Strings(names)
+	return names
 }

--- a/providers/okta/user_schema.go
+++ b/providers/okta/user_schema.go
@@ -89,11 +89,8 @@ func (g *UserSchemaPropertyGenerator) InitResources() error {
 				return err
 			}
 
-			userTypeID := "default"
 			userTypeName := getUserTypeName(userType)
-			if userTypeName != "user" {
-				userTypeID = userType.GetId()
-			}
+			userTypeID := getUserTypeResourceID(userType)
 
 			resources = append(resources, g.createResources(schema, userTypeID, userTypeName)...)
 		}
@@ -122,11 +119,25 @@ func getUserTypes(ctx context.Context, client *okta.APIClient) ([]okta.UserType,
 }
 
 func getUserTypeName(ut okta.UserType) string {
-	if name, ok := ut.AdditionalProperties["name"].(string); ok && name != "" {
+	if name := getUserTypeAPIName(ut); name != "" {
 		return name
 	}
 	if displayName, ok := ut.AdditionalProperties["displayName"].(string); ok && displayName != "" {
 		return displayName
+	}
+	return ut.GetId()
+}
+
+func getUserTypeAPIName(ut okta.UserType) string {
+	if name, ok := ut.AdditionalProperties["name"].(string); ok {
+		return name
+	}
+	return ""
+}
+
+func getUserTypeResourceID(ut okta.UserType) string {
+	if getUserTypeAPIName(ut) == "user" {
+		return "default"
 	}
 	return ut.GetId()
 }

--- a/providers/okta/user_type.go
+++ b/providers/okta/user_type.go
@@ -4,19 +4,19 @@ package okta
 
 import (
 	"github.com/chenrui333/terraformer/terraformutils"
-	"github.com/okta/okta-sdk-golang/v2/okta"
+	"github.com/okta/okta-sdk-golang/v6/okta"
 )
 
 type UserTypeGenerator struct {
 	OktaService
 }
 
-func (g UserTypeGenerator) createResources(userTypeList []*okta.UserType) []terraformutils.Resource {
+func (g UserTypeGenerator) createResources(userTypeList []okta.UserType) []terraformutils.Resource {
 	var resources []terraformutils.Resource
 	for _, userType := range userTypeList {
 		resources = append(resources, terraformutils.NewSimpleResource(
-			userType.Id,
-			"usertype_"+userType.Name,
+			userType.GetId(),
+			"usertype_"+getUserTypeName(userType),
 			"okta_user_type",
 			"okta",
 			[]string{}))
@@ -30,14 +30,14 @@ func (g *UserTypeGenerator) InitResources() error {
 		return e
 	}
 
-	output, resp, err := client.UserType.ListUserTypes(ctx)
+	output, resp, err := client.UserTypeAPI.ListUserTypes(ctx).Execute()
 	if err != nil {
 		return err
 	}
 
 	for resp.HasNextPage() {
-		var nextUserTypeSet []*okta.UserType
-		resp, err = resp.Next(ctx, &nextUserTypeSet)
+		var nextUserTypeSet []okta.UserType
+		resp, err = resp.Next(&nextUserTypeSet)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
## Summary

Migrates the Okta provider to github.com/okta/okta-sdk-golang/v6 source usage and removes the legacy v2 SDK from the tidy module graph.

This follows issue #595, where the dependency-only v6 update was not tidy-stable because providers/okta still imported the legacy v2 module.

## Changes

- Update remaining Okta provider source from okta-sdk-golang/v2 to okta-sdk-golang/v6.
- Add focused tests for provider registration, IDP/policy resource mapping, IDP pagination, empty responses, and second-page error propagation.
- Preserve Terraformer resource names and import IDs for migrated generators.
- Sort user schema property resources for deterministic output.
- Run go mod tidy so only Okta SDK v6 remains in go.mod/go.sum.

## Testing

- go test ./providers/okta -count=1
- go test ./providers/okta -race -count=1
- go test ./providers/okta -coverprofile=/tmp/terraformer-okta-after.cover
- go vet ./providers/okta
- golangci-lint run --new-from-rev=origin/main ./providers/okta
- go test ./providers/okta ./providers/github ./providers/linode ./providers/myrasec -count=1
- GOMAXPROCS=4 go test -p=1 ./providers/... -count=1
- GOMAXPROCS=4 go vet ./...
- govulncheck ./providers/okta
- govulncheck ./...

## Notes

- No real Okta credentials were used.
- Final tests use httptest-backed Okta responses.
- No Okta resources were created, mutated, or deleted.

Fixes #595.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Migrates the Okta provider to `github.com/okta/okta-sdk-golang/v6`, replacing all v2 usages, unifying the client, and keeping resource names/import IDs stable with deterministic user/app schema output.

- **Refactors**
  - Switch to v6 `okta.APIClient` and API groups (e.g., `PolicyAPI`, `ApplicationAPI`, `SchemaAPI`); `Client()` now returns v6 (`ClientV6()` is an alias).
  - Adopt v6 pagination (`resp.Next(&dst)`) and union types (e.g., `ListApplications200ResponseInner`); add helpers like `getApplicationSummary`, `oktaPolicySummaryFromListPolicy`, and paginated `getAuthorizationServerPolicies`.
  - Preserve Terraformer resource names and import IDs; map default user type to ID `default`; sort custom and base schema properties for stable user/app schema output; preserve group names from v6 profiles (`OktaUserGroupProfile`, `OktaActiveDirectoryGroupProfile`) with ID fallback.
  - Add focused tests for provider registration; IDP discovery (pagination, empty responses, next-page error propagation); authorization server policy pagination; policy resource naming; and group name preservation.

- **Dependencies**
  - Remove `github.com/okta/okta-sdk-golang/v2`; depend on `github.com/okta/okta-sdk-golang/v6`.
  - Run `go mod tidy` to drop unused transitives (e.g., `github.com/go-jose/go-jose/v3`).

<sup>Written for commit a0d5b1151c2a72d5a226e728b9ed8e589b6ea707. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/chenrui333/terraformer/pull/632?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

