### PR TITLE
chore(deps): update Go to 1.26.5

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/chenrui333/terraformer
 
-go 1.26.4
+go 1.26.5
 
 require (
 	cloud.google.com/go v0.123.0 // indirect


### PR DESCRIPTION
## Summary

- Update the repository Go toolchain from 1.26.4 to 1.26.5.
- Clear the blocking standard-library vulnerability scan for GO-2026-5856 and GO-2026-4970.

## References

- https://go.dev/doc/devel/release#go1.26.5
- https://pkg.go.dev/vuln/GO-2026-5856
- https://pkg.go.dev/vuln/GO-2026-4970


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Upgraded the Go toolchain to 1.26.5 to pull in upstream security fixes and clear vulnerability scanners for GO-2026-5856 and GO-2026-4970. Updated the `go` directive in `go.mod` from 1.26.4 to 1.26.5.

- **Migration**
  - Ensure your local Go version is 1.26.5 before running builds.

<sup>Written for commit b7ed28851ab09696441e46ad0c5531f0d7575e61. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/chenrui333/terraformer/pull/674?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

