### PR TITLE
fix(docs): unify unsupported resource taxonomy

### DIFF
--- a/docs/aws-gap-inventory.md
+++ b/docs/aws-gap-inventory.md
@@ -50,7 +50,9 @@ AWS provider gaps.
 
 Resources that cannot be imported safely should be recorded in
 providers/aws/unsupported_resources.json instead of being added as misleading
-Terraformer support.
+Terraformer support. The canonical status vocabulary and definitions are in
+[Unsupported Resource Metadata](unsupported-resources.md#status-values); this
+AWS workflow does not define a separate status list.
 
 ~~~json
 {
@@ -59,26 +61,31 @@ Terraformer support.
     {
       "resource": "aws_example_resource",
       "service_family": "example",
-      "reason": "AWS does not expose a list API with enough parent context for safe discovery.",
-      "evidence": "Checked Terraform AWS provider schema and AWS service API reference.",
-      "status": "unsafe-discovery",
+      "reason": "Importability needs a dedicated design for parent-scoped discovery.",
+      "evidence": "The AWS list API omits the parent identifier required by the Terraform provider importer.",
+      "status": "deferred",
       "references": [
-        "https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/example_resource"
+        "https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/example_resource",
+        "https://github.com/chenrui333/terraformer/issues/338"
       ]
     }
   ]
 }
 ~~~
 
-Supported statuses:
-
-- needs-research
-- not-importable
-- unsupported
-- unsafe-discovery
-- deferred
+Missing Terraformer support alone does not justify an unsupported-resource
+record. Every record needs concrete evidence of the import limitation.
+`deferred` is appropriate only after investigation identifies specific design
+work; `unsupported` or a more specific status requires evidence of the actual
+unsafe or non-viable behavior.
 
 The provider schema lists resource types, not importer contracts. Before adding
-an AWS resource importer, still verify the Terraform AWS provider read/import ID
-shape, AWS list and describe APIs, pagination, region or global behavior,
-generated address uniqueness, filter behavior, and unsupported or deleted states.
+an AWS resource importer or metadata record, verify:
+
+- Terraform AWS provider importer support.
+- The exact import ID and provider Read behavior.
+- AWS list and read APIs, including pagination.
+- Region or global ownership.
+- Generated address uniqueness.
+- Filter behavior.
+- Deleted and otherwise unsupported states.

--- a/docs/unsupported-resources.md
+++ b/docs/unsupported-resources.md
@@ -2,6 +2,8 @@
 
 Provider-local `unsupported_resources.json` files document resources that Terraformer should not import broadly without additional provider-specific work. They are evidence records, not a backlog of unimplemented resources.
 
+This document's [Status Values](#status-values) table is the human-readable source of truth for the repository-wide status vocabulary. The shared validator in `providers/unsupported_resources_test.go` is the machine source of truth and checks that the two sets match exactly.
+
 Keep these files next to the provider implementation, for example [providers/aws/unsupported_resources.json](../providers/aws/unsupported_resources.json). Omit the file when a provider has no evidence-backed unsupported resources yet.
 
 ## When To Add An Entry
@@ -48,8 +50,8 @@ Required fields for each resource entry:
 | Status | Meaning |
 | --- | --- |
 | `unsupported` | Import is known to be unsafe or not viable with the current provider/API behavior. |
-| `deferred` | Needs a dedicated follow-up because ownership, API shape, feature gates, or framework support require more design. |
-| `not-importable` | Terraform provider or resource semantics do not expose a usable import/read path. |
+| `deferred` | Importability has not been rejected, but ownership, API shape, feature gates, or framework support require dedicated design or follow-up. |
+| `not-importable` | The Terraform provider or resource semantics do not expose a usable import/read path. |
 | `cloudflare-managed` | Cloudflare owns or manages the configuration, so Terraformer should not emit it as user-managed Terraform. |
 | `secret-required` | Required configuration contains write-only credentials, secrets, private keys, or tokens. |
 | `request-style` | Resource represents a request, handshake, approval, or lifecycle action rather than stable inventory. |
@@ -57,6 +59,8 @@ Required fields for each resource entry:
 | `runtime-data` | Resource represents runtime data or observed state rather than desired configuration. |
 | `action-style` | Resource represents an action or operation rather than durable configuration. |
 | `policy-skip` | Resource is intentionally skipped by provider import policy even though it may be visible in discovery. |
+
+Provider-local tests may impose stricter naming, ordering, reference, or coverage requirements, but they must not redefine this shared vocabulary. Adding or changing a status requires documented semantics here, a matching update to the shared validator, exact synchronization tests, and review of the implications for existing metadata.
 
 ## Evidence Expectations
 
