### PR TITLE
docs: prepare v0.13.15 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,24 @@
 
 ## Unreleased
 
+## 0.13.15
+
+`0.13.15` is an AWS importer correctness, security/toolchain, provider SDK,
+and CI reliability patch.
+
+### Highlights
+
+* Ignore external AWS security group references instead of emitting invalid
+  Terraform dependencies for groups outside the imported set.
+* Move the Go baseline to `1.26.5` to pick up standard-library vulnerability
+  fixes, and skip no-op incremental lint analysis for dependency-only changes
+  that otherwise exhaust runner memory.
+* Refresh provider and client dependencies across AWS, Azure, GCP, IBM,
+  TencentCloud, Yandex, Auth0, Okta, Opal, Linode, IONOS, Kubernetes, Helm,
+  VCS, Fastly, and shared Go module families.
+
+**Full Changelog**: <https://github.com/chenrui333/terraformer/compare/v0.13.14...v0.13.15>
+
 ## 0.13.14
 
 `0.13.14` is a provider SDK migration, provider hardening, dependency refresh,


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Prepare v0.13.15 release notes in CHANGELOG. Highlights include an AWS importer fix (ignore external security group refs), a Go baseline bump to 1.26.5 for security, a CI lint optimization to avoid OOM on dependency-only diffs, and broad provider/client dependency updates with a link to the full compare.

<sup>Written for commit d2e9e59aef53b690a40fbb61c2476a681780d088. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/chenrui333/terraformer/pull/688?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added release notes for version 0.13.15.
  * Documented improvements to AWS security group reference handling.
  * Noted updated Go tooling and refreshed provider/client dependencies.
  * Added a link to the full changelog comparing versions 0.13.14 and 0.13.15.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->