### PR TITLE
fix(github): harden provider discovery

### DIFF
--- a/providers/github/github_provider_test.go
+++ b/providers/github/github_provider_test.go
@@ -120,23 +120,54 @@ func TestGithubServiceCreateEnterpriseClientUsesNormalizedBaseURL(t *testing.T) 
 }
 
 func TestGithubServiceCreateEnterpriseClientRejectsInvalidBaseURL(t *testing.T) {
-	service := &GithubService{}
-	service.SetArgs(map[string]interface{}{
-		"base_url":        "github.example.com/api/v3",
-		"app_id":          int64(0),
-		"installation_id": int64(0),
-		"pem":             "",
-		"token":           "test-token",
-	})
+	tests := []struct {
+		name      string
+		baseURL   string
+		errorText string
+	}{
+		{
+			name:      "missing scheme",
+			baseURL:   "github.example.com/api/v3",
+			errorText: "scheme must be http or https",
+		},
+		{
+			name:      "credentials",
+			baseURL:   "https://user:pass@github.example.com/api/v3",
+			errorText: "credentials are not allowed",
+		},
+		{
+			name:      "query",
+			baseURL:   "https://github.example.com/api/v3?token=secret",
+			errorText: "query parameters are not allowed",
+		},
+		{
+			name:      "fragment",
+			baseURL:   "https://github.example.com/api/v3#fragment",
+			errorText: "fragments are not allowed",
+		},
+	}
 
-	client, err := service.createClient()
-	if err == nil {
-		t.Fatal("expected invalid base_url error")
-	}
-	if client != nil {
-		t.Fatalf("client = %v, want nil", client)
-	}
-	if !strings.Contains(err.Error(), "scheme must be http or https") {
-		t.Fatalf("error = %q, want scheme validation", err)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			service := &GithubService{}
+			service.SetArgs(map[string]interface{}{
+				"base_url":        tt.baseURL,
+				"app_id":          int64(0),
+				"installation_id": int64(0),
+				"pem":             "",
+				"token":           "test-token",
+			})
+
+			client, err := service.createClient()
+			if err == nil {
+				t.Fatal("expected invalid base_url error")
+			}
+			if client != nil {
+				t.Fatalf("client = %v, want nil", client)
+			}
+			if !strings.Contains(err.Error(), tt.errorText) {
+				t.Fatalf("error = %q, want %q", err, tt.errorText)
+			}
+		})
 	}
 }

