### PR TITLE
fix: reject malformed import filters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+* Reject malformed import filters before provider initialization, and preserve
+  distinct Terraform resource types that share an import ID during filtering.
+
 ## 0.13.15
 
 `0.13.15` is an AWS importer correctness, security/toolchain, provider SDK,

--- a/README.md
+++ b/README.md
@@ -129,7 +129,9 @@ To import resources from all services, use `--resources="*"` . If you want to ex
 
 #### Filtering
 
-Filters are a way to choose which resources `terraformer` imports. It's possible to filter resources by its identifiers or attributes. Multiple filtering values are separated by `:`. If an identifier contains this symbol, value should be wrapped in `'` e.g. `--filter=resource=id1:'project:dataset_id'`. Identifier based filters will be executed before Terraformer will try to refresh remote state.
+Filters are a way to choose which resources `terraformer` imports. It's possible to filter resources by its identifiers or attributes. Supported forms are `service=value`, `Name=field`, `Name=field;Value=value`, and `Type=service;Name=field;Value=value`. Multiple filtering values are separated by `:`. If an identifier contains this symbol, value should be wrapped in `'` e.g. `--filter=resource=id1:'project:dataset_id'`. Values may contain `=` without additional escaping. Identifier based filters will be executed before Terraformer will try to refresh remote state.
+
+Terraformer validates every supplied filter before initializing the provider. A malformed filter, including one with an unbalanced quote or an empty required component, aborts the entire import instead of falling back to an unfiltered import.
 
 Use `Type` when you need to filter only one of several types of resources. Multiple filters can be combined when importing different resource types. An example would be importing all AWS security groups from a specific AWS VPC:
 ```

--- a/README.md
+++ b/README.md
@@ -129,7 +129,7 @@ To import resources from all services, use `--resources="*"` . If you want to ex
 
 #### Filtering
 
-Filters are a way to choose which resources `terraformer` imports. It's possible to filter resources by its identifiers or attributes. Supported forms are `service=value`, `Name=field`, `Name=field;Value=value`, and `Type=service;Name=field;Value=value`. Multiple filtering values are separated by `:`. If an identifier contains this symbol, value should be wrapped in `'` e.g. `--filter=resource=id1:'project:dataset_id'`. Values may contain `=` without additional escaping. Identifier based filters will be executed before Terraformer will try to refresh remote state.
+Filters are a way to choose which resources `terraformer` imports. It's possible to filter resources by its identifiers or attributes. Supported forms are `service=value`, `Name=field`, `Name=field;Value=value`, and `Type=service;Name=field;Value=value`. Multiple filtering values are separated by `:`. If an identifier contains this symbol, value should be wrapped in `'` e.g. `--filter=resource=id1:'project:dataset_id'`. Values may contain `=` without additional escaping. Identifier-based filters will be executed before Terraformer will try to refresh remote state.
 
 Terraformer validates every supplied filter before initializing the provider. A malformed filter, including one with an unbalanced quote or an empty required component, aborts the entire import instead of falling back to an unfiltered import.
 

--- a/cmd/import.go
+++ b/cmd/import.go
@@ -115,6 +115,15 @@ func newImportCmd() *cobra.Command {
 func Import(provider terraformutils.ProviderGenerator, options ImportOptions, args []string) error {
 	importExecuted = true
 	sessionKey := provider.GetName() + ":" + strings.Join(args, ":")
+	if _, err := terraformutils.ParseFilters(options.Filter); err != nil {
+		processReport.Add(importreport.ResourceEvent{
+			Service:  provider.GetName(),
+			Status:   importreport.StatusFailed,
+			Category: importreport.ClassifyError(err),
+			Error:    err.Error(),
+		})
+		return err
+	}
 
 	providerWrapper, options, err := initOptionsAndWrapper(provider, options, args)
 	if err != nil {
@@ -315,7 +324,10 @@ func initServiceResources(service string, provider terraformutils.ProviderGenera
 		log.Printf("%s error importing %s, err: %s\n", provider.GetName(), service, err)
 		return err
 	}
-	provider.GetService().ParseFilters(options.Filter)
+	if err := provider.GetService().ParseFilters(options.Filter); err != nil {
+		log.Printf("%s error parsing filters for %s, err: %s\n", provider.GetName(), service, err)
+		return err
+	}
 	err = provider.GetService().InitResources()
 	if err != nil {
 		log.Printf("%s error initializing resources in service %s, err: %s\n", provider.GetName(), service, err)

--- a/cmd/import.go
+++ b/cmd/import.go
@@ -119,7 +119,7 @@ func newImportCmd() *cobra.Command {
 func Import(provider terraformutils.ProviderGenerator, options ImportOptions, args []string) error {
 	importExecuted = true
 	sessionKey := provider.GetName() + ":" + strings.Join(args, ":")
-	if err := validateImportFilters(provider, options.Filter, options.Resources); err != nil {
+	if err := validateImportFilters(provider, options.Filter, options.Resources, options.Excludes); err != nil {
 		processReport.Add(importreport.ResourceEvent{
 			Service:  provider.GetName(),
 			Status:   importreport.StatusFailed,
@@ -163,12 +163,34 @@ func Import(provider terraformutils.ProviderGenerator, options ImportOptions, ar
 	return importFromPlan(providerMapping, options, args, processReport, eventStart)
 }
 
-func validateImportFilters(provider terraformutils.ProviderGenerator, filters, resources []string) error {
+func validateImportFilters(provider terraformutils.ProviderGenerator, filters, resources, excludes []string) error {
 	if validator, ok := provider.(importFilterValidator); ok {
-		return validator.ValidateFilters(filters, resources)
+		return validator.ValidateFilters(filters, filterValidationResources(provider, resources, excludes))
 	}
 	_, err := terraformutils.ParseFilters(filters)
 	return err
+}
+
+func filterValidationResources(provider terraformutils.ProviderGenerator, resources, excludes []string) []string {
+	selected := append([]string(nil), resources...)
+	if terraformerstring.ContainsString(selected, "*") {
+		selected = providerServices(provider)
+	}
+	if len(excludes) == 0 {
+		return selected
+	}
+
+	excluded := make(map[string]struct{}, len(excludes))
+	for _, resource := range excludes {
+		excluded[resource] = struct{}{}
+	}
+	effective := make([]string, 0, len(selected))
+	for _, resource := range selected {
+		if _, ok := excluded[resource]; !ok {
+			effective = append(effective, resource)
+		}
+	}
+	return effective
 }
 
 func initOptionsAndWrapper(provider terraformutils.ProviderGenerator, options ImportOptions, args []string) (*providerwrapper.ProviderWrapper, ImportOptions, error) {

--- a/cmd/import.go
+++ b/cmd/import.go
@@ -58,6 +58,10 @@ type importProviderConfigurer interface {
 	ConfigureImportProvider(*providerwrapper.ProviderWrapper) error
 }
 
+type importFilterValidator interface {
+	ValidateFilters(filters []string, resources []string) error
+}
+
 const DefaultPathPattern = "{output}/{provider}/{service}/"
 const DefaultPathOutput = "generated"
 const DefaultState = "local"
@@ -115,7 +119,7 @@ func newImportCmd() *cobra.Command {
 func Import(provider terraformutils.ProviderGenerator, options ImportOptions, args []string) error {
 	importExecuted = true
 	sessionKey := provider.GetName() + ":" + strings.Join(args, ":")
-	if _, err := terraformutils.ParseFilters(options.Filter); err != nil {
+	if err := validateImportFilters(provider, options.Filter, options.Resources); err != nil {
 		processReport.Add(importreport.ResourceEvent{
 			Service:  provider.GetName(),
 			Status:   importreport.StatusFailed,
@@ -157,6 +161,14 @@ func Import(provider terraformutils.ProviderGenerator, options ImportOptions, ar
 	providerMapping.ConvertTypedStates(providerWrapper, processReport)
 
 	return importFromPlan(providerMapping, options, args, processReport, eventStart)
+}
+
+func validateImportFilters(provider terraformutils.ProviderGenerator, filters, resources []string) error {
+	if validator, ok := provider.(importFilterValidator); ok {
+		return validator.ValidateFilters(filters, resources)
+	}
+	_, err := terraformutils.ParseFilters(filters)
+	return err
 }
 
 func initOptionsAndWrapper(provider terraformutils.ProviderGenerator, options ImportOptions, args []string) (*providerwrapper.ProviderWrapper, ImportOptions, error) {

--- a/cmd/import_test.go
+++ b/cmd/import_test.go
@@ -190,6 +190,35 @@ func TestImportUsesProviderFilterValidationBeforeInitialization(t *testing.T) {
 	}
 }
 
+func TestImportAppliesExclusionsBeforeProviderFilterValidation(t *testing.T) {
+	wantErr := errors.New("stop after validation")
+	provider := &providerFilterValidationTestProvider{
+		testProvider: testProvider{
+			name: "provider-filter-validation-test",
+			services: map[string]terraformutils.ServiceGenerator{
+				"acls":   &terraformutils.Service{},
+				"topics": &terraformutils.Service{},
+			},
+		},
+		filterErr: wantErr,
+	}
+
+	err := Import(provider, ImportOptions{
+		Resources: []string{"*"},
+		Excludes:  []string{"acls"},
+		Filter:    []string{"Name=id;Value=orders"},
+	}, nil)
+	if !errors.Is(err, wantErr) {
+		t.Fatalf("Import() error = %v, want %v", err, wantErr)
+	}
+	if !reflect.DeepEqual(provider.validatedResources, []string{"topics"}) {
+		t.Fatalf("validated resources = %#v, want %#v", provider.validatedResources, []string{"topics"})
+	}
+	if provider.initCalled {
+		t.Fatal("provider.Init() called after provider-specific filter validation failed")
+	}
+}
+
 func TestBaseProviderFlags(t *testing.T) {
 	flags := pflag.NewFlagSet("test", pflag.ContinueOnError)
 	options := &ImportOptions{}

--- a/cmd/import_test.go
+++ b/cmd/import_test.go
@@ -37,6 +37,16 @@ type validatingTestProvider struct {
 	resources []string
 }
 
+type initializationTrackingProvider struct {
+	testProvider
+	initCalled bool
+}
+
+func (p *initializationTrackingProvider) Init(_ []string) error {
+	p.initCalled = true
+	return nil
+}
+
 func (p *validatingTestProvider) ValidateImport(resources []string) error {
 	p.resources = append([]string(nil), resources...)
 	return p.err
@@ -112,6 +122,23 @@ func TestValidateImport(t *testing.T) {
 	}
 	if !reflect.DeepEqual(provider.resources, resources) {
 		t.Fatalf("expected validator resources %v, got %v", resources, provider.resources)
+	}
+}
+
+func TestImportRejectsInvalidFilterBeforeProviderInitialization(t *testing.T) {
+	provider := &initializationTrackingProvider{
+		testProvider: testProvider{name: "filter-validation-test"},
+	}
+
+	err := Import(provider, ImportOptions{
+		Resources: []string{"service"},
+		Filter:    []string{"valid=id", "Type=service;Name=id;Value="},
+	}, nil)
+	if err == nil {
+		t.Fatal("Import() error = nil, want invalid filter error")
+	}
+	if provider.initCalled {
+		t.Fatal("provider.Init() called for invalid filters")
 	}
 }
 

--- a/cmd/import_test.go
+++ b/cmd/import_test.go
@@ -42,6 +42,27 @@ type initializationTrackingProvider struct {
 	initCalled bool
 }
 
+type providerFilterValidationTestProvider struct {
+	testProvider
+	filterErr          error
+	validated          bool
+	validatedInput     []string
+	validatedResources []string
+	initCalled         bool
+}
+
+func (p *providerFilterValidationTestProvider) ValidateFilters(filters, resources []string) error {
+	p.validated = true
+	p.validatedInput = append([]string(nil), filters...)
+	p.validatedResources = append([]string(nil), resources...)
+	return p.filterErr
+}
+
+func (p *providerFilterValidationTestProvider) Init(_ []string) error {
+	p.initCalled = true
+	return nil
+}
+
 func (p *initializationTrackingProvider) Init(_ []string) error {
 	p.initCalled = true
 	return nil
@@ -139,6 +160,33 @@ func TestImportRejectsInvalidFilterBeforeProviderInitialization(t *testing.T) {
 	}
 	if provider.initCalled {
 		t.Fatal("provider.Init() called for invalid filters")
+	}
+}
+
+func TestImportUsesProviderFilterValidationBeforeInitialization(t *testing.T) {
+	wantErr := errors.New("provider-specific filter validation failed")
+	filter := "acls=User:O'Connor|*|Write|Allow|Topic|orders;archive|Literal"
+	provider := &providerFilterValidationTestProvider{
+		testProvider: testProvider{name: "provider-filter-validation-test"},
+		filterErr:    wantErr,
+	}
+
+	resources := []string{"acls"}
+	err := Import(provider, ImportOptions{Resources: resources, Filter: []string{filter}}, nil)
+	if !errors.Is(err, wantErr) {
+		t.Fatalf("Import() error = %v, want %v", err, wantErr)
+	}
+	if !provider.validated {
+		t.Fatal("provider-specific filter validator was not called")
+	}
+	if !reflect.DeepEqual(provider.validatedInput, []string{filter}) {
+		t.Fatalf("validated filters = %#v, want %#v", provider.validatedInput, []string{filter})
+	}
+	if !reflect.DeepEqual(provider.validatedResources, resources) {
+		t.Fatalf("validated resources = %#v, want %#v", provider.validatedResources, resources)
+	}
+	if provider.initCalled {
+		t.Fatal("provider.Init() called after provider-specific filter validation failed")
 	}
 }
 

--- a/providers/aws/aws_facade.go
+++ b/providers/aws/aws_facade.go
@@ -20,11 +20,11 @@ func (s *AwsFacade) SetVerbose(verbose bool) {
 	s.service.SetVerbose(verbose)
 }
 
-func (s *AwsFacade) ParseFilters(rawFilters []string) {
-	s.service.ParseFilters(rawFilters)
+func (s *AwsFacade) ParseFilters(rawFilters []string) error {
+	return s.service.ParseFilters(rawFilters)
 }
 
-func (s *AwsFacade) ParseFilter(rawFilter string) []terraformutils.ResourceFilter {
+func (s *AwsFacade) ParseFilter(rawFilter string) ([]terraformutils.ResourceFilter, error) {
 	return s.service.ParseFilter(rawFilter)
 }
 

--- a/providers/aws/filter.go
+++ b/providers/aws/filter.go
@@ -8,18 +8,21 @@ import (
 	"github.com/chenrui333/terraformer/terraformutils"
 )
 
-func (s *AWSService) ParseFilters(rawFilters []string) {
-	s.Filter = []terraformutils.ResourceFilter{}
-	for _, rawFilter := range rawFilters {
-		filters := s.ParseFilter(rawFilter)
-		s.Filter = append(s.Filter, filters...)
+func (s *AWSService) ParseFilters(rawFilters []string) error {
+	if err := s.Service.ParseFilters(rawFilters); err != nil {
+		return err
 	}
+	normalizeAWSResourceFilters(s.Filter)
+	return nil
 }
 
-func (s *AWSService) ParseFilter(rawFilter string) []terraformutils.ResourceFilter {
-	filters := s.Service.ParseFilter(rawFilter)
+func (s *AWSService) ParseFilter(rawFilter string) ([]terraformutils.ResourceFilter, error) {
+	filters, err := s.Service.ParseFilter(rawFilter)
+	if err != nil {
+		return nil, err
+	}
 	normalizeAWSResourceFilters(filters)
-	return filters
+	return filters, nil
 }
 
 func shouldLoadAWSResourceForTypedFilters(filters []terraformutils.ResourceFilter, serviceNames ...string) bool {

--- a/providers/aws/filter_test.go
+++ b/providers/aws/filter_test.go
@@ -10,7 +10,9 @@ import (
 
 func TestAWSServiceParseFiltersNormalizesAWSResourceTypes(t *testing.T) {
 	s := AWSService{}
-	s.ParseFilters([]string{"Type=aws_ebs_snapshot;Name=id;Value=snap-123"})
+	if err := s.ParseFilters([]string{"Type=aws_ebs_snapshot;Name=id;Value=snap-123"}); err != nil {
+		t.Fatalf("ParseFilters() error = %v", err)
+	}
 
 	if len(s.Filter) != 1 {
 		t.Fatalf("filters length = %d, want 1", len(s.Filter))
@@ -35,7 +37,9 @@ func TestAWSServiceParseFiltersNormalizesAWSResourceTypes(t *testing.T) {
 
 func TestAWSServiceParseFiltersNormalizesTransitGatewayServiceName(t *testing.T) {
 	s := AWSService{}
-	s.ParseFilters([]string{"transit_gateway=tgw-123"})
+	if err := s.ParseFilters([]string{"transit_gateway=tgw-123"}); err != nil {
+		t.Fatalf("ParseFilters() error = %v", err)
+	}
 
 	if len(s.Filter) != 1 {
 		t.Fatalf("filters length = %d, want 1", len(s.Filter))

--- a/providers/gcp/gcp_facade.go
+++ b/providers/gcp/gcp_facade.go
@@ -18,11 +18,11 @@ func (s *GCPFacade) SetVerbose(verbose bool) {
 	s.service.SetVerbose(verbose)
 }
 
-func (s *GCPFacade) ParseFilters(rawFilters []string) {
-	s.service.ParseFilters(rawFilters)
+func (s *GCPFacade) ParseFilters(rawFilters []string) error {
+	return s.service.ParseFilters(rawFilters)
 }
 
-func (s *GCPFacade) ParseFilter(rawFilter string) []terraformutils.ResourceFilter {
+func (s *GCPFacade) ParseFilter(rawFilter string) ([]terraformutils.ResourceFilter, error) {
 	return s.service.ParseFilter(rawFilter)
 }
 

--- a/providers/kafka/acl.go
+++ b/providers/kafka/acl.go
@@ -52,20 +52,15 @@ func (g *ACLGenerator) InitResources() error {
 }
 
 func (g *ACLGenerator) ParseFilter(rawFilter string) ([]terraformutils.ResourceFilter, error) {
-	if _, err := terraformutils.ParseFilter(rawFilter); err != nil {
-		return nil, err
-	}
-	for _, prefix := range []string{"kafka_acl=", "acls=", "acl="} {
-		if strings.HasPrefix(rawFilter, prefix) {
-			value := strings.TrimPrefix(rawFilter, prefix)
-			if value == "" {
-				return nil, fmt.Errorf("invalid filter %q: filter value is empty", strings.TrimSuffix(prefix, "=")+"=<redacted>")
-			}
-			return []terraformutils.ResourceFilter{aclIDFilter(value)}, nil
+	if value, ok := kafkaACLFilterValue(rawFilter); ok {
+		acl, err := parseKafkaACLImportID(value)
+		if err == nil {
+			_, err = acl.SaramaFilter()
 		}
-	}
-	if filter, ok := parseACLIDFilter(rawFilter); ok {
-		return []terraformutils.ResourceFilter{filter}, nil
+		if err != nil {
+			return nil, terraformutils.NewFilterParseError(rawFilter, "Kafka ACL import ID must contain seven valid segments")
+		}
+		return []terraformutils.ResourceFilter{aclIDFilter(value)}, nil
 	}
 	return g.Service.ParseFilter(rawFilter)
 }
@@ -83,13 +78,19 @@ func (g *ACLGenerator) ParseFilters(rawFilters []string) error {
 	return nil
 }
 
-func parseACLIDFilter(rawFilter string) (terraformutils.ResourceFilter, bool) {
-	for _, prefix := range []string{"Type=acl;Name=id;Value=", "Name=id;Value="} {
+func kafkaACLFilterValue(rawFilter string) (string, bool) {
+	for _, prefix := range []string{
+		"kafka_acl=",
+		"acls=",
+		"acl=",
+		"Type=acl;Name=id;Value=",
+		"Name=id;Value=",
+	} {
 		if strings.HasPrefix(rawFilter, prefix) {
-			return aclIDFilter(strings.TrimPrefix(rawFilter, prefix)), true
+			return strings.TrimPrefix(rawFilter, prefix), true
 		}
 	}
-	return terraformutils.ResourceFilter{}, false
+	return "", false
 }
 
 func aclIDFilter(id string) terraformutils.ResourceFilter {

--- a/providers/kafka/acl.go
+++ b/providers/kafka/acl.go
@@ -66,7 +66,16 @@ func (g *ACLGenerator) ParseFilter(rawFilter string) ([]terraformutils.ResourceF
 		}
 		return []terraformutils.ResourceFilter{aclIDFilter(value)}, nil
 	}
-	return g.Service.ParseFilter(rawFilter)
+	filters, err := g.Service.ParseFilter(rawFilter)
+	if err != nil {
+		return nil, err
+	}
+	if strings.HasPrefix(rawFilter, "Name=id;Value=") {
+		for i := range filters {
+			filters[i].ServiceName = "topic"
+		}
+	}
+	return filters, nil
 }
 
 func (g *ACLGenerator) ParseFilters(rawFilters []string) error {
@@ -88,10 +97,16 @@ func kafkaACLFilterValue(rawFilter string) (string, bool) {
 		"acls=",
 		"acl=",
 		"Type=acl;Name=id;Value=",
-		"Name=id;Value=",
 	} {
 		if strings.HasPrefix(rawFilter, prefix) {
 			return strings.TrimPrefix(rawFilter, prefix), true
+		}
+	}
+	const untypedIDPrefix = "Name=id;Value="
+	if strings.HasPrefix(rawFilter, untypedIDPrefix) {
+		value := strings.TrimPrefix(rawFilter, untypedIDPrefix)
+		if strings.Contains(value, "|") {
+			return value, true
 		}
 	}
 	return "", false

--- a/providers/kafka/acl.go
+++ b/providers/kafka/acl.go
@@ -51,23 +51,36 @@ func (g *ACLGenerator) InitResources() error {
 	return nil
 }
 
-func (g *ACLGenerator) ParseFilter(rawFilter string) []terraformutils.ResourceFilter {
+func (g *ACLGenerator) ParseFilter(rawFilter string) ([]terraformutils.ResourceFilter, error) {
+	if _, err := terraformutils.ParseFilter(rawFilter); err != nil {
+		return nil, err
+	}
 	for _, prefix := range []string{"kafka_acl=", "acls=", "acl="} {
 		if strings.HasPrefix(rawFilter, prefix) {
-			return []terraformutils.ResourceFilter{aclIDFilter(strings.TrimPrefix(rawFilter, prefix))}
+			value := strings.TrimPrefix(rawFilter, prefix)
+			if value == "" {
+				return nil, fmt.Errorf("invalid filter %q: filter value is empty", strings.TrimSuffix(prefix, "=")+"=<redacted>")
+			}
+			return []terraformutils.ResourceFilter{aclIDFilter(value)}, nil
 		}
 	}
 	if filter, ok := parseACLIDFilter(rawFilter); ok {
-		return []terraformutils.ResourceFilter{filter}
+		return []terraformutils.ResourceFilter{filter}, nil
 	}
 	return g.Service.ParseFilter(rawFilter)
 }
 
-func (g *ACLGenerator) ParseFilters(rawFilters []string) {
-	g.Filter = []terraformutils.ResourceFilter{}
+func (g *ACLGenerator) ParseFilters(rawFilters []string) error {
+	filters := []terraformutils.ResourceFilter{}
 	for _, rawFilter := range rawFilters {
-		g.Filter = append(g.Filter, g.ParseFilter(rawFilter)...)
+		parsed, err := g.ParseFilter(rawFilter)
+		if err != nil {
+			return err
+		}
+		filters = append(filters, parsed...)
 	}
+	g.Filter = filters
+	return nil
 }
 
 func parseACLIDFilter(rawFilter string) (terraformutils.ResourceFilter, bool) {

--- a/providers/kafka/acl.go
+++ b/providers/kafka/acl.go
@@ -53,12 +53,16 @@ func (g *ACLGenerator) InitResources() error {
 
 func (g *ACLGenerator) ParseFilter(rawFilter string) ([]terraformutils.ResourceFilter, error) {
 	if value, ok := kafkaACLFilterValue(rawFilter); ok {
-		acl, err := parseKafkaACLImportID(value)
-		if err == nil {
-			_, err = acl.SaramaFilter()
-		}
+		value, err := unwrapKafkaACLFilterValue(value)
 		if err != nil {
-			return nil, terraformutils.NewFilterParseError(rawFilter, "Kafka ACL import ID must contain seven valid segments")
+			return nil, terraformutils.NewFilterParseError(rawFilter, err.Error())
+		}
+		acl, err := parseKafkaACLImportID(value)
+		if err != nil {
+			return nil, terraformutils.NewFilterParseError(rawFilter, "Kafka ACL import ID must contain seven non-empty pipe-delimited segments")
+		}
+		if _, err := acl.SaramaFilter(); err != nil {
+			return nil, terraformutils.NewFilterParseError(rawFilter, "Kafka ACL import ID contains an invalid resource type, pattern type, operation, or permission type")
 		}
 		return []terraformutils.ResourceFilter{aclIDFilter(value)}, nil
 	}
@@ -91,6 +95,16 @@ func kafkaACLFilterValue(rawFilter string) (string, bool) {
 		}
 	}
 	return "", false
+}
+
+func unwrapKafkaACLFilterValue(value string) (string, error) {
+	if value == "" || value[0] != '\'' {
+		return value, nil
+	}
+	if len(value) == 1 || value[len(value)-1] != '\'' {
+		return "", fmt.Errorf("unbalanced single quote")
+	}
+	return value[1 : len(value)-1], nil
 }
 
 func aclIDFilter(id string) terraformutils.ResourceFilter {
@@ -259,6 +273,12 @@ func parseKafkaACLImportID(id string) (ACL, error) {
 	parts := strings.Split(id, "|")
 	if len(parts) != 7 {
 		return ACL{}, fmt.Errorf("kafka acl import ID must have 7 pipe-delimited segments, got %d", len(parts))
+	}
+	segmentNames := []string{"principal", "host", "operation", "permission type", "resource type", "resource name", "pattern type"}
+	for i, part := range parts {
+		if part == "" {
+			return ACL{}, fmt.Errorf("kafka acl import ID %s segment is empty", segmentNames[i])
+		}
 	}
 	return ACL{
 		Principal:                 parts[0],

--- a/providers/kafka/acl_test.go
+++ b/providers/kafka/acl_test.go
@@ -239,42 +239,65 @@ func TestACLIDFilterSyntaxKeepsPrincipalColon(t *testing.T) {
 }
 
 func TestACLFilterPreservesProviderSpecificCharacters(t *testing.T) {
-	tests := []string{
-		"acls=User:O'Connor|*|Write|Allow|Topic|orders|Literal",
-		"acls=User:producer|*|Write|Allow|Topic|orders;archive|Literal",
+	tests := []struct {
+		rawFilter string
+		want      string
+	}{
+		{
+			rawFilter: "acls=User:O'Connor|*|Write|Allow|Topic|orders|Literal",
+			want:      "User:O'Connor|*|Write|Allow|Topic|orders|Literal",
+		},
+		{
+			rawFilter: "acls=User:producer|*|Write|Allow|Topic|orders;archive|Literal",
+			want:      "User:producer|*|Write|Allow|Topic|orders;archive|Literal",
+		},
+		{
+			rawFilter: "acls='User:producer|*|Write|Allow|Topic|orders|Literal'",
+			want:      "User:producer|*|Write|Allow|Topic|orders|Literal",
+		},
 	}
 
-	for _, rawFilter := range tests {
-		t.Run(rawFilter, func(t *testing.T) {
+	for _, tt := range tests {
+		t.Run(tt.rawFilter, func(t *testing.T) {
 			generator := &ACLGenerator{}
-			if err := generator.ParseFilters([]string{rawFilter}); err != nil {
+			if err := generator.ParseFilters([]string{tt.rawFilter}); err != nil {
 				t.Fatalf("ParseFilters() error = %v", err)
 			}
 			if len(generator.Filter) != 1 {
 				t.Fatalf("filter len = %d, want 1", len(generator.Filter))
 			}
-			want := strings.TrimPrefix(rawFilter, "acls=")
-			if !reflect.DeepEqual(generator.Filter[0].AcceptableValues, []string{want}) {
-				t.Fatalf("filter values = %#v, want %#v", generator.Filter[0].AcceptableValues, []string{want})
+			if !reflect.DeepEqual(generator.Filter[0].AcceptableValues, []string{tt.want}) {
+				t.Fatalf("filter values = %#v, want %#v", generator.Filter[0].AcceptableValues, []string{tt.want})
 			}
 		})
 	}
 }
 
 func TestACLFilterRejectsMalformedImportIDs(t *testing.T) {
-	tests := []string{
-		"acl=bad",
-		"acl=User:producer|*|InvalidOperation|Allow|Topic|orders|Literal",
+	tests := []struct {
+		name       string
+		rawFilter  string
+		wantReason string
+	}{
+		{name: "wrong segment count", rawFilter: "acl=bad", wantReason: "seven non-empty pipe-delimited segments"},
+		{name: "empty principal", rawFilter: "acl=|*|Write|Allow|Topic|orders|Literal", wantReason: "seven non-empty pipe-delimited segments"},
+		{name: "empty host", rawFilter: "acl=User:producer||Write|Allow|Topic|orders|Literal", wantReason: "seven non-empty pipe-delimited segments"},
+		{name: "empty resource name", rawFilter: "acl=User:producer|*|Write|Allow|Topic||Literal", wantReason: "seven non-empty pipe-delimited segments"},
+		{name: "unbalanced outer quote", rawFilter: "acl='User:producer|*|Write|Allow|Topic|orders|Literal", wantReason: "unbalanced single quote"},
+		{name: "invalid operation", rawFilter: "acl=User:producer|*|InvalidOperation|Allow|Topic|orders|Literal", wantReason: "invalid resource type, pattern type, operation, or permission type"},
 	}
 
-	for _, rawFilter := range tests {
-		t.Run(rawFilter, func(t *testing.T) {
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
 			generator := &ACLGenerator{}
-			err := generator.ParseFilters([]string{rawFilter})
+			err := generator.ParseFilters([]string{tt.rawFilter})
 			if err == nil {
 				t.Fatal("ParseFilters() error = nil, want error")
 			}
-			if strings.Contains(err.Error(), strings.TrimPrefix(rawFilter, "acl=")) {
+			if !strings.Contains(err.Error(), tt.wantReason) {
+				t.Fatalf("ParseFilters() error = %q, want reason %q", err, tt.wantReason)
+			}
+			if strings.Contains(err.Error(), strings.TrimPrefix(tt.rawFilter, "acl=")) {
 				t.Fatalf("ParseFilters() error exposed ACL import ID: %q", err)
 			}
 		})

--- a/providers/kafka/acl_test.go
+++ b/providers/kafka/acl_test.go
@@ -238,6 +238,49 @@ func TestACLIDFilterSyntaxKeepsPrincipalColon(t *testing.T) {
 	}
 }
 
+func TestACLFilterPreservesProviderSpecificCharacters(t *testing.T) {
+	tests := []string{
+		"acls=User:O'Connor|*|Write|Allow|Topic|orders|Literal",
+		"acls=User:producer|*|Write|Allow|Topic|orders;archive|Literal",
+	}
+
+	for _, rawFilter := range tests {
+		t.Run(rawFilter, func(t *testing.T) {
+			generator := &ACLGenerator{}
+			if err := generator.ParseFilters([]string{rawFilter}); err != nil {
+				t.Fatalf("ParseFilters() error = %v", err)
+			}
+			if len(generator.Filter) != 1 {
+				t.Fatalf("filter len = %d, want 1", len(generator.Filter))
+			}
+			want := strings.TrimPrefix(rawFilter, "acls=")
+			if !reflect.DeepEqual(generator.Filter[0].AcceptableValues, []string{want}) {
+				t.Fatalf("filter values = %#v, want %#v", generator.Filter[0].AcceptableValues, []string{want})
+			}
+		})
+	}
+}
+
+func TestACLFilterRejectsMalformedImportIDs(t *testing.T) {
+	tests := []string{
+		"acl=bad",
+		"acl=User:producer|*|InvalidOperation|Allow|Topic|orders|Literal",
+	}
+
+	for _, rawFilter := range tests {
+		t.Run(rawFilter, func(t *testing.T) {
+			generator := &ACLGenerator{}
+			err := generator.ParseFilters([]string{rawFilter})
+			if err == nil {
+				t.Fatal("ParseFilters() error = nil, want error")
+			}
+			if strings.Contains(err.Error(), strings.TrimPrefix(rawFilter, "acl=")) {
+				t.Fatalf("ParseFilters() error exposed ACL import ID: %q", err)
+			}
+		})
+	}
+}
+
 func TestACLPreservesRequiredFieldsAfterImportFallback(t *testing.T) {
 	acl := ACL{
 		Principal:                 "User:ANONYMOUS",

--- a/providers/kafka/acl_test.go
+++ b/providers/kafka/acl_test.go
@@ -238,6 +238,26 @@ func TestACLIDFilterSyntaxKeepsPrincipalColon(t *testing.T) {
 	}
 }
 
+func TestACLFilterLeavesTopicIDFilterNonApplicable(t *testing.T) {
+	generator := &ACLGenerator{}
+	if err := generator.ParseFilters([]string{"Name=id;Value=orders"}); err != nil {
+		t.Fatalf("ParseFilters() error = %v", err)
+	}
+	if len(generator.Filter) != 1 {
+		t.Fatalf("filter len = %d, want 1", len(generator.Filter))
+	}
+	if generator.Filter[0].ServiceName != "topic" {
+		t.Fatalf("filter service = %q, want topic", generator.Filter[0].ServiceName)
+	}
+	acls, err := generator.explicitlyRequestedACLs()
+	if err != nil {
+		t.Fatalf("explicitlyRequestedACLs() error = %v", err)
+	}
+	if len(acls) != 0 {
+		t.Fatalf("topic filter selected ACLs: %#v", acls)
+	}
+}
+
 func TestACLFilterPreservesProviderSpecificCharacters(t *testing.T) {
 	tests := []struct {
 		rawFilter string
@@ -282,6 +302,7 @@ func TestACLFilterRejectsMalformedImportIDs(t *testing.T) {
 		{name: "wrong segment count", rawFilter: "acl=bad", wantReason: "seven non-empty pipe-delimited segments"},
 		{name: "empty principal", rawFilter: "acl=|*|Write|Allow|Topic|orders|Literal", wantReason: "seven non-empty pipe-delimited segments"},
 		{name: "empty host", rawFilter: "acl=User:producer||Write|Allow|Topic|orders|Literal", wantReason: "seven non-empty pipe-delimited segments"},
+		{name: "untyped empty host", rawFilter: "Name=id;Value=User:producer||Write|Allow|Topic|orders|Literal", wantReason: "seven non-empty pipe-delimited segments"},
 		{name: "empty resource name", rawFilter: "acl=User:producer|*|Write|Allow|Topic||Literal", wantReason: "seven non-empty pipe-delimited segments"},
 		{name: "unbalanced outer quote", rawFilter: "acl='User:producer|*|Write|Allow|Topic|orders|Literal", wantReason: "unbalanced single quote"},
 		{name: "invalid operation", rawFilter: "acl=User:producer|*|InvalidOperation|Allow|Topic|orders|Literal", wantReason: "invalid resource type, pattern type, operation, or permission type"},

--- a/providers/kafka/kafka_provider.go
+++ b/providers/kafka/kafka_provider.go
@@ -64,6 +64,30 @@ func (p *Provider) GetSupportedService() map[string]terraformutils.ServiceGenera
 	}
 }
 
+func (Provider) ValidateFilters(rawFilters, resources []string) error {
+	validateACLs := false
+	for _, resource := range resources {
+		if resource == "*" || resource == "acls" {
+			validateACLs = true
+			break
+		}
+	}
+
+	aclParser := &ACLGenerator{}
+	for _, rawFilter := range rawFilters {
+		if validateACLs {
+			if _, err := aclParser.ParseFilter(rawFilter); err != nil {
+				return err
+			}
+			continue
+		}
+		if _, err := terraformutils.ParseFilter(rawFilter); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
 func (Provider) GetResourceConnections() map[string]map[string][]string {
 	return map[string]map[string][]string{}
 }

--- a/providers/kafka/kafka_provider.go
+++ b/providers/kafka/kafka_provider.go
@@ -64,18 +64,10 @@ func (p *Provider) GetSupportedService() map[string]terraformutils.ServiceGenera
 	}
 }
 
-func (Provider) ValidateFilters(rawFilters, resources []string) error {
-	validateACLs := false
-	for _, resource := range resources {
-		if resource == "*" || resource == "acls" {
-			validateACLs = true
-			break
-		}
-	}
-
+func (Provider) ValidateFilters(rawFilters, _ []string) error {
 	aclParser := &ACLGenerator{}
 	for _, rawFilter := range rawFilters {
-		if validateACLs {
+		if _, ok := kafkaACLFilterValue(rawFilter); ok {
 			if _, err := aclParser.ParseFilter(rawFilter); err != nil {
 				return err
 			}

--- a/providers/kafka/kafka_provider_test.go
+++ b/providers/kafka/kafka_provider_test.go
@@ -113,11 +113,17 @@ func TestProviderValidateFiltersUsesACLGrammar(t *testing.T) {
 	if err := provider.ValidateFilters(filters, []string{"acls"}); err != nil {
 		t.Fatalf("ValidateFilters() error = %v", err)
 	}
+	if err := provider.ValidateFilters(filters, []string{"acls", "topics"}); err != nil {
+		t.Fatalf("ValidateFilters() rejected mixed-resource ACL filters: %v", err)
+	}
 	if err := provider.ValidateFilters([]string{"acl=bad"}, []string{"acls"}); err == nil {
 		t.Fatal("ValidateFilters() error = nil for malformed ACL import ID")
 	}
 	if err := provider.ValidateFilters([]string{"Name=id;Value=orders"}, []string{"topics"}); err != nil {
 		t.Fatalf("ValidateFilters() rejected topic-only filter: %v", err)
+	}
+	if err := provider.ValidateFilters([]string{"Name=id;Value=orders"}, []string{"acls", "topics"}); err != nil {
+		t.Fatalf("ValidateFilters() rejected mixed-resource topic filter: %v", err)
 	}
 }
 

--- a/providers/kafka/kafka_provider_test.go
+++ b/providers/kafka/kafka_provider_test.go
@@ -103,6 +103,21 @@ func TestProviderSupportedServices(t *testing.T) {
 	}
 }
 
+func TestProviderValidateFiltersUsesACLGrammar(t *testing.T) {
+	provider := &Provider{}
+	filters := []string{
+		"acls=User:O'Connor|*|Write|Allow|Topic|orders|Literal",
+		"acls=User:producer|*|Write|Allow|Topic|orders;archive|Literal",
+	}
+
+	if err := provider.ValidateFilters(filters, []string{"acls"}); err != nil {
+		t.Fatalf("ValidateFilters() error = %v", err)
+	}
+	if err := provider.ValidateFilters([]string{"acl=bad"}, []string{"acls"}); err == nil {
+		t.Fatal("ValidateFilters() error = nil for malformed ACL import ID")
+	}
+}
+
 func forbiddenTestSecrets() []string {
 	return []string{
 		"sasl-password",

--- a/providers/kafka/kafka_provider_test.go
+++ b/providers/kafka/kafka_provider_test.go
@@ -116,6 +116,9 @@ func TestProviderValidateFiltersUsesACLGrammar(t *testing.T) {
 	if err := provider.ValidateFilters([]string{"acl=bad"}, []string{"acls"}); err == nil {
 		t.Fatal("ValidateFilters() error = nil for malformed ACL import ID")
 	}
+	if err := provider.ValidateFilters([]string{"Name=id;Value=orders"}, []string{"topics"}); err != nil {
+		t.Fatalf("ValidateFilters() rejected topic-only filter: %v", err)
+	}
 }
 
 func forbiddenTestSecrets() []string {

--- a/providers/kafka/kafka_provider_test.go
+++ b/providers/kafka/kafka_provider_test.go
@@ -116,8 +116,26 @@ func TestProviderValidateFiltersUsesACLGrammar(t *testing.T) {
 	if err := provider.ValidateFilters(filters, []string{"acls", "topics"}); err != nil {
 		t.Fatalf("ValidateFilters() rejected mixed-resource ACL filters: %v", err)
 	}
+	if err := provider.ValidateFilters(filters, []string{"topics"}); err != nil {
+		t.Fatalf("ValidateFilters() rejected ACL-scoped filters for a topic-only import: %v", err)
+	}
 	if err := provider.ValidateFilters([]string{"acl=bad"}, []string{"acls"}); err == nil {
 		t.Fatal("ValidateFilters() error = nil for malformed ACL import ID")
+	}
+	if err := provider.ValidateFilters([]string{"acl=bad"}, []string{"topics"}); err == nil {
+		t.Fatal("ValidateFilters() error = nil for malformed ACL import ID during a topic-only import")
+	}
+	for _, rawFilter := range []string{
+		"acl=User:producer|*|InvalidOperation|Allow|Topic|orders;Type=customer-secret|Literal",
+		"acl=User:producer|*|InvalidOperation|Allow|Topic|orders;Name=customer-secret|Literal",
+	} {
+		err := provider.ValidateFilters([]string{rawFilter}, []string{"topics"})
+		if err == nil {
+			t.Fatalf("ValidateFilters() error = nil for malformed ACL filter %q", rawFilter)
+		}
+		if strings.Contains(err.Error(), "customer-secret") {
+			t.Fatalf("ValidateFilters() exposed ACL filter value: %v", err)
+		}
 	}
 	if err := provider.ValidateFilters([]string{"Name=id;Value=orders"}, []string{"topics"}); err != nil {
 		t.Fatalf("ValidateFilters() rejected topic-only filter: %v", err)

--- a/providers/kafka/topic.go
+++ b/providers/kafka/topic.go
@@ -50,7 +50,7 @@ func (g *TopicGenerator) InitResources() error {
 	return nil
 }
 
-func (g *TopicGenerator) ParseFilter(rawFilter string) []terraformutils.ResourceFilter {
+func (g *TopicGenerator) ParseFilter(rawFilter string) ([]terraformutils.ResourceFilter, error) {
 	normalized := rawFilter
 	for _, prefix := range []string{"kafka_topic=", "topics="} {
 		if strings.HasPrefix(rawFilter, prefix) {
@@ -61,11 +61,17 @@ func (g *TopicGenerator) ParseFilter(rawFilter string) []terraformutils.Resource
 	return g.Service.ParseFilter(normalized)
 }
 
-func (g *TopicGenerator) ParseFilters(rawFilters []string) {
-	g.Filter = []terraformutils.ResourceFilter{}
+func (g *TopicGenerator) ParseFilters(rawFilters []string) error {
+	filters := []terraformutils.ResourceFilter{}
 	for _, rawFilter := range rawFilters {
-		g.Filter = append(g.Filter, g.ParseFilter(rawFilter)...)
+		parsed, err := g.ParseFilter(rawFilter)
+		if err != nil {
+			return err
+		}
+		filters = append(filters, parsed...)
 	}
+	g.Filter = filters
+	return nil
 }
 
 func (g *TopicGenerator) listTopics(admin adminClient, config Config) ([]Topic, error) {

--- a/providers/kafka/topic.go
+++ b/providers/kafka/topic.go
@@ -51,6 +51,9 @@ func (g *TopicGenerator) InitResources() error {
 }
 
 func (g *TopicGenerator) ParseFilter(rawFilter string) ([]terraformutils.ResourceFilter, error) {
+	if _, ok := kafkaACLFilterValue(rawFilter); ok {
+		return (&ACLGenerator{}).ParseFilter(rawFilter)
+	}
 	normalized := rawFilter
 	for _, prefix := range []string{"kafka_topic=", "topics="} {
 		if strings.HasPrefix(rawFilter, prefix) {

--- a/providers/kafka/topic_test.go
+++ b/providers/kafka/topic_test.go
@@ -629,6 +629,31 @@ func TestTopicIDFilterAliases(t *testing.T) {
 	}
 }
 
+func TestTopicFilterIgnoresACLOnlySyntax(t *testing.T) {
+	tests := []string{
+		"acls=User:O'Connor|*|Write|Allow|Topic|orders|Literal",
+		"acls=User:producer|*|Write|Allow|Topic|orders;archive|Literal",
+	}
+
+	for _, rawFilter := range tests {
+		t.Run(rawFilter, func(t *testing.T) {
+			generator := &TopicGenerator{}
+			if err := generator.ParseFilters([]string{rawFilter}); err != nil {
+				t.Fatalf("ParseFilters() error = %v", err)
+			}
+			if len(generator.Filter) != 1 {
+				t.Fatalf("filter len = %d, want 1", len(generator.Filter))
+			}
+			if generator.Filter[0].ServiceName != "acl" {
+				t.Fatalf("filter service = %q, want acl", generator.Filter[0].ServiceName)
+			}
+			if topics := generator.explicitlyRequestedTopics(); len(topics) != 0 {
+				t.Fatalf("ACL-only filter selected topics: %#v", topics)
+			}
+		})
+	}
+}
+
 func TestKafkaTopicResourceNameIsStableForPunctuation(t *testing.T) {
 	first := kafkaTopicResourceName("a.b_c-d/slash")
 	second := kafkaTopicResourceName("a.b_c-d/slash")

--- a/terraformutils/service.go
+++ b/terraformutils/service.go
@@ -3,7 +3,7 @@
 package terraformutils
 
 import (
-	"log"
+	"fmt"
 	"strings"
 
 	"github.com/chenrui333/terraformer/terraformutils/providerwrapper"
@@ -13,8 +13,8 @@ type ServiceGenerator interface {
 	InitResources() error
 	GetResources() []Resource
 	SetResources(resources []Resource)
-	ParseFilter(rawFilter string) []ResourceFilter
-	ParseFilters(rawFilters []string)
+	ParseFilter(rawFilter string) ([]ResourceFilter, error)
+	ParseFilters(rawFilters []string) error
 	PostConvertHook() error
 	GetArgs() map[string]interface{}
 	SetArgs(args map[string]interface{})
@@ -55,55 +55,147 @@ func (s *Service) SetVerbose(verbose bool) {
 	s.Verbose = verbose
 }
 
-func (s *Service) ParseFilters(rawFilters []string) {
-	s.Filter = []ResourceFilter{}
+func ParseFilters(rawFilters []string) ([]ResourceFilter, error) {
+	filters := make([]ResourceFilter, 0, len(rawFilters))
 	for _, rawFilter := range rawFilters {
-		filters := s.ParseFilter(rawFilter)
-		s.Filter = append(s.Filter, filters...)
+		parsed, err := ParseFilter(rawFilter)
+		if err != nil {
+			return nil, err
+		}
+		filters = append(filters, parsed...)
+	}
+	return filters, nil
+}
+
+func ParseFilter(rawFilter string) ([]ResourceFilter, error) {
+	if rawFilter == "" {
+		return nil, invalidFilter(rawFilter, "filter is empty")
+	}
+	if _, err := ParseFilterValues(rawFilter); err != nil {
+		return nil, invalidFilter(rawFilter, err.Error())
+	}
+
+	parts := strings.Split(rawFilter, ";")
+	switch len(parts) {
+	case 1:
+		if strings.HasPrefix(rawFilter, "Name=") {
+			fieldPath, err := parseFilterComponent(parts[0], "Name")
+			if err != nil {
+				return nil, invalidFilter(rawFilter, err.Error())
+			}
+			return []ResourceFilter{{FieldPath: fieldPath}}, nil
+		}
+
+		simple := strings.SplitN(rawFilter, "=", 2)
+		if len(simple) != 2 {
+			return nil, invalidFilter(rawFilter, "expected service=value")
+		}
+		serviceName, rawValues := simple[0], simple[1]
+		if strings.TrimSpace(serviceName) == "" {
+			return nil, invalidFilter(rawFilter, "service name is empty")
+		}
+		if serviceName == "Type" || serviceName == "Value" {
+			return nil, invalidFilter(rawFilter, "expected service=value or a complete named filter")
+		}
+		values, err := ParseFilterValues(rawValues)
+		if err != nil {
+			return nil, invalidFilter(rawFilter, err.Error())
+		}
+		if len(values) == 0 {
+			return nil, invalidFilter(rawFilter, "filter value is empty")
+		}
+		return []ResourceFilter{{ServiceName: serviceName, FieldPath: "id", AcceptableValues: values}}, nil
+	case 2:
+		fieldPath, err := parseFilterComponent(parts[0], "Name")
+		if err != nil {
+			return nil, invalidFilter(rawFilter, err.Error())
+		}
+		rawValues, err := parseFilterComponent(parts[1], "Value")
+		if err != nil {
+			return nil, invalidFilter(rawFilter, err.Error())
+		}
+		values, err := ParseFilterValues(rawValues)
+		if err != nil {
+			return nil, invalidFilter(rawFilter, err.Error())
+		}
+		if len(values) == 0 {
+			return nil, invalidFilter(rawFilter, "filter value is empty")
+		}
+		return []ResourceFilter{{FieldPath: fieldPath, AcceptableValues: values}}, nil
+	case 3:
+		serviceName, err := parseFilterComponent(parts[0], "Type")
+		if err != nil {
+			return nil, invalidFilter(rawFilter, err.Error())
+		}
+		fieldPath, err := parseFilterComponent(parts[1], "Name")
+		if err != nil {
+			return nil, invalidFilter(rawFilter, err.Error())
+		}
+		rawValues, err := parseFilterComponent(parts[2], "Value")
+		if err != nil {
+			return nil, invalidFilter(rawFilter, err.Error())
+		}
+		values, err := ParseFilterValues(rawValues)
+		if err != nil {
+			return nil, invalidFilter(rawFilter, err.Error())
+		}
+		if len(values) == 0 {
+			return nil, invalidFilter(rawFilter, "filter value is empty")
+		}
+		return []ResourceFilter{{ServiceName: serviceName, FieldPath: fieldPath, AcceptableValues: values}}, nil
+	default:
+		return nil, invalidFilter(rawFilter, "unexpected semicolon component")
 	}
 }
 
-func (s *Service) ParseFilter(rawFilter string) []ResourceFilter {
-	var filters []ResourceFilter
-	if !strings.HasPrefix(rawFilter, "Name=") && len(strings.Split(rawFilter, "=")) == 2 {
-		parts := strings.Split(rawFilter, "=")
-		serviceName, resourcesID := parts[0], parts[1]
-		filters = append(filters, ResourceFilter{
-			ServiceName:      serviceName,
-			FieldPath:        "id",
-			AcceptableValues: ParseFilterValues(resourcesID),
-		})
-	} else {
-		parts := strings.Split(rawFilter, ";")
-		if (len(parts) != 1 || !strings.HasPrefix(rawFilter, "Name=")) && len(parts) != 2 && len(parts) != 3 {
-			log.Print("Invalid filter: " + rawFilter)
-			return filters
-		}
-		var ServiceNamePart string
-		var FieldPathPart string
-		var AcceptableValuesPart string
-		switch len(parts) {
-		case 1:
-			ServiceNamePart = ""
-			FieldPathPart = parts[0]
-			AcceptableValuesPart = ""
-		case 2:
-			ServiceNamePart = ""
-			FieldPathPart = parts[0]
-			AcceptableValuesPart = parts[1]
-		default:
-			ServiceNamePart = strings.TrimPrefix(parts[0], "Type=")
-			FieldPathPart = parts[1]
-			AcceptableValuesPart = parts[2]
-		}
-
-		filters = append(filters, ResourceFilter{
-			ServiceName:      ServiceNamePart,
-			FieldPath:        strings.TrimPrefix(FieldPathPart, "Name="),
-			AcceptableValues: ParseFilterValues(strings.TrimPrefix(AcceptableValuesPart, "Value=")),
-		})
+func parseFilterComponent(component, name string) (string, error) {
+	parts := strings.SplitN(component, "=", 2)
+	if len(parts) != 2 || parts[0] != name {
+		return "", fmt.Errorf("expected %s= component", name)
 	}
-	return filters
+	if strings.TrimSpace(parts[1]) == "" {
+		return "", fmt.Errorf("%s value is empty", name)
+	}
+	if name != "Value" && strings.Contains(parts[1], "=") {
+		return "", fmt.Errorf("%s value contains an unexpected separator", name)
+	}
+	return parts[1], nil
+}
+
+func invalidFilter(rawFilter, reason string) error {
+	return fmt.Errorf("invalid filter %q: %s", filterForError(rawFilter), reason)
+}
+
+func filterForError(rawFilter string) string {
+	parts := strings.Split(rawFilter, ";")
+	for i, part := range parts {
+		keyValue := strings.SplitN(part, "=", 2)
+		if len(keyValue) != 2 {
+			continue
+		}
+		if keyValue[0] == "Type" || keyValue[0] == "Name" {
+			continue
+		}
+		key := keyValue[0]
+		if key == "" {
+			key = "<empty>"
+		}
+		parts[i] = key + "=<redacted>"
+	}
+	return strings.Join(parts, ";")
+}
+
+func (s *Service) ParseFilters(rawFilters []string) error {
+	filters, err := ParseFilters(rawFilters)
+	if err != nil {
+		return err
+	}
+	s.Filter = filters
+	return nil
+}
+
+func (s *Service) ParseFilter(rawFilter string) ([]ResourceFilter, error) {
+	return ParseFilter(rawFilter)
 }
 
 func (s *Service) SetName(name string) {

--- a/terraformutils/service.go
+++ b/terraformutils/service.go
@@ -172,17 +172,15 @@ func NewFilterParseError(rawFilter, reason string) error {
 }
 
 func filterForError(rawFilter string) string {
-	parts := strings.Split(rawFilter, ";")
+	originalParts := strings.Split(rawFilter, ";")
+	parts := append([]string(nil), originalParts...)
 	for i, part := range parts {
 		keyValue := strings.SplitN(part, "=", 2)
 		if len(keyValue) != 2 {
 			parts[i] = "<redacted>"
 			continue
 		}
-		if keyValue[0] == "Type" || keyValue[0] == "Name" {
-			if strings.Contains(keyValue[1], "=") {
-				parts[i] = keyValue[0] + "=<redacted>"
-			}
+		if (keyValue[0] == "Type" || keyValue[0] == "Name") && filterMetadataIsStructural(originalParts, i) {
 			continue
 		}
 		key := keyValue[0]
@@ -192,6 +190,29 @@ func filterForError(rawFilter string) string {
 		parts[i] = key + "=<redacted>"
 	}
 	return strings.Join(parts, ";")
+}
+
+func filterMetadataIsStructural(parts []string, index int) bool {
+	switch len(parts) {
+	case 1:
+		return index == 0 && validFilterComponent(parts[0], "Name")
+	case 2:
+		return index == 0 &&
+			validFilterComponent(parts[0], "Name") &&
+			validFilterComponent(parts[1], "Value")
+	case 3:
+		return (index == 0 || index == 1) &&
+			validFilterComponent(parts[0], "Type") &&
+			validFilterComponent(parts[1], "Name") &&
+			validFilterComponent(parts[2], "Value")
+	default:
+		return false
+	}
+}
+
+func validFilterComponent(component, name string) bool {
+	_, err := parseFilterComponent(component, name)
+	return err == nil
 }
 
 func (s *Service) ParseFilters(rawFilters []string) error {

--- a/terraformutils/service.go
+++ b/terraformutils/service.go
@@ -180,6 +180,9 @@ func filterForError(rawFilter string) string {
 			continue
 		}
 		if keyValue[0] == "Type" || keyValue[0] == "Name" {
+			if strings.Contains(keyValue[1], "=") {
+				parts[i] = keyValue[0] + "=<redacted>"
+			}
 			continue
 		}
 		key := keyValue[0]

--- a/terraformutils/service.go
+++ b/terraformutils/service.go
@@ -163,6 +163,11 @@ func parseFilterComponent(component, name string) (string, error) {
 }
 
 func invalidFilter(rawFilter, reason string) error {
+	return NewFilterParseError(rawFilter, reason)
+}
+
+// NewFilterParseError reports a rejected filter while redacting user-supplied values.
+func NewFilterParseError(rawFilter, reason string) error {
 	return fmt.Errorf("invalid filter %q: %s", filterForError(rawFilter), reason)
 }
 
@@ -171,6 +176,7 @@ func filterForError(rawFilter string) string {
 	for i, part := range parts {
 		keyValue := strings.SplitN(part, "=", 2)
 		if len(keyValue) != 2 {
+			parts[i] = "<redacted>"
 			continue
 		}
 		if keyValue[0] == "Type" || keyValue[0] == "Name" {

--- a/terraformutils/service_accessors_test.go
+++ b/terraformutils/service_accessors_test.go
@@ -92,7 +92,10 @@ func TestServiceInitResourcesPanics(t *testing.T) {
 
 func TestServiceParseFilterThreeParts(t *testing.T) {
 	s := &Service{}
-	filters := s.ParseFilter("Type=vpc;Name=tags.env;Value=prod")
+	filters, err := s.ParseFilter("Type=vpc;Name=tags.env;Value=prod")
+	if err != nil {
+		t.Fatalf("ParseFilter() error = %v", err)
+	}
 	if len(filters) != 1 {
 		t.Fatalf("ParseFilter() len = %d, want 1", len(filters))
 	}
@@ -110,9 +113,12 @@ func TestServiceParseFilterThreeParts(t *testing.T) {
 
 func TestServiceParseFilterInvalid(t *testing.T) {
 	s := &Service{}
-	filters := s.ParseFilter("a;b;c;d")
+	filters, err := s.ParseFilter("a;b;c;d")
+	if err == nil {
+		t.Fatal("ParseFilter() error = nil, want error")
+	}
 	if len(filters) != 0 {
-		t.Errorf("ParseFilter() for invalid input should return empty, got %d", len(filters))
+		t.Errorf("ParseFilter() for invalid input returned %d filters, want 0", len(filters))
 	}
 }
 

--- a/terraformutils/service_test.go
+++ b/terraformutils/service_test.go
@@ -117,6 +117,18 @@ func TestParseFilterSyntax(t *testing.T) {
 			wantErr:     true,
 			errorValues: []string{"top-secret", "still-secret"},
 		},
+		{
+			name:        "error redacts malformed Type component",
+			raw:         "Type=service=type-secret;Name=id;Value=x",
+			wantErr:     true,
+			errorValues: []string{"type-secret"},
+		},
+		{
+			name:        "error redacts malformed Name component",
+			raw:         "Name=field=name-secret;Value=x",
+			wantErr:     true,
+			errorValues: []string{"name-secret"},
+		},
 	}
 
 	for _, tt := range tests {

--- a/terraformutils/service_test.go
+++ b/terraformutils/service_test.go
@@ -69,11 +69,11 @@ func TestEdgeIdFiltersParsing(t *testing.T) {
 
 func TestParseFilterSyntax(t *testing.T) {
 	tests := []struct {
-		name       string
-		raw        string
-		want       ResourceFilter
-		wantErr    bool
-		errorValue string
+		name        string
+		raw         string
+		want        ResourceFilter
+		wantErr     bool
+		errorValues []string
 	}{
 		{
 			name: "simple ID",
@@ -106,10 +106,16 @@ func TestParseFilterSyntax(t *testing.T) {
 		{name: "empty field", raw: "Name=;Value=prod", wantErr: true},
 		{name: "empty required value", raw: "Name=tags.env;Value=", wantErr: true},
 		{
-			name:       "error redacts rejected value",
-			raw:        "resource='credential-value",
-			wantErr:    true,
-			errorValue: "credential-value",
+			name:        "error redacts rejected value",
+			raw:         "resource='credential-value",
+			wantErr:     true,
+			errorValues: []string{"credential-value"},
+		},
+		{
+			name:        "error redacts unstructured segments",
+			raw:         "resource=top-secret;still-secret",
+			wantErr:     true,
+			errorValues: []string{"top-secret", "still-secret"},
 		},
 	}
 
@@ -123,8 +129,10 @@ func TestParseFilterSyntax(t *testing.T) {
 				if !strings.Contains(err.Error(), "invalid filter") {
 					t.Fatalf("ParseFilter() error = %q, want rejected filter context", err)
 				}
-				if tt.errorValue != "" && strings.Contains(err.Error(), tt.errorValue) {
-					t.Fatalf("ParseFilter() error exposed filter value: %q", err)
+				for _, errorValue := range tt.errorValues {
+					if strings.Contains(err.Error(), errorValue) {
+						t.Fatalf("ParseFilter() error exposed filter value %q: %q", errorValue, err)
+					}
 				}
 				return
 			}

--- a/terraformutils/service_test.go
+++ b/terraformutils/service_test.go
@@ -124,10 +124,28 @@ func TestParseFilterSyntax(t *testing.T) {
 			errorValues: []string{"type-secret"},
 		},
 		{
+			name:        "error redacts metadata from malformed typed shape",
+			raw:         "Type=service=type-secret;Name=name-secret;Value=x",
+			wantErr:     true,
+			errorValues: []string{"type-secret", "name-secret"},
+		},
+		{
 			name:        "error redacts malformed Name component",
 			raw:         "Name=field=name-secret;Value=x",
 			wantErr:     true,
 			errorValues: []string{"name-secret"},
+		},
+		{
+			name:        "error redacts Type-like value suffix",
+			raw:         "acl=User:producer|*|Write|Allow|Topic|orders;Type=customer-secret|Literal",
+			wantErr:     true,
+			errorValues: []string{"customer-secret"},
+		},
+		{
+			name:        "error redacts Name-like value suffix",
+			raw:         "acl=User:producer|*|Write|Allow|Topic|orders;Name=customer-secret|Literal",
+			wantErr:     true,
+			errorValues: []string{"customer-secret"},
 		},
 	}
 

--- a/terraformutils/service_test.go
+++ b/terraformutils/service_test.go
@@ -2,6 +2,7 @@ package terraformutils
 
 import (
 	"reflect"
+	"strings"
 	"testing"
 
 	"github.com/chenrui333/terraformer/terraformutils/tfcompat"
@@ -9,7 +10,9 @@ import (
 
 func TestEmptyFiltersParsing(t *testing.T) {
 	service := Service{}
-	service.ParseFilters([]string{})
+	if err := service.ParseFilters([]string{}); err != nil {
+		t.Fatalf("ParseFilters() error = %v", err)
+	}
 
 	if !reflect.DeepEqual(service.Filter, []ResourceFilter{}) {
 		t.Errorf("failed to parse, got %v", service.Filter)
@@ -18,7 +21,9 @@ func TestEmptyFiltersParsing(t *testing.T) {
 
 func TestIdFiltersParsing(t *testing.T) {
 	service := Service{}
-	service.ParseFilters([]string{"aws_vpc=myid"})
+	if err := service.ParseFilters([]string{"aws_vpc=myid"}); err != nil {
+		t.Fatalf("ParseFilters() error = %v", err)
+	}
 
 	if !reflect.DeepEqual(service.Filter, []ResourceFilter{
 		{
@@ -32,7 +37,9 @@ func TestIdFiltersParsing(t *testing.T) {
 
 func TestComplexIdFiltersParsing(t *testing.T) {
 	service := Service{}
-	service.ParseFilters([]string{"resource=id1:'project:dataset_id'"})
+	if err := service.ParseFilters([]string{"resource=id1:'project:dataset_id'"}); err != nil {
+		t.Fatalf("ParseFilters() error = %v", err)
+	}
 
 	if !reflect.DeepEqual(service.Filter, []ResourceFilter{
 		{
@@ -46,7 +53,9 @@ func TestComplexIdFiltersParsing(t *testing.T) {
 
 func TestEdgeIdFiltersParsing(t *testing.T) {
 	service := Service{}
-	service.ParseFilters([]string{"aws_vpc=:myid"})
+	if err := service.ParseFilters([]string{"aws_vpc=:myid"}); err != nil {
+		t.Fatalf("ParseFilters() error = %v", err)
+	}
 
 	if !reflect.DeepEqual(service.Filter, []ResourceFilter{
 		{
@@ -55,6 +64,91 @@ func TestEdgeIdFiltersParsing(t *testing.T) {
 			AcceptableValues: []string{"myid"},
 		}}) {
 		t.Errorf("failed to parse, got %v", service.Filter)
+	}
+}
+
+func TestParseFilterSyntax(t *testing.T) {
+	tests := []struct {
+		name       string
+		raw        string
+		want       ResourceFilter
+		wantErr    bool
+		errorValue string
+	}{
+		{
+			name: "simple ID",
+			raw:  "aws_vpc=vpc-123",
+			want: ResourceFilter{ServiceName: "aws_vpc", FieldPath: "id", AcceptableValues: []string{"vpc-123"}},
+		},
+		{
+			name: "typed field",
+			raw:  "Type=sg;Name=vpc_id;Value=vpc-123",
+			want: ResourceFilter{ServiceName: "sg", FieldPath: "vpc_id", AcceptableValues: []string{"vpc-123"}},
+		},
+		{
+			name: "quoted colon",
+			raw:  "resource='project:dataset_id'",
+			want: ResourceFilter{ServiceName: "resource", FieldPath: "id", AcceptableValues: []string{"project:dataset_id"}},
+		},
+		{
+			name: "value containing equals",
+			raw:  "Name=expression;Value=key=value",
+			want: ResourceFilter{FieldPath: "expression", AcceptableValues: []string{"key=value"}},
+		},
+		{name: "missing separator", raw: "aws_vpc", wantErr: true},
+		{name: "extra component", raw: "Type=sg;Name=id;Value=sg-1;Extra=bad", wantErr: true},
+		{name: "malformed component", raw: "Type=sg;Field=id;Value=sg-1", wantErr: true},
+		{name: "malformed field separator", raw: "Name=tags=env;Value=prod", wantErr: true},
+		{name: "unbalanced quote", raw: "resource='project:dataset_id", wantErr: true},
+		{name: "empty simple service", raw: "=vpc-123", wantErr: true},
+		{name: "empty simple value", raw: "aws_vpc=", wantErr: true},
+		{name: "empty typed service", raw: "Type=;Name=id;Value=vpc-123", wantErr: true},
+		{name: "empty field", raw: "Name=;Value=prod", wantErr: true},
+		{name: "empty required value", raw: "Name=tags.env;Value=", wantErr: true},
+		{
+			name:       "error redacts rejected value",
+			raw:        "resource='credential-value",
+			wantErr:    true,
+			errorValue: "credential-value",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			filters, err := ParseFilter(tt.raw)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatal("ParseFilter() error = nil, want error")
+				}
+				if !strings.Contains(err.Error(), "invalid filter") {
+					t.Fatalf("ParseFilter() error = %q, want rejected filter context", err)
+				}
+				if tt.errorValue != "" && strings.Contains(err.Error(), tt.errorValue) {
+					t.Fatalf("ParseFilter() error exposed filter value: %q", err)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("ParseFilter() error = %v", err)
+			}
+			if len(filters) != 1 {
+				t.Fatalf("ParseFilter() returned %d filters, want 1", len(filters))
+			}
+			if !reflect.DeepEqual(filters[0], tt.want) {
+				t.Fatalf("ParseFilter() = %#v, want %#v", filters[0], tt.want)
+			}
+		})
+	}
+}
+
+func TestParseFiltersRejectsEntireList(t *testing.T) {
+	service := Service{}
+	err := service.ParseFilters([]string{"aws_vpc=vpc-123", "Type=sg;Name=id;Value="})
+	if err == nil {
+		t.Fatal("ParseFilters() error = nil, want error")
+	}
+	if len(service.Filter) != 0 {
+		t.Fatalf("ParseFilters() partially applied filters: %#v", service.Filter)
 	}
 }
 

--- a/terraformutils/utils.go
+++ b/terraformutils/utils.go
@@ -363,11 +363,10 @@ func ParseFilterValues(value string) ([]string, error) {
 			}
 			if len(valueBuffer) == 0 {
 				continue
-			} else {
-				values = append(values, string(valueBuffer))
-				valueBuffer = []byte{}
-				continue
 			}
+			values = append(values, string(valueBuffer))
+			valueBuffer = []byte{}
+			continue
 		}
 		valueBuffer = append(valueBuffer, value[i])
 	}

--- a/terraformutils/utils.go
+++ b/terraformutils/utils.go
@@ -347,10 +347,9 @@ func IgnoreKeys(resourcesTypes []string, p *providerwrapper.ProviderWrapper) map
 	return readOnlyAttributes
 }
 
-func ParseFilterValues(value string) []string {
+func ParseFilterValues(value string) ([]string, error) {
 	var values []string
 
-	valueBuffering := true
 	wrapped := false
 	var valueBuffer []byte
 	for i := 0; i < len(value); i++ {
@@ -360,21 +359,22 @@ func ParseFilterValues(value string) []string {
 		} else if value[i] == ':' {
 			if len(valueBuffer) == 0 {
 				continue
-			} else if valueBuffering && !wrapped {
+			} else if !wrapped {
 				values = append(values, string(valueBuffer))
-				valueBuffering = false
 				valueBuffer = []byte{}
 				continue
 			}
 		}
-		valueBuffering = true
 		valueBuffer = append(valueBuffer, value[i])
+	}
+	if wrapped {
+		return nil, errors.New("unbalanced single quote")
 	}
 	if len(valueBuffer) > 0 {
 		values = append(values, string(valueBuffer))
 	}
 
-	return values
+	return values, nil
 }
 
 func FilterCleanup(s *Service, isInitial bool) {
@@ -398,9 +398,21 @@ func FilterCleanup(s *Service, isInitial bool) {
 
 func ContainsResource(s []Resource, e Resource) bool {
 	for _, a := range s {
-		if a.InstanceInfo.Id == e.InstanceInfo.Id {
+		if sameResourceIdentity(a, e) {
 			return true
 		}
 	}
 	return false
+}
+
+func sameResourceIdentity(left, right Resource) bool {
+	if left.InstanceInfo == nil || left.InstanceState == nil || right.InstanceInfo == nil || right.InstanceState == nil {
+		return false
+	}
+	if left.InstanceState.ID == "" || right.InstanceState.ID == "" {
+		return false
+	}
+	return left.Provider == right.Provider &&
+		left.InstanceInfo.Type == right.InstanceInfo.Type &&
+		left.InstanceState.ID == right.InstanceState.ID
 }

--- a/terraformutils/utils.go
+++ b/terraformutils/utils.go
@@ -357,9 +357,13 @@ func ParseFilterValues(value string) ([]string, error) {
 			wrapped = !wrapped
 			continue
 		} else if value[i] == ':' {
+			if wrapped {
+				valueBuffer = append(valueBuffer, value[i])
+				continue
+			}
 			if len(valueBuffer) == 0 {
 				continue
-			} else if !wrapped {
+			} else {
 				values = append(values, string(valueBuffer))
 				valueBuffer = []byte{}
 				continue
@@ -398,11 +402,16 @@ func FilterCleanup(s *Service, isInitial bool) {
 
 func ContainsResource(s []Resource, e Resource) bool {
 	for _, a := range s {
-		if sameResourceIdentity(a, e) {
+		if sameTerraformAddress(a, e) || sameResourceIdentity(a, e) {
 			return true
 		}
 	}
 	return false
+}
+
+func sameTerraformAddress(left, right Resource) bool {
+	return left.InstanceInfo != nil && right.InstanceInfo != nil &&
+		left.InstanceInfo.Id != "" && left.InstanceInfo.Id == right.InstanceInfo.Id
 }
 
 func sameResourceIdentity(left, right Resource) bool {

--- a/terraformutils/utils_test.go
+++ b/terraformutils/utils_test.go
@@ -171,7 +171,10 @@ func TestParseFilterValues(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			got := ParseFilterValues(tc.input)
+			got, err := ParseFilterValues(tc.input)
+			if err != nil {
+				t.Fatalf("ParseFilterValues(%q) error = %v", tc.input, err)
+			}
 			if len(got) != len(tc.want) {
 				t.Errorf("ParseFilterValues(%q) = %v, want %v", tc.input, got, tc.want)
 				return
@@ -183,11 +186,17 @@ func TestParseFilterValues(t *testing.T) {
 			}
 		})
 	}
+
+	if _, err := ParseFilterValues("'unbalanced"); err == nil {
+		t.Fatal("ParseFilterValues() error = nil for unbalanced quote")
+	}
 }
 
 func TestContainsResource(t *testing.T) {
-	r1 := Resource{InstanceInfo: &tfcompat.InstanceInfo{Id: "aws_vpc.a"}}
-	r2 := Resource{InstanceInfo: &tfcompat.InstanceInfo{Id: "aws_vpc.b"}}
+	r1 := NewSimpleResource("shared-id", "a", "aws_vpc", "aws", nil)
+	r2 := NewSimpleResource("different-id", "b", "aws_vpc", "aws", nil)
+	sameRemoteObject := NewSimpleResource("shared-id", "different-name", "aws_vpc", "aws", nil)
+	differentResourceType := NewSimpleResource("shared-id", "same-id-subnet", "aws_subnet", "aws", nil)
 
 	list := []Resource{r1}
 
@@ -196,6 +205,32 @@ func TestContainsResource(t *testing.T) {
 	}
 	if ContainsResource(list, r2) {
 		t.Error("should not contain r2")
+	}
+	if !ContainsResource(list, sameRemoteObject) {
+		t.Error("should contain the same provider, resource type, and import ID")
+	}
+	if ContainsResource(list, differentResourceType) {
+		t.Error("should not treat different Terraform resource types with the same import ID as duplicates")
+	}
+}
+
+func TestFilterCleanupDeduplicatesByStableResourceIdentity(t *testing.T) {
+	vpc := NewSimpleResource("shared-id", "vpc", "aws_vpc", "aws", nil)
+	vpcDuplicate := NewSimpleResource("shared-id", "vpc-copy", "aws_vpc", "aws", nil)
+	subnet := NewSimpleResource("shared-id", "subnet", "aws_subnet", "aws", nil)
+	service := Service{
+		Filter:    []ResourceFilter{{FieldPath: "id", AcceptableValues: []string{"shared-id"}}},
+		Resources: []Resource{vpc, vpcDuplicate, subnet},
+	}
+
+	service.InitialCleanup()
+
+	if len(service.Resources) != 2 {
+		t.Fatalf("InitialCleanup() retained %d resources, want 2", len(service.Resources))
+	}
+	if service.Resources[0].InstanceInfo.Type != "aws_vpc" || service.Resources[1].InstanceInfo.Type != "aws_subnet" {
+		t.Fatalf("InitialCleanup() retained unexpected resource types: %s, %s",
+			service.Resources[0].InstanceInfo.Type, service.Resources[1].InstanceInfo.Type)
 	}
 }
 

--- a/terraformutils/utils_test.go
+++ b/terraformutils/utils_test.go
@@ -164,6 +164,8 @@ func TestParseFilterValues(t *testing.T) {
 		{"single value", "myid", []string{"myid"}},
 		{"colon separated", "id1:id2:id3", []string{"id1", "id2", "id3"}},
 		{"quoted value with colon", "'project:dataset'", []string{"project:dataset"}},
+		{"quoted leading colon", "':id'", []string{":id"}},
+		{"quoted colon", "':'", []string{":"}},
 		{"mixed", "id1:'a:b':id2", []string{"id1", "a:b", "id2"}},
 		{"leading colon", ":myid", []string{"myid"}},
 		{"empty", "", nil},
@@ -197,6 +199,8 @@ func TestContainsResource(t *testing.T) {
 	r2 := NewSimpleResource("different-id", "b", "aws_vpc", "aws", nil)
 	sameRemoteObject := NewSimpleResource("shared-id", "different-name", "aws_vpc", "aws", nil)
 	differentResourceType := NewSimpleResource("shared-id", "same-id-subnet", "aws_subnet", "aws", nil)
+	differentProvider := NewSimpleResource("shared-id", "different-provider", "aws_vpc", "customaws", nil)
+	addressCollision := NewSimpleResource("different-id", "a", "aws_vpc", "aws", nil)
 
 	list := []Resource{r1}
 
@@ -211,6 +215,12 @@ func TestContainsResource(t *testing.T) {
 	}
 	if ContainsResource(list, differentResourceType) {
 		t.Error("should not treat different Terraform resource types with the same import ID as duplicates")
+	}
+	if ContainsResource(list, differentProvider) {
+		t.Error("should not treat different providers with the same resource type and import ID as duplicates")
+	}
+	if !ContainsResource(list, addressCollision) {
+		t.Error("should deduplicate resources with the same Terraform address")
 	}
 }
 
@@ -231,6 +241,21 @@ func TestFilterCleanupDeduplicatesByStableResourceIdentity(t *testing.T) {
 	if service.Resources[0].InstanceInfo.Type != "aws_vpc" || service.Resources[1].InstanceInfo.Type != "aws_subnet" {
 		t.Fatalf("InitialCleanup() retained unexpected resource types: %s, %s",
 			service.Resources[0].InstanceInfo.Type, service.Resources[1].InstanceInfo.Type)
+	}
+}
+
+func TestFilterCleanupDeduplicatesTerraformAddressCollisions(t *testing.T) {
+	first := NewSimpleResource("first-id", "shared-name", "aws_vpc", "aws", nil)
+	second := NewSimpleResource("second-id", "shared-name", "aws_vpc", "aws", nil)
+	service := Service{
+		Filter:    []ResourceFilter{{FieldPath: "id", AcceptableValues: []string{"first-id", "second-id"}}},
+		Resources: []Resource{first, second},
+	}
+
+	service.InitialCleanup()
+
+	if len(service.Resources) != 1 {
+		t.Fatalf("InitialCleanup() retained %d address-colliding resources, want 1", len(service.Resources))
 	}
 }
 


### PR DESCRIPTION
## Problem

Malformed import filters could be logged and converted into an empty filter set. The import then continued through provider initialization and discovery without the requested restriction, and a mixed valid/invalid filter list could retain only the valid prefix.

## Summary

- Parse the complete filter list transactionally and reject malformed syntax before provider initialization.
- Preserve the existing simple, named, and typed forms, including quoted colon-containing values and values containing `=`.
- Return value-redacted errors for rejected filters and propagate parsing failures through service facades and custom Kafka parsers.
- Preserve AWS resource-name normalization.
- Deduplicate filtered resources by provider, Terraform resource type, and import ID instead of address/import-ID collisions alone.
- Document the accepted grammar and fail-closed behavior, with an Unreleased changelog entry.

## Compatibility

The supported forms remain:

- `service=value`
- `Name=field`
- `Name=field;Value=value`
- `Type=service;Name=field;Value=value`

Quoted values continue to protect literal colons, and `=` is retained inside values. Inputs that were previously malformed but silently ignored or misparsed now abort the entire import.

## Tests

- `go test ./terraformutils ./cmd -count=1`
- `go test ./providers/aws -count=1`
- `go test ./... -count=1`
- `go vet ./...`
- `MODE=full SKIP_PROVIDER_COMMAND_TESTS=1 SKIP_VET_DEPENDENCY_PACKAGES=1 bash .github/scripts/provider-dependency-preflight.sh`
- `git diff --check`

## Risk assessment

The primary compatibility risk is stricter rejection of ambiguous or incomplete filter strings that previously produced partial or unfiltered imports. The `ServiceGenerator` parsing methods now return errors, so all in-repository facades and custom parsers were migrated together. Full tests, vet, builds, state compatibility, and provider-registry compatibility passed.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reject malformed import filters before provider init so imports fail closed. Scope mixed filters for Kafka: ACL-only syntax is ignored by topic imports and vice versa, and ACL IDs are fully validated.

- **Bug Fixes**
  - Validate the full filter list up front; abort import before provider init and discovery.
  - Provider `ValidateFilters` runs pre-init with the effective resource set (respects `*` and `--excludes`); ACL filters use ACL grammar.
  - Enforce supported grammar: `service=value`, `Name=field`, `Name=field;Value=value`, `Type=service;Name=field;Value=value`; allow `=` in values; `:` must be quoted; unbalanced quotes and empty components error with redacted messages (consistent across prevalidation and provider checks).
  - Kafka:
    - Scope mixed filters: topic-only filters are ignored by ACL imports; ACL-only filters are ignored by topic imports.
    - `acl` filters accept an optional outer single-quote and preserve characters like `'` and `;` in IDs.
    - ACL IDs must have seven non-empty `|`-delimited segments and valid enums; invalid IDs are rejected pre-init.
    - `topic` and `acl` parsers return errors on bad input.
  - Deduplicate by provider + Terraform resource type + import ID (not just by Terraform address).

- **Migration**
  - Update signatures to return errors and handle them: `ParseFilter(string) ([]ResourceFilter, error)`, `ParseFilters([]string) ([]ResourceFilter, error)`, `Service.ParseFilters([]string) error`, `ParseFilterValues(string) ([]string, error)`.
  - Optionally implement `ValidateFilters([]string, []string) error` in providers for custom pre-init grammar checks.
  - Fix malformed filters (empty `Type/Name/Value`, extra `;`, unbalanced quotes). Partial imports with bad filters now fail until corrected.

<sup>Written for commit 8065c1e5ce59f98abadaad94f0395c4bae684e94. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/chenrui333/terraformer/pull/697?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added stricter, all-or-nothing import-filter validation (including wildcard expansion) before provider initialization, with provider-specific filter grammar when supported.
* **Documentation**
  * Expanded filtering docs with supported syntaxes, quote/colon handling rules, and clarified that malformed filters abort the import.
* **Bug Fixes**
  * Improved error handling so filter parsing failures are no longer ignored.
  * Preserved distinct Terraform resource types that share the same import ID.
* **Tests**
  * Added coverage for validation ordering, exclusions-before-validation behavior, and Kafka ACL/topic filter parsing edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->