### PR TITLE
fix(panos): skip unsafe bgp auth profile imports

### DIFF
--- a/docs/panos.md
+++ b/docs/panos.md
@@ -22,6 +22,8 @@ The list of usable environment variables is the same as the [pango go-client](ht
 *  `PANOS_VERIFY_CERTIFICATE`
 *  `PANOS_LOGGING`
 
+Unsupported PAN-OS resources are tracked in [providers/panos/unsupported_resources.json](../providers/panos/unsupported_resources.json). BGP auth profile resources are not imported because PAN-OS returns `"(incorrect)"` instead of the real auth secret.
+
 Here is the list of resources which are currently supported:
 
 *   `firewall_device_config`
@@ -38,7 +40,6 @@ Here is the list of resources which are currently supported:
     * `panos_bgp_aggregate`
     * `panos_bgp_aggregate_advertise_filter`
     * `panos_bgp_aggregate_suppress_filter`
-    * `panos_bgp_auth_profile` # The secret argument will contain "(incorrect)"
     * `panos_bgp_conditional_adv`
     * `panos_bgp_conditional_adv_advertise_filter`
     * `panos_bgp_conditional_adv_non_exist_filter`
@@ -108,7 +109,6 @@ Here is the list of resources which are currently supported:
     * `panos_panorama_bgp_aggregate`
     * `panos_panorama_bgp_aggregate_advertise_filter`
     * `panos_panorama_bgp_aggregate_suppress_filter`
-    * `panos_panorama_bgp_auth_profile` # The secret argument will contain "(incorrect)"
     * `panos_panorama_bgp_conditional_adv`
     * `panos_panorama_bgp_conditional_adv_advertise_filter`
     * `panos_panorama_bgp_conditional_adv_non_exist_filter`

--- a/docs/unsupported-resources.md
+++ b/docs/unsupported-resources.md
@@ -126,7 +126,7 @@ This inventory is an informational coverage snapshot. The source of truth is the
 | openstack | no | no | not present yet |
 | opsgenie | no | no | not present yet |
 | pagerduty | no | no | not present yet |
-| panos | no | no | not present yet |
+| panos | yes | no | metadata present |
 | rabbitmq | no | no | not present yet |
 | tencentcloud | no | no | not present yet |
 | vault | no | no | not present yet |

--- a/providers/panos/firewall_networking.go
+++ b/providers/panos/firewall_networking.go
@@ -158,12 +158,10 @@ func (g *FirewallNetworkingGenerator) createBGPAggregateSuppressFilterResources(
 	)
 }
 
-// The secret argument will contain "(incorrect)", not the real value
+// PAN-OS returns "(incorrect)" instead of the real auth secret, so broad import
+// would generate non-reconstructable Terraform for this resource.
 func (g *FirewallNetworkingGenerator) createBGPAuthProfileResources(virtualRouter string) []terraformutils.Resource {
-	return g.createResourcesFromList(
-		getGeneric{g.client.(*pango.Firewall).Network.BgpAuthProfile, []string{virtualRouter}},
-		virtualRouter+":", true, "panos_bgp_auth_profile", false, "",
-	)
+	return nil
 }
 
 func (g *FirewallNetworkingGenerator) createBGPConditionalAdvertisementResources(virtualRouter string) (resources []terraformutils.Resource) {

--- a/providers/panos/panorama_networking.go
+++ b/providers/panos/panorama_networking.go
@@ -165,12 +165,10 @@ func (g *PanoramaNetworkingGenerator) createBGPAggregateSuppressFilterResources(
 	)
 }
 