--- a/providers/github/github_provider_test.go
+++ b/providers/github/github_provider_test.go
@@ -1,0 +1,142 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package github
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	githubAPI "github.com/google/go-github/v88/github"
+)
+
+func TestGithubProviderServiceRegistration(t *testing.T) {
+	var provider GithubProvider
+
+	if got := provider.GetName(); got != "github" {
+		t.Fatalf("GetName() = %q, want github", got)
+	}
+
+	services := provider.GetSupportedService()
+	for _, name := range []string{
+		"members",
+		"organization",
+		"organization_blocks",
+		"organization_projects",
+		"organization_webhooks",
+		"repositories",
+		"teams",
+		"user_ssh_keys",
+	} {
+		if services[name] == nil {
+			t.Fatalf("supported services missing %q", name)
+		}
+	}
+
+	if err := provider.Init([]string{"test-org", "test-token"}); err != nil {
+		t.Fatalf("Init returned error: %v", err)
+	}
+	if err := provider.InitService("repositories", false); err != nil {
+		t.Fatalf("InitService returned error: %v", err)
+	}
+	args := provider.Service.GetArgs()
+	if got := args["owner"]; got != "test-org" {
+		t.Fatalf("service owner arg = %q, want test-org", got)
+	}
+	if got := args["token"]; got != "test-token" {
+		t.Fatalf("service token arg = %q, want test-token", got)
+	}
+	if got := args["base_url"]; got != githubDefaultURL {
+		t.Fatalf("service base_url arg = %q, want %q", got, githubDefaultURL)
+	}
+
+	if err := provider.InitService("missing", false); err == nil {
+		t.Fatal("expected unsupported service error")
+	}
+}
+
+func TestGithubProviderInitEmptyBaseURLUsesPublicDefault(t *testing.T) {
+	var provider GithubProvider
+
+	if err := provider.Init([]string{"test-org", "test-token", ""}); err != nil {
+		t.Fatalf("Init returned error: %v", err)
+	}
+	if provider.baseURL != githubDefaultURL {
+		t.Fatalf("baseURL = %q, want %q", provider.baseURL, githubDefaultURL)
+	}
+}
+
+func TestGithubServiceCreateEnterpriseClientUsesNormalizedBaseURL(t *testing.T) {
+	var seenPath string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			t.Errorf("method = %s, want GET", r.Method)
+			http.Error(w, "unexpected method", http.StatusBadRequest)
+			return
+		}
+		seenPath = r.URL.Path
+		if r.URL.Path != "/api/v3/orgs/test-org/repos" {
+			t.Errorf("path = %s, want /api/v3/orgs/test-org/repos", r.URL.Path)
+			http.Error(w, "unexpected path", http.StatusNotFound)
+			return
+		}
+		if got := r.Header.Get("Authorization"); got != "Bearer test-token" {
+			t.Errorf("Authorization = %q, want bearer token", got)
+			http.Error(w, "unexpected auth", http.StatusUnauthorized)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`[]`))
+	}))
+	t.Cleanup(server.Close)
+
+	service := &GithubService{}
+	service.SetArgs(map[string]interface{}{
+		"base_url":        strings.TrimRight(server.URL, "/"),
+		"app_id":          int64(0),
+		"installation_id": int64(0),
+		"pem":             "",
+		"token":           "test-token",
+	})
+
+	client, err := service.createClient()
+	if err != nil {
+		t.Fatalf("createClient returned error: %v", err)
+	}
+	repos, _, err := client.Repositories.ListByOrg(context.Background(), "test-org", &githubAPI.RepositoryListByOrgOptions{
+		ListOptions: githubAPI.ListOptions{PerPage: 100},
+	})
+	if err != nil {
+		t.Fatalf("ListByOrg returned error: %v", err)
+	}
+	if len(repos) != 0 {
+		t.Fatalf("repos = %d, want 0", len(repos))
+	}
+	if seenPath != "/api/v3/orgs/test-org/repos" {
+		t.Fatalf("seen path = %q, want enterprise API path", seenPath)
+	}
+}
+
+func TestGithubServiceCreateEnterpriseClientRejectsInvalidBaseURL(t *testing.T) {
+	service := &GithubService{}
+	service.SetArgs(map[string]interface{}{
+		"base_url":        "github.example.com/api/v3",
+		"app_id":          int64(0),
+		"installation_id": int64(0),
+		"pem":             "",
+		"token":           "test-token",
+	})
+
+	client, err := service.createClient()
+	if err == nil {
+		t.Fatal("expected invalid base_url error")
+	}
+	if client != nil {
+		t.Fatalf("client = %v, want nil", client)
+	}
+	if !strings.Contains(err.Error(), "scheme must be http or https") {
+		t.Fatalf("error = %q, want scheme validation", err)
+	}
+}

