### PR TITLE
fix(vultr): harden provider discovery

### DIFF
--- a/README.md
+++ b/README.md
@@ -272,7 +272,7 @@ Links to download Terraform provider plugins:
     * Linode provider >1.8.0 - [here](https://releases.hashicorp.com/terraform-provider-linode/)
     * OpenStack provider >1.21.1 - [here](https://releases.hashicorp.com/terraform-provider-openstack/)
     * TencentCloud provider >1.50.0 - [here](https://releases.hashicorp.com/terraform-provider-tencentcloud/)
-    * Vultr provider >=2.11.0 - [here](https://github.com/vultr/terraform-provider-vultr/releases)
+    * Vultr provider >=2.16.0 - [here](https://github.com/vultr/terraform-provider-vultr/releases)
     * Yandex provider >0.42.0 - [here](https://releases.hashicorp.com/terraform-provider-yandex/)
     * Ionoscloud provider >6.3.3 - [here](https://github.com/ionos-cloud/terraform-provider-ionoscloud/releases)
 * Infrastructure Software

--- a/README.md
+++ b/README.md
@@ -272,7 +272,7 @@ Links to download Terraform provider plugins:
     * Linode provider >1.8.0 - [here](https://releases.hashicorp.com/terraform-provider-linode/)
     * OpenStack provider >1.21.1 - [here](https://releases.hashicorp.com/terraform-provider-openstack/)
     * TencentCloud provider >1.50.0 - [here](https://releases.hashicorp.com/terraform-provider-tencentcloud/)
-    * Vultr provider >=2.16.0 - [here](https://github.com/vultr/terraform-provider-vultr/releases)
+    * Vultr provider >=2.16.0 - [Vultr Terraform provider releases](https://github.com/vultr/terraform-provider-vultr/releases)
     * Yandex provider >0.42.0 - [here](https://releases.hashicorp.com/terraform-provider-yandex/)
     * Ionoscloud provider >6.3.3 - [here](https://github.com/ionos-cloud/terraform-provider-ionoscloud/releases)
 * Infrastructure Software

--- a/README.md
+++ b/README.md
@@ -272,7 +272,7 @@ Links to download Terraform provider plugins:
     * Linode provider >1.8.0 - [here](https://releases.hashicorp.com/terraform-provider-linode/)
     * OpenStack provider >1.21.1 - [here](https://releases.hashicorp.com/terraform-provider-openstack/)
     * TencentCloud provider >1.50.0 - [here](https://releases.hashicorp.com/terraform-provider-tencentcloud/)
-    * Vultr provider >1.0.5 - [here](https://releases.hashicorp.com/terraform-provider-vultr/)
+    * Vultr provider >=2.0.0 - [here](https://github.com/vultr/terraform-provider-vultr/releases)
     * Yandex provider >0.42.0 - [here](https://releases.hashicorp.com/terraform-provider-yandex/)
     * Ionoscloud provider >6.3.3 - [here](https://github.com/ionos-cloud/terraform-provider-ionoscloud/releases)
 * Infrastructure Software

--- a/README.md
+++ b/README.md
@@ -272,7 +272,7 @@ Links to download Terraform provider plugins:
     * Linode provider >1.8.0 - [here](https://releases.hashicorp.com/terraform-provider-linode/)
     * OpenStack provider >1.21.1 - [here](https://releases.hashicorp.com/terraform-provider-openstack/)
     * TencentCloud provider >1.50.0 - [here](https://releases.hashicorp.com/terraform-provider-tencentcloud/)
-    * Vultr provider >=2.0.0 - [here](https://github.com/vultr/terraform-provider-vultr/releases)
+    * Vultr provider >=2.11.0 - [here](https://github.com/vultr/terraform-provider-vultr/releases)
     * Yandex provider >0.42.0 - [here](https://releases.hashicorp.com/terraform-provider-yandex/)
     * Ionoscloud provider >6.3.3 - [here](https://github.com/ionos-cloud/terraform-provider-ionoscloud/releases)
 * Infrastructure Software

--- a/cmd/provider_cmd_vultr.go
+++ b/cmd/provider_cmd_vultr.go
@@ -24,7 +24,7 @@ func newCmdVultrImporter(options ImportOptions) *cobra.Command {
 	}
 
 	cmd.AddCommand(listCmd(newVultrProvider()))
-	baseProviderFlags(cmd.PersistentFlags(), &options, "server", "server=name1:name2:name3")
+	baseProviderFlags(cmd.PersistentFlags(), &options, "instance", "instance=name1:name2:name3")
 	return cmd
 }
 

--- a/docs/vultr.md
+++ b/docs/vultr.md
@@ -4,7 +4,7 @@ Example:
 
 ```
 export VULTR_API_KEY=[VULTR_API_KEY]
-./terraformer import vultr -r server
+./terraformer import vultr -r instance
 ```
 
 List of supported Vultr resources:
@@ -19,12 +19,10 @@ List of supported Vultr resources:
 *   `firewall_group`
     * `vultr_firewall_group`
     * `vultr_firewall_rule`
-*   `network`
-    * `vultr_network`
+*   `instance`
+    * `vultr_instance`
 *   `reserved_ip`
     * `vultr_reserved_ip`
-*   `server`
-    * `vultr_server`
 *   `snapshot`
     * `vultr_snapshot`
 *   `ssh_key`
@@ -33,3 +31,5 @@ List of supported Vultr resources:
     * `vultr_startup_script`
 *   `user`
     * `vultr_user`
+*   `vpc`
+    * `vultr_vpc`

--- a/providers/vultr/bare_metal_server.go
+++ b/providers/vultr/bare_metal_server.go
@@ -4,6 +4,7 @@ package vultr
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/chenrui333/terraformer/terraformutils"
 	"github.com/vultr/govultr/v3"
@@ -27,10 +28,13 @@ func (g BareMetalServerGenerator) createResources(serverList []govultr.BareMetal
 }
 
 func (g *BareMetalServerGenerator) InitResources() error {
-	client := g.generateClient()
-	output, _, _, err := client.BareMetalServer.List(context.Background(), nil)
+	client, err := g.generateClient()
 	if err != nil {
 		return err
+	}
+	output, err := listAllVultrResources(context.Background(), client.BareMetalServer.List)
+	if err != nil {
+		return fmt.Errorf("list vultr bare metal servers: %w", err)
 	}
 	g.Resources = g.createResources(output)
 	return nil

--- a/providers/vultr/block_storage.go
+++ b/providers/vultr/block_storage.go
@@ -4,6 +4,7 @@ package vultr
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/chenrui333/terraformer/terraformutils"
 	"github.com/vultr/govultr/v3"
@@ -27,10 +28,13 @@ func (g BlockStorageGenerator) createResources(blockStorageList []govultr.BlockS
 }
 
 func (g *BlockStorageGenerator) InitResources() error {
-	client := g.generateClient()
-	output, _, _, err := client.BlockStorage.List(context.Background(), nil)
+	client, err := g.generateClient()
 	if err != nil {
 		return err
+	}
+	output, err := listAllVultrResources(context.Background(), client.BlockStorage.List)
+	if err != nil {
+		return fmt.Errorf("list vultr block storage: %w", err)
 	}
 	g.Resources = g.createResources(output)
 	return nil

--- a/providers/vultr/dns_domain.go
+++ b/providers/vultr/dns_domain.go
@@ -4,6 +4,8 @@ package vultr
 
 import (
 	"context"
+	"fmt"
+	"net/http"
 
 	"github.com/chenrui333/terraformer/terraformutils"
 	"github.com/vultr/govultr/v3"
@@ -14,9 +16,9 @@ type DNSDomainGenerator struct {
 }
 
 func (g *DNSDomainGenerator) loadDNSDomains(client *govultr.Client) ([]govultr.Domain, error) {
-	domainList, _, _, err := client.Domain.List(context.Background(), nil)
+	domainList, err := listAllVultrResources(context.Background(), client.Domain.List)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("list vultr DNS domains: %w", err)
 	}
 	for _, domain := range domainList {
 		g.Resources = append(g.Resources, terraformutils.NewSimpleResource(
@@ -30,9 +32,11 @@ func (g *DNSDomainGenerator) loadDNSDomains(client *govultr.Client) ([]govultr.D
 }
 
 func (g *DNSDomainGenerator) loadDNSRecords(client *govultr.Client, domain string) error {
-	recordList, _, _, err := client.DomainRecord.List(context.Background(), domain, nil)
+	recordList, err := listAllVultrResources(context.Background(), func(ctx context.Context, opt *govultr.ListOptions) ([]govultr.DomainRecord, *govultr.Meta, *http.Response, error) {
+		return client.DomainRecord.List(ctx, domain, opt)
+	})
 	if err != nil {
-		return err
+		return fmt.Errorf("list vultr DNS records for %q: %w", domain, err)
 	}
 	for _, record := range recordList {
 		g.Resources = append(g.Resources, terraformutils.NewResource(
@@ -48,7 +52,10 @@ func (g *DNSDomainGenerator) loadDNSRecords(client *govultr.Client, domain strin
 }
 
 func (g *DNSDomainGenerator) InitResources() error {
-	client := g.generateClient()
+	client, err := g.generateClient()
+	if err != nil {
+		return err
+	}
 	domainList, err := g.loadDNSDomains(client)
 	if err != nil {
 		return err

--- a/providers/vultr/firewall_group.go
+++ b/providers/vultr/firewall_group.go
@@ -32,29 +32,31 @@ func (g *FirewallGroupGenerator) loadFirewallGroups(client *govultr.Client) ([]g
 	return firewallGroups, nil
 }
 
-func (g *FirewallGroupGenerator) loadFirewallRulesByIPType(client *govultr.Client, firewallGroupID string, ipType string) error {
+func (g *FirewallGroupGenerator) loadFirewallRules(client *govultr.Client, firewallGroupID string) error {
 	firewallRules, err := listAllVultrResources(context.Background(), func(ctx context.Context, opt *govultr.ListOptions) ([]govultr.FirewallRule, *govultr.Meta, *http.Response, error) {
 		return client.FirewallRule.List(ctx, firewallGroupID, opt)
 	})
 	if err != nil {
 		return fmt.Errorf("list vultr firewall rules for %q: %w", firewallGroupID, err)
 	}
-	for _, firewallRule := range firewallRules {
-		if firewallRule.IPType != ipType {
-			continue
-		}
+	for _, ipType := range []string{"v4", "v6"} {
+		for _, firewallRule := range firewallRules {
+			if firewallRule.IPType != ipType {
+				continue
+			}
 
-		g.Resources = append(g.Resources, terraformutils.NewResource(
-			strconv.Itoa(firewallRule.ID),
-			strconv.Itoa(firewallRule.ID),
-			"vultr_firewall_rule",
-			"vultr",
-			map[string]string{
-				"firewall_group_id": firewallGroupID,
-				"ip_type":           ipType,
-			},
-			[]string{},
-			map[string]interface{}{}))
+			g.Resources = append(g.Resources, terraformutils.NewResource(
+				strconv.Itoa(firewallRule.ID),
+				strconv.Itoa(firewallRule.ID),
+				"vultr_firewall_rule",
+				"vultr",
+				map[string]string{
+					"firewall_group_id": firewallGroupID,
+					"ip_type":           ipType,
+				},
+				[]string{},
+				map[string]interface{}{}))
+		}
 	}
 	return nil
 }
@@ -69,11 +71,7 @@ func (g *FirewallGroupGenerator) InitResources() error {
 		return err
 	}
 	for _, firewallGroup := range firewallGroups {
-		err := g.loadFirewallRulesByIPType(client, firewallGroup.ID, "v4")
-		if err != nil {
-			return err
-		}
-		err = g.loadFirewallRulesByIPType(client, firewallGroup.ID, "v6")
+		err := g.loadFirewallRules(client, firewallGroup.ID)
 		if err != nil {
 			return err
 		}

--- a/providers/vultr/firewall_group.go
+++ b/providers/vultr/firewall_group.go
@@ -4,6 +4,8 @@ package vultr
 
 import (
 	"context"
+	"fmt"
+	"net/http"
 	"strconv"
 
 	"github.com/chenrui333/terraformer/terraformutils"
@@ -15,9 +17,9 @@ type FirewallGroupGenerator struct {
 }
 
 func (g *FirewallGroupGenerator) loadFirewallGroups(client *govultr.Client) ([]govultr.FirewallGroup, error) {
-	firewallGroups, _, _, err := client.FirewallGroup.List(context.Background(), nil)
+	firewallGroups, err := listAllVultrResources(context.Background(), client.FirewallGroup.List)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("list vultr firewall groups: %w", err)
 	}
 	for _, firewallGroup := range firewallGroups {
 		g.Resources = append(g.Resources, terraformutils.NewSimpleResource(
@@ -31,9 +33,11 @@ func (g *FirewallGroupGenerator) loadFirewallGroups(client *govultr.Client) ([]g
 }
 
 func (g *FirewallGroupGenerator) loadFirewallRulesByIPType(client *govultr.Client, firewallGroupID string, ipType string) error {
-	firewallRules, _, _, err := client.FirewallRule.List(context.Background(), firewallGroupID, nil)
+	firewallRules, err := listAllVultrResources(context.Background(), func(ctx context.Context, opt *govultr.ListOptions) ([]govultr.FirewallRule, *govultr.Meta, *http.Response, error) {
+		return client.FirewallRule.List(ctx, firewallGroupID, opt)
+	})
 	if err != nil {
-		return err
+		return fmt.Errorf("list vultr firewall rules for %q: %w", firewallGroupID, err)
 	}
 	for _, firewallRule := range firewallRules {
 		if firewallRule.IPType != ipType {
@@ -56,7 +60,10 @@ func (g *FirewallGroupGenerator) loadFirewallRulesByIPType(client *govultr.Clien
 }
 
 func (g *FirewallGroupGenerator) InitResources() error {
-	client := g.generateClient()
+	client, err := g.generateClient()
+	if err != nil {
+		return err
+	}
 	firewallGroups, err := g.loadFirewallGroups(client)
 	if err != nil {
 		return err

--- a/providers/vultr/network.go
+++ b/providers/vultr/network.go
@@ -4,6 +4,7 @@ package vultr
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/chenrui333/terraformer/terraformutils"
 	"github.com/vultr/govultr/v3"
@@ -19,7 +20,7 @@ func (g NetworkGenerator) createResources(networkList []govultr.VPC) []terraform
 		resources = append(resources, terraformutils.NewSimpleResource(
 			network.ID,
 			network.ID,
-			"vultr_network",
+			"vultr_vpc",
 			"vultr",
 			[]string{}))
 	}
@@ -27,10 +28,13 @@ func (g NetworkGenerator) createResources(networkList []govultr.VPC) []terraform
 }
 
 func (g *NetworkGenerator) InitResources() error {
-	client := g.generateClient()
-	output, _, _, err := client.VPC.List(context.Background(), nil)
+	client, err := g.generateClient()
 	if err != nil {
 		return err
+	}
+	output, err := listAllVultrResources(context.Background(), client.VPC.List)
+	if err != nil {
+		return fmt.Errorf("list vultr VPCs: %w", err)
 	}
 	g.Resources = g.createResources(output)
 	return nil

--- a/providers/vultr/pagination.go
+++ b/providers/vultr/pagination.go
@@ -1,0 +1,33 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package vultr
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/vultr/govultr/v3"
+)
+
+func listAllVultrResources[T any](ctx context.Context, list func(context.Context, *govultr.ListOptions) ([]T, *govultr.Meta, *http.Response, error)) ([]T, error) {
+	opt := &govultr.ListOptions{PerPage: 100}
+	var resources []T
+
+	for {
+		pageResources, meta, resp, err := list(ctx, opt)
+		if resp != nil && resp.Body != nil {
+			_ = resp.Body.Close()
+		}
+		if err != nil {
+			return nil, err
+		}
+		resources = append(resources, pageResources...)
+
+		if meta == nil || meta.Links == nil || meta.Links.Next == "" {
+			break
+		}
+		opt.Cursor = meta.Links.Next
+	}
+
+	return resources, nil
+}

--- a/providers/vultr/reserved_ip.go
+++ b/providers/vultr/reserved_ip.go
@@ -4,6 +4,7 @@ package vultr
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/chenrui333/terraformer/terraformutils"
 	"github.com/vultr/govultr/v3"
@@ -27,10 +28,13 @@ func (g ReservedIPGenerator) createResources(ipList []govultr.ReservedIP) []terr
 }
 
 func (g *ReservedIPGenerator) InitResources() error {
-	client := g.generateClient()
-	output, _, _, err := client.ReservedIP.List(context.Background(), nil)
+	client, err := g.generateClient()
 	if err != nil {
 		return err
+	}
+	output, err := listAllVultrResources(context.Background(), client.ReservedIP.List)
+	if err != nil {
+		return fmt.Errorf("list vultr reserved IPs: %w", err)
 	}
 	g.Resources = g.createResources(output)
 	return nil

--- a/providers/vultr/server.go
+++ b/providers/vultr/server.go
@@ -5,6 +5,9 @@ package vultr
 import (
 	"context"
 	"fmt"
+	"net/http"
+	"sort"
+	"strconv"
 
 	"github.com/chenrui333/terraformer/terraformutils"
 	"github.com/vultr/govultr/v3"
@@ -14,26 +17,92 @@ type ServerGenerator struct {
 	VultrService
 }
 
-func (g ServerGenerator) createResources(serverList []govultr.Instance) []terraformutils.Resource {
+type vultrInstanceAttachments struct {
+	vpcIDs  []string
+	vpc2IDs []string
+}
+
+func (g ServerGenerator) createResources(serverList []govultr.Instance, attachments map[string]vultrInstanceAttachments) []terraformutils.Resource {
 	var resources []terraformutils.Resource
 	for _, server := range serverList {
-		resources = append(resources, terraformutils.NewSimpleResource(
+		resources = append(resources, terraformutils.NewResource(
 			server.ID,
 			server.ID,
 			"vultr_instance",
 			"vultr",
-			[]string{}))
+			vultrInstanceAttachmentAttributes(attachments[server.ID]),
+			[]string{},
+			map[string]interface{}{}))
 	}
 	return resources
 }
 
-func (g *ServerGenerator) initResources(client *govultr.Client) error {
-	output, err := listAllVultrResources(context.Background(), client.Instance.List)
-	if err != nil {
-		return fmt.Errorf("list vultr instances: %w", err)
+func vultrInstanceAttachmentAttributes(attachments vultrInstanceAttachments) map[string]string {
+	attributes := map[string]string{}
+	addVultrStringSetAttributes(attributes, "vpc_ids", attachments.vpcIDs)
+	addVultrStringSetAttributes(attributes, "vpc2_ids", attachments.vpc2IDs)
+	return attributes
+}
+
+func addVultrStringSetAttributes(attributes map[string]string, field string, values []string) {
+	if len(values) == 0 {
+		return
 	}
-	g.Resources = g.createResources(output)
-	return nil
+	attributes[field+".#"] = strconv.Itoa(len(values))
+	for _, value := range values {
+		attributes[fmt.Sprintf("%s.%d", field, terraformutils.HashString(value))] = value
+	}
+}
+
+func (g *ServerGenerator) loadInstanceAttachments(client *govultr.Client, instances []govultr.Instance) (map[string]vultrInstanceAttachments, error) {
+	attachments := map[string]vultrInstanceAttachments{}
+	for _, instance := range instances {
+		vpcIDs, err := listVultrInstanceVPCIDs(client, instance.ID)
+		if err != nil {
+			return nil, err
+		}
+		vpc2IDs, err := listVultrInstanceVPC2IDs(client, instance.ID)
+		if err != nil {
+			return nil, err
+		}
+		attachments[instance.ID] = vultrInstanceAttachments{
+			vpcIDs:  vpcIDs,
+			vpc2IDs: vpc2IDs,
+		}
+	}
+	return attachments, nil
+}
+
+func listVultrInstanceVPCIDs(client *govultr.Client, instanceID string) ([]string, error) {
+	vpcs, err := listAllVultrResources(context.Background(), func(ctx context.Context, opt *govultr.ListOptions) ([]govultr.VPCInfo, *govultr.Meta, *http.Response, error) {
+		return client.Instance.ListVPCInfo(ctx, instanceID, opt)
+	})
+	if err != nil {
+		return nil, fmt.Errorf("list vultr VPC attachments for instance %q: %w", instanceID, err)
+	}
+	ids := make([]string, 0, len(vpcs))
+	for _, vpc := range vpcs {
+		ids = append(ids, vpc.ID)
+	}
+	sort.Strings(ids)
+	return ids, nil
+}
+
+func listVultrInstanceVPC2IDs(client *govultr.Client, instanceID string) ([]string, error) {
+	//nolint:staticcheck // Existing instances can still have deprecated VPC2 attachments that must be preserved.
+	vpcs, err := listAllVultrResources(context.Background(), func(ctx context.Context, opt *govultr.ListOptions) ([]govultr.VPC2Info, *govultr.Meta, *http.Response, error) {
+		//nolint:staticcheck // Existing instances can still have deprecated VPC2 attachments that must be preserved.
+		return client.Instance.ListVPC2Info(ctx, instanceID, opt)
+	})
+	if err != nil {
+		return nil, fmt.Errorf("list vultr VPC2 attachments for instance %q: %w", instanceID, err)
+	}
+	ids := make([]string, 0, len(vpcs))
+	for _, vpc := range vpcs {
+		ids = append(ids, vpc.ID)
+	}
+	sort.Strings(ids)
+	return ids, nil
 }
 
 func (g *ServerGenerator) InitResources() error {
@@ -42,4 +111,17 @@ func (g *ServerGenerator) InitResources() error {
 		return err
 	}
 	return g.initResources(client)
+}
+
+func (g *ServerGenerator) initResources(client *govultr.Client) error {
+	output, err := listAllVultrResources(context.Background(), client.Instance.List)
+	if err != nil {
+		return fmt.Errorf("list vultr instances: %w", err)
+	}
+	attachments, err := g.loadInstanceAttachments(client, output)
+	if err != nil {
+		return err
+	}
+	g.Resources = g.createResources(output, attachments)
+	return nil
 }

--- a/providers/vultr/server.go
+++ b/providers/vultr/server.go
@@ -45,13 +45,27 @@ func vultrInstanceAttachmentAttributes(attachments vultrInstanceAttachments) map
 }
 
 func addVultrStringSetAttributes(attributes map[string]string, field string, values []string) {
-	if len(values) == 0 {
+	uniqueValues := uniqueVultrStrings(values)
+	if len(uniqueValues) == 0 {
 		return
 	}
-	attributes[field+".#"] = strconv.Itoa(len(values))
-	for _, value := range values {
+	attributes[field+".#"] = strconv.Itoa(len(uniqueValues))
+	for _, value := range uniqueValues {
 		attributes[fmt.Sprintf("%s.%d", field, terraformutils.HashString(value))] = value
 	}
+}
+
+func uniqueVultrStrings(values []string) []string {
+	seen := make(map[string]struct{}, len(values))
+	uniqueValues := make([]string, 0, len(values))
+	for _, value := range values {
+		if _, ok := seen[value]; ok {
+			continue
+		}
+		seen[value] = struct{}{}
+		uniqueValues = append(uniqueValues, value)
+	}
+	return uniqueValues
 }
 
 func (g *ServerGenerator) loadInstanceAttachments(client *govultr.Client, instances []govultr.Instance) (map[string]vultrInstanceAttachments, error) {

--- a/providers/vultr/server.go
+++ b/providers/vultr/server.go
@@ -4,6 +4,7 @@ package vultr
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/chenrui333/terraformer/terraformutils"
 	"github.com/vultr/govultr/v3"
@@ -19,19 +20,26 @@ func (g ServerGenerator) createResources(serverList []govultr.Instance) []terraf
 		resources = append(resources, terraformutils.NewSimpleResource(
 			server.ID,
 			server.ID,
-			"vultr_server",
+			"vultr_instance",
 			"vultr",
 			[]string{}))
 	}
 	return resources
 }
 
-func (g *ServerGenerator) InitResources() error {
-	client := g.generateClient()
-	output, _, _, err := client.Instance.List(context.Background(), nil)
+func (g *ServerGenerator) initResources(client *govultr.Client) error {
+	output, err := listAllVultrResources(context.Background(), client.Instance.List)
 	if err != nil {
-		return err
+		return fmt.Errorf("list vultr instances: %w", err)
 	}
 	g.Resources = g.createResources(output)
 	return nil
+}
+
+func (g *ServerGenerator) InitResources() error {
+	client, err := g.generateClient()
+	if err != nil {
+		return err
+	}
+	return g.initResources(client)
 }

--- a/providers/vultr/snapshot.go
+++ b/providers/vultr/snapshot.go
@@ -4,6 +4,7 @@ package vultr
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/chenrui333/terraformer/terraformutils"
 	"github.com/vultr/govultr/v3"
@@ -27,10 +28,13 @@ func (g SnapshotGenerator) createResources(snapshotList []govultr.Snapshot) []te
 }
 
 func (g *SnapshotGenerator) InitResources() error {
-	client := g.generateClient()
-	output, _, _, err := client.Snapshot.List(context.Background(), nil)
+	client, err := g.generateClient()
 	if err != nil {
 		return err
+	}
+	output, err := listAllVultrResources(context.Background(), client.Snapshot.List)
+	if err != nil {
+		return fmt.Errorf("list vultr snapshots: %w", err)
 	}
 	g.Resources = g.createResources(output)
 	return nil

--- a/providers/vultr/ssh_key.go
+++ b/providers/vultr/ssh_key.go
@@ -4,6 +4,7 @@ package vultr
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/chenrui333/terraformer/terraformutils"
 	"github.com/vultr/govultr/v3"
@@ -27,10 +28,13 @@ func (g SSHKeyGenerator) createResources(keyList []govultr.SSHKey) []terraformut
 }
 
 func (g *SSHKeyGenerator) InitResources() error {
-	client := g.generateClient()
-	output, _, _, err := client.SSHKey.List(context.Background(), nil)
+	client, err := g.generateClient()
 	if err != nil {
 		return err
+	}
+	output, err := listAllVultrResources(context.Background(), client.SSHKey.List)
+	if err != nil {
+		return fmt.Errorf("list vultr SSH keys: %w", err)
 	}
 	g.Resources = g.createResources(output)
 	return nil

--- a/providers/vultr/startup_script.go
+++ b/providers/vultr/startup_script.go
@@ -4,6 +4,7 @@ package vultr
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/chenrui333/terraformer/terraformutils"
 	"github.com/vultr/govultr/v3"
@@ -27,10 +28,13 @@ func (g StartupScriptGenerator) createResources(scriptList []govultr.StartupScri
 }
 
 func (g *StartupScriptGenerator) InitResources() error {
-	client := g.generateClient()
-	output, _, _, err := client.StartupScript.List(context.Background(), nil)
+	client, err := g.generateClient()
 	if err != nil {
 		return err
+	}
+	output, err := listAllVultrResources(context.Background(), client.StartupScript.List)
+	if err != nil {
+		return fmt.Errorf("list vultr startup scripts: %w", err)
 	}
 	g.Resources = g.createResources(output)
 	return nil

--- a/providers/vultr/user.go
+++ b/providers/vultr/user.go
@@ -4,6 +4,7 @@ package vultr
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/chenrui333/terraformer/terraformutils"
 	"github.com/vultr/govultr/v3"
@@ -27,10 +28,13 @@ func (g UserGenerator) createResources(userList []govultr.User) []terraformutils
 }
 
 func (g *UserGenerator) InitResources() error {
-	client := g.generateClient()
-	output, _, _, err := client.User.List(context.Background(), nil)
+	client, err := g.generateClient()
 	if err != nil {
 		return err
+	}
+	output, err := listAllVultrResources(context.Background(), client.User.List)
+	if err != nil {
+		return fmt.Errorf("list vultr users: %w", err)
 	}
 	g.Resources = g.createResources(output)
 	return nil

--- a/providers/vultr/vultr_discovery_test.go
+++ b/providers/vultr/vultr_discovery_test.go
@@ -1,0 +1,374 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package vultr
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"sort"
+	"strings"
+	"sync/atomic"
+	"testing"
+
+	"github.com/chenrui333/terraformer/terraformutils"
+	"github.com/vultr/govultr/v3"
+)
+
+func TestVultrProviderSupportedServicesUseV3Names(t *testing.T) {
+	provider := &VultrProvider{}
+	services := provider.GetSupportedService()
+
+	wantServices := []string{
+		"bare_metal_server",
+		"block_storage",
+		"dns_domain",
+		"firewall_group",
+		"instance",
+		"reserved_ip",
+		"snapshot",
+		"ssh_key",
+		"startup_script",
+		"user",
+		"vpc",
+	}
+	for _, service := range wantServices {
+		if _, ok := services[service]; !ok {
+			t.Fatalf("supported services missing %q; got %v", service, sortedVultrServiceNames(services))
+		}
+	}
+	for _, service := range []string{"server", "network"} {
+		if _, ok := services[service]; ok {
+			t.Fatalf("legacy service %q should not be registered; got %v", service, sortedVultrServiceNames(services))
+		}
+	}
+	if got := provider.GetName(); got != "vultr" {
+		t.Fatalf("GetName() = %q, want vultr", got)
+	}
+
+	provider.apiKey = "test-token"
+	if err := provider.InitService("instance", false); err != nil {
+		t.Fatalf("InitService(instance) returned error: %v", err)
+	}
+	if got := provider.Service.GetArgs()["api_key"]; got != "test-token" {
+		t.Fatalf("InitService(instance) api_key = %v, want test-token", got)
+	}
+	if err := provider.InitService("server", false); err == nil {
+		t.Fatal("InitService(server) returned nil error, want unsupported service error")
+	}
+}
+
+func TestVultrServiceGenerateClientValidatesAPIKey(t *testing.T) {
+	tests := []struct {
+		name string
+		args map[string]interface{}
+	}{
+		{name: "missing", args: nil},
+		{name: "empty", args: map[string]interface{}{"api_key": ""}},
+		{name: "non string", args: map[string]interface{}{"api_key": 123}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			service := &VultrService{}
+			service.SetArgs(tt.args)
+
+			_, err := service.generateClient()
+			if err == nil {
+				t.Fatal("generateClient() returned nil error, want validation error")
+			}
+			if !strings.Contains(err.Error(), "api_key") {
+				t.Fatalf("generateClient() error = %q, want api_key context", err)
+			}
+		})
+	}
+}
+
+func TestVultrServiceGenerateClientUsesBearerToken(t *testing.T) {
+	var seen atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		seen.Add(1)
+		if r.URL.Path != "/v2/instances" {
+			t.Errorf("request path = %q, want /v2/instances", r.URL.Path)
+			http.Error(w, "unexpected path", http.StatusNotFound)
+			return
+		}
+		if got := r.Header.Get("Authorization"); got != "Bearer test-token" {
+			t.Errorf("Authorization header = %q, want Bearer test-token", got)
+			http.Error(w, "unexpected authorization", http.StatusUnauthorized)
+			return
+		}
+		writeVultrJSON(w, http.StatusOK, map[string]interface{}{
+			"instances": []map[string]interface{}{},
+			"meta":      emptyVultrMeta(),
+		})
+	}))
+	defer server.Close()
+
+	service := &VultrService{}
+	service.SetArgs(map[string]interface{}{"api_key": "test-token"})
+	client, err := service.generateClient()
+	if err != nil {
+		t.Fatalf("generateClient() returned error: %v", err)
+	}
+	configureTestVultrClient(t, client, server.URL)
+
+	_, _, resp, err := client.Instance.List(context.Background(), &govultr.ListOptions{PerPage: 100})
+	if resp != nil && resp.Body != nil {
+		_ = resp.Body.Close()
+	}
+	if err != nil {
+		t.Fatalf("Instance.List returned error: %v", err)
+	}
+	if got := seen.Load(); got != 1 {
+		t.Fatalf("request count = %d, want 1", got)
+	}
+}
+
+func TestServerGeneratorInitResourcesPaginatesInstances(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/v2/instances" {
+			t.Errorf("request path = %q, want /v2/instances", r.URL.Path)
+			http.Error(w, "unexpected path", http.StatusNotFound)
+			return
+		}
+		switch cursor := r.URL.Query().Get("cursor"); cursor {
+		case "":
+			if !assertVultrListQuery(t, w, r, "") {
+				return
+			}
+			writeVultrJSON(w, http.StatusOK, map[string]interface{}{
+				"instances": []map[string]interface{}{{"id": "instance-1"}},
+				"meta":      vultrMeta("cursor-2"),
+			})
+		case "cursor-2":
+			if !assertVultrListQuery(t, w, r, "cursor-2") {
+				return
+			}
+			writeVultrJSON(w, http.StatusOK, map[string]interface{}{
+				"instances": []map[string]interface{}{{"id": "instance-2"}},
+				"meta":      emptyVultrMeta(),
+			})
+		default:
+			t.Errorf("cursor = %q, want empty or cursor-2", cursor)
+			http.Error(w, "unexpected cursor", http.StatusBadRequest)
+		}
+	}))
+	defer server.Close()
+
+	generator := &ServerGenerator{}
+	if err := generator.initResources(newTestVultrClient(t, server)); err != nil {
+		t.Fatalf("initResources returned error: %v", err)
+	}
+
+	if got := len(generator.Resources); got != 2 {
+		t.Fatalf("resource count = %d, want 2", got)
+	}
+	assertVultrResource(t, generator.Resources[0], "instance-1", "instance-1", "vultr_instance")
+	assertVultrResource(t, generator.Resources[1], "instance-2", "instance-2", "vultr_instance")
+}
+
+func TestServerGeneratorInitResourcesHandlesEmptyPage(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/v2/instances" {
+			t.Errorf("request path = %q, want /v2/instances", r.URL.Path)
+			http.Error(w, "unexpected path", http.StatusNotFound)
+			return
+		}
+		if !assertVultrListQuery(t, w, r, "") {
+			return
+		}
+		writeVultrJSON(w, http.StatusOK, map[string]interface{}{
+			"instances": []map[string]interface{}{},
+			"meta":      emptyVultrMeta(),
+		})
+	}))
+	defer server.Close()
+
+	generator := &ServerGenerator{}
+	if err := generator.initResources(newTestVultrClient(t, server)); err != nil {
+		t.Fatalf("initResources returned error: %v", err)
+	}
+	if got := len(generator.Resources); got != 0 {
+		t.Fatalf("resource count = %d, want 0", got)
+	}
+}
+
+func TestServerGeneratorInitResourcesReturnsSecondPageError(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/v2/instances" {
+			t.Errorf("request path = %q, want /v2/instances", r.URL.Path)
+			http.Error(w, "unexpected path", http.StatusNotFound)
+			return
+		}
+		switch cursor := r.URL.Query().Get("cursor"); cursor {
+		case "":
+			if !assertVultrListQuery(t, w, r, "") {
+				return
+			}
+			writeVultrJSON(w, http.StatusOK, map[string]interface{}{
+				"instances": []map[string]interface{}{{"id": "instance-1"}},
+				"meta":      vultrMeta("cursor-2"),
+			})
+		case "cursor-2":
+			if !assertVultrListQuery(t, w, r, "cursor-2") {
+				return
+			}
+			writeVultrJSON(w, http.StatusInternalServerError, map[string]interface{}{"error": "backend unavailable"})
+		default:
+			t.Errorf("cursor = %q, want empty or cursor-2", cursor)
+			http.Error(w, "unexpected cursor", http.StatusBadRequest)
+		}
+	}))
+	defer server.Close()
+
+	generator := &ServerGenerator{}
+	err := generator.initResources(newTestVultrClient(t, server))
+	if err == nil {
+		t.Fatal("initResources returned nil error, want second page error")
+	}
+	if !strings.Contains(err.Error(), "list vultr instances") {
+		t.Fatalf("initResources error = %q, want list context", err)
+	}
+}
+
+func TestVultrResourceMappingUsesV3TerraformTypes(t *testing.T) {
+	instances := ServerGenerator{}.createResources([]govultr.Instance{{ID: "instance-id"}})
+	if got := len(instances); got != 1 {
+		t.Fatalf("instance resource count = %d, want 1", got)
+	}
+	assertVultrResource(t, instances[0], "instance-id", "instance-id", "vultr_instance")
+
+	vpcs := NetworkGenerator{}.createResources([]govultr.VPC{{ID: "vpc-id"}})
+	if got := len(vpcs); got != 1 {
+		t.Fatalf("VPC resource count = %d, want 1", got)
+	}
+	assertVultrResource(t, vpcs[0], "vpc-id", "vpc-id", "vultr_vpc")
+}
+
+func TestDNSDomainGeneratorMapsDomainsAndRecords(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/v2/domains":
+			if !assertVultrListQuery(t, w, r, "") {
+				return
+			}
+			writeVultrJSON(w, http.StatusOK, map[string]interface{}{
+				"domains": []map[string]interface{}{{"domain": "example.com"}},
+				"meta":    emptyVultrMeta(),
+			})
+		case "/v2/domains/example.com/records":
+			if !assertVultrListQuery(t, w, r, "") {
+				return
+			}
+			writeVultrJSON(w, http.StatusOK, map[string]interface{}{
+				"records": []map[string]interface{}{{"id": "record-1", "type": "A", "name": "www", "data": "192.0.2.1"}},
+				"meta":    emptyVultrMeta(),
+			})
+		default:
+			t.Errorf("request path = %q, want DNS domain or records path", r.URL.Path)
+			http.Error(w, "unexpected path", http.StatusNotFound)
+		}
+	}))
+	defer server.Close()
+
+	generator := &DNSDomainGenerator{}
+	client := newTestVultrClient(t, server)
+	domains, err := generator.loadDNSDomains(client)
+	if err != nil {
+		t.Fatalf("loadDNSDomains returned error: %v", err)
+	}
+	if got := len(domains); got != 1 {
+		t.Fatalf("domain count = %d, want 1", got)
+	}
+	if err := generator.loadDNSRecords(client, "example.com"); err != nil {
+		t.Fatalf("loadDNSRecords returned error: %v", err)
+	}
+
+	if got := len(generator.Resources); got != 2 {
+		t.Fatalf("resource count = %d, want 2", got)
+	}
+	assertVultrResource(t, generator.Resources[0], "example.com", "example.com", "vultr_dns_domain")
+	assertVultrResource(t, generator.Resources[1], "record-1", "record-1", "vultr_dns_record")
+	if got := generator.Resources[1].InstanceState.Attributes["domain"]; got != "example.com" {
+		t.Fatalf("DNS record domain attribute = %q, want example.com", got)
+	}
+}
+
+func sortedVultrServiceNames(services map[string]terraformutils.ServiceGenerator) []string {
+	names := make([]string, 0, len(services))
+	for name := range services {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	return names
+}
+
+func newTestVultrClient(t *testing.T, server *httptest.Server) *govultr.Client {
+	t.Helper()
+	client := govultr.NewClient(server.Client())
+	configureTestVultrClient(t, client, server.URL)
+	return client
+}
+
+func configureTestVultrClient(t *testing.T, client *govultr.Client, baseURL string) {
+	t.Helper()
+	client.SetRetryLimit(0)
+	client.SetRateLimit(0)
+	if err := client.SetBaseURL(baseURL); err != nil {
+		t.Fatalf("SetBaseURL(%q) returned error: %v", baseURL, err)
+	}
+}
+
+func assertVultrListQuery(t *testing.T, w http.ResponseWriter, r *http.Request, wantCursor string) bool {
+	if r.Method != http.MethodGet {
+		t.Errorf("request method = %q, want GET", r.Method)
+		http.Error(w, "unexpected method", http.StatusMethodNotAllowed)
+		return false
+	}
+	if got := r.URL.Query().Get("per_page"); got != "100" {
+		t.Errorf("per_page query = %q, want 100", got)
+		http.Error(w, "unexpected per_page", http.StatusBadRequest)
+		return false
+	}
+	if got := r.URL.Query().Get("cursor"); got != wantCursor {
+		t.Errorf("cursor query = %q, want %q", got, wantCursor)
+		http.Error(w, "unexpected cursor", http.StatusBadRequest)
+		return false
+	}
+	return true
+}
+
+func assertVultrResource(t *testing.T, resource terraformutils.Resource, wantID, wantName, wantType string) {
+	t.Helper()
+	if got := resource.InstanceState.ID; got != wantID {
+		t.Fatalf("resource ID = %q, want %q", got, wantID)
+	}
+	if got := resource.ResourceName; got != terraformutils.TfSanitize(wantName) {
+		t.Fatalf("resource name = %q, want sanitized %q", got, wantName)
+	}
+	if got := resource.InstanceInfo.Type; got != wantType {
+		t.Fatalf("resource type = %q, want %q", got, wantType)
+	}
+}
+
+func writeVultrJSON(w http.ResponseWriter, status int, payload interface{}) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	_ = json.NewEncoder(w).Encode(payload)
+}
+
+func vultrMeta(next string) map[string]interface{} {
+	return map[string]interface{}{
+		"total": 1,
+		"links": map[string]string{
+			"next": next,
+			"prev": "",
+		},
+	}
+}
+
+func emptyVultrMeta() map[string]interface{} {
+	return vultrMeta("")
+}

--- a/providers/vultr/vultr_discovery_test.go
+++ b/providers/vultr/vultr_discovery_test.go
@@ -159,7 +159,7 @@ func TestServerGeneratorInitResourcesPaginatesInstances(t *testing.T) {
 					return
 				}
 				writeVultrJSON(w, http.StatusOK, map[string]interface{}{
-					"vpcs": []map[string]interface{}{{"id": "vpc-b"}, {"id": "vpc-a"}},
+					"vpcs": []map[string]interface{}{{"id": "vpc-b"}},
 					"meta": vultrMeta("vpc-cursor-2"),
 				})
 			case "vpc-cursor-2":
@@ -167,7 +167,7 @@ func TestServerGeneratorInitResourcesPaginatesInstances(t *testing.T) {
 					return
 				}
 				writeVultrJSON(w, http.StatusOK, map[string]interface{}{
-					"vpcs": []map[string]interface{}{{"id": "vpc-a"}},
+					"vpcs": []map[string]interface{}{{"id": "vpc-a"}, {"id": "vpc-a"}},
 					"meta": emptyVultrMeta(),
 				})
 			default:

--- a/providers/vultr/vultr_discovery_test.go
+++ b/providers/vultr/vultr_discovery_test.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"sort"
+	"strconv"
 	"strings"
 	"sync/atomic"
 	"testing"
@@ -128,31 +129,70 @@ func TestVultrServiceGenerateClientUsesBearerToken(t *testing.T) {
 
 func TestServerGeneratorInitResourcesPaginatesInstances(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.URL.Path != "/v2/instances" {
-			t.Errorf("request path = %q, want /v2/instances", r.URL.Path)
-			http.Error(w, "unexpected path", http.StatusNotFound)
-			return
-		}
-		switch cursor := r.URL.Query().Get("cursor"); cursor {
-		case "":
+		switch r.URL.Path {
+		case "/v2/instances":
+			switch cursor := r.URL.Query().Get("cursor"); cursor {
+			case "":
+				if !assertVultrListQuery(t, w, r, "") {
+					return
+				}
+				writeVultrJSON(w, http.StatusOK, map[string]interface{}{
+					"instances": []map[string]interface{}{{"id": "instance-1"}},
+					"meta":      vultrMeta("cursor-2"),
+				})
+			case "cursor-2":
+				if !assertVultrListQuery(t, w, r, "cursor-2") {
+					return
+				}
+				writeVultrJSON(w, http.StatusOK, map[string]interface{}{
+					"instances": []map[string]interface{}{{"id": "instance-2"}},
+					"meta":      emptyVultrMeta(),
+				})
+			default:
+				t.Errorf("cursor = %q, want empty or cursor-2", cursor)
+				http.Error(w, "unexpected cursor", http.StatusBadRequest)
+			}
+		case "/v2/instances/instance-1/vpcs":
+			switch cursor := r.URL.Query().Get("cursor"); cursor {
+			case "":
+				if !assertVultrListQuery(t, w, r, "") {
+					return
+				}
+				writeVultrJSON(w, http.StatusOK, map[string]interface{}{
+					"vpcs": []map[string]interface{}{{"id": "vpc-b"}},
+					"meta": vultrMeta("vpc-cursor-2"),
+				})
+			case "vpc-cursor-2":
+				if !assertVultrListQuery(t, w, r, "vpc-cursor-2") {
+					return
+				}
+				writeVultrJSON(w, http.StatusOK, map[string]interface{}{
+					"vpcs": []map[string]interface{}{{"id": "vpc-a"}},
+					"meta": emptyVultrMeta(),
+				})
+			default:
+				t.Errorf("cursor = %q, want empty or vpc-cursor-2", cursor)
+				http.Error(w, "unexpected cursor", http.StatusBadRequest)
+			}
+		case "/v2/instances/instance-1/vpc2":
 			if !assertVultrListQuery(t, w, r, "") {
 				return
 			}
 			writeVultrJSON(w, http.StatusOK, map[string]interface{}{
-				"instances": []map[string]interface{}{{"id": "instance-1"}},
-				"meta":      vultrMeta("cursor-2"),
+				"vpcs": []map[string]interface{}{{"id": "vpc2-a"}},
+				"meta": emptyVultrMeta(),
 			})
-		case "cursor-2":
-			if !assertVultrListQuery(t, w, r, "cursor-2") {
+		case "/v2/instances/instance-2/vpcs", "/v2/instances/instance-2/vpc2":
+			if !assertVultrListQuery(t, w, r, "") {
 				return
 			}
 			writeVultrJSON(w, http.StatusOK, map[string]interface{}{
-				"instances": []map[string]interface{}{{"id": "instance-2"}},
-				"meta":      emptyVultrMeta(),
+				"vpcs": []map[string]interface{}{},
+				"meta": emptyVultrMeta(),
 			})
 		default:
-			t.Errorf("cursor = %q, want empty or cursor-2", cursor)
-			http.Error(w, "unexpected cursor", http.StatusBadRequest)
+			t.Errorf("request path = %q, want instances or attachment path", r.URL.Path)
+			http.Error(w, "unexpected path", http.StatusNotFound)
 		}
 	}))
 	defer server.Close()
@@ -166,7 +206,11 @@ func TestServerGeneratorInitResourcesPaginatesInstances(t *testing.T) {
 		t.Fatalf("resource count = %d, want 2", got)
 	}
 	assertVultrResource(t, generator.Resources[0], "instance-1", "instance-1", "vultr_instance")
+	assertFlatmapStringSet(t, generator.Resources[0].InstanceState.Attributes, "vpc_ids", []string{"vpc-a", "vpc-b"})
+	assertFlatmapStringSet(t, generator.Resources[0].InstanceState.Attributes, "vpc2_ids", []string{"vpc2-a"})
 	assertVultrResource(t, generator.Resources[1], "instance-2", "instance-2", "vultr_instance")
+	assertFlatmapStringSet(t, generator.Resources[1].InstanceState.Attributes, "vpc_ids", nil)
+	assertFlatmapStringSet(t, generator.Resources[1].InstanceState.Attributes, "vpc2_ids", nil)
 }
 
 func TestServerGeneratorInitResourcesHandlesEmptyPage(t *testing.T) {
@@ -233,12 +277,52 @@ func TestServerGeneratorInitResourcesReturnsSecondPageError(t *testing.T) {
 	}
 }
 
+func TestServerGeneratorInitResourcesReturnsAttachmentError(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/v2/instances":
+			if !assertVultrListQuery(t, w, r, "") {
+				return
+			}
+			writeVultrJSON(w, http.StatusOK, map[string]interface{}{
+				"instances": []map[string]interface{}{{"id": "instance-1"}},
+				"meta":      emptyVultrMeta(),
+			})
+		case "/v2/instances/instance-1/vpcs":
+			if !assertVultrListQuery(t, w, r, "") {
+				return
+			}
+			writeVultrJSON(w, http.StatusInternalServerError, map[string]interface{}{"error": "backend unavailable"})
+		default:
+			t.Errorf("request path = %q, want instances or VPC attachment path", r.URL.Path)
+			http.Error(w, "unexpected path", http.StatusNotFound)
+		}
+	}))
+	defer server.Close()
+
+	generator := &ServerGenerator{}
+	err := generator.initResources(newTestVultrClient(t, server))
+	if err == nil {
+		t.Fatal("initResources returned nil error, want attachment error")
+	}
+	if !strings.Contains(err.Error(), "list vultr VPC attachments for instance \"instance-1\"") {
+		t.Fatalf("initResources error = %q, want attachment context", err)
+	}
+}
+
 func TestVultrResourceMappingUsesV3TerraformTypes(t *testing.T) {
-	instances := ServerGenerator{}.createResources([]govultr.Instance{{ID: "instance-id"}})
+	instances := ServerGenerator{}.createResources([]govultr.Instance{{ID: "instance-id"}}, map[string]vultrInstanceAttachments{
+		"instance-id": {
+			vpcIDs:  []string{"vpc-id"},
+			vpc2IDs: []string{"vpc2-id"},
+		},
+	})
 	if got := len(instances); got != 1 {
 		t.Fatalf("instance resource count = %d, want 1", got)
 	}
 	assertVultrResource(t, instances[0], "instance-id", "instance-id", "vultr_instance")
+	assertFlatmapStringSet(t, instances[0].InstanceState.Attributes, "vpc_ids", []string{"vpc-id"})
+	assertFlatmapStringSet(t, instances[0].InstanceState.Attributes, "vpc2_ids", []string{"vpc2-id"})
 
 	vpcs := NetworkGenerator{}.createResources([]govultr.VPC{{ID: "vpc-id"}})
 	if got := len(vpcs); got != 1 {
@@ -350,6 +434,26 @@ func assertVultrResource(t *testing.T, resource terraformutils.Resource, wantID,
 	}
 	if got := resource.InstanceInfo.Type; got != wantType {
 		t.Fatalf("resource type = %q, want %q", got, wantType)
+	}
+}
+
+func assertFlatmapStringSet(t *testing.T, attributes map[string]string, field string, want []string) {
+	t.Helper()
+	if len(want) == 0 {
+		if _, ok := attributes[field+".#"]; ok {
+			t.Fatalf("%s.# is present for empty set: %#v", field, attributes)
+		}
+		return
+	}
+
+	if got := attributes[field+".#"]; got != strconv.Itoa(len(want)) {
+		t.Fatalf("%s.# = %q, want %d", field, got, len(want))
+	}
+	for _, value := range want {
+		key := field + "." + strconv.Itoa(terraformutils.HashString(value))
+		if got := attributes[key]; got != value {
+			t.Fatalf("%s = %q, want %q", key, got, value)
+		}
 	}
 }
 

--- a/providers/vultr/vultr_discovery_test.go
+++ b/providers/vultr/vultr_discovery_test.go
@@ -380,6 +380,132 @@ func TestDNSDomainGeneratorMapsDomainsAndRecords(t *testing.T) {
 	}
 }
 
+func TestFirewallGroupGeneratorMapsRules(t *testing.T) {
+	var rulesRequests atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/v2/firewalls":
+			if !assertVultrListQuery(t, w, r, "") {
+				return
+			}
+			writeVultrJSON(w, http.StatusOK, map[string]interface{}{
+				"firewall_groups": []map[string]interface{}{{"id": "fw-1"}},
+				"meta":            emptyVultrMeta(),
+			})
+		case "/v2/firewalls/fw-1/rules":
+			rulesRequests.Add(1)
+			if !assertVultrListQuery(t, w, r, "") {
+				return
+			}
+			writeVultrJSON(w, http.StatusOK, map[string]interface{}{
+				"firewall_rules": []map[string]interface{}{
+					{"id": 20, "ip_type": "v6"},
+					{"id": 10, "ip_type": "v4"},
+					{"id": 30, "ip_type": "unknown"},
+				},
+				"meta": emptyVultrMeta(),
+			})
+		default:
+			t.Errorf("request path = %q, want firewall group or rules path", r.URL.Path)
+			http.Error(w, "unexpected path", http.StatusNotFound)
+		}
+	}))
+	defer server.Close()
+
+	generator := &FirewallGroupGenerator{}
+	client := newTestVultrClient(t, server)
+	groups, err := generator.loadFirewallGroups(client)
+	if err != nil {
+		t.Fatalf("loadFirewallGroups returned error: %v", err)
+	}
+	if got := len(groups); got != 1 {
+		t.Fatalf("firewall group count = %d, want 1", got)
+	}
+	if err := generator.loadFirewallRules(client, groups[0].ID); err != nil {
+		t.Fatalf("loadFirewallRules returned error: %v", err)
+	}
+	if got := rulesRequests.Load(); got != 1 {
+		t.Fatalf("firewall rule list request count = %d, want 1", got)
+	}
+
+	if got := len(generator.Resources); got != 3 {
+		t.Fatalf("resource count = %d, want 3", got)
+	}
+	assertVultrResource(t, generator.Resources[0], "fw-1", "fw-1", "vultr_firewall_group")
+	assertVultrResource(t, generator.Resources[1], "10", "10", "vultr_firewall_rule")
+	assertFirewallRuleAttributes(t, generator.Resources[1], "fw-1", "v4")
+	assertVultrResource(t, generator.Resources[2], "20", "20", "vultr_firewall_rule")
+	assertFirewallRuleAttributes(t, generator.Resources[2], "fw-1", "v6")
+}
+
+func TestVultrSimpleGeneratorResourceTypes(t *testing.T) {
+	tests := []struct {
+		name      string
+		wantType  string
+		resources func() []terraformutils.Resource
+	}{
+		{
+			name:     "bare metal server",
+			wantType: "vultr_bare_metal_server",
+			resources: func() []terraformutils.Resource {
+				return BareMetalServerGenerator{}.createResources([]govultr.BareMetalServer{{ID: "resource-id"}})
+			},
+		},
+		{
+			name:     "block storage",
+			wantType: "vultr_block_storage",
+			resources: func() []terraformutils.Resource {
+				return BlockStorageGenerator{}.createResources([]govultr.BlockStorage{{ID: "resource-id"}})
+			},
+		},
+		{
+			name:     "reserved IP",
+			wantType: "vultr_reserved_ip",
+			resources: func() []terraformutils.Resource {
+				return ReservedIPGenerator{}.createResources([]govultr.ReservedIP{{ID: "resource-id"}})
+			},
+		},
+		{
+			name:     "snapshot",
+			wantType: "vultr_snapshot",
+			resources: func() []terraformutils.Resource {
+				return SnapshotGenerator{}.createResources([]govultr.Snapshot{{ID: "resource-id"}})
+			},
+		},
+		{
+			name:     "SSH key",
+			wantType: "vultr_ssh_key",
+			resources: func() []terraformutils.Resource {
+				return SSHKeyGenerator{}.createResources([]govultr.SSHKey{{ID: "resource-id"}})
+			},
+		},
+		{
+			name:     "startup script",
+			wantType: "vultr_startup_script",
+			resources: func() []terraformutils.Resource {
+				return StartupScriptGenerator{}.createResources([]govultr.StartupScript{{ID: "resource-id"}})
+			},
+		},
+		{
+			name:     "user",
+			wantType: "vultr_user",
+			resources: func() []terraformutils.Resource {
+				return UserGenerator{}.createResources([]govultr.User{{ID: "resource-id"}})
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			resources := tt.resources()
+			if got := len(resources); got != 1 {
+				t.Fatalf("resource count = %d, want 1", got)
+			}
+			assertVultrResource(t, resources[0], "resource-id", "resource-id", tt.wantType)
+		})
+	}
+}
+
 func sortedVultrServiceNames(services map[string]terraformutils.ServiceGenerator) []string {
 	names := make([]string, 0, len(services))
 	for name := range services {
@@ -434,6 +560,16 @@ func assertVultrResource(t *testing.T, resource terraformutils.Resource, wantID,
 	}
 	if got := resource.InstanceInfo.Type; got != wantType {
 		t.Fatalf("resource type = %q, want %q", got, wantType)
+	}
+}
+
+func assertFirewallRuleAttributes(t *testing.T, resource terraformutils.Resource, wantGroupID, wantIPType string) {
+	t.Helper()
+	if got := resource.InstanceState.Attributes["firewall_group_id"]; got != wantGroupID {
+		t.Fatalf("firewall_group_id = %q, want %q", got, wantGroupID)
+	}
+	if got := resource.InstanceState.Attributes["ip_type"]; got != wantIPType {
+		t.Fatalf("ip_type = %q, want %q", got, wantIPType)
 	}
 }
 

--- a/providers/vultr/vultr_discovery_test.go
+++ b/providers/vultr/vultr_discovery_test.go
@@ -159,7 +159,7 @@ func TestServerGeneratorInitResourcesPaginatesInstances(t *testing.T) {
 					return
 				}
 				writeVultrJSON(w, http.StatusOK, map[string]interface{}{
-					"vpcs": []map[string]interface{}{{"id": "vpc-b"}},
+					"vpcs": []map[string]interface{}{{"id": "vpc-b"}, {"id": "vpc-a"}},
 					"meta": vultrMeta("vpc-cursor-2"),
 				})
 			case "vpc-cursor-2":
@@ -179,7 +179,7 @@ func TestServerGeneratorInitResourcesPaginatesInstances(t *testing.T) {
 				return
 			}
 			writeVultrJSON(w, http.StatusOK, map[string]interface{}{
-				"vpcs": []map[string]interface{}{{"id": "vpc2-a"}},
+				"vpcs": []map[string]interface{}{{"id": "vpc2-a"}, {"id": "vpc2-a"}},
 				"meta": emptyVultrMeta(),
 			})
 		case "/v2/instances/instance-2/vpcs", "/v2/instances/instance-2/vpc2":

--- a/providers/vultr/vultr_provider.go
+++ b/providers/vultr/vultr_provider.go
@@ -44,13 +44,13 @@ func (p *VultrProvider) GetSupportedService() map[string]terraformutils.ServiceG
 		"block_storage":     &BlockStorageGenerator{},
 		"dns_domain":        &DNSDomainGenerator{},
 		"firewall_group":    &FirewallGroupGenerator{},
-		"network":           &NetworkGenerator{},
+		"instance":          &ServerGenerator{},
 		"reserved_ip":       &ReservedIPGenerator{},
-		"server":            &ServerGenerator{},
 		"snapshot":          &SnapshotGenerator{},
 		"ssh_key":           &SSHKeyGenerator{},
 		"startup_script":    &StartupScriptGenerator{},
 		"user":              &UserGenerator{},
+		"vpc":               &NetworkGenerator{},
 	}
 }
 

--- a/providers/vultr/vultr_service.go
+++ b/providers/vultr/vultr_service.go
@@ -4,6 +4,7 @@ package vultr
 
 import (
 	"context"
+	"errors"
 
 	"github.com/chenrui333/terraformer/terraformutils"
 	"github.com/vultr/govultr/v3"
@@ -14,8 +15,13 @@ type VultrService struct { //nolint
 	terraformutils.Service
 }
 
-func (s *VultrService) generateClient() *govultr.Client {
+func (s *VultrService) generateClient() (*govultr.Client, error) {
+	apiKey, ok := s.Args["api_key"].(string)
+	if !ok || apiKey == "" {
+		return nil, errors.New("vultr: api_key arg is missing or not a string")
+	}
+
 	ctx := context.Background()
-	tokenSource := oauth2.StaticTokenSource(&oauth2.Token{AccessToken: s.Args["api_key"].(string)})
-	return govultr.NewClient(oauth2.NewClient(ctx, tokenSource))
+	tokenSource := oauth2.StaticTokenSource(&oauth2.Token{AccessToken: apiKey})
+	return govultr.NewClient(oauth2.NewClient(ctx, tokenSource)), nil
 }


### PR DESCRIPTION
## Summary

Hardens the Vultr provider discovery path and completes the remaining `govultr/v3` closeout from #207.

## Changes

- Add shared govultr cursor pagination for Vultr list endpoints.
- Switch remaining v1-era Vultr service/resource names from `server`/`network` to `instance`/`vpc`.
- Validate Vultr API key service args instead of panicking on malformed direct service setup.
- Add httptest-backed coverage for client setup, pagination, empty responses, second-page errors, and resource mapping.
- Update Vultr docs and CLI default examples to use v2-era Terraform resource names.

## Testing

- `go test ./providers/vultr -count=1`
- `go test ./providers/vultr -race -count=1`
- `go test ./providers/vultr -coverprofile=/tmp/terraformer-vultr-after.cover`
- `go vet ./providers/vultr`
- `golangci-lint run --new-from-rev=origin/main ./providers/vultr`
- `go test ./providers/vultr ./providers/github ./providers/okta ./providers/linode ./providers/myrasec -count=1`
- `GOMAXPROCS=4 go test -p=1 ./providers/... -count=1`
- `GOMAXPROCS=4 go vet ./...`
- `govulncheck ./providers/vultr`
- `govulncheck ./...`

## Notes

- No real Vultr token was used.
- No live Vultr API calls were made.
- No cloud resources were created, mutated, or deleted.

Fixes #207.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hardens Vultr discovery with shared cursor pagination, strict `api_key` validation, and stable export of instance VPC/VPC2 attachments. Renames to v2-era types (`instance`, `vpc`), updates docs/CLI, and adds `httptest` coverage including paginated attachment merge; completes the `govultr/v3` closeout for #207.

- **Bug Fixes**
  - Shared cursor-based pagination across all Vultr list endpoints; avoid duplicate pagination for firewall rules.
  - Validate `api_key` in service args; return errors instead of panicking.
  - Preserve instance network attachments by exporting `vpc_ids` and `vpc2_ids` on `vultr_instance` (deduped, stable ordering, merged across pages).

- **Migration**
  - Use `instance` instead of `server` and `vpc` instead of `network` (Terraform types `vultr_instance`, `vultr_vpc`); CLI example now uses `instance`.
  - Require Vultr Terraform provider `>=2.16.0`.

<sup>Written for commit b27c3a6da4318aa7e2d1316f19e2c1a243218089. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/chenrui333/terraformer/pull/635?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added VPC resource support for the Vultr provider, including attaching VPC/VPC2 data to instance resources.
  * Updated the Vultr importer CLI to use the `instance` flag key (replacing `server`).

* **Bug Fixes**
  * Improved resource discovery/listing reliability with clearer, contextual error reporting.
  * Strengthened validation and error handling for API key–based client creation.

* **Tests**
  * Added extensive Vultr discovery and resource-generation tests.

* **Documentation**
  * Updated Vultr docs and Terraform Providers entry (release link and minimum version).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->