### PR TITLE
ci: skip incremental lint without Go changes

### DIFF
--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -31,11 +31,20 @@ jobs:
       env:
         BASE_SHA: ${{ github.event_name == 'pull_request' && github.event.pull_request.base.sha || github.event.before }}
       run: |
-        if git diff --quiet "$BASE_SHA" HEAD -- '*.go' '.golangci.json'; then
-          echo "lint=false" >> "$GITHUB_OUTPUT"
-        else
+        if ! git rev-parse --verify "$BASE_SHA^{commit}" >/dev/null 2>&1; then
           echo "lint=true" >> "$GITHUB_OUTPUT"
+          exit 0
         fi
+
+        echo "base_sha=$BASE_SHA" >> "$GITHUB_OUTPUT"
+        lint=false
+        if ! git diff --quiet "$BASE_SHA" HEAD -- '*.go' '.golangci.json'; then
+          lint=true
+        fi
+        if git diff --unified=0 "$BASE_SHA" HEAD -- go.mod | grep -Eq '^[+-](go|toolchain)[[:space:]]'; then
+          lint=true
+        fi
+        echo "lint=$lint" >> "$GITHUB_OUTPUT"
     - name: golangci-lint
       if: github.event_name == 'workflow_dispatch' || steps.changes.outputs.lint == 'true'
       uses: reviewdog/action-golangci-lint@c76cceaaab89abe74e649d2e34c6c9adc26662d2
@@ -45,7 +54,7 @@ jobs:
         reviewdog_version: v0.21.0
         go_version_file: go.mod
         github_token: ${{ secrets.GITHUB_TOKEN }}
-        golangci_lint_flags: ${{ github.event_name == 'pull_request' && format('--new-from-rev={0}', github.event.pull_request.base.sha) || github.event_name == 'push' && format('--new-from-rev={0}', github.event.before) || '' }}
+        golangci_lint_flags: ${{ steps.changes.outputs.base_sha && format('--new-from-rev={0}', steps.changes.outputs.base_sha) || '' }}
         reporter: ${{ github.event_name == 'pull_request' && 'github-pr-check' || 'github-check' }}
         filter_mode: added
         fail_level: error

--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -25,7 +25,19 @@ jobs:
       uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
       with:
         fetch-depth: 0
+    - name: Check for lintable changes
+      id: changes
+      if: github.event_name != 'workflow_dispatch'
+      env:
+        BASE_SHA: ${{ github.event_name == 'pull_request' && github.event.pull_request.base.sha || github.event.before }}
+      run: |
+        if git diff --quiet "$BASE_SHA" HEAD -- '*.go' '.golangci.json'; then
+          echo "lint=false" >> "$GITHUB_OUTPUT"
+        else
+          echo "lint=true" >> "$GITHUB_OUTPUT"
+        fi
     - name: golangci-lint
+      if: github.event_name == 'workflow_dispatch' || steps.changes.outputs.lint == 'true'
       uses: reviewdog/action-golangci-lint@c76cceaaab89abe74e649d2e34c6c9adc26662d2
       with:
         cache: true


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Skip `golangci-lint` when no Go changes (`*.go`, `.golangci.json`, or `go`/`toolchain` in go.mod); `workflow_dispatch` still runs it. Incremental lint uses the base SHA and falls back to full lint when the base commit is unavailable.

<sup>Written for commit aecf44a0c8ddf1c5a557f2d7f6e26c5e43d61270. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/chenrui333/terraformer/pull/679?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved automated code quality checks by running lint validation only when relevant source or configuration files change.
  * Added support for manually triggering lint validation when needed.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->