@@ -78,19 +82,19 @@ Run the shared validation with:
 go test ./providers
 ```
 
-The repo-wide test discovers every `providers/*/unsupported_resources.json` file and validates JSON decoding, schema version, required fields, non-empty references, allowed statuses, and duplicate resources. Provider-local tests may still add provider-specific assertions, such as expected Kubernetes skip-policy coverage.
+The repo-wide test discovers every `providers/*/unsupported_resources.json` file and validates JSON decoding, schema version, required fields, non-empty references, allowed statuses, and duplicate resources. It also parses the status table above and requires an exact match with the machine allowlist. Provider-local tests may still add provider-specific assertions, such as expected Kubernetes skip-policy coverage, without maintaining a separate general status allowlist.
 
 For provider resource PRs, use the pull request checklist to confirm that evidence-backed unsupported resources discovered during the work were added to the provider-local metadata file, or that no metadata update was needed.
 
 ## Inventory
 
-This inventory is an informational coverage snapshot. The source of truth is the discovered `providers/*/unsupported_resources.json` files validated by the Go test. Providers without metadata should remain `not present yet` until an evidence-backed unsupported resource has been investigated.
+This inventory is a validated coverage snapshot. A test compares every direct provider directory with the table and checks for the exact presence of `unsupported_resources.json` and provider-local `unsupported_resources_test.go` files. Providers without metadata should remain `not present yet` until an evidence-backed unsupported resource has been investigated.
 
 | Provider | Has `unsupported_resources.json` | Has provider-local `unsupported_resources_test.go` | Notes |
 | --- | --- | --- | --- |
 | alicloud | no | no | not present yet |
 | auth0 | yes | no | metadata present |
-| aws | yes | no | metadata present |
+| aws | yes | yes | metadata present; AWS-specific naming, ordering, and tracking-issue assertions |
 | azure | no | no | not present yet |
 | azuread | no | no | not present yet |
 | azuredevops | no | no | not present yet |
@@ -105,6 +109,7 @@ This inventory is an informational coverage snapshot. The source of truth is the
 | gitlab | no | no | not present yet |
 | gmailfilter | no | no | not present yet |
 | grafana | no | no | not present yet |
+| helm | no | no | not present yet |
 | heroku | no | no | not present yet |
 | honeycombio | no | no | not present yet |
 | ibm | no | no | not present yet |
@@ -112,7 +117,7 @@ This inventory is an informational coverage snapshot. The source of truth is the
 | keycloak | no | no | not present yet |
 | kafka | yes | yes | metadata present; provider-specific assertions |
 | kubernetes | yes | yes | metadata present; provider-specific assertions |
-| launchdarkly | yes | no | metadata present |
+| launchdarkly | yes | yes | metadata present; provider-specific assertions |
 | linode | no | no | not present yet |
 | logzio | no | no | not present yet |
 | mackerel | no | no | not present yet |

--- a/docs/unsupported-resources.md
+++ b/docs/unsupported-resources.md
@@ -2,7 +2,7 @@
 
 Provider-local `unsupported_resources.json` files document resources that Terraformer should not import broadly without additional provider-specific work. They are evidence records, not a backlog of unimplemented resources.
 
-This document's [Status Values](#status-values) table is the human-readable source of truth for the repository-wide status vocabulary. The shared validator in `providers/unsupported_resources_test.go` is the machine source of truth and checks that the two sets match exactly.
+This document's [Status Values](#status-values) table is the human-readable source of truth for the repository-wide status vocabulary. The shared definition in `internal/unsupportedresources/status.go` is the machine source of truth; repository tests check that the two sets match exactly, and metadata consumers reuse the same definition at runtime.
 
 Keep these files next to the provider implementation, for example [providers/aws/unsupported_resources.json](../providers/aws/unsupported_resources.json). Omit the file when a provider has no evidence-backed unsupported resources yet.
 
@@ -60,7 +60,7 @@ Required fields for each resource entry:
 | `action-style` | Resource represents an action or operation rather than durable configuration. |
 | `policy-skip` | Resource is intentionally skipped by provider import policy even though it may be visible in discovery. |
 
-Provider-local tests may impose stricter naming, ordering, reference, or coverage requirements, but they must not redefine this shared vocabulary. Adding or changing a status requires documented semantics here, a matching update to the shared validator, exact synchronization tests, and review of the implications for existing metadata.
+Provider-local tests may impose stricter naming, ordering, reference, or coverage requirements, but they must not redefine this shared vocabulary. Adding or changing a status requires documented semantics here, a matching update to the shared machine definition, exact synchronization tests, and review of the implications for existing metadata.
 
 ## Evidence Expectations
 

--- a/internal/unsupportedresources/status.go
+++ b/internal/unsupportedresources/status.go
@@ -1,0 +1,31 @@
+// SPDX-License-Identifier: Apache-2.0
+
+// Package unsupportedresources defines the repository-wide unsupported-resource
+// metadata status vocabulary.
+package unsupportedresources
+
+import "slices"
+
+var canonicalStatuses = [...]string{
+	"action-style",
+	"cloudflare-managed",
+	"deferred",
+	"not-importable",
+	"policy-skip",
+	"request-style",
+	"runtime-data",
+	"runtime-generated",
+	"secret-required",
+	"unsupported",
+}
+
+// IsValidStatus reports whether status exactly matches a canonical status.
+func IsValidStatus(status string) bool {
+	_, found := slices.BinarySearch(canonicalStatuses[:], status)
+	return found
+}
+
+// Statuses returns the sorted canonical status vocabulary.
+func Statuses() []string {
+	return slices.Clone(canonicalStatuses[:])
+}

--- a/internal/unsupportedresources/status_test.go
+++ b/internal/unsupportedresources/status_test.go
@@ -1,0 +1,36 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package unsupportedresources
+
+import (
+	"slices"
+	"testing"
+)
+
+func TestStatuses(t *testing.T) {
+	statuses := Statuses()
+	if !slices.IsSorted(statuses) {
+		t.Fatalf("Statuses() = %v, want sorted statuses", statuses)
+	}
+	for index, status := range statuses {
+		if !IsValidStatus(status) {
+			t.Fatalf("IsValidStatus(%q) = false, want true", status)
+		}
+		if index > 0 && statuses[index-1] == status {
+			t.Fatalf("Statuses() contains duplicate status %q", status)
+		}
+	}
+
+	statuses[0] = "mutated"
+	if IsValidStatus("mutated") || Statuses()[0] == "mutated" {
+		t.Fatal("Statuses() exposed mutable canonical status storage")
+	}
+}
+
+func TestIsValidStatusRejectsNonCanonicalValues(t *testing.T) {
+	for _, status := range []string{"", "future-status", "needs-research", "unsafe-discovery", " action-style "} {
+		if IsValidStatus(status) {
+			t.Fatalf("IsValidStatus(%q) = true, want false", status)
+		}
+	}
+}

--- a/providers/aws/unsupported_resources_test.go
+++ b/providers/aws/unsupported_resources_test.go
@@ -4,6 +4,7 @@ package aws
 
 import (
 	"encoding/json"
+	"fmt"
 	"os"
 	"strings"
 	"testing"
@@ -11,86 +12,105 @@ import (
 
 const awsUnsupportedIssue = "https://github.com/chenrui333/terraformer/issues/338"
 
+type awsUnsupportedResourcesFile struct {
+	Version   int                                    `json:"version"`
+	Resources []awsUnsupportedResourceMetadataRecord `json:"resources"`
+}
+
+type awsUnsupportedResourceMetadataRecord struct {
+	Resource      string   `json:"resource"`
+	ServiceFamily string   `json:"service_family"`
+	Reason        string   `json:"reason"`
+	Evidence      string   `json:"evidence"`
+	Status        string   `json:"status"`
+	References    []string `json:"references"`
+}
+
 func TestAWSUnsupportedResourcesMetadata(t *testing.T) {
 	data, err := os.ReadFile("unsupported_resources.json")
 	if err != nil {
 		t.Fatalf("read unsupported resources: %v", err)
 	}
 
-	var metadata map[string]interface{}
+	var metadata awsUnsupportedResourcesFile
 	if err := json.Unmarshal(data, &metadata); err != nil {
 		t.Fatalf("decode unsupported resources: %v", err)
 	}
-	if version, ok := metadata["version"].(float64); !ok || version != 1 {
-		t.Fatalf("unsupported resources version = %v, want 1", metadata["version"])
-	}
-	rawResources, ok := metadata["resources"].([]interface{})
-	if !ok || len(rawResources) == 0 {
-		t.Fatal("unsupported resources file is missing resources list")
-	}
-
-	allowedStatuses := map[string]bool{
-		"deferred":       true,
-		"not-importable": true,
-		"runtime-data":   true,
-		"unsupported":    true,
-	}
-	seen := map[string]bool{}
-	previousResource := ""
-	for _, rawResource := range rawResources {
-		resource, ok := rawResource.(map[string]interface{})
-		if !ok {
-			t.Fatalf("unsupported resource entry has unexpected type %T", rawResource)
-		}
-		name, _ := resource["resource"].(string)
-		serviceFamily, _ := resource["service_family"].(string)
-		reason, _ := resource["reason"].(string)
-		evidence, _ := resource["evidence"].(string)
-		status, _ := resource["status"].(string)
-		references, _ := resource["references"].([]interface{})
-
-		if name == "" {
-			t.Fatal("unsupported resource entry is missing resource")
-		}
-		if !strings.HasPrefix(name, "aws_") {
-			t.Fatalf("unsupported resource %q does not use aws_ prefix", name)
-		}
-		if seen[name] {
-			t.Fatalf("unsupported resource %q is duplicated", name)
-		}
-		seen[name] = true
-		if previousResource != "" && previousResource > name {
-			t.Fatalf("unsupported resources are not sorted by resource: %q before %q", previousResource, name)
-		}
-		previousResource = name
-
-		if serviceFamily == "" {
-			t.Fatalf("unsupported resource %q is missing service_family", name)
-		}
-		if reason == "" {
-			t.Fatalf("unsupported resource %q is missing reason", name)
-		}
-		if evidence == "" {
-			t.Fatalf("unsupported resource %q is missing evidence", name)
-		}
-		if !allowedStatuses[status] {
-			t.Fatalf("unsupported resource %q has unknown status %q", name, status)
-		}
-		if !hasUnsupportedResourceReference(references, awsUnsupportedIssue) {
-			t.Fatalf("unsupported resource %q is missing issue #338 reference", name)
-		}
-		for _, rawReference := range references {
-			reference, _ := rawReference.(string)
-			if strings.TrimSpace(reference) == "" {
-				t.Fatalf("unsupported resource %q has an empty reference", name)
-			}
-		}
+	if err := validateAWSUnsupportedResourcesMetadata(metadata); err != nil {
+		t.Fatal(err)
 	}
 }
 
-func hasUnsupportedResourceReference(references []interface{}, expected string) bool {
-	for _, rawReference := range references {
-		if reference, _ := rawReference.(string); reference == expected {
+func TestAWSUnsupportedResourcesMetadataDoesNotRedefineSharedStatuses(t *testing.T) {
+	metadata := awsUnsupportedResourcesFile{
+		Version: 1,
+		Resources: []awsUnsupportedResourceMetadataRecord{
+			{
+				Resource:      "aws_example_action",
+				ServiceFamily: "example",
+				Reason:        "The resource represents an action.",
+				Evidence:      "The provider invokes an operation instead of managing durable configuration.",
+				Status:        "action-style",
+				References:    []string{awsUnsupportedIssue},
+			},
+		},
+	}
+	if err := validateAWSUnsupportedResourcesMetadata(metadata); err != nil {
+		t.Fatalf("AWS-local validation rejected shared canonical status: %v", err)
+	}
+}
+
+func validateAWSUnsupportedResourcesMetadata(metadata awsUnsupportedResourcesFile) error {
+	if metadata.Version != 1 {
+		return fmt.Errorf("unsupported resources version = %d, want 1", metadata.Version)
+	}
+	if len(metadata.Resources) == 0 {
+		return fmt.Errorf("unsupported resources file is missing resources list")
+	}
+
+	seen := map[string]bool{}
+	previousResource := ""
+	for _, resource := range metadata.Resources {
+		name := strings.TrimSpace(resource.Resource)
+		if name == "" {
+			return fmt.Errorf("unsupported resource entry is missing resource")
+		}
+		if !strings.HasPrefix(name, "aws_") {
+			return fmt.Errorf("unsupported resource %q does not use aws_ prefix", name)
+		}
+		if seen[name] {
+			return fmt.Errorf("unsupported resource %q is duplicated", name)
+		}
+		seen[name] = true
+		if previousResource != "" && previousResource > name {
+			return fmt.Errorf("unsupported resources are not sorted by resource: %q before %q", previousResource, name)
+		}
+		previousResource = name
+
+		if strings.TrimSpace(resource.ServiceFamily) == "" {
+			return fmt.Errorf("unsupported resource %q is missing service_family", name)
+		}
+		if strings.TrimSpace(resource.Reason) == "" {
+			return fmt.Errorf("unsupported resource %q is missing reason", name)
+		}
+		if strings.TrimSpace(resource.Evidence) == "" {
+			return fmt.Errorf("unsupported resource %q is missing evidence", name)
+		}
+		if !hasUnsupportedResourceReference(resource.References, awsUnsupportedIssue) {
+			return fmt.Errorf("unsupported resource %q is missing issue #338 reference", name)
+		}
+		for _, reference := range resource.References {
+			if strings.TrimSpace(reference) == "" {
+				return fmt.Errorf("unsupported resource %q has an empty reference", name)
+			}
+		}
+	}
+	return nil
+}
+
+func hasUnsupportedResourceReference(references []string, expected string) bool {
+	for _, reference := range references {
+		if reference == expected {
 			return true
 		}
 	}

--- a/providers/aws/unsupported_resources_test.go
+++ b/providers/aws/unsupported_resources_test.go
@@ -41,22 +41,44 @@ func TestAWSUnsupportedResourcesMetadata(t *testing.T) {
 	}
 }
 
-func TestAWSUnsupportedResourcesMetadataDoesNotRedefineSharedStatuses(t *testing.T) {
-	metadata := awsUnsupportedResourcesFile{
-		Version: 1,
-		Resources: []awsUnsupportedResourceMetadataRecord{
-			{
-				Resource:      "aws_example_action",
-				ServiceFamily: "example",
-				Reason:        "The resource represents an action.",
-				Evidence:      "The provider invokes an operation instead of managing durable configuration.",
-				Status:        "action-style",
-				References:    []string{awsUnsupportedIssue},
-			},
-		},
+func TestAWSUnsupportedResourcesMetadataDoesNotValidateStatusMembership(t *testing.T) {
+	tests := []struct {
+		name            string
+		status          string
+		wantErrContains string
+	}{
+		{name: "synthetic noncanonical status", status: "future-status"},
+		{name: "canonical status", status: "unsupported"},
+		{name: "empty status", wantErrContains: "missing status"},
+		{name: "whitespace-only status", status: " \t ", wantErrContains: "missing status"},
 	}
-	if err := validateAWSUnsupportedResourcesMetadata(metadata); err != nil {
-		t.Fatalf("AWS-local validation rejected shared canonical status: %v", err)
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			metadata := awsUnsupportedResourcesFile{
+				Version: 1,
+				Resources: []awsUnsupportedResourceMetadataRecord{
+					{
+						Resource:      "aws_example_action",
+						ServiceFamily: "example",
+						Reason:        "The resource represents an action.",
+						Evidence:      "The provider invokes an operation instead of managing durable configuration.",
+						Status:        test.status,
+						References:    []string{awsUnsupportedIssue},
+					},
+				},
+			}
+			err := validateAWSUnsupportedResourcesMetadata(metadata)
+			if test.wantErrContains == "" {
+				if err != nil {
+					t.Fatalf("AWS-local structural validation rejected status %q: %v", test.status, err)
+				}
+				return
+			}
+			if err == nil || !strings.Contains(err.Error(), test.wantErrContains) {
+				t.Fatalf("validateAWSUnsupportedResourcesMetadata() error = %v, want substring %q", err, test.wantErrContains)
+			}
+		})
 	}
 }
 
@@ -95,6 +117,9 @@ func validateAWSUnsupportedResourcesMetadata(metadata awsUnsupportedResourcesFil
 		}
 		if strings.TrimSpace(resource.Evidence) == "" {
 			return fmt.Errorf("unsupported resource %q is missing evidence", name)
+		}
+		if strings.TrimSpace(resource.Status) == "" {
+			return fmt.Errorf("unsupported resource %q is missing status", name)
 		}
 		if !hasUnsupportedResourceReference(resource.References, awsUnsupportedIssue) {
 			return fmt.Errorf("unsupported resource %q is missing issue #338 reference", name)

--- a/providers/cloudflare/unsupported_resources_test.go
+++ b/providers/cloudflare/unsupported_resources_test.go
@@ -42,14 +42,6 @@ func TestCloudflareUnsupportedResourcesMetadata(t *testing.T) {
 		t.Fatal("unsupported resources file is missing resources list")
 	}
 
-	allowedStatuses := map[string]bool{
-		"cloudflare-managed": true,
-		"deferred":           true,
-		"not-importable":     true,
-		"request-style":      true,
-		"secret-required":    true,
-		"unsupported":        true,
-	}
 	seen := map[string]bool{}
 	previousResource := ""
 	for _, resource := range metadata.Resources {
@@ -76,9 +68,6 @@ func TestCloudflareUnsupportedResourcesMetadata(t *testing.T) {
 		}
 		if resource.Evidence == "" {
 			t.Fatalf("unsupported resource %q is missing evidence", resource.Resource)
-		}
-		if !allowedStatuses[resource.Status] {
-			t.Fatalf("unsupported resource %q has unknown status %q", resource.Resource, resource.Status)
 		}
 		if !hasReference(resource.References, cloudflareUnsupportedIssue) {
 			t.Fatalf("unsupported resource %q is missing issue #335 reference", resource.Resource)

--- a/providers/kubernetes/unsupported_resources_test.go
+++ b/providers/kubernetes/unsupported_resources_test.go
@@ -28,11 +28,6 @@ func TestUnsupportedResourceMetadata(t *testing.T) {
 		t.Fatal("unsupported resources file is missing resources list")
 	}
 
-	allowedStatuses := map[string]struct{}{
-		"not-importable":    {},
-		"policy-skip":       {},
-		"runtime-generated": {},
-	}
 	entries := map[string]string{}
 	resources := make([]string, 0, len(rawEntries))
 	for _, rawEntry := range rawEntries {
@@ -51,9 +46,6 @@ func TestUnsupportedResourceMetadata(t *testing.T) {
 		}
 		if len(references) == 0 {
 			t.Fatalf("%s unsupported entry is missing references", resource)
-		}
-		if _, ok := allowedStatuses[status]; !ok {
-			t.Fatalf("%s status = %q, want one of %v", resource, status, sortedKeys(allowedStatuses))
 		}
 		if _, exists := entries[resource]; exists {
 			t.Fatalf("duplicate unsupported resource entry: %s", resource)
@@ -94,13 +86,4 @@ func unsupportedResourceMetadataName(resource kubernetesResourceID) string {
 		return resource.version + " " + resource.kind
 	}
 	return resource.group + "/" + resource.version + " " + resource.kind
-}
-
-func sortedKeys(values map[string]struct{}) []string {
-	keys := make([]string, 0, len(values))
-	for key := range values {
-		keys = append(keys, key)
-	}
-	sort.Strings(keys)
-	return keys
 }

--- a/providers/launchdarkly/unsupported_resources_test.go
+++ b/providers/launchdarkly/unsupported_resources_test.go
@@ -27,10 +27,6 @@ func TestLaunchDarklyUnsupportedResourcesMetadata(t *testing.T) {
 		t.Fatal("unsupported resources file is missing resources list")
 	}
 
-	allowedStatuses := map[string]bool{
-		"deferred":    true,
-		"unsupported": true,
-	}
 	seen := map[string]bool{}
 	previousResource := ""
 	for _, rawResource := range rawResources {
@@ -42,7 +38,6 @@ func TestLaunchDarklyUnsupportedResourcesMetadata(t *testing.T) {
 		serviceFamily, _ := resource["service_family"].(string)
 		reason, _ := resource["reason"].(string)
 		evidence, _ := resource["evidence"].(string)
-		status, _ := resource["status"].(string)
 		references, _ := resource["references"].([]interface{})
 
 		if name == "" {
@@ -68,9 +63,6 @@ func TestLaunchDarklyUnsupportedResourcesMetadata(t *testing.T) {
 		}
 		if evidence == "" {
 			t.Fatalf("unsupported resource %q is missing evidence", name)
-		}
-		if !allowedStatuses[status] {
-			t.Fatalf("unsupported resource %q has unknown status %q", name, status)
 		}
 		if len(references) == 0 {
 			t.Fatalf("unsupported resource %q is missing references", name)

--- a/providers/unsupported_resources_documentation_test.go
+++ b/providers/unsupported_resources_documentation_test.go
@@ -1,0 +1,673 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package providers
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"testing"
+)
+
+const (
+	unsupportedResourcesDocumentationPath = "../docs/unsupported-resources.md"
+	unsupportedResourceStatusHeading      = "## Status Values"
+	unsupportedResourceInventoryHeading   = "## Inventory"
+)
+
+// There are currently no non-provider directories directly under providers.
+// Add any future shared directory here with a reason instead of silently
+// excluding it from the documented inventory.
+var unsupportedResourceInventoryExcludedDirectories = map[string]string{}
+
+type parsedUnsupportedResourceStatusTable struct {
+	statuses   map[string]struct{}
+	duplicates []string
+}
+
+type unsupportedResourceProviderInventoryEntry struct {
+	hasMetadata  bool
+	hasLocalTest bool
+}
+
+type parsedUnsupportedResourceProviderInventory struct {
+	entries    map[string]unsupportedResourceProviderInventoryEntry
+	duplicates []string
+}
+
+type unsupportedResourceProviderFiles struct {
+	hasMetadata  bool
+	hasLocalTest bool
+}
+
+func TestUnsupportedResourceStatusesMatchDocumentation(t *testing.T) {
+	markdown := readUnsupportedResourcesDocumentation(t)
+	if err := validateUnsupportedResourceStatusDocumentation(markdown, allowedUnsupportedResourceStatuses); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestParseUnsupportedResourceStatusTable(t *testing.T) {
+	tests := []struct {
+		name            string
+		markdown        string
+		allowed         map[string]struct{}
+		wantErrContains string
+	}{
+		{
+			name:     "valid table",
+			markdown: statusTableMarkdown("alpha", "beta"),
+			allowed:  stringSet("alpha", "beta"),
+		},
+		{
+			name:            "missing section",
+			markdown:        "# Unsupported resources\n\nNo status table.\n",
+			allowed:         stringSet("alpha"),
+			wantErrContains: "missing section",
+		},
+		{
+			name: "missing table",
+			markdown: "# Unsupported resources\n\n" + unsupportedResourceStatusHeading +
+				"\n\nStatus prose only.\n",
+			allowed:         stringSet("alpha"),
+			wantErrContains: "missing Markdown table",
+		},
+		{
+			name:            "missing canonical status",
+			markdown:        statusTableMarkdown("alpha"),
+			allowed:         stringSet("alpha", "beta"),
+			wantErrContains: "missing documentation statuses: [beta]",
+		},
+		{
+			name:            "unknown status",
+			markdown:        statusTableMarkdown("alpha", "gamma"),
+			allowed:         stringSet("alpha"),
+			wantErrContains: "unknown documented statuses: [gamma]",
+		},
+		{
+			name:            "duplicate status",
+			markdown:        statusTableMarkdown("alpha", "alpha"),
+			allowed:         stringSet("alpha"),
+			wantErrContains: "duplicate documented statuses: [alpha]",
+		},
+		{
+			name: "malformed table row",
+			markdown: "# Unsupported resources\n\n" + unsupportedResourceStatusHeading + "\n\n" +
+				"| Status | Meaning |\n" +
+				"| --- | --- |\n" +
+				"| alpha | Missing code delimiters. |\n",
+			allowed:         stringSet("alpha"),
+			wantErrContains: "status must be a backtick-delimited",
+		},
+		{
+			name: "prose outside table does not count",
+			markdown: "# Unsupported resources\n\nThe `beta` status appears in prose.\n\n" +
+				statusTableMarkdown("alpha"),
+			allowed:         stringSet("alpha", "beta"),
+			wantErrContains: "missing documentation statuses: [beta]",
+		},
+		{
+			name: "unrelated table does not count",
+			markdown: "# Unsupported resources\n\n" + unsupportedResourceStatusHeading + "\n\n" +
+				"| Other | Value |\n| --- | --- |\n| `gamma` | Unrelated table. |\n\n" +
+				"| Status | Meaning |\n| --- | --- |\n| `alpha` | Meaning for alpha. |\n",
+			allowed: stringSet("alpha"),
+		},
+		{
+			name: "section ends at next level two heading",
+			markdown: statusTableMarkdown("alpha") + "\n## Other\n\n" +
+				"| Status | Meaning |\n| --- | --- |\n| `gamma` | Outside the section. |\n",
+			allowed: stringSet("alpha"),
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			err := validateUnsupportedResourceStatusDocumentation(test.markdown, test.allowed)
+			if test.wantErrContains == "" {
+				if err != nil {
+					t.Fatalf("validateUnsupportedResourceStatusDocumentation() error = %v", err)
+				}
+				return
+			}
+			if err == nil || !strings.Contains(err.Error(), test.wantErrContains) {
+				t.Fatalf("validateUnsupportedResourceStatusDocumentation() error = %v, want substring %q", err, test.wantErrContains)
+			}
+		})
+	}
+}
+
+func TestUnsupportedResourceProviderInventoryMatchesFilesystem(t *testing.T) {
+	markdown := readUnsupportedResourcesDocumentation(t)
+	actual, err := collectUnsupportedResourceProviderFiles(".", unsupportedResourceInventoryExcludedDirectories)
+	if err != nil {
+		t.Fatalf("collect provider inventory: %v", err)
+	}
+	if err := validateUnsupportedResourceProviderInventory(markdown, actual); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestParseUnsupportedResourceProviderInventory(t *testing.T) {
+	actual := map[string]unsupportedResourceProviderFiles{
+		"alpha": {hasMetadata: true, hasLocalTest: true},
+		"beta":  {hasMetadata: false, hasLocalTest: false},
+	}
+	validRows := []string{
+		"| alpha | yes | yes | metadata [details](alpha.md); `provider-specific` assertions |",
+		"| beta | no | no | not present yet |",
+	}
+
+	tests := []struct {
+		name            string
+		markdown        string
+		wantErrContains string
+	}{
+		{
+			name:     "valid inventory",
+			markdown: providerInventoryMarkdown(validRows...),
+		},
+		{
+			name:            "missing provider row",
+			markdown:        providerInventoryMarkdown(validRows[0]),
+			wantErrContains: "missing provider rows: [beta]",
+		},
+		{
+			name: "duplicate provider row",
+			markdown: providerInventoryMarkdown(
+				validRows[0],
+				validRows[0],
+				validRows[1],
+			),
+			wantErrContains: "duplicate provider rows: [alpha]",
+		},
+		{
+			name: "unknown provider row",
+			markdown: providerInventoryMarkdown(
+				validRows[0],
+				validRows[1],
+				"| gamma | no | no | unknown provider |",
+			),
+			wantErrContains: "unknown provider rows: [gamma]",
+		},
+		{
+			name: "incorrect metadata value",
+			markdown: providerInventoryMarkdown(
+				"| alpha | no | yes | stale metadata value |",
+				validRows[1],
+			),
+			wantErrContains: "metadata file mismatches: [alpha (documented no, actual yes)]",
+		},
+		{
+			name: "incorrect local test value",
+			markdown: providerInventoryMarkdown(
+				"| alpha | yes | no | stale test value |",
+				validRows[1],
+			),
+			wantErrContains: "local test mismatches: [alpha (documented no, actual yes)]",
+		},
+		{
+			name: "malformed row",
+			markdown: providerInventoryMarkdown(
+				"| alpha | yes | yes |",
+				validRows[1],
+			),
+			wantErrContains: "inventory row must contain 4 columns",
+		},
+		{
+			name: "notes containing Markdown punctuation",
+			markdown: providerInventoryMarkdown(
+				"| alpha | yes | yes | metadata [details](alpha.md); `provider-specific` assertions and escaped \\| note |",
+				validRows[1],
+			),
+		},
+		{
+			name: "rows outside inventory are ignored",
+			markdown: "# Unsupported resources\n\n| Provider | Has `unsupported_resources.json` | Has provider-local `unsupported_resources_test.go` | Notes |\n" +
+				"| --- | --- | --- | --- |\n| gamma | no | no | outside inventory |\n\n" +
+				providerInventoryMarkdown(validRows...) +
+				"\n## Other\n\n| Provider | Has `unsupported_resources.json` | Has provider-local `unsupported_resources_test.go` | Notes |\n" +
+				"| --- | --- | --- | --- |\n| gamma | no | no | outside inventory |\n",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			err := validateUnsupportedResourceProviderInventory(test.markdown, actual)
+			if test.wantErrContains == "" {
+				if err != nil {
+					t.Fatalf("validateUnsupportedResourceProviderInventory() error = %v", err)
+				}
+				return
+			}
+			if err == nil || !strings.Contains(err.Error(), test.wantErrContains) {
+				t.Fatalf("validateUnsupportedResourceProviderInventory() error = %v, want substring %q", err, test.wantErrContains)
+			}
+		})
+	}
+}
+
+func validateUnsupportedResourceStatusDocumentation(markdown string, allowed map[string]struct{}) error {
+	parsed, err := parseUnsupportedResourceStatusTable(markdown)
+	if err != nil {
+		return err
+	}
+
+	missing := setDifference(allowed, parsed.statuses)
+	unknown := setDifference(parsed.statuses, allowed)
+	duplicates := sortedUniqueStrings(parsed.duplicates)
+	problems := make([]string, 0, 3)
+	if len(missing) > 0 {
+		problems = append(problems, fmt.Sprintf("missing documentation statuses: %v", missing))
+	}
+	if len(unknown) > 0 {
+		problems = append(problems, fmt.Sprintf("unknown documented statuses: %v", unknown))
+	}
+	if len(duplicates) > 0 {
+		problems = append(problems, fmt.Sprintf("duplicate documented statuses: %v", duplicates))
+	}
+	if len(problems) > 0 {
+		return fmt.Errorf("unsupported resource status table mismatch: %s", strings.Join(problems, "; "))
+	}
+	return nil
+}
+
+func parseUnsupportedResourceStatusTable(markdown string) (parsedUnsupportedResourceStatusTable, error) {
+	section, err := markdownLevelTwoSection(markdown, unsupportedResourceStatusHeading)
+	if err != nil {
+		return parsedUnsupportedResourceStatusTable{}, err
+	}
+	rows, err := markdownTableRows(section, []string{"Status", "Meaning"})
+	if err != nil {
+		return parsedUnsupportedResourceStatusTable{}, fmt.Errorf("parse %s: %w", unsupportedResourceStatusHeading, err)
+	}
+
+	parsed := parsedUnsupportedResourceStatusTable{statuses: map[string]struct{}{}}
+	for index, row := range rows {
+		if len(row) != 2 {
+			return parsedUnsupportedResourceStatusTable{}, fmt.Errorf("parse %s row %d: status row must contain 2 columns, got %d", unsupportedResourceStatusHeading, index+1, len(row))
+		}
+		status, err := backtickDelimitedStatus(row[0])
+		if err != nil {
+			return parsedUnsupportedResourceStatusTable{}, fmt.Errorf("parse %s row %d: %w", unsupportedResourceStatusHeading, index+1, err)
+		}
+		if strings.TrimSpace(row[1]) == "" {
+			return parsedUnsupportedResourceStatusTable{}, fmt.Errorf("parse %s row %d: status %q is missing a meaning", unsupportedResourceStatusHeading, index+1, status)
+		}
+		if _, exists := parsed.statuses[status]; exists {
+			parsed.duplicates = append(parsed.duplicates, status)
+		}
+		parsed.statuses[status] = struct{}{}
+	}
+	return parsed, nil
+}
+
+func backtickDelimitedStatus(value string) (string, error) {
+	value = strings.TrimSpace(value)
+	if len(value) < 3 || value[0] != '`' || value[len(value)-1] != '`' || strings.Count(value, "`") != 2 {
+		return "", fmt.Errorf("status must be a backtick-delimited non-empty name, got %q", value)
+	}
+	status := value[1 : len(value)-1]
+	if strings.TrimSpace(status) != status || status == "" {
+		return "", fmt.Errorf("status must be a backtick-delimited non-empty name, got %q", value)
+	}
+	for _, character := range []byte(status) {
+		if !isLowerASCII(character) && !isASCIIDigit(character) && character != '-' {
+			return "", fmt.Errorf("status %q must contain only lowercase letters, digits, and hyphens", status)
+		}
+	}
+	return status, nil
+}
+
+func validateUnsupportedResourceProviderInventory(markdown string, actual map[string]unsupportedResourceProviderFiles) error {
+	parsed, err := parseUnsupportedResourceProviderInventory(markdown)
+	if err != nil {
+		return err
+	}
+
+	actualProviders := make(map[string]struct{}, len(actual))
+	for provider := range actual {
+		actualProviders[provider] = struct{}{}
+	}
+	documentedProviders := make(map[string]struct{}, len(parsed.entries))
+	for provider := range parsed.entries {
+		documentedProviders[provider] = struct{}{}
+	}
+
+	problems := make([]string, 0, 5)
+	if missing := setDifference(actualProviders, documentedProviders); len(missing) > 0 {
+		problems = append(problems, fmt.Sprintf("missing provider rows: %v", missing))
+	}
+	if unknown := setDifference(documentedProviders, actualProviders); len(unknown) > 0 {
+		problems = append(problems, fmt.Sprintf("unknown provider rows: %v", unknown))
+	}
+	if duplicates := sortedUniqueStrings(parsed.duplicates); len(duplicates) > 0 {
+		problems = append(problems, fmt.Sprintf("duplicate provider rows: %v", duplicates))
+	}
+
+	metadataMismatches := []string{}
+	localTestMismatches := []string{}
+	for provider, files := range actual {
+		entry, ok := parsed.entries[provider]
+		if !ok {
+			continue
+		}
+		if entry.hasMetadata != files.hasMetadata {
+			metadataMismatches = append(metadataMismatches, inventoryBooleanMismatch(provider, entry.hasMetadata, files.hasMetadata))
+		}
+		if entry.hasLocalTest != files.hasLocalTest {
+			localTestMismatches = append(localTestMismatches, inventoryBooleanMismatch(provider, entry.hasLocalTest, files.hasLocalTest))
+		}
+	}
+	sort.Strings(metadataMismatches)
+	sort.Strings(localTestMismatches)
+	if len(metadataMismatches) > 0 {
+		problems = append(problems, fmt.Sprintf("metadata file mismatches: %v", metadataMismatches))
+	}
+	if len(localTestMismatches) > 0 {
+		problems = append(problems, fmt.Sprintf("local test mismatches: %v", localTestMismatches))
+	}
+	if len(problems) > 0 {
+		return fmt.Errorf("unsupported resource provider inventory mismatch: %s", strings.Join(problems, "; "))
+	}
+	return nil
+}
+
+func parseUnsupportedResourceProviderInventory(markdown string) (parsedUnsupportedResourceProviderInventory, error) {
+	section, err := markdownLevelTwoSection(markdown, unsupportedResourceInventoryHeading)
+	if err != nil {
+		return parsedUnsupportedResourceProviderInventory{}, err
+	}
+	rows, err := markdownTableRows(section, []string{
+		"Provider",
+		"Has `unsupported_resources.json`",
+		"Has provider-local `unsupported_resources_test.go`",
+		"Notes",
+	})
+	if err != nil {
+		return parsedUnsupportedResourceProviderInventory{}, fmt.Errorf("parse %s: %w", unsupportedResourceInventoryHeading, err)
+	}
+
+	parsed := parsedUnsupportedResourceProviderInventory{entries: map[string]unsupportedResourceProviderInventoryEntry{}}
+	for index, row := range rows {
+		if len(row) != 4 {
+			return parsedUnsupportedResourceProviderInventory{}, fmt.Errorf("parse %s row %d: inventory row must contain 4 columns, got %d", unsupportedResourceInventoryHeading, index+1, len(row))
+		}
+		provider := strings.TrimSpace(row[0])
+		if provider == "" {
+			return parsedUnsupportedResourceProviderInventory{}, fmt.Errorf("parse %s row %d: provider name is empty", unsupportedResourceInventoryHeading, index+1)
+		}
+		for _, character := range []byte(provider) {
+			if !isLowerASCII(character) && !isASCIIDigit(character) && character != '-' && character != '_' {
+				return parsedUnsupportedResourceProviderInventory{}, fmt.Errorf("parse %s row %d: invalid provider name %q", unsupportedResourceInventoryHeading, index+1, provider)
+			}
+		}
+		hasMetadata, err := parseYesNo(row[1])
+		if err != nil {
+			return parsedUnsupportedResourceProviderInventory{}, fmt.Errorf("parse %s row %d metadata column: %w", unsupportedResourceInventoryHeading, index+1, err)
+		}
+		hasLocalTest, err := parseYesNo(row[2])
+		if err != nil {
+			return parsedUnsupportedResourceProviderInventory{}, fmt.Errorf("parse %s row %d local test column: %w", unsupportedResourceInventoryHeading, index+1, err)
+		}
+		notes := strings.TrimSpace(row[3])
+		if notes == "" {
+			return parsedUnsupportedResourceProviderInventory{}, fmt.Errorf("parse %s row %d: provider %q has empty notes", unsupportedResourceInventoryHeading, index+1, provider)
+		}
+		if _, exists := parsed.entries[provider]; exists {
+			parsed.duplicates = append(parsed.duplicates, provider)
+			continue
+		}
+		parsed.entries[provider] = unsupportedResourceProviderInventoryEntry{
+			hasMetadata:  hasMetadata,
+			hasLocalTest: hasLocalTest,
+		}
+	}
+	return parsed, nil
+}
+
+func collectUnsupportedResourceProviderFiles(root string, excluded map[string]string) (map[string]unsupportedResourceProviderFiles, error) {
+	entries, err := os.ReadDir(root)
+	if err != nil {
+		return nil, err
+	}
+
+	providers := map[string]unsupportedResourceProviderFiles{}
+	for _, entry := range entries {
+		if !entry.IsDir() {
+			continue
+		}
+		if _, skip := excluded[entry.Name()]; skip {
+			continue
+		}
+		hasMetadata, err := regularFileExists(filepath.Join(root, entry.Name(), "unsupported_resources.json"))
+		if err != nil {
+			return nil, err
+		}
+		hasLocalTest, err := regularFileExists(filepath.Join(root, entry.Name(), "unsupported_resources_test.go"))
+		if err != nil {
+			return nil, err
+		}
+		providers[entry.Name()] = unsupportedResourceProviderFiles{
+			hasMetadata:  hasMetadata,
+			hasLocalTest: hasLocalTest,
+		}
+	}
+	return providers, nil
+}
+
+func markdownLevelTwoSection(markdown, heading string) ([]string, error) {
+	lines := strings.Split(strings.ReplaceAll(markdown, "\r\n", "\n"), "\n")
+	start := -1
+	for index, line := range lines {
+		if strings.TrimSpace(line) == heading {
+			start = index + 1
+			break
+		}
+	}
+	if start == -1 {
+		return nil, fmt.Errorf("missing section %q", heading)
+	}
+
+	end := len(lines)
+	for index := start; index < len(lines); index++ {
+		if strings.HasPrefix(strings.TrimSpace(lines[index]), "## ") {
+			end = index
+			break
+		}
+	}
+	return lines[start:end], nil
+}
+
+func markdownTableRows(section []string, expectedHeader []string) ([][]string, error) {
+	for index, line := range section {
+		cells, ok, err := splitMarkdownTableRow(line)
+		if err != nil || !ok || !equalStrings(cells, expectedHeader) {
+			continue
+		}
+		if index+1 >= len(section) {
+			return nil, fmt.Errorf("missing Markdown table separator")
+		}
+		separator, ok, err := splitMarkdownTableRow(section[index+1])
+		if err != nil || !ok || !isMarkdownTableSeparator(separator, len(expectedHeader)) {
+			return nil, fmt.Errorf("missing Markdown table separator after header")
+		}
+
+		rows := [][]string{}
+		for rowIndex := index + 2; rowIndex < len(section); rowIndex++ {
+			if !strings.HasPrefix(strings.TrimSpace(section[rowIndex]), "|") {
+				break
+			}
+			row, ok, err := splitMarkdownTableRow(section[rowIndex])
+			if err != nil {
+				return nil, err
+			}
+			if !ok {
+				break
+			}
+			rows = append(rows, row)
+		}
+		if len(rows) == 0 {
+			return nil, fmt.Errorf("Markdown table has no data rows")
+		}
+		return rows, nil
+	}
+	return nil, fmt.Errorf("missing Markdown table with header %v", expectedHeader)
+}
+
+func splitMarkdownTableRow(line string) ([]string, bool, error) {
+	line = strings.TrimSpace(line)
+	if !strings.HasPrefix(line, "|") {
+		return nil, false, nil
+	}
+	if !strings.HasSuffix(line, "|") {
+		return nil, false, fmt.Errorf("malformed Markdown table row %q: missing trailing pipe", line)
+	}
+
+	line = strings.TrimSuffix(strings.TrimPrefix(line, "|"), "|")
+	cells := []string{}
+	var cell strings.Builder
+	for index := 0; index < len(line); index++ {
+		if line[index] == '\\' && index+1 < len(line) && line[index+1] == '|' {
+			cell.WriteByte('|')
+			index++
+			continue
+		}
+		if line[index] == '|' {
+			cells = append(cells, strings.TrimSpace(cell.String()))
+			cell.Reset()
+			continue
+		}
+		cell.WriteByte(line[index])
+	}
+	cells = append(cells, strings.TrimSpace(cell.String()))
+	return cells, true, nil
+}
+
+func isMarkdownTableSeparator(cells []string, wantColumns int) bool {
+	if len(cells) != wantColumns {
+		return false
+	}
+	for _, cell := range cells {
+		cell = strings.TrimSpace(cell)
+		cell = strings.TrimPrefix(cell, ":")
+		cell = strings.TrimSuffix(cell, ":")
+		if len(cell) < 3 || strings.Trim(cell, "-") != "" {
+			return false
+		}
+	}
+	return true
+}
+
+func regularFileExists(path string) (bool, error) {
+	info, err := os.Stat(path)
+	if os.IsNotExist(err) {
+		return false, nil
+	}
+	if err != nil {
+		return false, err
+	}
+	return info.Mode().IsRegular(), nil
+}
+
+func parseYesNo(value string) (bool, error) {
+	switch strings.TrimSpace(value) {
+	case "yes":
+		return true, nil
+	case "no":
+		return false, nil
+	default:
+		return false, fmt.Errorf("want yes or no, got %q", value)
+	}
+}
+
+func isLowerASCII(value byte) bool {
+	return value >= 'a' && value <= 'z'
+}
+
+func isASCIIDigit(value byte) bool {
+	return value >= '0' && value <= '9'
+}
+
+func inventoryBooleanMismatch(provider string, documented, actual bool) string {
+	return fmt.Sprintf("%s (documented %s, actual %s)", provider, yesNo(documented), yesNo(actual))
+}
+
+func yesNo(value bool) string {
+	if value {
+		return "yes"
+	}
+	return "no"
+}
+
+func setDifference(left, right map[string]struct{}) []string {
+	values := []string{}
+	for value := range left {
+		if _, ok := right[value]; !ok {
+			values = append(values, value)
+		}
+	}
+	sort.Strings(values)
+	return values
+}
+
+func sortedUniqueStrings(values []string) []string {
+	unique := map[string]struct{}{}
+	for _, value := range values {
+		unique[value] = struct{}{}
+	}
+	result := make([]string, 0, len(unique))
+	for value := range unique {
+		result = append(result, value)
+	}
+	sort.Strings(result)
+	return result
+}
+
+func stringSet(values ...string) map[string]struct{} {
+	result := make(map[string]struct{}, len(values))
+	for _, value := range values {
+		result[value] = struct{}{}
+	}
+	return result
+}
+
+func equalStrings(left, right []string) bool {
+	if len(left) != len(right) {
+		return false
+	}
+	for index := range left {
+		if left[index] != right[index] {
+			return false
+		}
+	}
+	return true
+}
+
+func readUnsupportedResourcesDocumentation(t *testing.T) string {
+	t.Helper()
+	data, err := os.ReadFile(unsupportedResourcesDocumentationPath)
+	if err != nil {
+		t.Fatalf("read unsupported resources documentation: %v", err)
+	}
+	return string(data)
+}
+
+func statusTableMarkdown(statuses ...string) string {
+	var markdown strings.Builder
+	markdown.WriteString("# Unsupported resources\n\n")
+	markdown.WriteString(unsupportedResourceStatusHeading)
+	markdown.WriteString("\n\n| Status | Meaning |\n| --- | --- |\n")
+	for _, status := range statuses {
+		fmt.Fprintf(&markdown, "| `%s` | Meaning for %s. |\n", status, status)
+	}
+	return markdown.String()
+}
+
+func providerInventoryMarkdown(rows ...string) string {
+	return "# Unsupported resources\n\n" + unsupportedResourceInventoryHeading + "\n\n" +
+		"| Provider | Has `unsupported_resources.json` | Has provider-local `unsupported_resources_test.go` | Notes |\n" +
+		"| --- | --- | --- | --- |\n" + strings.Join(rows, "\n") + "\n"
+}

--- a/providers/unsupported_resources_documentation_test.go
+++ b/providers/unsupported_resources_documentation_test.go
@@ -9,6 +9,8 @@ import (
 	"sort"
 	"strings"
 	"testing"
+
+	"github.com/chenrui333/terraformer/internal/unsupportedresources"
 )
 
 const (
@@ -44,7 +46,7 @@ type unsupportedResourceProviderFiles struct {
 
 func TestUnsupportedResourceStatusesMatchDocumentation(t *testing.T) {
 	markdown := readUnsupportedResourcesDocumentation(t)
-	if err := validateUnsupportedResourceStatusDocumentation(markdown, allowedUnsupportedResourceStatuses); err != nil {
+	if err := validateUnsupportedResourceStatusDocumentation(markdown, stringSet(unsupportedresources.Statuses()...)); err != nil {
 		t.Fatal(err)
 	}
 }

--- a/providers/unsupported_resources_documentation_test.go
+++ b/providers/unsupported_resources_documentation_test.go
@@ -118,6 +118,32 @@ func TestParseUnsupportedResourceStatusTable(t *testing.T) {
 			allowed: stringSet("alpha"),
 		},
 		{
+			name: "unrelated table after intended table does not count",
+			markdown: statusTableMarkdown("alpha") + "\n" +
+				"| Other | Value |\n| --- | --- |\n| `gamma` | Unrelated table. |\n",
+			allowed: stringSet("alpha"),
+		},
+		{
+			name: "duplicate status tables",
+			markdown: "# Unsupported resources\n\n" + unsupportedResourceStatusHeading + "\n\n" +
+				statusMarkdownTable("alpha") + "\n" + statusMarkdownTable("beta"),
+			allowed:         stringSet("alpha"),
+			wantErrContains: "duplicate Markdown table with header [Status Meaning]",
+		},
+		{
+			name: "malformed intended separator",
+			markdown: "# Unsupported resources\n\n" + unsupportedResourceStatusHeading + "\n\n" +
+				"| Status | Meaning |\n| -- | --- |\n| `alpha` | Meaning for alpha. |\n",
+			allowed:         stringSet("alpha"),
+			wantErrContains: "missing Markdown table separator after header",
+		},
+		{
+			name:            "duplicate status sections",
+			markdown:        statusTableMarkdown("alpha") + "\n" + statusTableMarkdown("alpha"),
+			allowed:         stringSet("alpha"),
+			wantErrContains: "duplicate section \"## Status Values\"",
+		},
+		{
 			name: "section ends at next level two heading",
 			markdown: statusTableMarkdown("alpha") + "\n## Other\n\n" +
 				"| Status | Meaning |\n| --- | --- |\n| `gamma` | Outside the section. |\n",
@@ -136,6 +162,77 @@ func TestParseUnsupportedResourceStatusTable(t *testing.T) {
 			}
 			if err == nil || !strings.Contains(err.Error(), test.wantErrContains) {
 				t.Fatalf("validateUnsupportedResourceStatusDocumentation() error = %v, want substring %q", err, test.wantErrContains)
+			}
+		})
+	}
+}
+
+func TestUnsupportedResourceMarkdownLevelTwoSection(t *testing.T) {
+	tests := []struct {
+		name            string
+		markdown        string
+		heading         string
+		want            string
+		wantErrContains string
+	}{
+		{
+			name:     "requested section after another section",
+			markdown: "## Other\nignored\n## Status Values\nwanted\n## Next\nignored",
+			heading:  unsupportedResourceStatusHeading,
+			want:     "wanted",
+		},
+		{
+			name:     "requested section before another section",
+			markdown: "## Inventory\nwanted\n## Other\nignored",
+			heading:  unsupportedResourceInventoryHeading,
+			want:     "wanted",
+		},
+		{
+			name:     "requested section at end",
+			markdown: "# Document\n## Status Values\nfirst\nsecond",
+			heading:  unsupportedResourceStatusHeading,
+			want:     "first\nsecond",
+		},
+		{
+			name:     "CRLF section extraction",
+			markdown: "## Other\r\nignored\r\n## Inventory\r\nwanted\r\n## Next\r\nignored",
+			heading:  unsupportedResourceInventoryHeading,
+			want:     "wanted",
+		},
+		{
+			name:            "missing section",
+			markdown:        "## Other\nignored",
+			heading:         unsupportedResourceStatusHeading,
+			wantErrContains: "missing section \"## Status Values\"",
+		},
+		{
+			name:            "duplicate status sections",
+			markdown:        "## Status Values\nfirst\n## Other\nignored\n## Status Values\nsecond",
+			heading:         unsupportedResourceStatusHeading,
+			wantErrContains: "duplicate section \"## Status Values\"",
+		},
+		{
+			name:            "duplicate inventory sections",
+			markdown:        "## Inventory\nfirst\n## Other\nignored\n## Inventory\nsecond",
+			heading:         unsupportedResourceInventoryHeading,
+			wantErrContains: "duplicate section \"## Inventory\"",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			lines, err := markdownLevelTwoSection(test.markdown, test.heading)
+			if test.wantErrContains != "" {
+				if err == nil || !strings.Contains(err.Error(), test.wantErrContains) {
+					t.Fatalf("markdownLevelTwoSection() error = %v, want substring %q", err, test.wantErrContains)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("markdownLevelTwoSection() error = %v", err)
+			}
+			if got := strings.Join(lines, "\n"); got != test.want {
+				t.Fatalf("markdownLevelTwoSection() = %q, want %q", got, test.want)
 			}
 		})
 	}
@@ -224,6 +321,36 @@ func TestParseUnsupportedResourceProviderInventory(t *testing.T) {
 				"| alpha | yes | yes | metadata [details](alpha.md); `provider-specific` assertions and escaped \\| note |",
 				validRows[1],
 			),
+		},
+		{
+			name: "unrelated table before intended table",
+			markdown: "# Unsupported resources\n\n" + unsupportedResourceInventoryHeading + "\n\n" +
+				"| Other | Value |\n| --- | --- |\n| gamma | unrelated |\n\n" +
+				providerInventoryMarkdownTable(validRows...),
+		},
+		{
+			name: "unrelated table after intended table",
+			markdown: providerInventoryMarkdown(validRows...) + "\n" +
+				"| Other | Value |\n| --- | --- |\n| gamma | unrelated |\n",
+		},
+		{
+			name: "duplicate inventory tables",
+			markdown: "# Unsupported resources\n\n" + unsupportedResourceInventoryHeading + "\n\n" +
+				providerInventoryMarkdownTable(validRows...) + "\n" +
+				providerInventoryMarkdownTable("| alpha | no | no | conflicting row |"),
+			wantErrContains: "duplicate Markdown table with header [Provider Has `unsupported_resources.json` Has provider-local `unsupported_resources_test.go` Notes]",
+		},
+		{
+			name: "malformed intended separator",
+			markdown: "# Unsupported resources\n\n" + unsupportedResourceInventoryHeading + "\n\n" +
+				"| Provider | Has `unsupported_resources.json` | Has provider-local `unsupported_resources_test.go` | Notes |\n" +
+				"| -- | --- | --- | --- |\n" + validRows[0] + "\n" + validRows[1] + "\n",
+			wantErrContains: "missing Markdown table separator after header",
+		},
+		{
+			name:            "duplicate inventory sections",
+			markdown:        providerInventoryMarkdown(validRows...) + "\n" + providerInventoryMarkdown(validRows...),
+			wantErrContains: "duplicate section \"## Inventory\"",
 		},
 		{
 			name: "rows outside inventory are ignored",
@@ -463,60 +590,69 @@ func collectUnsupportedResourceProviderFiles(root string, excluded map[string]st
 func markdownLevelTwoSection(markdown, heading string) ([]string, error) {
 	lines := strings.Split(strings.ReplaceAll(markdown, "\r\n", "\n"), "\n")
 	start := -1
+	end := len(lines)
 	for index, line := range lines {
-		if strings.TrimSpace(line) == heading {
+		trimmed := strings.TrimSpace(line)
+		if trimmed == heading {
+			if start != -1 {
+				return nil, fmt.Errorf("duplicate section %q", heading)
+			}
 			start = index + 1
-			break
+			continue
+		}
+		if start != -1 && end == len(lines) && strings.HasPrefix(trimmed, "## ") {
+			end = index
 		}
 	}
 	if start == -1 {
 		return nil, fmt.Errorf("missing section %q", heading)
 	}
-
-	end := len(lines)
-	for index := start; index < len(lines); index++ {
-		if strings.HasPrefix(strings.TrimSpace(lines[index]), "## ") {
-			end = index
-			break
-		}
-	}
 	return lines[start:end], nil
 }
 
 func markdownTableRows(section []string, expectedHeader []string) ([][]string, error) {
+	headerIndexes := []int{}
 	for index, line := range section {
 		cells, ok, err := splitMarkdownTableRow(line)
 		if err != nil || !ok || !equalStrings(cells, expectedHeader) {
 			continue
 		}
-		if index+1 >= len(section) {
-			return nil, fmt.Errorf("missing Markdown table separator")
-		}
-		separator, ok, err := splitMarkdownTableRow(section[index+1])
-		if err != nil || !ok || !isMarkdownTableSeparator(separator, len(expectedHeader)) {
-			return nil, fmt.Errorf("missing Markdown table separator after header")
-		}
-
-		rows := [][]string{}
-		for rowIndex := index + 2; rowIndex < len(section); rowIndex++ {
-			if !strings.HasPrefix(strings.TrimSpace(section[rowIndex]), "|") {
-				break
-			}
-			row, ok, err := splitMarkdownTableRow(section[rowIndex])
-			if err != nil {
-				return nil, err
-			}
-			if !ok {
-				break
-			}
-			rows = append(rows, row)
-		}
-		if len(rows) == 0 {
-			return nil, fmt.Errorf("Markdown table has no data rows")
-		}
-		return rows, nil
+		headerIndexes = append(headerIndexes, index)
 	}
-	return nil, fmt.Errorf("missing Markdown table with header %v", expectedHeader)
+	if len(headerIndexes) == 0 {
+		return nil, fmt.Errorf("missing Markdown table with header %v", expectedHeader)
+	}
+	if len(headerIndexes) > 1 {
+		return nil, fmt.Errorf("duplicate Markdown table with header %v", expectedHeader)
+	}
+
+	headerIndex := headerIndexes[0]
+	if headerIndex+1 >= len(section) {
+		return nil, fmt.Errorf("missing Markdown table separator")
+	}
+	separator, ok, err := splitMarkdownTableRow(section[headerIndex+1])
+	if err != nil || !ok || !isMarkdownTableSeparator(separator, len(expectedHeader)) {
+		return nil, fmt.Errorf("missing Markdown table separator after header")
+	}
+
+	rows := [][]string{}
+	for rowIndex := headerIndex + 2; rowIndex < len(section); rowIndex++ {
+		if !strings.HasPrefix(strings.TrimSpace(section[rowIndex]), "|") {
+			break
+		}
+		row, ok, err := splitMarkdownTableRow(section[rowIndex])
+		if err != nil {
+			return nil, err
+		}
+		if !ok {
+			break
+		}
+		rows = append(rows, row)
+	}
+	if len(rows) == 0 {
+		return nil, fmt.Errorf("Markdown table has no data rows")
+	}
+	return rows, nil
 }
 
 func splitMarkdownTableRow(line string) ([]string, bool, error) {
@@ -658,10 +794,12 @@ func readUnsupportedResourcesDocumentation(t *testing.T) string {
 }
 
 func statusTableMarkdown(statuses ...string) string {
+	return "# Unsupported resources\n\n" + unsupportedResourceStatusHeading + "\n\n" + statusMarkdownTable(statuses...)
+}
+
+func statusMarkdownTable(statuses ...string) string {
 	var markdown strings.Builder
-	markdown.WriteString("# Unsupported resources\n\n")
-	markdown.WriteString(unsupportedResourceStatusHeading)
-	markdown.WriteString("\n\n| Status | Meaning |\n| --- | --- |\n")
+	markdown.WriteString("| Status | Meaning |\n| --- | --- |\n")
 	for _, status := range statuses {
 		fmt.Fprintf(&markdown, "| `%s` | Meaning for %s. |\n", status, status)
 	}
@@ -670,6 +808,11 @@ func statusTableMarkdown(statuses ...string) string {
 
 func providerInventoryMarkdown(rows ...string) string {
 	return "# Unsupported resources\n\n" + unsupportedResourceInventoryHeading + "\n\n" +
+		providerInventoryMarkdownTable(rows...)
+}
+
+func providerInventoryMarkdownTable(rows ...string) string {
+	return "" +
 		"| Provider | Has `unsupported_resources.json` | Has provider-local `unsupported_resources_test.go` | Notes |\n" +
 		"| --- | --- | --- | --- |\n" + strings.Join(rows, "\n") + "\n"
 }

--- a/providers/unsupported_resources_test.go
+++ b/providers/unsupported_resources_test.go
@@ -9,22 +9,11 @@ import (
 	"sort"
 	"strings"
 	"testing"
+
+	"github.com/chenrui333/terraformer/internal/unsupportedresources"
 )
 
 const unsupportedResourcesVersion = 1
-
-var allowedUnsupportedResourceStatuses = map[string]struct{}{
-	"action-style":       {},
-	"cloudflare-managed": {},
-	"deferred":           {},
-	"not-importable":     {},
-	"policy-skip":        {},
-	"request-style":      {},
-	"runtime-data":       {},
-	"runtime-generated":  {},
-	"secret-required":    {},
-	"unsupported":        {},
-}
 
 type unsupportedResourcesFile struct {
 	Version   *int                          `json:"version"`
@@ -108,12 +97,11 @@ func validateRequiredString(t *testing.T, metadataFile, resource, field, value s
 func validateUnsupportedResourceStatus(t *testing.T, metadataFile, resource, status string) {
 	t.Helper()
 
-	status = strings.TrimSpace(status)
-	if status == "" {
+	if strings.TrimSpace(status) == "" {
 		t.Fatalf("%s resource %q is missing status", metadataFile, resource)
 	}
-	if _, ok := allowedUnsupportedResourceStatuses[status]; !ok {
-		t.Fatalf("%s resource %q has unsupported status %q, want one of %v", metadataFile, resource, status, sortedUnsupportedResourceStatuses())
+	if !unsupportedresources.IsValidStatus(status) {
+		t.Fatalf("%s resource %q has unsupported status %q, want one of %v", metadataFile, resource, status, unsupportedresources.Statuses())
 	}
 }
 
@@ -128,13 +116,4 @@ func validateUnsupportedResourceReferences(t *testing.T, metadataFile, resource 
 			t.Fatalf("%s resource %q has empty references[%d]", metadataFile, resource, index)
 		}
 	}
-}
-
-func sortedUnsupportedResourceStatuses() []string {
-	statuses := make([]string, 0, len(allowedUnsupportedResourceStatuses))
-	for status := range allowedUnsupportedResourceStatuses {
-		statuses = append(statuses, status)
-	}
-	sort.Strings(statuses)
-	return statuses
 }

--- a/providers/unsupported_resources_test.go
+++ b/providers/unsupported_resources_test.go
@@ -4,7 +4,6 @@ package providers
 
 import (
 	"encoding/json"
-	"fmt"
 	"os"
 	"path/filepath"
 	"sort"
@@ -138,16 +137,4 @@ func sortedUnsupportedResourceStatuses() []string {
 	}
 	sort.Strings(statuses)
 	return statuses
-}
-
-func TestUnsupportedResourceStatusesAreDocumented(t *testing.T) {
-	data, err := os.ReadFile(filepath.Join("..", "docs", "unsupported-resources.md"))
-	if err != nil {
-		t.Fatalf("read unsupported resources documentation: %v", err)
-	}
-	for _, status := range sortedUnsupportedResourceStatuses() {
-		if !strings.Contains(string(data), fmt.Sprintf("`%s`", status)) {
-			t.Fatalf("status %q is not documented", status)
-		}
-	}
 }

--- a/tools/aws-gap-inventory/inventory.go
+++ b/tools/aws-gap-inventory/inventory.go
@@ -16,6 +16,8 @@ import (
 	"regexp"
 	"sort"
 	"strings"
+
+	"github.com/chenrui333/terraformer/internal/unsupportedresources"
 )
 
 const awsProviderAddress = "registry.terraform.io/hashicorp/aws"
@@ -436,10 +438,8 @@ func readSkipList(path string) ([]skipListEntry, error) {
 	if list.Version != 1 {
 		return nil, fmt.Errorf("unsupported skip-list version %d", list.Version)
 	}
-	// The repository-wide providers test owns status membership validation.
-	// This tool requires a non-empty status and preserves it in its output.
 	for i, entry := range list.Resources {
-		if entry.Resource == "" || entry.ServiceFamily == "" || entry.Reason == "" || entry.Status == "" {
+		if entry.Resource == "" || entry.ServiceFamily == "" || entry.Reason == "" || strings.TrimSpace(entry.Status) == "" {
 			return nil, fmt.Errorf("skip-list resource %d is missing a required field", i)
 		}
 		if entry.Evidence == "" && entry.SourceNotes == "" {
@@ -447,6 +447,9 @@ func readSkipList(path string) ([]skipListEntry, error) {
 		}
 		if !awsResourceRe.MatchString(entry.Resource) {
 			return nil, fmt.Errorf("skip-list resource %d has invalid resource %q", i, entry.Resource)
+		}
+		if !unsupportedresources.IsValidStatus(entry.Status) {
+			return nil, fmt.Errorf("skip-list resource %q has invalid status %q, want one of %v", entry.Resource, entry.Status, unsupportedresources.Statuses())
 		}
 	}
 	sort.Slice(list.Resources, func(i, j int) bool {

--- a/tools/aws-gap-inventory/inventory.go
+++ b/tools/aws-gap-inventory/inventory.go
@@ -21,17 +21,9 @@ import (
 const awsProviderAddress = "registry.terraform.io/hashicorp/aws"
 
 var (
-	docsServiceRe   = regexp.MustCompile("^\\*\\s+`([^`]+)`")
-	docsResourceRe  = regexp.MustCompile("^\\s+\\*\\s+`(aws_[^`]+)`")
-	awsResourceRe   = regexp.MustCompile("^aws_[a-z0-9_]+$")
-	validSkipStatus = map[string]bool{
-		"deferred":         true,
-		"needs-research":   true,
-		"not-importable":   true,
-		"runtime-data":     true,
-		"unsupported":      true,
-		"unsafe-discovery": true,
-	}
+	docsServiceRe            = regexp.MustCompile("^\\*\\s+`([^`]+)`")
+	docsResourceRe           = regexp.MustCompile("^\\s+\\*\\s+`(aws_[^`]+)`")
+	awsResourceRe            = regexp.MustCompile("^aws_[a-z0-9_]+$")
 	resourceServiceOverrides = map[string]map[string][]string{
 		"lex.go": {
 			"aws_lex_bot":                {"lex"},
@@ -444,6 +436,8 @@ func readSkipList(path string) ([]skipListEntry, error) {
 	if list.Version != 1 {
 		return nil, fmt.Errorf("unsupported skip-list version %d", list.Version)
 	}
+	// The repository-wide providers test owns status membership validation.
+	// This tool requires a non-empty status and preserves it in its output.
 	for i, entry := range list.Resources {
 		if entry.Resource == "" || entry.ServiceFamily == "" || entry.Reason == "" || entry.Status == "" {
 			return nil, fmt.Errorf("skip-list resource %d is missing a required field", i)
@@ -453,9 +447,6 @@ func readSkipList(path string) ([]skipListEntry, error) {
 		}
 		if !awsResourceRe.MatchString(entry.Resource) {
 			return nil, fmt.Errorf("skip-list resource %d has invalid resource %q", i, entry.Resource)
-		}
-		if !validSkipStatus[entry.Status] {
-			return nil, fmt.Errorf("skip-list resource %q has invalid status %q", entry.Resource, entry.Status)
 		}
 	}
 	sort.Slice(list.Resources, func(i, j int) bool {

--- a/tools/aws-gap-inventory/inventory.go
+++ b/tools/aws-gap-inventory/inventory.go
@@ -438,11 +438,25 @@ func readSkipList(path string) ([]skipListEntry, error) {
 	if list.Version != 1 {
 		return nil, fmt.Errorf("unsupported skip-list version %d", list.Version)
 	}
+	type skipListIdentity struct {
+		resource      string
+		serviceFamily string
+	}
+	seen := make(map[skipListIdentity]struct{}, len(list.Resources))
 	for i, entry := range list.Resources {
-		if entry.Resource == "" || entry.ServiceFamily == "" || entry.Reason == "" || strings.TrimSpace(entry.Status) == "" {
-			return nil, fmt.Errorf("skip-list resource %d is missing a required field", i)
+		if strings.TrimSpace(entry.Resource) == "" {
+			return nil, fmt.Errorf("skip-list resource %d is missing resource", i)
 		}
-		if entry.Evidence == "" && entry.SourceNotes == "" {
+		if strings.TrimSpace(entry.ServiceFamily) == "" {
+			return nil, fmt.Errorf("skip-list resource %d is missing service_family", i)
+		}
+		if strings.TrimSpace(entry.Reason) == "" {
+			return nil, fmt.Errorf("skip-list resource %d is missing reason", i)
+		}
+		if strings.TrimSpace(entry.Status) == "" {
+			return nil, fmt.Errorf("skip-list resource %d is missing status", i)
+		}
+		if strings.TrimSpace(entry.Evidence) == "" && strings.TrimSpace(entry.SourceNotes) == "" {
 			return nil, fmt.Errorf("skip-list resource %q requires evidence or source_notes", entry.Resource)
 		}
 		if !awsResourceRe.MatchString(entry.Resource) {
@@ -451,6 +465,16 @@ func readSkipList(path string) ([]skipListEntry, error) {
 		if !unsupportedresources.IsValidStatus(entry.Status) {
 			return nil, fmt.Errorf("skip-list resource %q has invalid status %q, want one of %v", entry.Resource, entry.Status, unsupportedresources.Statuses())
 		}
+		for referenceIndex, reference := range entry.References {
+			if strings.TrimSpace(reference) == "" {
+				return nil, fmt.Errorf("skip-list resource %q has empty reference at index %d", entry.Resource, referenceIndex)
+			}
+		}
+		identity := skipListIdentity{resource: entry.Resource, serviceFamily: entry.ServiceFamily}
+		if _, exists := seen[identity]; exists {
+			return nil, fmt.Errorf("skip-list has duplicate resource %q in service family %q", entry.Resource, entry.ServiceFamily)
+		}
+		seen[identity] = struct{}{}
 	}
 	sort.Slice(list.Resources, func(i, j int) bool {
 		if list.Resources[i].ServiceFamily == list.Resources[j].ServiceFamily {

--- a/tools/aws-gap-inventory/inventory_test.go
+++ b/tools/aws-gap-inventory/inventory_test.go
@@ -4,6 +4,7 @@ package main
 
 import (
 	"bytes"
+	"encoding/json"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -115,8 +116,149 @@ func TestReadSkipListValidatesRequiredFields(t *testing.T) {
 	if err == nil {
 		t.Fatal("readSkipList() error = nil, want validation error")
 	}
-	if !strings.Contains(err.Error(), "missing a required field") {
-		t.Fatalf("readSkipList() error = %q, want required field error", err)
+	if !strings.Contains(err.Error(), "missing status") {
+		t.Fatalf("readSkipList() error = %q, want missing status error", err)
+	}
+}
+
+func TestReadSkipListRejectsWhitespaceOnlyFields(t *testing.T) {
+	tests := []struct {
+		name            string
+		mutate          func(*skipListEntry)
+		wantErrContains string
+		wantEvidence    string
+		wantSourceNotes string
+	}{
+		{name: "resource", mutate: func(entry *skipListEntry) { entry.Resource = " \t " }, wantErrContains: "missing resource"},
+		{name: "service family", mutate: func(entry *skipListEntry) { entry.ServiceFamily = " \t " }, wantErrContains: "missing service_family"},
+		{name: "reason", mutate: func(entry *skipListEntry) { entry.Reason = "\t" }, wantErrContains: "missing reason"},
+		{name: "status", mutate: func(entry *skipListEntry) { entry.Status = " \n " }, wantErrContains: "missing status"},
+		{
+			name: "evidence without source notes",
+			mutate: func(entry *skipListEntry) {
+				entry.Evidence = " \n "
+				entry.SourceNotes = ""
+			},
+			wantErrContains: "requires evidence or source_notes",
+		},
+		{
+			name: "source notes without evidence",
+			mutate: func(entry *skipListEntry) {
+				entry.Evidence = ""
+				entry.SourceNotes = " \n "
+			},
+			wantErrContains: "requires evidence or source_notes",
+		},
+		{
+			name: "valid source notes with whitespace evidence",
+			mutate: func(entry *skipListEntry) {
+				entry.Evidence = " \n "
+				entry.SourceNotes = "Legacy source notes."
+			},
+			wantEvidence:    " \n ",
+			wantSourceNotes: "Legacy source notes.",
+		},
+		{
+			name: "valid evidence with whitespace source notes",
+			mutate: func(entry *skipListEntry) {
+				entry.Evidence = "Provider read-path evidence."
+				entry.SourceNotes = " \n "
+			},
+			wantEvidence:    "Provider read-path evidence.",
+			wantSourceNotes: " \n ",
+		},
+		{
+			name: "reference",
+			mutate: func(entry *skipListEntry) {
+				entry.References = []string{"https://example.com/evidence", " \t "}
+			},
+			wantErrContains: "empty reference",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			entry := validSkipListEntry("aws_example_action", "example")
+			test.mutate(&entry)
+			entries, err := readSkipList(writeSkipListFixture(t, entry))
+			if test.wantErrContains != "" {
+				if err == nil || !strings.Contains(err.Error(), test.wantErrContains) {
+					t.Fatalf("readSkipList() error = %v, want substring %q", err, test.wantErrContains)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("readSkipList() error = %v", err)
+			}
+			if entries[0].Evidence != test.wantEvidence || entries[0].SourceNotes != test.wantSourceNotes {
+				t.Fatalf("readSkipList() = %#v, want evidence %q and source_notes %q preserved", entries[0], test.wantEvidence, test.wantSourceNotes)
+			}
+		})
+	}
+}
+
+func TestReadSkipListRejectsDuplicateResourceFamilyPairs(t *testing.T) {
+	tests := []struct {
+		name            string
+		entries         []skipListEntry
+		wantErrContains string
+		wantOrder       []resourceRecord
+	}{
+		{
+			name:            "exact duplicate pair",
+			entries:         []skipListEntry{validSkipListEntry("aws_example_one", "example"), validSkipListEntry("aws_example_one", "example")},
+			wantErrContains: `duplicate resource "aws_example_one" in service family "example"`,
+		},
+		{
+			name: "duplicate pair with different status",
+			entries: func() []skipListEntry {
+				first := validSkipListEntry("aws_example_one", "example")
+				second := validSkipListEntry("aws_example_one", "example")
+				second.Status = "deferred"
+				return []skipListEntry{first, second}
+			}(),
+			wantErrContains: `duplicate resource "aws_example_one" in service family "example"`,
+		},
+		{
+			name: "duplicate pair with different reason",
+			entries: func() []skipListEntry {
+				first := validSkipListEntry("aws_example_one", "example")
+				second := validSkipListEntry("aws_example_one", "example")
+				second.Reason = "A different limitation."
+				return []skipListEntry{first, second}
+			}(),
+			wantErrContains: `duplicate resource "aws_example_one" in service family "example"`,
+		},
+		{
+			name:      "same resource in different families",
+			entries:   []skipListEntry{validSkipListEntry("aws_example_one", "zeta"), validSkipListEntry("aws_example_one", "alpha")},
+			wantOrder: []resourceRecord{{Resource: "aws_example_one", ServiceFamily: "alpha"}, {Resource: "aws_example_one", ServiceFamily: "zeta"}},
+		},
+		{
+			name:      "different resources in same family",
+			entries:   []skipListEntry{validSkipListEntry("aws_example_two", "example"), validSkipListEntry("aws_example_one", "example")},
+			wantOrder: []resourceRecord{{Resource: "aws_example_one", ServiceFamily: "example"}, {Resource: "aws_example_two", ServiceFamily: "example"}},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			entries, err := readSkipList(writeSkipListFixture(t, test.entries...))
+			if test.wantErrContains != "" {
+				if err == nil || !strings.Contains(err.Error(), test.wantErrContains) {
+					t.Fatalf("readSkipList() error = %v, want substring %q", err, test.wantErrContains)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("readSkipList() error = %v", err)
+			}
+			gotOrder := make([]resourceRecord, 0, len(entries))
+			for _, entry := range entries {
+				gotOrder = append(gotOrder, resourceRecord{Resource: entry.Resource, ServiceFamily: entry.ServiceFamily})
+			}
+			assertRecords(t, gotOrder, test.wantOrder)
+		})
 	}
 }
 
@@ -368,6 +510,28 @@ func writeFile(t *testing.T, path string, contents string) {
 	}
 	if err := os.WriteFile(path, []byte(contents), 0o644); err != nil {
 		t.Fatal(err)
+	}
+}
+
+func writeSkipListFixture(t *testing.T, entries ...skipListEntry) string {
+	t.Helper()
+	data, err := json.Marshal(skipList{Version: 1, Resources: entries})
+	if err != nil {
+		t.Fatal(err)
+	}
+	path := filepath.Join(t.TempDir(), "unsupported_resources.json")
+	writeFile(t, path, string(data))
+	return path
+}
+
+func validSkipListEntry(resource, serviceFamily string) skipListEntry {
+	return skipListEntry{
+		Resource:      resource,
+		ServiceFamily: serviceFamily,
+		Reason:        "The resource cannot be imported safely.",
+		Evidence:      "Provider and API behavior demonstrate the limitation.",
+		Status:        "unsupported",
+		References:    []string{"https://example.com/evidence"},
 	}
 }
 

--- a/tools/aws-gap-inventory/inventory_test.go
+++ b/tools/aws-gap-inventory/inventory_test.go
@@ -4,6 +4,7 @@ package main
 
 import (
 	"bytes"
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -141,6 +142,35 @@ func TestReadSkipListPreservesCanonicalStatus(t *testing.T) {
 	}
 	if len(entries) != 1 || entries[0].Status != "action-style" {
 		t.Fatalf("readSkipList() = %#v, want preserved action-style status", entries)
+	}
+}
+
+func TestReadSkipListRejectsUnknownStatuses(t *testing.T) {
+	for _, status := range []string{"future-status", "needs-research", "unsafe-discovery", " action-style "} {
+		t.Run(status, func(t *testing.T) {
+			path := filepath.Join(t.TempDir(), "unsupported_resources.json")
+			writeFile(t, path, fmt.Sprintf(`{
+  "version": 1,
+  "resources": [
+    {
+      "resource": "aws_example_action",
+      "service_family": "example",
+      "reason": "The resource performs an operation.",
+      "evidence": "The provider invokes an action instead of managing durable configuration.",
+      "status": %q
+    }
+  ]
+}
+`, status))
+
+			_, err := readSkipList(path)
+			if err == nil {
+				t.Fatalf("readSkipList() error = nil, want invalid status error for %q", status)
+			}
+			if !strings.Contains(err.Error(), "invalid status") {
+				t.Fatalf("readSkipList() error = %q, want invalid status error", err)
+			}
+		})
 	}
 }
 

--- a/tools/aws-gap-inventory/inventory_test.go
+++ b/tools/aws-gap-inventory/inventory_test.go
@@ -119,6 +119,31 @@ func TestReadSkipListValidatesRequiredFields(t *testing.T) {
 	}
 }
 
+func TestReadSkipListPreservesCanonicalStatus(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "unsupported_resources.json")
+	writeFile(t, path,
+		"{\n"+
+			"  \"version\": 1,\n"+
+			"  \"resources\": [\n"+
+			"    {\n"+
+			"      \"resource\": \"aws_example_action\",\n"+
+			"      \"service_family\": \"example\",\n"+
+			"      \"reason\": \"The resource performs an operation.\",\n"+
+			"      \"evidence\": \"The provider invokes an action instead of managing durable configuration.\",\n"+
+			"      \"status\": \"action-style\"\n"+
+			"    }\n"+
+			"  ]\n"+
+			"}\n")
+
+	entries, err := readSkipList(path)
+	if err != nil {
+		t.Fatalf("readSkipList() error = %v", err)
+	}
+	if len(entries) != 1 || entries[0].Status != "action-style" {
+		t.Fatalf("readSkipList() = %#v, want preserved action-style status", entries)
+	}
+}
+
 func TestBuildInventoryPreservesDuplicateDocsResourceFamilies(t *testing.T) {
 	root := t.TempDir()
 	awsDir := filepath.Join(root, "providers", "aws")


### PR DESCRIPTION
## Summary

- make `internal/unsupportedresources` the single machine source of canonical status membership and the `## Status Values` table the human source of truth
- enforce exact status-table and provider-inventory synchronization, including duplicate authoritative section/table rejection
- keep provider-local tests focused on provider-specific structure while requiring AWS statuses to be non-empty
- harden arbitrary AWS gap `-skip-list` inputs against noncanonical statuses, whitespace-only fields/references, and duplicate resource/family identities
- correct the AWS gap guide and provider inventory without changing metadata classifications or Terraformer import behavior

## Taxonomy

The canonical vocabulary remains unchanged:

- `action-style`
- `cloudflare-managed`
- `deferred`
- `not-importable`
- `policy-skip`
- `request-style`
- `runtime-data`
- `runtime-generated`
- `secret-required`
- `unsupported`

No statuses were added, removed, renamed, or merged. All 295 existing metadata records already use canonical values, so no `unsupported_resources.json` files changed.

Previously, AWS documentation and the AWS gap tool also listed `needs-research` and `unsafe-discovery`, while provider-local tests independently accepted narrower subsets. The gap guide now links to the canonical table, and local tests enforce only structural and provider-specific rules. Runtime AWS skip-list validation still rejects arbitrary or retired statuses through the shared canonical definition.

## Consistency checks

The tests now:

- require exactly one `## Status Values` section and one matching status table
- require exactly one `## Inventory` section and one matching inventory table while allowing unrelated tables
- compare documented statuses exactly with the shared machine definition
- compare every direct provider directory's metadata/test-file presence with the documented inventory
- prove AWS-local structural validation rejects blank statuses without redefining membership; a synthetic non-empty `future-status` passes only that local helper boundary
- reject whitespace-only required skip-list fields and references without normalizing valid input
- reject duplicate `(resource, service_family)` records while allowing the same resource in distinct service families
- prove runtime skip-list validation preserves canonical statuses exactly and rejects arbitrary, retired, and padded values
- prove callers cannot mutate shared canonical status storage

The inventory corrections remain:

- AWS local test: `no` to `yes`
- LaunchDarkly local test: `no` to `yes`
- Helm: added the missing provider row with `no` / `no`

## Validation

All passed on final head `b53351f03f9ea251c4e4f289e563311ec86c1f0c`:

- `go test ./internal/unsupportedresources -count=1` (2 tests)
- `go test ./providers -run 'Test.*Unsupported' -count=1` (49 tests)
- `go test ./providers/aws -run 'Test.*Unsupported' -count=1` (27 tests)
- `go test ./tools/aws-gap-inventory -count=1` (29 tests)
- focused race run across the shared taxonomy, providers, and inventory tool (72 tests)
- `go test ./providers -count=1` (49 tests)
- `go test ./providers/aws -count=1` (2,361 tests)
- `go test ./... -count=1` (4,603 tests across 78 repository packages)
- `go vet ./...`
- scoped `golangci-lint` (0 issues)
- JSON decoding for every provider-local `unsupported_resources.json`
- canonical status usage audit and stale-vocabulary search
- `git diff --check`
- full provider dependency preflight, including non-fixture build, utility tests, Terraform state compatibility, and provider registry compatibility

## Risk

Low. This changes validation tests, documentation consistency enforcement, a dependency-free internal taxonomy package, and the read-only AWS inventory tool. It does not change provider import paths, resource classification metadata, external dependencies, generated files, or runtime Terraformer imports.