-// The secret argument will contain "(incorrect)", not the real value
+// PAN-OS returns "(incorrect)" instead of the real auth secret, so broad import
+// would generate non-reconstructable Terraform for this resource.
 func (g *PanoramaNetworkingGenerator) createBGPAuthProfileResources(tmpl, ts, virtualRouter string) []terraformutils.Resource {
-	return g.createResourcesFromList(
-		getGeneric{g.client.(*pango.Panorama).Network.BgpAuthProfile, []string{tmpl, ts, virtualRouter}},
-		tmpl+":"+ts+":"+virtualRouter+":", true, "panos_panorama_bgp_auth_profile",
-	)
+	return nil
 }
 
 func (g *PanoramaNetworkingGenerator) createBGPConditionalAdvertisementResources(tmpl, ts, virtualRouter string) (resources []terraformutils.Resource) {

--- a/providers/panos/panos_provider_test.go
+++ b/providers/panos/panos_provider_test.go
@@ -3,9 +3,22 @@
 package panos
 
 import (
+	"encoding/json"
+	"os"
 	"strings"
 	"testing"
 )
+
+type panosUnsupportedResourcesFile struct {
+	Version   int                                `json:"version"`
+	Resources []panosUnsupportedResourceMetadata `json:"resources"`
+}
+
+type panosUnsupportedResourceMetadata struct {
+	Resource   string   `json:"resource"`
+	Status     string   `json:"status"`
+	References []string `json:"references"`
+}
 
 func TestPanosProviderInitRequiresArgs(t *testing.T) {
 	provider := PanosProvider{vsys: "old-vsys"}
@@ -30,5 +43,48 @@ func TestPanosProviderInitStoresArgs(t *testing.T) {
 	}
 	if provider.vsys != "vsys1" {
 		t.Fatalf("vsys = %q, want vsys1", provider.vsys)
+	}
+}
+
+func TestPanosBGPAuthProfileResourcesAreSkipped(t *testing.T) {
+	if resources := (&FirewallNetworkingGenerator{}).createBGPAuthProfileResources("virtual-router"); len(resources) != 0 {
+		t.Fatalf("firewall BGP auth profile resources len = %d, want 0", len(resources))
+	}
+
+	if resources := (&PanoramaNetworkingGenerator{}).createBGPAuthProfileResources("template", "template-stack", "virtual-router"); len(resources) != 0 {
+		t.Fatalf("panorama BGP auth profile resources len = %d, want 0", len(resources))
+	}
+}
+
+func TestPanosUnsupportedResourcesMetadata(t *testing.T) {
+	data, err := os.ReadFile("unsupported_resources.json")
+	if err != nil {
+		t.Fatalf("read unsupported resources: %v", err)
+	}
+
+	var metadata panosUnsupportedResourcesFile
+	if err := json.Unmarshal(data, &metadata); err != nil {
+		t.Fatalf("decode unsupported resources: %v", err)
+	}
+	if metadata.Version != 1 {
+		t.Fatalf("unsupported resources version = %d, want 1", metadata.Version)
+	}
+
+	entries := map[string]panosUnsupportedResourceMetadata{}
+	for _, resource := range metadata.Resources {
+		entries[resource.Resource] = resource
+	}
+
+	for _, resourceName := range []string{"panos_bgp_auth_profile", "panos_panorama_bgp_auth_profile"} {
+		resource, ok := entries[resourceName]
+		if !ok {
+			t.Fatalf("unsupported metadata is missing %s", resourceName)
+		}
+		if resource.Status != "secret-required" {
+			t.Fatalf("%s status = %q, want secret-required", resourceName, resource.Status)
+		}
+		if len(resource.References) == 0 {
+			t.Fatalf("%s metadata is missing references", resourceName)
+		}
 	}
 }

--- a/providers/panos/unsupported_resources.json
+++ b/providers/panos/unsupported_resources.json
@@ -1,0 +1,25 @@
+{
+  "version": 1,
+  "resources": [
+    {
+      "resource": "panos_bgp_auth_profile",
+      "service_family": "networking",
+      "reason": "PAN-OS BGP auth profiles require the real shared secret, but PAN-OS discovery returns the placeholder \"(incorrect)\" instead of the secret value.",
+      "evidence": "Terraformer previously documented and generated panos_bgp_auth_profile with the secret argument set to \"(incorrect)\". That placeholder is not the real credential, so generated Terraform cannot safely recreate or refresh the existing auth profile.",
+      "status": "secret-required",
+      "references": [
+        "https://registry.terraform.io/providers/PaloAltoNetworks/panos/latest/docs/resources/bgp_auth_profile"
+      ]
+    },
+    {
+      "resource": "panos_panorama_bgp_auth_profile",
+      "service_family": "networking",
+      "reason": "Panorama BGP auth profiles require the real shared secret, but PAN-OS discovery returns the placeholder \"(incorrect)\" instead of the secret value.",
+      "evidence": "Terraformer previously documented and generated panos_panorama_bgp_auth_profile with the secret argument set to \"(incorrect)\". That placeholder is not the real credential, so generated Terraform cannot safely recreate or refresh the existing auth profile.",
+      "status": "secret-required",
+      "references": [
+        "https://registry.terraform.io/providers/PaloAltoNetworks/panos/latest/docs/resources/panorama_bgp_auth_profile"
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Hardened the PanOS provider by skipping BGP auth profile imports that cannot be reconstructed safely.

Terraformer previously documented that these resources imported the secret argument as "(incorrect)", not the real auth secret. This PR stops generating those unsafe resources and records them in unsupported-resource metadata.

## Changes

- Skip panos_bgp_auth_profile and panos_panorama_bgp_auth_profile generation.
- Add providers/panos/unsupported_resources.json entries with secret-required status.
- Remove those resources from docs/panos.md supported-resource lists.
- Update docs/unsupported-resources.md inventory for PanOS metadata.
- Add focused PanOS tests for skipped generators and metadata presence.

## Validation

- go test ./providers/panos -count=1
- go test ./providers/panos -run "TestPanosBGPAuthProfileResourcesAreSkipped|TestPanosUnsupportedResourcesMetadata" -count=1 -v
- go test ./providers -run "TestUnsupportedResourcesMetadata|TestUnsupportedResourceStatusesAreDocumented" -count=1
- go test ./providers/panos ./providers -count=1
- go vet ./providers/panos
- git diff --check

Report: /tmp/terraformer-panos-provider-hardening-20260613.md

No real credentials or live provider API calls were used.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Skip importing PAN-OS BGP auth profile resources because PAN-OS returns "(incorrect)" instead of the real secret, making Terraform output unsafe. Adds unsupported metadata and tests, and updates docs.

- **Bug Fixes**
  - Skip generation of `panos_bgp_auth_profile` and `panos_panorama_bgp_auth_profile`.
  - Track both in `providers/panos/unsupported_resources.json` with status `secret-required`.
  - Update `docs/panos.md` and `docs/unsupported-resources.md` to reflect unsupported status.
  - Add tests to ensure generators return none and metadata is present/valid.

<sup>Written for commit bd846ba7264cb3f63c98a20e92bd05617e0751a3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/chenrui333/terraformer/pull/637?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

