### PR TITLE
fix(aws): detect security group egress cycles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,8 @@
 * Reject malformed import filters before provider initialization, and preserve
   distinct Terraform resource types that share an import ID during filtering.
 * Detect AWS security group dependency cycles that include egress or mixed
-  ingress and egress references when deciding whether to emit standalone rules.
+  ingress and egress references when deciding whether to emit standalone rules,
+  without dropping cross-account rule owner IDs.
 
 ## 0.13.15
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,8 @@
   distinct Terraform resource types that share an import ID during filtering.
 * Detect AWS security group dependency cycles that include egress or mixed
   ingress and egress references when deciding whether to emit standalone rules,
-  without dropping cross-account rule owner IDs or duplicating dual-stack rules.
+  without dropping cross-account rule owner IDs or duplicating compound rule
+  sources.
 
 ## 0.13.15
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 * Reject malformed import filters before provider initialization, and preserve
   distinct Terraform resource types that share an import ID during filtering.
+* Detect AWS security group dependency cycles that include egress or mixed
+  ingress and egress references when deciding whether to emit standalone rules.
 
 ## 0.13.15
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
   distinct Terraform resource types that share an import ID during filtering.
 * Detect AWS security group dependency cycles that include egress or mixed
   ingress and egress references when deciding whether to emit standalone rules,
-  without dropping cross-account rule owner IDs.
+  without dropping cross-account rule owner IDs or duplicating dual-stack rules.
 
 ## 0.13.15
 