--- a/providers/github/github_service.go
+++ b/providers/github/github_service.go
@@ -4,7 +4,10 @@ package github
 
 import (
 	"context"
+	"fmt"
 	"net/http"
+	"net/url"
+	"strings"
 
 	"github.com/bradleyfalzon/ghinstallation/v2"
 	"github.com/chenrui333/terraformer/terraformutils"
@@ -43,7 +46,10 @@ func (g *GithubService) createRegularClient() (*github.Client, error) {
 
 func (g *GithubService) createEnterpriseClient() (*github.Client, error) {
 	ctx := context.Background()
-	baseURL := g.GetArgs()["base_url"].(string)
+	baseURL, err := normalizeGithubBaseURL(g.GetArgs()["base_url"].(string))
+	if err != nil {
+		return nil, err
+	}
 	if g.Args["app_id"].(int64) != 0 && g.Args["installation_id"].(int64) != 0 && g.Args["pem"].(string) != "" {
 		itr, err := ghinstallation.New(http.DefaultTransport, g.Args["app_id"].(int64), g.Args["installation_id"].(int64), []byte(g.Args["pem"].(string)))
 		if err != nil {
@@ -62,4 +68,22 @@ func (g *GithubService) createEnterpriseClient() (*github.Client, error) {
 		github.WithEnterpriseURLs(baseURL, baseURL),
 		github.WithHTTPClient(tc),
 	)
+}
+
+func normalizeGithubBaseURL(baseURL string) (string, error) {
+	baseURL = strings.TrimSpace(baseURL)
+	parsed, err := url.Parse(baseURL)
+	if err != nil {
+		return "", fmt.Errorf("github: invalid base_url %q: %w", baseURL, err)
+	}
+	if parsed.Scheme != "http" && parsed.Scheme != "https" {
+		return "", fmt.Errorf("github: invalid base_url %q: scheme must be http or https", baseURL)
+	}
+	if parsed.Host == "" {
+		return "", fmt.Errorf("github: invalid base_url %q: host is required", baseURL)
+	}
+	if !strings.HasSuffix(parsed.Path, "/") {
+		parsed.Path += "/"
+	}
+	return parsed.String(), nil
 }

--- a/providers/github/github_service.go
+++ b/providers/github/github_service.go
@@ -4,6 +4,7 @@ package github
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net/http"
 	"net/url"
@@ -75,6 +76,15 @@ func normalizeGithubBaseURL(baseURL string) (string, error) {
 	parsed, err := url.Parse(baseURL)
 	if err != nil {
 		return "", fmt.Errorf("github: invalid base_url %q: %w", baseURL, err)
+	}
+	if parsed.User != nil {
+		return "", errors.New("github: invalid base_url: credentials are not allowed")
+	}
+	if parsed.RawQuery != "" {
+		return "", errors.New("github: invalid base_url: query parameters are not allowed")
+	}
+	if parsed.Fragment != "" {
+		return "", errors.New("github: invalid base_url: fragments are not allowed")
 	}
 	if parsed.Scheme != "http" && parsed.Scheme != "https" {
 		return "", fmt.Errorf("github: invalid base_url %q: scheme must be http or https", baseURL)

--- a/providers/github/repositories.go
+++ b/providers/github/repositories.go
@@ -75,78 +75,110 @@ func (g *RepositoriesGenerator) InitResources() error {
 
 func (g *RepositoriesGenerator) createRepositoryWebhookResources(ctx context.Context, client *githubAPI.Client, repo *githubAPI.Repository) ([]terraformutils.Resource, error) {
 	resources := []terraformutils.Resource{}
-	hooks, _, err := client.Repositories.ListHooks(ctx, g.GetArgs()["owner"].(string), repo.GetName(), nil)
-	if err != nil {
-		return nil, fmt.Errorf("list github repository webhooks for %s: %w", repo.GetName(), err)
-	}
-	for _, hook := range hooks {
-		resources = append(resources, terraformutils.NewResource(
-			strconv.FormatInt(hook.GetID(), 10),
-			repo.GetName()+"_"+strconv.FormatInt(hook.GetID(), 10),
-			"github_repository_webhook",
-			"github",
-			map[string]string{
-				"repository": repo.GetName(),
-			},
-			[]string{},
-			map[string]interface{}{},
-		))
+	opt := &githubAPI.ListOptions{PerPage: 100}
+	for {
+		hooks, resp, err := client.Repositories.ListHooks(ctx, g.GetArgs()["owner"].(string), repo.GetName(), opt)
+		if err != nil {
+			return nil, fmt.Errorf("list github repository webhooks for %s: %w", repo.GetName(), err)
+		}
+		for _, hook := range hooks {
+			resources = append(resources, terraformutils.NewResource(
+				strconv.FormatInt(hook.GetID(), 10),
+				repo.GetName()+"_"+strconv.FormatInt(hook.GetID(), 10),
+				"github_repository_webhook",
+				"github",
+				map[string]string{
+					"repository": repo.GetName(),
+				},
+				[]string{},
+				map[string]interface{}{},
+			))
+		}
+		if resp.NextPage == 0 {
+			break
+		}
+		opt.Page = resp.NextPage
 	}
 	return resources, nil
 }
 
 func (g *RepositoriesGenerator) createRepositoryBranchProtectionResources(ctx context.Context, client *githubAPI.Client, repo *githubAPI.Repository) ([]terraformutils.Resource, error) {
 	resources := []terraformutils.Resource{}
-	branches, _, err := client.Repositories.ListBranches(ctx, g.GetArgs()["owner"].(string), repo.GetName(), nil)
-	if err != nil {
-		return nil, fmt.Errorf("list github repository branches for %s: %w", repo.GetName(), err)
+	opt := &githubAPI.BranchListOptions{
+		ListOptions: githubAPI.ListOptions{PerPage: 100},
 	}
-	for _, branch := range branches {
-		if branch.GetProtected() {
-			resources = append(resources, terraformutils.NewSimpleResource(
-				repo.GetName()+":"+branch.GetName(),
-				repo.GetName()+"_"+branch.GetName(),
-				"github_branch_protection",
-				"github",
-				[]string{},
-			))
+	for {
+		branches, resp, err := client.Repositories.ListBranches(ctx, g.GetArgs()["owner"].(string), repo.GetName(), opt)
+		if err != nil {
+			return nil, fmt.Errorf("list github repository branches for %s: %w", repo.GetName(), err)
 		}
+		for _, branch := range branches {
+			if branch.GetProtected() {
+				resources = append(resources, terraformutils.NewSimpleResource(
+					repo.GetName()+":"+branch.GetName(),
+					repo.GetName()+"_"+branch.GetName(),
+					"github_branch_protection",
+					"github",
+					[]string{},
+				))
+			}
+		}
+		if resp.NextPage == 0 {
+			break
+		}
+		opt.Page = resp.NextPage
 	}
 	return resources, nil
 }
 
 func (g *RepositoriesGenerator) createRepositoryCollaboratorResources(ctx context.Context, client *githubAPI.Client, repo *githubAPI.Repository) ([]terraformutils.Resource, error) {
 	resources := []terraformutils.Resource{}
-	collaborators, _, err := client.Repositories.ListCollaborators(ctx, g.GetArgs()["owner"].(string), repo.GetName(), nil)
-	if err != nil {
-		return nil, fmt.Errorf("list github repository collaborators for %s: %w", repo.GetName(), err)
+	opt := &githubAPI.ListCollaboratorsOptions{
+		ListOptions: githubAPI.ListOptions{PerPage: 100},
 	}
-	for _, collaborator := range collaborators {
-		resources = append(resources, terraformutils.NewSimpleResource(
-			repo.GetName()+":"+collaborator.GetLogin(),
-			repo.GetName()+":"+collaborator.GetLogin(),
-			"github_repository_collaborator",
-			"github",
-			[]string{},
-		))
+	for {
+		collaborators, resp, err := client.Repositories.ListCollaborators(ctx, g.GetArgs()["owner"].(string), repo.GetName(), opt)
+		if err != nil {
+			return nil, fmt.Errorf("list github repository collaborators for %s: %w", repo.GetName(), err)
+		}
+		for _, collaborator := range collaborators {
+			resources = append(resources, terraformutils.NewSimpleResource(
+				repo.GetName()+":"+collaborator.GetLogin(),
+				repo.GetName()+":"+collaborator.GetLogin(),
+				"github_repository_collaborator",
+				"github",
+				[]string{},
+			))
+		}
+		if resp.NextPage == 0 {
+			break
+		}
+		opt.Page = resp.NextPage
 	}
 	return resources, nil
 }
 
 func (g *RepositoriesGenerator) createRepositoryDeployKeyResources(ctx context.Context, client *githubAPI.Client, repo *githubAPI.Repository) ([]terraformutils.Resource, error) {
 	resources := []terraformutils.Resource{}
-	deployKeys, _, err := client.Repositories.ListKeys(ctx, g.GetArgs()["owner"].(string), repo.GetName(), nil)
-	if err != nil {
-		return nil, fmt.Errorf("list github repository deploy keys for %s: %w", repo.GetName(), err)
-	}
-	for _, key := range deployKeys {
-		resources = append(resources, terraformutils.NewSimpleResource(
-			repo.GetName()+":"+strconv.FormatInt(key.GetID(), 10),
-			repo.GetName()+":"+key.GetTitle(),
-			"github_repository_deploy_key",
-			"github",
-			[]string{},
-		))
+	opt := &githubAPI.ListOptions{PerPage: 100}
+	for {
+		deployKeys, resp, err := client.Repositories.ListKeys(ctx, g.GetArgs()["owner"].(string), repo.GetName(), opt)
+		if err != nil {
+			return nil, fmt.Errorf("list github repository deploy keys for %s: %w", repo.GetName(), err)
+		}
+		for _, key := range deployKeys {
+			resources = append(resources, terraformutils.NewSimpleResource(
+				repo.GetName()+":"+strconv.FormatInt(key.GetID(), 10),
+				repo.GetName()+":"+key.GetTitle(),
+				"github_repository_deploy_key",
+				"github",
+				[]string{},
+			))
+		}
+		if resp.NextPage == 0 {
+			break
+		}
+		opt.Page = resp.NextPage
 	}
 	return resources, nil
 }

--- a/providers/github/repositories_test.go
+++ b/providers/github/repositories_test.go
@@ -1,0 +1,251 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package github
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/chenrui333/terraformer/terraformutils"
+	githubAPI "github.com/google/go-github/v88/github"
+)
+
+func TestRepositoryChildResourcesPaginateAndMap(t *testing.T) {
+	ctx := context.Background()
+	var server *httptest.Server
+	server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		page, ok := githubTestPage(t, r)
+		if !ok {
+			http.Error(w, "unexpected pagination query", http.StatusBadRequest)
+			return
+		}
+
+		switch r.URL.Path {
+		case "/repos/test-org/test-repo/hooks":
+			switch page {
+			case 1:
+				writeGitHubTestPage(w, r, server.URL, 2, `[{"id":101}]`)
+			case 2:
+				writeGitHubTestPage(w, r, server.URL, 0, `[{"id":102}]`)
+			default:
+				unexpectedGitHubPage(t, w, r, page)
+			}
+		case "/repos/test-org/test-repo/branches":
+			switch page {
+			case 1:
+				writeGitHubTestPage(w, r, server.URL, 2, `[{"name":"main","protected":true}]`)
+			case 2:
+				writeGitHubTestPage(w, r, server.URL, 0, `[{"name":"dev","protected":false},{"name":"release","protected":true}]`)
+			default:
+				unexpectedGitHubPage(t, w, r, page)
+			}
+		case "/repos/test-org/test-repo/collaborators":
+			switch page {
+			case 1:
+				writeGitHubTestPage(w, r, server.URL, 2, `[{"login":"alice"}]`)
+			case 2:
+				writeGitHubTestPage(w, r, server.URL, 0, `[{"login":"bob"}]`)
+			default:
+				unexpectedGitHubPage(t, w, r, page)
+			}
+		case "/repos/test-org/test-repo/keys":
+			switch page {
+			case 1:
+				writeGitHubTestPage(w, r, server.URL, 2, `[{"id":201,"title":"deploy-main"}]`)
+			case 2:
+				writeGitHubTestPage(w, r, server.URL, 0, `[{"id":202,"title":"deploy-release"}]`)
+			default:
+				unexpectedGitHubPage(t, w, r, page)
+			}
+		default:
+			unexpectedGitHubRequest(t, w, r)
+		}
+	}))
+	t.Cleanup(server.Close)
+
+	client := newTestGitHubClient(t, server)
+	g := RepositoriesGenerator{}
+	g.SetArgs(map[string]interface{}{"owner": "test-org"})
+	repoName := "test-repo"
+	repo := &githubAPI.Repository{Name: &repoName}
+
+	hooks, err := g.createRepositoryWebhookResources(ctx, client, repo)
+	if err != nil {
+		t.Fatalf("createRepositoryWebhookResources returned error: %v", err)
+	}
+	assertGithubResources(t, hooks, []githubResourceWant{
+		{id: "101", name: "tfer--test-repo_101", typ: "github_repository_webhook"},
+		{id: "102", name: "tfer--test-repo_102", typ: "github_repository_webhook"},
+	})
+	if got := hooks[0].InstanceState.Attributes["repository"]; got != "test-repo" {
+		t.Fatalf("webhook repository attribute = %q, want test-repo", got)
+	}
+
+	branches, err := g.createRepositoryBranchProtectionResources(ctx, client, repo)
+	if err != nil {
+		t.Fatalf("createRepositoryBranchProtectionResources returned error: %v", err)
+	}
+	assertGithubResources(t, branches, []githubResourceWant{
+		{id: "test-repo:main", name: "tfer--test-repo_main", typ: "github_branch_protection"},
+		{id: "test-repo:release", name: "tfer--test-repo_release", typ: "github_branch_protection"},
+	})
+
+	collaborators, err := g.createRepositoryCollaboratorResources(ctx, client, repo)
+	if err != nil {
+		t.Fatalf("createRepositoryCollaboratorResources returned error: %v", err)
+	}
+	assertGithubResources(t, collaborators, []githubResourceWant{
+		{id: "test-repo:alice", name: "tfer--test-repo-003A-alice", typ: "github_repository_collaborator"},
+		{id: "test-repo:bob", name: "tfer--test-repo-003A-bob", typ: "github_repository_collaborator"},
+	})
+
+	keys, err := g.createRepositoryDeployKeyResources(ctx, client, repo)
+	if err != nil {
+		t.Fatalf("createRepositoryDeployKeyResources returned error: %v", err)
+	}
+	assertGithubResources(t, keys, []githubResourceWant{
+		{id: "test-repo:201", name: "tfer--test-repo-003A-deploy-main", typ: "github_repository_deploy_key"},
+		{id: "test-repo:202", name: "tfer--test-repo-003A-deploy-release", typ: "github_repository_deploy_key"},
+	})
+}
+
+func TestCreateRepositoryWebhookResourcesReturnsSecondPageError(t *testing.T) {
+	ctx := context.Background()
+	var server *httptest.Server
+	server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		page, ok := githubTestPage(t, r)
+		if !ok {
+			http.Error(w, "unexpected pagination query", http.StatusBadRequest)
+			return
+		}
+		if r.URL.Path != "/repos/test-org/test-repo/hooks" {
+			unexpectedGitHubRequest(t, w, r)
+			return
+		}
+
+		switch page {
+		case 1:
+			writeGitHubTestPage(w, r, server.URL, 2, `[{"id":101}]`)
+		case 2:
+			http.Error(w, `{"message":"service unavailable"}`, http.StatusServiceUnavailable)
+		default:
+			unexpectedGitHubPage(t, w, r, page)
+		}
+	}))
+	t.Cleanup(server.Close)
+
+	client := newTestGitHubClient(t, server)
+	g := RepositoriesGenerator{}
+	g.SetArgs(map[string]interface{}{"owner": "test-org"})
+
+	repoName := "test-repo"
+	_, err := g.createRepositoryWebhookResources(ctx, client, &githubAPI.Repository{Name: &repoName})
+	if err == nil {
+		t.Fatal("expected second page webhook error")
+	}
+	if !strings.Contains(err.Error(), "list github repository webhooks for test-repo") {
+		t.Fatalf("error = %q, want repository webhook context", err)
+	}
+}
+
+func TestCreateMembershipsResourcesHandlesEmptyPage(t *testing.T) {
+	ctx := context.Background()
+	var server *httptest.Server
+	server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		page, ok := githubTestPage(t, r)
+		if !ok {
+			http.Error(w, "unexpected pagination query", http.StatusBadRequest)
+			return
+		}
+		if page != 1 {
+			unexpectedGitHubPage(t, w, r, page)
+			return
+		}
+		if r.URL.Path != "/orgs/test-org/members" {
+			unexpectedGitHubRequest(t, w, r)
+			return
+		}
+		writeGitHubTestPage(w, r, server.URL, 0, `[]`)
+	}))
+	t.Cleanup(server.Close)
+
+	client := newTestGitHubClient(t, server)
+
+	resources, err := createMembershipsResources(ctx, client, "test-org")
+	if err != nil {
+		t.Fatalf("createMembershipsResources returned error: %v", err)
+	}
+	if len(resources) != 0 {
+		t.Fatalf("resources = %d, want 0", len(resources))
+	}
+}
+
+type githubResourceWant struct {
+	id   string
+	name string
+	typ  string
+}
+
+func assertGithubResources(t *testing.T, resources []terraformutils.Resource, wants []githubResourceWant) {
+	t.Helper()
+
+	if len(resources) != len(wants) {
+		t.Fatalf("resources = %d, want %d", len(resources), len(wants))
+	}
+	for i, want := range wants {
+		resource := resources[i]
+		if resource.InstanceState.ID != want.id {
+			t.Fatalf("resources[%d].InstanceState.ID = %q, want %q", i, resource.InstanceState.ID, want.id)
+		}
+		if resource.ResourceName != want.name {
+			t.Fatalf("resources[%d].ResourceName = %q, want %q", i, resource.ResourceName, want.name)
+		}
+		if resource.InstanceInfo.Type != want.typ {
+			t.Fatalf("resources[%d].InstanceInfo.Type = %q, want %q", i, resource.InstanceInfo.Type, want.typ)
+		}
+	}
+}
+
+func githubTestPage(t *testing.T, r *http.Request) (int, bool) {
+	if got := r.URL.Query().Get("per_page"); got != "100" {
+		t.Errorf("request %s per_page = %q, want 100", r.URL.Path, got)
+		return 0, false
+	}
+	pageValue := r.URL.Query().Get("page")
+	if pageValue == "" {
+		return 1, true
+	}
+	page, err := strconv.Atoi(pageValue)
+	if err != nil {
+		t.Errorf("request %s page = %q, want integer: %v", r.URL.Path, pageValue, err)
+		return 0, false
+	}
+	return page, true
+}
+
+func writeGitHubTestPage(w http.ResponseWriter, r *http.Request, serverURL string, nextPage int, body string) {
+	w.Header().Set("Content-Type", "application/json")
+	if nextPage != 0 {
+		nextURL := *r.URL
+		nextQuery := nextURL.Query()
+		nextQuery.Set("page", strconv.Itoa(nextPage))
+		nextURL.RawQuery = nextQuery.Encode()
+		w.Header().Set("Link", fmt.Sprintf("<%s%s>; rel=\"next\"", serverURL, nextURL.String()))
+	}
+	_, _ = w.Write([]byte(body))
+}
+
+func unexpectedGitHubRequest(t *testing.T, w http.ResponseWriter, r *http.Request) {
+	t.Errorf("unexpected %s request to %s", r.Method, r.URL.String())
+	http.Error(w, "unexpected request", http.StatusNotFound)
+}
+
+func unexpectedGitHubPage(t *testing.T, w http.ResponseWriter, r *http.Request, page int) {
+	t.Errorf("unexpected page %d for %s", page, r.URL.String())
+	http.Error(w, "unexpected page", http.StatusNotFound)
+}

--- a/providers/github/teams.go
+++ b/providers/github/teams.go
@@ -44,36 +44,52 @@ func (g *TeamsGenerator) createTeamsResources(ctx context.Context, teams []*gith
 
 func (g *TeamsGenerator) createTeamMembersResources(ctx context.Context, team *githubAPI.Team, client *githubAPI.Client) ([]terraformutils.Resource, error) {
 	resources := []terraformutils.Resource{}
-	members, _, err := client.Teams.ListTeamMembersBySlug(ctx, g.Args["owner"].(string), team.GetSlug(), nil)
-	if err != nil {
-		return nil, fmt.Errorf("list github team members for %s: %w", team.GetSlug(), err)
+	opt := &githubAPI.TeamListTeamMembersOptions{
+		ListOptions: githubAPI.ListOptions{PerPage: 100},
 	}
-	for _, member := range members {
-		resources = append(resources, terraformutils.NewSimpleResource(
-			strconv.FormatInt(team.GetID(), 10)+":"+member.GetLogin(),
-			team.GetName()+"_"+member.GetLogin(),
-			"github_team_membership",
-			"github",
-			[]string{},
-		))
+	for {
+		members, resp, err := client.Teams.ListTeamMembersBySlug(ctx, g.Args["owner"].(string), team.GetSlug(), opt)
+		if err != nil {
+			return nil, fmt.Errorf("list github team members for %s: %w", team.GetSlug(), err)
+		}
+		for _, member := range members {
+			resources = append(resources, terraformutils.NewSimpleResource(
+				strconv.FormatInt(team.GetID(), 10)+":"+member.GetLogin(),
+				team.GetName()+"_"+member.GetLogin(),
+				"github_team_membership",
+				"github",
+				[]string{},
+			))
+		}
+		if resp.NextPage == 0 {
+			break
+		}
+		opt.Page = resp.NextPage
 	}
 	return resources, nil
 }
 
 func (g *TeamsGenerator) createTeamRepositoriesResources(ctx context.Context, team *githubAPI.Team, client *githubAPI.Client) ([]terraformutils.Resource, error) {
 	resources := []terraformutils.Resource{}
-	repos, _, err := client.Teams.ListTeamReposBySlug(ctx, g.Args["owner"].(string), team.GetSlug(), nil)
-	if err != nil {
-		return nil, fmt.Errorf("list github team repositories for %s: %w", team.GetSlug(), err)
-	}
-	for _, repo := range repos {
-		resources = append(resources, terraformutils.NewSimpleResource(
-			strconv.FormatInt(team.GetID(), 10)+":"+repo.GetName(),
-			team.GetName()+"_"+repo.GetName(),
-			"github_team_repository",
-			"github",
-			[]string{},
-		))
+	opt := &githubAPI.ListOptions{PerPage: 100}
+	for {
+		repos, resp, err := client.Teams.ListTeamReposBySlug(ctx, g.Args["owner"].(string), team.GetSlug(), opt)
+		if err != nil {
+			return nil, fmt.Errorf("list github team repositories for %s: %w", team.GetSlug(), err)
+		}
+		for _, repo := range repos {
+			resources = append(resources, terraformutils.NewSimpleResource(
+				strconv.FormatInt(team.GetID(), 10)+":"+repo.GetName(),
+				team.GetName()+"_"+repo.GetName(),
+				"github_team_repository",
+				"github",
+				[]string{},
+			))
+		}
+		if resp.NextPage == 0 {
+			break
+		}
+		opt.Page = resp.NextPage
 	}
 	return resources, nil
 }

--- a/providers/github/teams_test.go
+++ b/providers/github/teams_test.go
@@ -1,0 +1,78 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package github
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	githubAPI "github.com/google/go-github/v88/github"
+)
+
+func TestTeamChildResourcesPaginateAndMap(t *testing.T) {
+	ctx := context.Background()
+	var server *httptest.Server
+	server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		page, ok := githubTestPage(t, r)
+		if !ok {
+			http.Error(w, "unexpected pagination query", http.StatusBadRequest)
+			return
+		}
+
+		switch r.URL.Path {
+		case "/orgs/test-org/teams/platform/members":
+			switch page {
+			case 1:
+				writeGitHubTestPage(w, r, server.URL, 2, `[{"login":"alice"}]`)
+			case 2:
+				writeGitHubTestPage(w, r, server.URL, 0, `[{"login":"bob"}]`)
+			default:
+				unexpectedGitHubPage(t, w, r, page)
+			}
+		case "/orgs/test-org/teams/platform/repos":
+			switch page {
+			case 1:
+				writeGitHubTestPage(w, r, server.URL, 2, `[{"name":"api"}]`)
+			case 2:
+				writeGitHubTestPage(w, r, server.URL, 0, `[{"name":"worker"}]`)
+			default:
+				unexpectedGitHubPage(t, w, r, page)
+			}
+		default:
+			unexpectedGitHubRequest(t, w, r)
+		}
+	}))
+	t.Cleanup(server.Close)
+
+	client := newTestGitHubClient(t, server)
+	g := TeamsGenerator{}
+	g.SetArgs(map[string]interface{}{"owner": "test-org"})
+	teamID := int64(42)
+	teamName := "Platform"
+	teamSlug := "platform"
+	team := &githubAPI.Team{
+		ID:   &teamID,
+		Name: &teamName,
+		Slug: &teamSlug,
+	}
+
+	members, err := g.createTeamMembersResources(ctx, team, client)
+	if err != nil {
+		t.Fatalf("createTeamMembersResources returned error: %v", err)
+	}
+	assertGithubResources(t, members, []githubResourceWant{
+		{id: "42:alice", name: "tfer--Platform_alice", typ: "github_team_membership"},
+		{id: "42:bob", name: "tfer--Platform_bob", typ: "github_team_membership"},
+	})
+
+	repos, err := g.createTeamRepositoriesResources(ctx, team, client)
+	if err != nil {
+		t.Fatalf("createTeamRepositoriesResources returned error: %v", err)
+	}
+	assertGithubResources(t, repos, []githubResourceWant{
+		{id: "42:api", name: "tfer--Platform_api", typ: "github_team_repository"},
+		{id: "42:worker", name: "tfer--Platform_worker", typ: "github_team_repository"},
+	})
+}


### PR DESCRIPTION
## Summary

Adds focused GitHub provider coverage and hardens provider discovery behavior.

This follows the provider audit finding that `providers/github` had low coverage and thin coverage around GitHub Enterprise/base URL handling and paginated discovery.

## Changes

- Validate and normalize GitHub Enterprise base URLs before constructing the SDK client.
- Paginate nested repository child discovery for webhooks, branch protections, collaborators, and deploy keys.
- Paginate nested team child discovery for members and repositories.
- Add httptest-backed coverage for Enterprise client initialization, pagination, error propagation, empty responses, and resource mapping.
- Preserve Terraformer resource names and import IDs.

## Notes

- No real GitHub token was used.
- No live GitHub API calls were made.
- No GitHub repositories, teams, collaborators, branches, or webhooks were created, mutated, or deleted.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hardens the GitHub provider by strictly validating Enterprise `base_url` and paginating nested discovery to avoid missed resources and unsafe clients. Adds focused tests for Enterprise client creation, pagination (including empty/second-page errors), and resource mapping in `providers/github`.

- **Bug Fixes**
  - Validate and normalize Enterprise `base_url`: require http/https and host; disallow credentials, query params, and fragments; ensure trailing slash; use normalized URL with `/api/v3`.
  - Paginate repository children: webhooks, branch protections, collaborators, deploy keys.
  - Paginate team children: members and repositories.
  - Add `httptest` coverage for provider/service init defaults, Enterprise client base URL handling (including rejects), multi-page pagination, empty pages, error propagation, and preserving Terraformer resource names/import IDs.

<sup>Written for commit 0cdd28e2f8ca69084d83e585c38e51695728cff8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/chenrui333/terraformer/pull/634?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved pagination handling for GitHub repository and team resources to ensure complete data sets are fetched
  * Added validation for enterprise GitHub URLs with enhanced error messaging

* **Tests**
  * Added comprehensive test coverage for GitHub provider integration and resource generation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->