### PR TITLE
fix(aws): ignore external security group references

### DIFF
--- a/providers/aws/sg.go
+++ b/providers/aws/sg.go
@@ -174,8 +174,12 @@ func findSgsToMoveOut(securityGroups []types.SecurityGroup) []string {
 			pairs := rule.UserIdGroupPairs
 			for _, pair := range pairs {
 				if pair.GroupId != nil {
+					toIdx, ok := sgToIdx[StringValue(pair.GroupId)]
+					if !ok {
+						continue
+					}
 					fromNode := sourceGraph.Node(int64(idx))
-					toNode := sourceGraph.Node(sgToIdx[StringValue(pair.GroupId)])
+					toNode := sourceGraph.Node(toIdx)
 					if fromNode.ID() != toNode.ID() {
 						sourceGraph.SetEdge(sourceGraph.NewEdge(fromNode, toNode))
 					}

--- a/providers/aws/sg_test.go
+++ b/providers/aws/sg_test.go
@@ -113,6 +113,41 @@ func TestNoCycleReference(t *testing.T) {
 	}
 }
 
+func TestNoCycleReferenceToExternalGroup(t *testing.T) {
+	securityGroups := []types.SecurityGroup{
+		{
+			GroupId: aws.String("aaaa"),
+			IpPermissions: []types.IpPermission{
+				{
+					UserIdGroupPairs: []types.UserIdGroupPair{
+						{
+							GroupId: aws.String("bbbb"),
+						},
+					},
+				},
+			},
+		},
+		{
+			GroupId: aws.String("bbbb"),
+			IpPermissions: []types.IpPermission{
+				{
+					UserIdGroupPairs: []types.UserIdGroupPair{
+						{
+							GroupId: aws.String("external"),
+						},
+					},
+				},
+			},
+		},
+	}
+
+	rulesToMoveOut := findSgsToMoveOut(securityGroups)
+
+	if len(rulesToMoveOut) != 0 {
+		t.Errorf("failed to ignore external security group reference: %v", rulesToMoveOut)
+	}
+}
+
 func Test3Cycle1CycleReference(t *testing.T) {
 	sgA := types.SecurityGroup{
 		GroupId: aws.String("aaaa"),


### PR DESCRIPTION
## Summary

- Ignore security-group rule references outside the discovered group set when building the cycle graph.
- Add regression coverage for an external reference that previously produced a false cycle.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Ignore security-group rule references to groups not in the discovered set when building the cycle graph in `providers/aws`. This prevents false cycle detection and avoids moving rules incorrectly; adds a regression test to ensure external references are ignored.

<sup>Written for commit f8421f5179fd77fdf125726419d425b546cbf772. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/chenrui333/terraformer/pull/673?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of security group references to external or unavailable groups.
  * Prevented incorrect dependency relationships and potential cycle detection errors.

* **Tests**
  * Added coverage confirming external security group references are safely ignored.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->