--- a/providers/aws/sg.go
+++ b/providers/aws/sg.go
@@ -85,7 +85,7 @@ func processRule(rule types.IpPermission, ruleType string, sg types.SecurityGrou
 		return resources
 	}
 	if len(rule.UserIdGroupPairs) > 0 {
-		if len(rule.IpRanges) > 0 || len(rule.Ipv6Ranges) > 0 { // we must unwind coupled CIDR ranges + security group rules
+		if len(rule.IpRanges) > 0 || len(rule.Ipv6Ranges) > 0 || len(rule.PrefixListIds) > 0 { // we must unwind coupled non-group sources + security group rules
 			attributes := baseRuleAttributes(ruleType, rule, sg)
 			resources = append(resources, terraformutils.NewResource(
 				permissionID(*sg.GroupId, ruleType, "", rule),
@@ -104,6 +104,7 @@ func processRule(rule types.IpPermission, ruleType string, sg types.SecurityGrou
 			attributes := baseRuleAttributes(ruleType, rule, sg)
 			delete(attributes, "cidr_blocks")
 			delete(attributes, "ipv6_cidr_blocks")
+			delete(attributes, "prefix_list_ids")
 			if referencedGroupID == securityGroupID { // Solution to C1
 				attributes["self"] = true
 			} else {
@@ -150,7 +151,7 @@ func baseRuleAttributes(ruleType string, rule types.IpPermission, sg types.Secur
 func sourceSecurityGroupID(groupPair types.UserIdGroupPair, ownerID string) string {
 	groupID := StringValue(groupPair.GroupId)
 	referencedOwnerID := StringValue(groupPair.UserId)
-	if ownerID != "" && referencedOwnerID != "" && ownerID != referencedOwnerID {
+	if referencedOwnerID != "" && ownerID != referencedOwnerID {
 		return referencedOwnerID + "/" + groupID
 	}
 	return groupID

--- a/providers/aws/sg.go
+++ b/providers/aws/sg.go
@@ -85,18 +85,7 @@ func processRule(rule types.IpPermission, ruleType string, sg types.SecurityGrou
 		return resources
 	}
 	if len(rule.UserIdGroupPairs) > 0 {
-		if len(rule.IpRanges) > 0 { // we must unwind coupled CIDR IPv4 range + security group rules
-			attributes := baseRuleAttributes(ruleType, rule, sg)
-			resources = append(resources, terraformutils.NewResource(
-				permissionID(*sg.GroupId, ruleType, "", rule),
-				permissionID(*sg.GroupId, ruleType, "", rule),
-				"aws_security_group_rule",
-				"aws",
-				terraformutils.Flatten(attributes),
-				SgAllowEmptyValues,
-				map[string]interface{}{}))
-		}
-		if len(rule.Ipv6Ranges) > 0 { // we must unwind coupled CIDR IPv6 range + security group rules
+		if len(rule.IpRanges) > 0 || len(rule.Ipv6Ranges) > 0 { // we must unwind coupled CIDR ranges + security group rules
 			attributes := baseRuleAttributes(ruleType, rule, sg)
 			resources = append(resources, terraformutils.NewResource(
 				permissionID(*sg.GroupId, ruleType, "", rule),
@@ -118,7 +107,7 @@ func processRule(rule types.IpPermission, ruleType string, sg types.SecurityGrou
 			if referencedGroupID == securityGroupID { // Solution to C1
 				attributes["self"] = true
 			} else {
-				attributes["source_security_group_id"] = sourceSecurityGroupID(groupPair)
+				attributes["source_security_group_id"] = sourceSecurityGroupID(groupPair, StringValue(sg.OwnerId))
 			}
 
 			resources = append(resources, terraformutils.NewResource(
@@ -158,10 +147,11 @@ func baseRuleAttributes(ruleType string, rule types.IpPermission, sg types.Secur
 	return attributes
 }
 
-func sourceSecurityGroupID(groupPair types.UserIdGroupPair) string {
+func sourceSecurityGroupID(groupPair types.UserIdGroupPair, ownerID string) string {
 	groupID := StringValue(groupPair.GroupId)
-	if ownerID := StringValue(groupPair.UserId); ownerID != "" {
-		return ownerID + "/" + groupID
+	referencedOwnerID := StringValue(groupPair.UserId)
+	if ownerID != "" && referencedOwnerID != "" && ownerID != referencedOwnerID {
+		return referencedOwnerID + "/" + groupID
 	}
 	return groupID
 }

--- a/providers/aws/sg.go
+++ b/providers/aws/sg.go
@@ -28,54 +28,49 @@ type SecurityGenerator struct {
 	AWSService
 }
 
-type ByGroupPair []types.UserIdGroupPair
-
-func (b ByGroupPair) Len() int      { return len(b) }
-func (b ByGroupPair) Swap(i, j int) { b[i], b[j] = b[j], b[i] }
-func (b ByGroupPair) Less(i, j int) bool {
-	if b[i].GroupId != nil && b[j].GroupId != nil {
-		return *b[i].GroupId < *b[j].GroupId
-	}
-	if b[i].GroupName != nil && b[j].GroupName != nil {
-		return *b[i].GroupName < *b[j].GroupName
-	}
-
-	panic("mismatched security group rules, may be a terraform bug")
-}
-
 func (SecurityGenerator) createResources(securityGroups []types.SecurityGroup) []terraformutils.Resource {
 	var sgIDsToMoveOut []string
 	_, shouldSplitRules := os.LookupEnv("SPLIT_SG_RULES")
 	if shouldSplitRules {
+		ids := make(map[string]struct{})
 		for _, sg := range securityGroups {
-			sgIDsToMoveOut = append(sgIDsToMoveOut, *sg.GroupId)
+			if groupID := StringValue(sg.GroupId); groupID != "" {
+				ids[groupID] = struct{}{}
+			}
 		}
+		for groupID := range ids {
+			sgIDsToMoveOut = append(sgIDsToMoveOut, groupID)
+		}
+		sort.Strings(sgIDsToMoveOut)
 	} else {
 		sgIDsToMoveOut = findSgsToMoveOut(securityGroups)
+	}
+	moveRulesOut := make(map[string]struct{}, len(sgIDsToMoveOut))
+	for _, groupID := range sgIDsToMoveOut {
+		moveRulesOut[groupID] = struct{}{}
 	}
 
 	var resources []terraformutils.Resource
 	for _, sg := range securityGroups {
-		if sg.VpcId == nil {
+		groupID := StringValue(sg.GroupId)
+		if groupID == "" || sg.VpcId == nil {
 			continue
 		}
 		ruleAttributes := map[string]interface{}{}
 		// we must move out all of the rules - https://github.com/hashicorp/terraform/issues/11011#issuecomment-283076580
-		for _, groupIDToMoveOut := range sgIDsToMoveOut {
-			if groupIDToMoveOut == *sg.GroupId {
-				ruleAttributes["clearRules"] = true
-				for _, rule := range sg.IpPermissions {
-					resources = processRule(rule, "ingress", sg, resources)
-				}
-				for _, rule := range sg.IpPermissionsEgress {
-					resources = processRule(rule, "egress", sg, resources)
-				}
+		if _, ok := moveRulesOut[groupID]; ok {
+			ruleAttributes["clearRules"] = true
+			for _, rule := range sg.IpPermissions {
+				resources = processRule(rule, "ingress", sg, resources)
+			}
+			for _, rule := range sg.IpPermissionsEgress {
+				resources = processRule(rule, "egress", sg, resources)
 			}
 		}
 
 		resources = append(resources, terraformutils.NewResource(
-			StringValue(sg.GroupId),
-			strings.Trim(StringValue(sg.GroupName)+"_"+StringValue(sg.GroupId), " "),
+			groupID,
+			strings.Trim(StringValue(sg.GroupName)+"_"+groupID, " "),
 			"aws_security_group",
 			"aws",
 			map[string]string{},
@@ -86,6 +81,10 @@ func (SecurityGenerator) createResources(securityGroups []types.SecurityGroup) [
 }
 
 func processRule(rule types.IpPermission, ruleType string, sg types.SecurityGroup, resources []terraformutils.Resource) []terraformutils.Resource {
+	securityGroupID := StringValue(sg.GroupId)
+	if securityGroupID == "" {
+		return resources
+	}
 	if len(rule.UserIdGroupPairs) > 0 {
 		if len(rule.IpRanges) > 0 { // we must unwind coupled CIDR IPv4 range + security group rules
 			attributes := baseRuleAttributes(ruleType, rule, sg)
@@ -110,18 +109,22 @@ func processRule(rule types.IpPermission, ruleType string, sg types.SecurityGrou
 				map[string]interface{}{}))
 		}
 		for _, groupPair := range rule.UserIdGroupPairs {
+			referencedGroupID := StringValue(groupPair.GroupId)
+			if referencedGroupID == "" {
+				continue
+			}
 			attributes := baseRuleAttributes(ruleType, rule, sg)
 			delete(attributes, "cidr_blocks")
 			delete(attributes, "ipv6_cidr_blocks")
-			if *groupPair.GroupId == *sg.GroupId { // Solution to C1
+			if referencedGroupID == securityGroupID { // Solution to C1
 				attributes["self"] = true
 			} else {
-				attributes["source_security_group_id"] = *groupPair.GroupId
+				attributes["source_security_group_id"] = referencedGroupID
 			}
 
 			resources = append(resources, terraformutils.NewResource(
-				permissionID(*sg.GroupId, ruleType, *groupPair.GroupId, rule),
-				permissionID(*sg.GroupId, ruleType, *groupPair.GroupId, rule),
+				permissionID(securityGroupID, ruleType, referencedGroupID, rule),
+				permissionID(securityGroupID, ruleType, referencedGroupID, rule),
 				"aws_security_group_rule",
 				"aws",
 				terraformutils.Flatten(attributes),
@@ -161,70 +164,132 @@ func baseRuleAttributes(ruleType string, rule types.IpPermission, sg types.Secur
 func findSgsToMoveOut(securityGroups []types.SecurityGroup) []string {
 	// Vertexes are security groups, edges are rules. The task is to find correct set of rule definitions, so that we
 	// won't have cycles
-	sourceGraph := simplegraph.NewDirectedGraph()
-	idToSg := make(map[int]types.SecurityGroup)
-	sgToIdx := make(map[string]int64)
-	for idx, sg := range securityGroups {
-		idToSg[idx] = sg
-		sgToIdx[StringValue(sg.GroupId)] = int64(idx)
-		sourceGraph.AddNode(sourceGraph.NewNode())
+	groupIDs := make([]string, 0, len(securityGroups))
+	groupIDSet := make(map[string]struct{}, len(securityGroups))
+	for _, sg := range securityGroups {
+		groupID := StringValue(sg.GroupId)
+		if groupID == "" {
+			continue
+		}
+		if _, exists := groupIDSet[groupID]; exists {
+			continue
+		}
+		groupIDSet[groupID] = struct{}{}
+		groupIDs = append(groupIDs, groupID)
 	}
-	for idx, sg := range securityGroups {
-		for _, rule := range sg.IpPermissions {
-			pairs := rule.UserIdGroupPairs
-			for _, pair := range pairs {
-				if pair.GroupId != nil {
-					toIdx, ok := sgToIdx[StringValue(pair.GroupId)]
-					if !ok {
-						continue
-					}
-					fromNode := sourceGraph.Node(int64(idx))
-					toNode := sourceGraph.Node(toIdx)
-					if fromNode.ID() != toNode.ID() {
-						sourceGraph.SetEdge(sourceGraph.NewEdge(fromNode, toNode))
-					}
-				}
+	sort.Strings(groupIDs)
+
+	sourceGraph := simplegraph.NewDirectedGraph()
+	groupIDToNode := make(map[string]int64, len(groupIDs))
+	nodeToGroupID := make(map[int64]string, len(groupIDs))
+	for _, groupID := range groupIDs {
+		node := sourceGraph.NewNode()
+		sourceGraph.AddNode(node)
+		groupIDToNode[groupID] = node.ID()
+		nodeToGroupID[node.ID()] = groupID
+	}
+
+	ruleCounts := make(map[string]int, len(groupIDs))
+	for _, sg := range securityGroups {
+		groupID := StringValue(sg.GroupId)
+		fromID, ok := groupIDToNode[groupID]
+		if !ok {
+			continue
+		}
+
+		// Duplicate API entries are collapsed by group ID. Keep the largest
+		// observed rule count so exact duplicates do not skew cycle selection.
+		ruleCount := len(sg.IpPermissions) + len(sg.IpPermissionsEgress)
+		if ruleCount > ruleCounts[groupID] {
+			ruleCounts[groupID] = ruleCount
+		}
+
+		for _, toID := range internalSecurityGroupReferences(sg, groupIDToNode) {
+			if fromID == toID {
+				continue
 			}
+			fromNode := sourceGraph.Node(fromID)
+			toNode := sourceGraph.Node(toID)
+			sourceGraph.SetEdge(sourceGraph.NewEdge(fromNode, toNode))
 		}
 	}
 
 	cyclesInLineGraph := topo.DirectedCyclesIn(sourceGraph) // C1 cycles won't be found but Terraform solves that issue
+	sort.Slice(cyclesInLineGraph, func(i, j int) bool {
+		return securityGroupCycleKey(cyclesInLineGraph[i], nodeToGroupID) <
+			securityGroupCycleKey(cyclesInLineGraph[j], nodeToGroupID)
+	})
 	resultingSet := make(map[string]void)
 
 	for _, v := range cyclesInLineGraph {
-		if elementAlreadyFound(resultingSet, v, idToSg) {
+		if securityGroupCycleAlreadyBroken(resultingSet, v, nodeToGroupID) {
 			continue
 		}
 
-		// Try to move out node with lowest number of rules
-		group := idToSg[int(v[0].ID())]
+		// Move out the node with the fewest total ingress and egress rules.
+		// Use the group ID as a stable tie-breaker.
+		groupID := ""
 		for _, vi := range v {
-			viGroup := idToSg[int(vi.ID())]
-			if len(viGroup.IpPermissions) < len(group.IpPermissions) {
-				group = viGroup
+			candidateID := nodeToGroupID[vi.ID()]
+			if groupID == "" ||
+				ruleCounts[candidateID] < ruleCounts[groupID] ||
+				(ruleCounts[candidateID] == ruleCounts[groupID] && candidateID < groupID) {
+				groupID = candidateID
 			}
 		}
-
-		resultingSet[*group.GroupId] = member
+		if groupID != "" {
+			resultingSet[groupID] = member
+		}
 	}
 
-	result := make([]string, len(resultingSet))
-	i := 0
-	for k := range resultingSet {
-		result[i] = k
-		i++
+	result := make([]string, 0, len(resultingSet))
+	for groupID := range resultingSet {
+		result = append(result, groupID)
 	}
+	sort.Strings(result)
 
 	return result
 }
 
-func elementAlreadyFound(resultingSet map[string]void, v []graph.Node, idToSg map[int]types.SecurityGroup) bool {
-	for k := range resultingSet {
-		for _, vi := range v {
-			viGroupID := *idToSg[int(vi.ID())].GroupId
-			if k == viGroupID {
-				return true
+func internalSecurityGroupReferences(sg types.SecurityGroup, importedGroupIndexes map[string]int64) []int64 {
+	referenceSet := make(map[int64]struct{})
+	permissions := [][]types.IpPermission{sg.IpPermissions, sg.IpPermissionsEgress}
+	for _, permissionSet := range permissions {
+		for _, permission := range permissionSet {
+			for _, pair := range permission.UserIdGroupPairs {
+				groupID := StringValue(pair.GroupId)
+				if groupID == "" {
+					continue
+				}
+				index, ok := importedGroupIndexes[groupID]
+				if !ok {
+					continue
+				}
+				referenceSet[index] = struct{}{}
 			}
+		}
+	}
+
+	references := make([]int64, 0, len(referenceSet))
+	for index := range referenceSet {
+		references = append(references, index)
+	}
+	sort.Slice(references, func(i, j int) bool { return references[i] < references[j] })
+	return references
+}
+
+func securityGroupCycleKey(cycle []graph.Node, nodeToGroupID map[int64]string) string {
+	groupIDs := make([]string, 0, len(cycle))
+	for _, node := range cycle {
+		groupIDs = append(groupIDs, nodeToGroupID[node.ID()])
+	}
+	return strings.Join(groupIDs, "\x00")
+}
+
+func securityGroupCycleAlreadyBroken(resultingSet map[string]void, cycle []graph.Node, nodeToGroupID map[int64]string) bool {
+	for _, node := range cycle {
+		if _, ok := resultingSet[nodeToGroupID[node.ID()]]; ok {
+			return true
 		}
 	}
 	return false
@@ -246,7 +311,7 @@ func (g *SecurityGenerator) InitResources() error {
 		resourcesToFilter = append(resourcesToFilter, page.SecurityGroups...)
 	}
 	sort.Slice(resourcesToFilter, func(i, j int) bool {
-		return *resourcesToFilter[i].GroupId < *resourcesToFilter[j].GroupId
+		return StringValue(resourcesToFilter[i].GroupId) < StringValue(resourcesToFilter[j].GroupId)
 	})
 	g.Resources = g.createResources(resourcesToFilter)
 

--- a/providers/aws/sg.go
+++ b/providers/aws/sg.go
@@ -13,7 +13,6 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/ec2"
 	"github.com/aws/aws-sdk-go-v2/service/ec2/types"
 	"github.com/chenrui333/terraformer/terraformutils"
-	"gonum.org/v1/gonum/graph"
 	simplegraph "gonum.org/v1/gonum/graph/simple"
 	"gonum.org/v1/gonum/graph/topo"
 )
@@ -119,7 +118,7 @@ func processRule(rule types.IpPermission, ruleType string, sg types.SecurityGrou
 			if referencedGroupID == securityGroupID { // Solution to C1
 				attributes["self"] = true
 			} else {
-				attributes["source_security_group_id"] = referencedGroupID
+				attributes["source_security_group_id"] = sourceSecurityGroupID(groupPair)
 			}
 
 			resources = append(resources, terraformutils.NewResource(
@@ -159,8 +158,15 @@ func baseRuleAttributes(ruleType string, rule types.IpPermission, sg types.Secur
 	return attributes
 }
 
-// Let's try to find all cycles by applying Johnson's method on the directed graph
-// We cannot build a line graph and move out only rules because of hashicorp/terraform#11011
+func sourceSecurityGroupID(groupPair types.UserIdGroupPair) string {
+	groupID := StringValue(groupPair.GroupId)
+	if ownerID := StringValue(groupPair.UserId); ownerID != "" {
+		return ownerID + "/" + groupID
+	}
+	return groupID
+}
+
+// We cannot build a line graph and move out only rules because of hashicorp/terraform#11011.
 func findSgsToMoveOut(securityGroups []types.SecurityGroup) []string {
 	// Vertexes are security groups, edges are rules. The task is to find correct set of rule definitions, so that we
 	// won't have cycles
@@ -214,31 +220,37 @@ func findSgsToMoveOut(securityGroups []types.SecurityGroup) []string {
 		}
 	}
 
-	cyclesInLineGraph := topo.DirectedCyclesIn(sourceGraph) // C1 cycles won't be found but Terraform solves that issue
-	sort.Slice(cyclesInLineGraph, func(i, j int) bool {
-		return securityGroupCycleKey(cyclesInLineGraph[i], nodeToGroupID) <
-			securityGroupCycleKey(cyclesInLineGraph[j], nodeToGroupID)
-	})
 	resultingSet := make(map[string]void)
-
-	for _, v := range cyclesInLineGraph {
-		if securityGroupCycleAlreadyBroken(resultingSet, v, nodeToGroupID) {
-			continue
-		}
-
-		// Move out the node with the fewest total ingress and egress rules.
-		// Use the group ID as a stable tie-breaker.
-		groupID := ""
-		for _, vi := range v {
-			candidateID := nodeToGroupID[vi.ID()]
-			if groupID == "" ||
-				ruleCounts[candidateID] < ruleCounts[groupID] ||
-				(ruleCounts[candidateID] == ruleCounts[groupID] && candidateID < groupID) {
-				groupID = candidateID
+	for {
+		var groupsToMoveOut []string
+		for _, component := range topo.TarjanSCC(sourceGraph) {
+			if len(component) < 2 { // Self references are not graph edges.
+				continue
 			}
+
+			// Move out the node with the fewest total ingress and egress rules.
+			// Use the group ID as a stable tie-breaker.
+			groupID := ""
+			for _, node := range component {
+				candidateID := nodeToGroupID[node.ID()]
+				if groupID == "" ||
+					ruleCounts[candidateID] < ruleCounts[groupID] ||
+					(ruleCounts[candidateID] == ruleCounts[groupID] && candidateID < groupID) {
+					groupID = candidateID
+				}
+			}
+			groupsToMoveOut = append(groupsToMoveOut, groupID)
 		}
-		if groupID != "" {
+		if len(groupsToMoveOut) == 0 {
+			break
+		}
+
+		// Components are disjoint, so their selected nodes can be removed together.
+		// A selected group has no inline outgoing rules and cannot join a later cycle.
+		sort.Strings(groupsToMoveOut)
+		for _, groupID := range groupsToMoveOut {
 			resultingSet[groupID] = member
+			sourceGraph.RemoveNode(groupIDToNode[groupID])
 		}
 	}
 
@@ -276,23 +288,6 @@ func internalSecurityGroupReferences(sg types.SecurityGroup, importedGroupIndexe
 	}
 	sort.Slice(references, func(i, j int) bool { return references[i] < references[j] })
 	return references
-}
-
-func securityGroupCycleKey(cycle []graph.Node, nodeToGroupID map[int64]string) string {
-	groupIDs := make([]string, 0, len(cycle))
-	for _, node := range cycle {
-		groupIDs = append(groupIDs, nodeToGroupID[node.ID()])
-	}
-	return strings.Join(groupIDs, "\x00")
-}
-
-func securityGroupCycleAlreadyBroken(resultingSet map[string]void, cycle []graph.Node, nodeToGroupID map[int64]string) bool {
-	for _, node := range cycle {
-		if _, ok := resultingSet[nodeToGroupID[node.ID()]]; ok {
-			return true
-		}
-	}
-	return false
 }
 
 func (g *SecurityGenerator) InitResources() error {

--- a/providers/aws/sg_test.go
+++ b/providers/aws/sg_test.go
@@ -3,11 +3,15 @@
 package aws
 
 import (
+	"os"
 	"reflect"
+	"sort"
+	"strings"
 	"testing"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/ec2/types"
+	"github.com/chenrui333/terraformer/terraformutils"
 )
 
 func TestEmptySgs(t *testing.T) {
@@ -216,4 +220,353 @@ func Test3Cycle1CycleReference(t *testing.T) {
 	if !reflect.DeepEqual(rulesToMoveOut[0], *sgA.GroupId) {
 		t.Errorf("failed to calculate rules to move out %v", rulesToMoveOut)
 	}
+}
+
+func TestSecurityGroupEgressAndMixedCycleDetection(t *testing.T) {
+	tests := []struct {
+		name   string
+		groups []types.SecurityGroup
+		want   []string
+	}{
+		{
+			name: "egress two group cycle",
+			groups: []types.SecurityGroup{
+				testSecurityGroup("aaaa", nil, []types.IpPermission{securityGroupPermission("bbbb")}),
+				testSecurityGroup("bbbb", nil, []types.IpPermission{securityGroupPermission("aaaa")}),
+			},
+			want: []string{"aaaa"},
+		},
+		{
+			name: "egress three group cycle",
+			groups: []types.SecurityGroup{
+				testSecurityGroup("aaaa", nil, []types.IpPermission{securityGroupPermission("bbbb")}),
+				testSecurityGroup("bbbb", nil, []types.IpPermission{securityGroupPermission("cccc")}),
+				testSecurityGroup("cccc", nil, []types.IpPermission{securityGroupPermission("aaaa")}),
+			},
+			want: []string{"aaaa"},
+		},
+		{
+			name: "mixed two group cycle",
+			groups: []types.SecurityGroup{
+				testSecurityGroup("aaaa", []types.IpPermission{securityGroupPermission("bbbb")}, nil),
+				testSecurityGroup("bbbb", nil, []types.IpPermission{securityGroupPermission("aaaa")}),
+			},
+			want: []string{"aaaa"},
+		},
+		{
+			name: "mixed three group cycle",
+			groups: []types.SecurityGroup{
+				testSecurityGroup("aaaa", []types.IpPermission{securityGroupPermission("bbbb")}, nil),
+				testSecurityGroup("bbbb", nil, []types.IpPermission{securityGroupPermission("cccc")}),
+				testSecurityGroup("cccc", []types.IpPermission{securityGroupPermission("aaaa")}, nil),
+			},
+			want: []string{"aaaa"},
+		},
+		{
+			name: "acyclic egress reference",
+			groups: []types.SecurityGroup{
+				testSecurityGroup("aaaa", nil, []types.IpPermission{securityGroupPermission("bbbb")}),
+				testSecurityGroup("bbbb", nil, nil),
+			},
+			want: []string{},
+		},
+		{
+			name: "external egress reference",
+			groups: []types.SecurityGroup{
+				testSecurityGroup("aaaa", nil, []types.IpPermission{securityGroupPermission("external")}),
+			},
+			want: []string{},
+		},
+		{
+			name: "egress self reference",
+			groups: []types.SecurityGroup{
+				testSecurityGroup("aaaa", nil, []types.IpPermission{securityGroupPermission("aaaa")}),
+			},
+			want: []string{},
+		},
+		{
+			name: "nil referenced group ID",
+			groups: []types.SecurityGroup{
+				testSecurityGroup("aaaa", []types.IpPermission{securityGroupPermissionPointer(nil)}, nil),
+			},
+			want: []string{},
+		},
+		{
+			name: "empty referenced group ID",
+			groups: []types.SecurityGroup{
+				testSecurityGroup("aaaa", nil, []types.IpPermission{securityGroupPermission("")}),
+			},
+			want: []string{},
+		},
+		{
+			name: "nil security group ID",
+			groups: []types.SecurityGroup{
+				{IpPermissions: []types.IpPermission{securityGroupPermission("aaaa")}},
+				testSecurityGroup("aaaa", nil, nil),
+			},
+			want: []string{},
+		},
+		{
+			name: "empty security group ID",
+			groups: []types.SecurityGroup{
+				testSecurityGroup("", []types.IpPermission{securityGroupPermission("aaaa")}, nil),
+				testSecurityGroup("aaaa", nil, nil),
+			},
+			want: []string{},
+		},
+		{
+			name: "groups without rules",
+			groups: []types.SecurityGroup{
+				testSecurityGroup("aaaa", nil, nil),
+				testSecurityGroup("bbbb", nil, nil),
+			},
+			want: []string{},
+		},
+		{
+			name: "duplicate ingress and egress references",
+			groups: []types.SecurityGroup{
+				testSecurityGroup(
+					"aaaa",
+					[]types.IpPermission{securityGroupPermission("bbbb"), securityGroupPermission("bbbb")},
+					[]types.IpPermission{securityGroupPermission("bbbb")},
+				),
+				testSecurityGroup("bbbb", []types.IpPermission{securityGroupPermission("aaaa")}, nil),
+			},
+			want: []string{"bbbb"},
+		},
+		{
+			name: "internal and external reference in one permission",
+			groups: []types.SecurityGroup{
+				testSecurityGroup("aaaa", nil, []types.IpPermission{securityGroupPermission("bbbb", "external")}),
+				testSecurityGroup("bbbb", nil, nil),
+			},
+			want: []string{},
+		},
+		{
+			name: "fewest total rules wins",
+			groups: []types.SecurityGroup{
+				testSecurityGroup(
+					"aaaa",
+					[]types.IpPermission{securityGroupPermission("bbbb")},
+					[]types.IpPermission{securityGroupPermission("external")},
+				),
+				testSecurityGroup("bbbb", nil, []types.IpPermission{securityGroupPermission("aaaa")}),
+			},
+			want: []string{"bbbb"},
+		},
+		{
+			name: "equal rule counts use group ID tie breaker",
+			groups: []types.SecurityGroup{
+				testSecurityGroup("bbbb", nil, []types.IpPermission{securityGroupPermission("aaaa")}),
+				testSecurityGroup("aaaa", []types.IpPermission{securityGroupPermission("bbbb")}, nil),
+			},
+			want: []string{"aaaa"},
+		},
+		{
+			name: "duplicate security group entries are collapsed",
+			groups: []types.SecurityGroup{
+				testSecurityGroup("aaaa", []types.IpPermission{securityGroupPermission("bbbb")}, nil),
+				testSecurityGroup("aaaa", nil, nil),
+				testSecurityGroup("bbbb", nil, []types.IpPermission{securityGroupPermission("aaaa")}),
+			},
+			want: []string{"aaaa"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := findSgsToMoveOut(tt.groups)
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Fatalf("findSgsToMoveOut() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestSecurityGroupCycleSelectionIsDeterministic(t *testing.T) {
+	groups := []types.SecurityGroup{
+		testSecurityGroup("dddd", nil, []types.IpPermission{securityGroupPermission("cccc")}),
+		testSecurityGroup("bbbb", []types.IpPermission{securityGroupPermission("aaaa")}, nil),
+		testSecurityGroup("cccc", []types.IpPermission{securityGroupPermission("dddd")}, nil),
+		testSecurityGroup("aaaa", nil, []types.IpPermission{securityGroupPermission("bbbb")}),
+	}
+	want := []string{"aaaa", "cccc"}
+
+	for i := 0; i < 100; i++ {
+		got := findSgsToMoveOut(groups)
+		if !reflect.DeepEqual(got, want) {
+			t.Fatalf("run %d: findSgsToMoveOut() = %v, want %v", i, got, want)
+		}
+		if !sort.StringsAreSorted(got) {
+			t.Fatalf("run %d: result is not sorted: %v", i, got)
+		}
+	}
+}
+
+func TestSecurityGroupCycleSelectionIsIndependentOfInputOrder(t *testing.T) {
+	groupA := testSecurityGroup("aaaa", []types.IpPermission{securityGroupPermission("bbbb")}, nil)
+	groupB := testSecurityGroup("bbbb", nil, []types.IpPermission{securityGroupPermission("aaaa")})
+
+	for _, groups := range [][]types.SecurityGroup{{groupA, groupB}, {groupB, groupA}} {
+		got := findSgsToMoveOut(groups)
+		want := []string{"aaaa"}
+		if !reflect.DeepEqual(got, want) {
+			t.Fatalf("findSgsToMoveOut(%v) = %v, want %v", securityGroupIDs(groups), got, want)
+		}
+	}
+}
+
+func TestSecurityGroupEgressCycleCreatesStandaloneRules(t *testing.T) {
+	disableSplitSecurityGroupRules(t)
+	groups := []types.SecurityGroup{
+		testSecurityGroup("aaaa", nil, []types.IpPermission{securityGroupPermission("bbbb")}),
+		testSecurityGroup("bbbb", nil, []types.IpPermission{securityGroupPermission("aaaa")}),
+	}
+
+	resources := (SecurityGenerator{}).createResources(groups)
+	assertSecurityGroupResourceCounts(t, resources, 1)
+	standaloneRules := resourcesOfType(resources, "aws_security_group_rule")
+	if got := standaloneRules[0].InstanceState.Attributes["type"]; got != "egress" {
+		t.Fatalf("standalone rule type = %q, want egress", got)
+	}
+	if !strings.HasPrefix(standaloneRules[0].InstanceState.ID, "aaaa_egress_") {
+		t.Fatalf("standalone rule ID = %q, want selected group aaaa egress rule", standaloneRules[0].InstanceState.ID)
+	}
+	assertSecurityGroupRulesCleared(t, resources, "aaaa", true)
+	assertSecurityGroupRulesCleared(t, resources, "bbbb", false)
+}
+
+func TestSecurityGroupAcyclicEgressKeepsInlineRules(t *testing.T) {
+	disableSplitSecurityGroupRules(t)
+	groups := []types.SecurityGroup{
+		testSecurityGroup("aaaa", nil, []types.IpPermission{securityGroupPermission("bbbb")}),
+		testSecurityGroup("bbbb", nil, nil),
+	}
+
+	resources := (SecurityGenerator{}).createResources(groups)
+	assertSecurityGroupResourceCounts(t, resources, 0)
+	assertSecurityGroupRulesCleared(t, resources, "aaaa", false)
+	assertSecurityGroupRulesCleared(t, resources, "bbbb", false)
+}
+
+func TestSecurityGroupResourceGenerationSkipsNilReferences(t *testing.T) {
+	disableSplitSecurityGroupRules(t)
+	groups := []types.SecurityGroup{
+		testSecurityGroup("aaaa", []types.IpPermission{
+			securityGroupPermissionPointers(nil, aws.String("bbbb")),
+		}, nil),
+		testSecurityGroup("bbbb", []types.IpPermission{securityGroupPermission("aaaa")}, nil),
+	}
+
+	resources := (SecurityGenerator{}).createResources(groups)
+	assertSecurityGroupResourceCounts(t, resources, 1)
+}
+
+func TestSplitSecurityGroupRulesPreservesOverrideBehavior(t *testing.T) {
+	t.Setenv("SPLIT_SG_RULES", "1")
+	groups := []types.SecurityGroup{
+		{VpcId: aws.String("vpc-test")},
+		testSecurityGroup("aaaa", nil, []types.IpPermission{securityGroupPermission("bbbb")}),
+		testSecurityGroup("bbbb", nil, []types.IpPermission{securityGroupPermission("bbbb")}),
+	}
+
+	resources := (SecurityGenerator{}).createResources(groups)
+	assertSecurityGroupResourceCounts(t, resources, 2)
+	assertSecurityGroupRulesCleared(t, resources, "aaaa", true)
+	assertSecurityGroupRulesCleared(t, resources, "bbbb", true)
+}
+
+func testSecurityGroup(id string, ingress, egress []types.IpPermission) types.SecurityGroup {
+	return types.SecurityGroup{
+		GroupId:             aws.String(id),
+		GroupName:           aws.String(id),
+		VpcId:               aws.String("vpc-test"),
+		IpPermissions:       ingress,
+		IpPermissionsEgress: egress,
+	}
+}
+
+func securityGroupPermission(groupIDs ...string) types.IpPermission {
+	pointers := make([]*string, 0, len(groupIDs))
+	for _, groupID := range groupIDs {
+		pointers = append(pointers, aws.String(groupID))
+	}
+	return securityGroupPermissionPointers(pointers...)
+}
+
+func securityGroupPermissionPointer(groupID *string) types.IpPermission {
+	return securityGroupPermissionPointers(groupID)
+}
+
+func securityGroupPermissionPointers(groupIDs ...*string) types.IpPermission {
+	pairs := make([]types.UserIdGroupPair, 0, len(groupIDs))
+	for _, groupID := range groupIDs {
+		pairs = append(pairs, types.UserIdGroupPair{GroupId: groupID})
+	}
+	return types.IpPermission{
+		IpProtocol:       aws.String("-1"),
+		UserIdGroupPairs: pairs,
+	}
+}
+
+func securityGroupIDs(groups []types.SecurityGroup) []string {
+	ids := make([]string, 0, len(groups))
+	for _, group := range groups {
+		ids = append(ids, StringValue(group.GroupId))
+	}
+	return ids
+}
+
+func disableSplitSecurityGroupRules(t *testing.T) {
+	t.Helper()
+	value, wasSet := os.LookupEnv("SPLIT_SG_RULES")
+	if err := os.Unsetenv("SPLIT_SG_RULES"); err != nil {
+		t.Fatalf("unset SPLIT_SG_RULES: %v", err)
+	}
+	t.Cleanup(func() {
+		if wasSet {
+			if err := os.Setenv("SPLIT_SG_RULES", value); err != nil {
+				t.Errorf("restore SPLIT_SG_RULES: %v", err)
+			}
+			return
+		}
+		if err := os.Unsetenv("SPLIT_SG_RULES"); err != nil {
+			t.Errorf("unset SPLIT_SG_RULES during cleanup: %v", err)
+		}
+	})
+}
+
+func resourcesOfType(resources []terraformutils.Resource, resourceType string) []terraformutils.Resource {
+	var matching []terraformutils.Resource
+	for _, resource := range resources {
+		if resource.InstanceInfo.Type == resourceType {
+			matching = append(matching, resource)
+		}
+	}
+	return matching
+}
+
+func assertSecurityGroupResourceCounts(t *testing.T, resources []terraformutils.Resource, rules int) {
+	t.Helper()
+	if got := len(resourcesOfType(resources, "aws_security_group")); got != 2 {
+		t.Fatalf("security group resource count = %d, want 2", got)
+	}
+	if got := len(resourcesOfType(resources, "aws_security_group_rule")); got != rules {
+		t.Fatalf("security group rule resource count = %d, want %d", got, rules)
+	}
+}
+
+func assertSecurityGroupRulesCleared(t *testing.T, resources []terraformutils.Resource, groupID string, want bool) {
+	t.Helper()
+	for _, resource := range resourcesOfType(resources, "aws_security_group") {
+		if resource.InstanceState.ID != groupID {
+			continue
+		}
+		got, _ := resource.AdditionalFields["clearRules"].(bool)
+		if got != want {
+			t.Fatalf("security group %s clearRules = %t, want %t", groupID, got, want)
+		}
+		return
+	}
+	t.Fatalf("security group resource %s not found", groupID)
 }

--- a/providers/aws/sg_test.go
+++ b/providers/aws/sg_test.go
@@ -3,6 +3,7 @@
 package aws
 
 import (
+	"fmt"
 	"os"
 	"reflect"
 	"sort"
@@ -416,6 +417,28 @@ func TestSecurityGroupCycleSelectionIsIndependentOfInputOrder(t *testing.T) {
 	}
 }
 
+func TestSecurityGroupDenseCycleDetection(t *testing.T) {
+	groups := denseSecurityGroups(10)
+	want := []string{
+		"sg-00", "sg-01", "sg-02", "sg-03", "sg-04",
+		"sg-05", "sg-06", "sg-07", "sg-08",
+	}
+
+	got := findSgsToMoveOut(groups)
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("findSgsToMoveOut() = %v, want %v", got, want)
+	}
+}
+
+func BenchmarkSecurityGroupDenseCycleDetection(b *testing.B) {
+	groups := denseSecurityGroups(10)
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		findSgsToMoveOut(groups)
+	}
+}
+
 func TestSecurityGroupEgressCycleCreatesStandaloneRules(t *testing.T) {
 	disableSplitSecurityGroupRules(t)
 	groups := []types.SecurityGroup{
@@ -462,6 +485,31 @@ func TestSecurityGroupResourceGenerationSkipsNilReferences(t *testing.T) {
 	assertSecurityGroupResourceCounts(t, resources, 1)
 }
 
+func TestSecurityGroupSplitRulePreservesCrossAccountOwner(t *testing.T) {
+	disableSplitSecurityGroupRules(t)
+	crossAccountPermission := securityGroupPermission("bbbb")
+	crossAccountPermission.UserIdGroupPairs = append(crossAccountPermission.UserIdGroupPairs, types.UserIdGroupPair{
+		GroupId: aws.String("external"),
+		UserId:  aws.String("test-owner"),
+	})
+	groups := []types.SecurityGroup{
+		testSecurityGroup("aaaa", nil, []types.IpPermission{crossAccountPermission}),
+		testSecurityGroup("bbbb", nil, []types.IpPermission{securityGroupPermission("aaaa")}),
+	}
+
+	resources := (SecurityGenerator{}).createResources(groups)
+	assertSecurityGroupResourceCounts(t, resources, 2)
+	var sources []string
+	for _, resource := range resourcesOfType(resources, "aws_security_group_rule") {
+		sources = append(sources, resource.InstanceState.Attributes["source_security_group_id"])
+	}
+	sort.Strings(sources)
+	want := []string{"bbbb", "test-owner/external"}
+	if !reflect.DeepEqual(sources, want) {
+		t.Fatalf("split rule sources = %v, want %v", sources, want)
+	}
+}
+
 func TestSplitSecurityGroupRulesPreservesOverrideBehavior(t *testing.T) {
 	t.Setenv("SPLIT_SG_RULES", "1")
 	groups := []types.SecurityGroup{
@@ -484,6 +532,29 @@ func testSecurityGroup(id string, ingress, egress []types.IpPermission) types.Se
 		IpPermissions:       ingress,
 		IpPermissionsEgress: egress,
 	}
+}
+
+func denseSecurityGroups(count int) []types.SecurityGroup {
+	groupIDs := make([]string, count)
+	for i := range groupIDs {
+		groupIDs[i] = fmt.Sprintf("sg-%02d", i)
+	}
+
+	groups := make([]types.SecurityGroup, 0, count)
+	for _, groupID := range groupIDs {
+		references := make([]string, 0, count-1)
+		for _, referencedGroupID := range groupIDs {
+			if referencedGroupID != groupID {
+				references = append(references, referencedGroupID)
+			}
+		}
+		groups = append(groups, testSecurityGroup(
+			groupID,
+			nil,
+			[]types.IpPermission{securityGroupPermission(references...)},
+		))
+	}
+	return groups
 }
 
 func securityGroupPermission(groupIDs ...string) types.IpPermission {

--- a/providers/aws/sg_test.go
+++ b/providers/aws/sg_test.go
@@ -485,17 +485,20 @@ func TestSecurityGroupResourceGenerationSkipsNilReferences(t *testing.T) {
 	assertSecurityGroupResourceCounts(t, resources, 1)
 }
 
-func TestSecurityGroupSplitRulePreservesCrossAccountOwner(t *testing.T) {
+func TestSecurityGroupSplitRulePreservesOwnerSemantics(t *testing.T) {
 	disableSplitSecurityGroupRules(t)
 	crossAccountPermission := securityGroupPermission("bbbb")
+	crossAccountPermission.UserIdGroupPairs[0].UserId = aws.String("local-owner")
 	crossAccountPermission.UserIdGroupPairs = append(crossAccountPermission.UserIdGroupPairs, types.UserIdGroupPair{
 		GroupId: aws.String("external"),
-		UserId:  aws.String("test-owner"),
+		UserId:  aws.String("remote-owner"),
 	})
 	groups := []types.SecurityGroup{
 		testSecurityGroup("aaaa", nil, []types.IpPermission{crossAccountPermission}),
 		testSecurityGroup("bbbb", nil, []types.IpPermission{securityGroupPermission("aaaa")}),
 	}
+	groups[0].OwnerId = aws.String("local-owner")
+	groups[1].OwnerId = aws.String("local-owner")
 
 	resources := (SecurityGenerator{}).createResources(groups)
 	assertSecurityGroupResourceCounts(t, resources, 2)
@@ -504,9 +507,39 @@ func TestSecurityGroupSplitRulePreservesCrossAccountOwner(t *testing.T) {
 		sources = append(sources, resource.InstanceState.Attributes["source_security_group_id"])
 	}
 	sort.Strings(sources)
-	want := []string{"bbbb", "test-owner/external"}
+	want := []string{"bbbb", "remote-owner/external"}
 	if !reflect.DeepEqual(sources, want) {
 		t.Fatalf("split rule sources = %v, want %v", sources, want)
+	}
+}
+
+func TestSecurityGroupSplitRuleCoalescesDualStackCIDRs(t *testing.T) {
+	disableSplitSecurityGroupRules(t)
+	compoundPermission := securityGroupPermission("bbbb")
+	compoundPermission.IpRanges = []types.IpRange{{CidrIp: aws.String("10.0.0.0/8")}}
+	compoundPermission.Ipv6Ranges = []types.Ipv6Range{{CidrIpv6: aws.String("2001:db8::/32")}}
+	groups := []types.SecurityGroup{
+		testSecurityGroup("aaaa", nil, []types.IpPermission{compoundPermission}),
+		testSecurityGroup("bbbb", nil, []types.IpPermission{securityGroupPermission("aaaa")}),
+	}
+
+	resources := (SecurityGenerator{}).createResources(groups)
+	assertSecurityGroupResourceCounts(t, resources, 2)
+	standaloneRules := resourcesOfType(resources, "aws_security_group_rule")
+	resourceIDs := make(map[string]struct{}, len(standaloneRules))
+	var dualStackRules int
+	for _, resource := range standaloneRules {
+		resourceIDs[resource.InstanceInfo.Id] = struct{}{}
+		attributes := resource.InstanceState.Attributes
+		if attributes["cidr_blocks.#"] == "1" && attributes["ipv6_cidr_blocks.#"] == "1" {
+			dualStackRules++
+		}
+	}
+	if len(resourceIDs) != len(standaloneRules) {
+		t.Fatalf("standalone rule IDs are not unique: %v", standaloneRules)
+	}
+	if dualStackRules != 1 {
+		t.Fatalf("dual-stack standalone rule count = %d, want 1", dualStackRules)
 	}
 }
 

--- a/providers/aws/sg_test.go
+++ b/providers/aws/sg_test.go
@@ -543,6 +543,77 @@ func TestSecurityGroupSplitRuleCoalescesDualStackCIDRs(t *testing.T) {
 	}
 }
 
+func TestSecurityGroupSplitRuleSeparatesPrefixListSources(t *testing.T) {
+	disableSplitSecurityGroupRules(t)
+	compoundPermission := securityGroupPermission("bbbb", "external")
+	compoundPermission.PrefixListIds = []types.PrefixListId{{PrefixListId: aws.String("pl-example")}}
+	groups := []types.SecurityGroup{
+		testSecurityGroup("aaaa", nil, []types.IpPermission{compoundPermission}),
+		testSecurityGroup("bbbb", nil, []types.IpPermission{securityGroupPermission("aaaa")}),
+	}
+
+	resources := (SecurityGenerator{}).createResources(groups)
+	assertSecurityGroupResourceCounts(t, resources, 3)
+	standaloneRules := resourcesOfType(resources, "aws_security_group_rule")
+	var prefixListRules, groupRules int
+	for _, resource := range standaloneRules {
+		attributes := resource.InstanceState.Attributes
+		if attributes["prefix_list_ids.#"] == "1" {
+			prefixListRules++
+		}
+		if _, ok := attributes["source_security_group_id"]; ok {
+			groupRules++
+			if _, ok := attributes["prefix_list_ids.#"]; ok {
+				t.Fatalf("group rule %q retains prefix-list sources: %v", resource.InstanceInfo.Id, attributes)
+			}
+		}
+	}
+	if prefixListRules != 1 {
+		t.Fatalf("prefix-list standalone rule count = %d, want 1", prefixListRules)
+	}
+	if groupRules != 2 {
+		t.Fatalf("security-group standalone rule count = %d, want 2", groupRules)
+	}
+}
+
+func TestSecurityGroupSplitRulePreservesPrefixOnlyPermissionWithNilGroupID(t *testing.T) {
+	t.Setenv("SPLIT_SG_RULES", "1")
+	prefixPermission := securityGroupPermissionPointers(nil)
+	prefixPermission.PrefixListIds = []types.PrefixListId{{PrefixListId: aws.String("pl-example")}}
+	resources := (SecurityGenerator{}).createResources([]types.SecurityGroup{
+		testSecurityGroup("aaaa", nil, []types.IpPermission{prefixPermission}),
+	})
+
+	standaloneRules := resourcesOfType(resources, "aws_security_group_rule")
+	if len(standaloneRules) != 1 {
+		t.Fatalf("security group rule resource count = %d, want 1", len(standaloneRules))
+	}
+	attributes := standaloneRules[0].InstanceState.Attributes
+	if attributes["prefix_list_ids.#"] != "1" {
+		t.Fatalf("prefix-list count = %q, want 1", attributes["prefix_list_ids.#"])
+	}
+	if source := attributes["source_security_group_id"]; source != "" {
+		t.Fatalf("source security group ID = %q, want empty", source)
+	}
+}
+
+func TestSecurityGroupSplitRulePreservesReferencedOwnerWhenGroupOwnerUnknown(t *testing.T) {
+	t.Setenv("SPLIT_SG_RULES", "1")
+	permission := securityGroupPermission("external")
+	permission.UserIdGroupPairs[0].UserId = aws.String("remote-owner")
+	resources := (SecurityGenerator{}).createResources([]types.SecurityGroup{
+		testSecurityGroup("aaaa", nil, []types.IpPermission{permission}),
+	})
+
+	standaloneRules := resourcesOfType(resources, "aws_security_group_rule")
+	if len(standaloneRules) != 1 {
+		t.Fatalf("security group rule resource count = %d, want 1", len(standaloneRules))
+	}
+	if source := standaloneRules[0].InstanceState.Attributes["source_security_group_id"]; source != "remote-owner/external" {
+		t.Fatalf("source security group ID = %q, want remote-owner/external", source)
+	}
+}
+
 func TestSplitSecurityGroupRulesPreservesOverrideBehavior(t *testing.T) {
 	t.Setenv("SPLIT_SG_RULES", "1")
 	groups := []types.SecurityGroup{


### PR DESCRIPTION
## Root cause

Terraformer built the security-group dependency graph from `IpPermissions` only, even though resource generation handles both `IpPermissions` and `IpPermissionsEgress`. Egress-only and mixed cycles therefore remained inline and could produce Terraform dependency cycles.

Examples previously missed:

- Egress-only: `sg-a egress -> sg-b`, `sg-b egress -> sg-a`.
- Mixed: `sg-a ingress -> sg-b`, `sg-b egress -> sg-a`.

## Changes

- Build graph edges from valid internal references in both ingress and egress permissions.
- Ignore nil, empty, and undiscovered group IDs, preserving external and cross-account behavior.
- Collapse duplicate imported group IDs for graph analysis and deduplicate repeated edges.
- Keep the fewest-rules heuristic, now counting ingress plus egress permissions; break equal-count ties by group ID, sort cycles before selection, and sort the final result.
- Preserve self-reference behavior and `SPLIT_SG_RULES`; remove the unused, potentially panicking `ByGroupPair` sorter.
- Skip incomplete group IDs safely during resource generation.

External references remain ignored because Terraformer cannot construct a dependency edge to an `aws_security_group` resource it did not import. This follows the Terraform AWS provider model: inline and standalone rules must not be mixed for one group, while a standalone rule can break a cross-group dependency cycle.

References:

- https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group_rule
- https://github.com/hashicorp/terraform-provider-aws/issues/32743

## Tests added

- Two- and three-group egress-only cycles.
- Two- and three-group mixed ingress/egress cycles.
- Acyclic, self, external, nil, empty, duplicate, and mixed internal/external references.
- Duplicate security-group entries and groups without rules.
- Fewest-total-rule selection, stable group-ID tie-breaking, repeated runs, reordered inputs, and sorted output.
- Standalone egress-rule generation, acyclic inline behavior, nil-pair handling, and `SPLIT_SG_RULES` compatibility.

## Validation

- `gofmt -w providers/aws/sg.go providers/aws/sg_test.go` — passed.
- `go test ./providers/aws -run 'Test.*(Cycle|Reference|Security|Sg|SG|Egress|Ingress|External)' -count=1` — passed, 65 tests.
- `go test -race ./providers/aws -run 'Test.*(Cycle|Reference|Security|Sg|SG|Egress|Ingress|External)' -count=1` — passed, 65 tests.
- `go test ./providers/aws -count=1` — passed, 2,350 tests.
- `go test ./... -count=1` — passed, 4,420 tests across 77 packages.
- `go vet ./...` — passed.
- `golangci-lint run --new-from-rev="$(git merge-base HEAD origin/main)" ./providers/aws/...` — passed.
- `git diff --check` — passed.
- `MODE=full SKIP_PROVIDER_COMMAND_TESTS=1 SKIP_VET_DEPENDENCY_PACKAGES=1 bash .github/scripts/provider-dependency-preflight.sh` — passed, including module-tidy integrity, 69-package non-fixture build, utility tests, Terraform 1.9.8–1.14.9 state compatibility, and provider registry compatibility with AWS 6.54.0.

## Risk and limitations

Risk is limited to deciding which existing security-group rules are emitted as standalone resources. Acyclic groups retain inline rules, and explicit `SPLIT_SG_RULES` mode continues to split all usable groups. Cross-account, deleted, inaccessible, and other undiscovered group IDs remain outside the graph. Legacy group-name-only references without `GroupId` also remain outside graph analysis. Incomplete responses with unusable group references are skipped.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Detects AWS security group cycles that include egress or mixed ingress/egress refs to prevent Terraform dependency loops, and fixes split rule output to preserve compound sources (IPv4, IPv6, prefix lists) without duplication. Emits the minimal, deterministic set of standalone `aws_security_group_rule` resources and preserves cross‑account owner IDs.

- **Bug Fixes**
  - Build the graph from ingress and egress rules; ignore nil/empty/undiscovered group IDs; dedupe groups and edges.
  - Break cycles by picking the group with the fewest total rules (ingress + egress); tie‑break by group ID; deterministic via SCC analysis; sorted results.
  - Correct split output: coalesce IPv4+IPv6 CIDRs and prefix list IDs into one non‑group rule; emit separate rules for group refs; set `source_security_group_id` as `owner/group` for cross‑account refs.
  - Harden splitting: skip incomplete IDs; clear rules only for selected groups; acyclic and self‑refs stay inline; `SPLIT_SG_RULES` splits all groups using unique, sorted group IDs.

<sup>Written for commit c0714a354428a55abdf8428261f482909126421e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/chenrui333/terraformer/pull/700?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved AWS security group rule generation for dependency cycles involving ingress, egress, or mixed references.
  * Creates standalone `aws_security_group_rule` resources when required while preserving inline rules for non-cyclic configurations.
  * Safely handles missing/empty security group references and improves determinism by making cycle selection independent of input order.
  * Preserves correct owner/source semantics and coalesces dual-stack CIDRs for split rules.
* **Documentation**
  * Added an Unreleased changelog entry describing the security group dependency-cycle improvements.
* **Tests**
  * Added extensive unit tests and a benchmark covering cycle detection, split-rule generation, nil/empty cases, and tie-breaking behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->